### PR TITLE
Prevent duplicates in stream

### DIFF
--- a/api.py
+++ b/api.py
@@ -59,7 +59,11 @@ def event_stream(query: str, thread_id: Optional[str]=None, query_type: Optional
     else:
         raise ValueError(f"Invalid query type from frontend: {query_type}")
 
-    for namespace,chunk in stream:
+    for namespace, chunk in stream:
+        # Avoid streaming duplicate output by skipping the
+        # messages without namespace.
+        if not namespace:
+            continue
         node_name = list(chunk.keys())[0]
         print(f"Namespace -> {namespace}")
         print(f"Node name -> {node_name}")


### PR DESCRIPTION
For some reason the graphs with subgraphs stream the same updates, once with a namespace of the tool, and once without. We can avoid this by skipping the ones without namespace. Can find more elegant solution later.