### PR TITLE
Add data-api example notebook for monitoring tools

### DIFF
--- a/nbs/09_data_api_otf_analysis_examples.ipynb
+++ b/nbs/09_data_api_otf_analysis_examples.ipynb
@@ -1,0 +1,1286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using the data-API for analysis\n",
+    "To cater to the Monitoring use case we need to build tools that can generate analysis against GFW, WRI, and LCL datasets. The [data-API](https://data-api.globalforestwatch.org/#tag/Query/operation/query_dataset_json_post_dataset__dataset___version__query_json_post) provides a way to carry out on-the-fly (OTF) raster analysis against a dataset by providing a sql string and a geojson object against which to carry out the zonal statistics.\n",
+    "\n",
+    "This notebook will show some examples analyses that will help build tooling for a data-API analysis agent. We will cover:\n",
+    "1. Basic single- and miltiple-location raster queries\n",
+    "2. Finding other compatible raster datasets for masking\n",
+    "3. Specific single-location queries for the monitoring use case\n",
+    "\n",
+    "## Priority datasets\n",
+    "\n",
+    "Datasets:\n",
+    "- `gfw_pixel_area` pixel area for summing over any other masked raster data layer \n",
+    "- Integrated alerts `gfw_integrated_alerts`\n",
+    "- Fires `nasa_viirs_fire_alerts`\n",
+    "- Tree cover loss `umd_tree_cover_loss`\n",
+    "- Tree cover gain `umd_tree_cover_gain`\n",
+    "- Tree cover extent `umd_tree_cover_density_2000` or `umd_tree_cover_density_2010`\n",
+    "- Forest Carbon flux (2001 to 2023) `gfw_forest_carbon_net_flux`\n",
+    "\n",
+    "Filters:\n",
+    "- Loss year `umd_tree_cover_loss__year`\n",
+    "- Tree cover loss diver (e.g. Fire) `tsc_tree_cover_loss_drivers__driver`\n",
+    "- Tree cover gain `is__umd_tree_cover_gain`\n",
+    "- Tree cover density (i.e. canopy cover) `umd_tree_cover_density_2000__threshold` or `umd_tree_cover_density_2010__threshold`\n",
+    "- Carbon flux `gfw_forest_carbon_net_flux__Mg_CO2e`\n",
+    "- Admin boundary:\n",
+    "    - `gadm_administrative_boundaries__adm0`\n",
+    "    - `gadm_administrative_boundaries__adm1`\n",
+    "    - `gadm_administrative_boundaries__adm2`\n",
+    "- Nature\n",
+    "    - Primary forest `is__umd_regional_primary_forest_2001` (boolean `'false'` or `'true'`)\n",
+    "    - Forest type `sbtn_natural_forests_map__class`\n",
+    "    - Intact Forest (boolean `0` or `1`)\n",
+    "        - `is__ifl_intact_forest_landscapes_2000`\n",
+    "        - `is__ifl_intact_forest_landscapes_2013`\n",
+    "- Land categories\n",
+    "    - KBA `is__birdlife_key_biodiversity_areas`\n",
+    "    - Protected area `wdpa_protected_areas__iucn_cat`\n",
+    "    - IPLC `is__gfw_land_rights`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "## Define your DATA_API_KEY\n",
+    "DATA_API_KEY = ''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define simple function\n",
+    "import requests\n",
+    "import json\n",
+    "\n",
+    "def execute_post_query(api_key, dataset, geojson_dict, sql=\"SELECT * FROM data LIMIT 5\", version='latest'):\n",
+    "    \"\"\"\n",
+    "    Executes a SQL query on a specified dataset against a single specified geometry.\n",
+    "    \n",
+    "    Parameters:\n",
+    "    - api_key (str): data-API key for authentication, if required. Defaults to None.\n",
+    "    - dataset (str): Slug identifier or name of the dataset to query.\n",
+    "    - geojson_dict (dict): A GeoJSON dictionary to use for spatially filtering the dataset.\n",
+    "    - sql (str, optional): The SQL query to execute. Defaults to simple test query.\n",
+    "    - version (str, optional): Specifies the dataset version to query. Defaults to 'latest'.\n",
+    "    \n",
+    "    Returns:\n",
+    "    - Data object\n",
+    "    \"\"\"\n",
+    "\n",
+    "    base_url = 'https://data-api.globalforestwatch.org/dataset/'\n",
+    "    url = base_url + dataset + f\"/{version}/query/json\"\n",
+    "    headers = {\n",
+    "        'x-api-key': api_key,\n",
+    "        'Content-Type': 'application/json',\n",
+    "        'Cache-Control': 'no-cache'\n",
+    "    }\n",
+    "    analysis_data = {\n",
+    "        \"sql\": sql,\n",
+    "        \"geometry\": geojson_dict\n",
+    "    }\n",
+    "\n",
+    "    r = requests.post(url, headers=headers, data=json.dumps(analysis_data))\n",
+    "    print(r.url)\n",
+    "\n",
+    "    return r.json().get('data', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## define a simple geom: https://geojson.io/\n",
+    "\n",
+    "geom = {\n",
+    "    \"type\": \"Polygon\",\n",
+    "    \"coordinates\":[[\n",
+    "            [\n",
+    "              -55.50426861018596,\n",
+    "              -12.2467435847567\n",
+    "            ],\n",
+    "            [\n",
+    "              -55.50426861018596,\n",
+    "              -13.96374196118029\n",
+    "            ],\n",
+    "            [\n",
+    "              -50.78682758780877,\n",
+    "              -13.96374196118029\n",
+    "            ],\n",
+    "            [\n",
+    "              -50.78682758780877,\n",
+    "              -12.2467435847567\n",
+    "            ],\n",
+    "            [\n",
+    "              -55.50426861018596,\n",
+    "              -12.2467435847567\n",
+    "            ]\n",
+    "      ]]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/gfw_pixel_area/v20150327/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'area_ha': 9717034.140190002}]"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "## Test query. Total pixel area in the location.\n",
+    "## NOTE: this doesnt exactly match geojson.io\n",
+    "\n",
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha\n",
+    "    FROM data \n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    api_key=DATA_API_KEY,\n",
+    "    dataset='gfw_pixel_area',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom\n",
+    ")\n",
+    "\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspecting available datasets for masking and aggregation\n",
+    "For any analysable dataset you can use the `/fields` endpoint to see what other raster datasets are avaible to use in your sql string. This is useful when filtering and aggregating.\n",
+    "\n",
+    "e.g Checking available datasets for tree cover loss\n",
+    "`https://data-api.globalforestwatch.org/dataset/umd_tree_cover_loss/latest/fields\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'pixel_meaning': 'area__ha',\n",
+       " 'unit': None,\n",
+       " 'description': None,\n",
+       " 'statistics': None,\n",
+       " 'values_table': None,\n",
+       " 'data_type': None,\n",
+       " 'compression': None,\n",
+       " 'no_data_value': None}"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "### Check available datasets for tree cover loss\n",
+    "\n",
+    "raster_datasets = requests.get(\"https://data-api.globalforestwatch.org/dataset/umd_tree_cover_loss/latest/fields\").json()['data']\n",
+    "raster_datasets[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['area__ha',\n",
+       " 'arg_native_forest_land_plan__category',\n",
+       " 'arg_otbn_forest_loss__year',\n",
+       " 'arg_otbn_forest_loss__year_only',\n",
+       " 'birdlife_biodiversity_intactness__intactness_index',\n",
+       " 'birdlife_biodiversity_significance__significance',\n",
+       " 'clark_labs_tropical_pond_aquaculture_1999__class',\n",
+       " 'clark_labs_tropical_pond_aquaculture_2014__class',\n",
+       " 'clark_labs_tropical_pond_aquaculture_2018__class',\n",
+       " 'clark_labs_tropical_pond_aquaculture_change_1999_2014__class',\n",
+       " 'clark_labs_tropical_pond_aquaculture_change_1999_2018__class',\n",
+       " 'clark_labs_tropical_pond_aquaculture_change_2014_2018__class',\n",
+       " 'esa_land_cover_2015__class',\n",
+       " 'esa_land_cover_2015__uint16',\n",
+       " 'gadm_administrative_boundaries__adm0',\n",
+       " 'gadm_administrative_boundaries__adm1',\n",
+       " 'gadm_administrative_boundaries__adm2',\n",
+       " 'gfw_aboveground_carbon__Mg_CO2',\n",
+       " 'gfw_aboveground_carbon__Mg_CO2_ha-1',\n",
+       " 'gfw_aboveground_carbon_stock_2000__Mg_C',\n",
+       " 'gfw_aboveground_carbon_stock_2000__Mg_C_ha-1',\n",
+       " 'gfw_belowground_carbon__Mg_CO2',\n",
+       " 'gfw_belowground_carbon__Mg_CO2_ha-1',\n",
+       " 'gfw_belowground_carbon_stock_2000__Mg_C',\n",
+       " 'gfw_belowground_carbon_stock_2000__Mg_C_ha-1',\n",
+       " 'gfw_deadwood_carbon__Mg_CO2',\n",
+       " 'gfw_deadwood_carbon__Mg_CO2_ha',\n",
+       " 'gfw_deadwood_carbon__Mg_CO2_ha-1',\n",
+       " 'gfw_deadwood_carbon_stock_2000__Mg_C',\n",
+       " 'gfw_deadwood_carbon_stock_2000__Mg_C_ha-1',\n",
+       " 'gfw_forest_age_category__category',\n",
+       " 'gfw_forest_carbon_gross_emissions__Mg_CO2e',\n",
+       " 'gfw_forest_carbon_gross_emissions__Mg_CO2e_ha-1',\n",
+       " 'gfw_forest_carbon_gross_emissions__Mg_CO2e_px-1',\n",
+       " 'gfw_forest_carbon_gross_removals__Mg_CO2e',\n",
+       " 'gfw_forest_carbon_gross_removals__Mg_CO2e_ha-1',\n",
+       " 'gfw_forest_carbon_gross_removals__Mg_CO2e_px-1',\n",
+       " 'gfw_forest_carbon_net_flux__Mg_CO2e',\n",
+       " 'gfw_forest_carbon_net_flux__Mg_CO2e_ha-1',\n",
+       " 'gfw_forest_carbon_net_flux__Mg_CO2e_px-1',\n",
+       " 'gfw_forest_flux_aboveground_carbon_stock_in_emissions_year__Mg_C',\n",
+       " 'gfw_forest_flux_aboveground_carbon_stock_in_emissions_year__Mg_C_ha-1',\n",
+       " 'gfw_forest_flux_belowground_carbon_stock_in_emissions_year__Mg_C',\n",
+       " 'gfw_forest_flux_belowground_carbon_stock_in_emissions_year__Mg_C_ha-1',\n",
+       " 'gfw_forest_flux_deadwood_carbon_stock_in_emissions_year__Mg_C',\n",
+       " 'gfw_forest_flux_deadwood_carbon_stock_in_emissions_year__Mg_C_ha-1',\n",
+       " 'gfw_forest_flux_forest_age_category__ageCategory',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_co2_only_biomass_soil__Mg_CO2',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_co2_only_biomass_soil__Mg_CO2_ha-1',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_co2_only_soil_only__Mg_CO2',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_co2_only_soil_only__Mg_CO2_ha-1',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_non_co2_biomass_soil__Mg_CO2e',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_non_co2_biomass_soil__Mg_CO2e_ha-1',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_non_co2_soil_only__Mg_CO2e',\n",
+       " 'gfw_forest_flux_full_extent_gross_emissions_non_co2_soil_only__Mg_CO2e_ha-1',\n",
+       " 'gfw_forest_flux_full_extent_gross_removals_aboveground__Mg_CO2',\n",
+       " 'gfw_forest_flux_full_extent_gross_removals_aboveground__Mg_CO2_ha-1',\n",
+       " 'gfw_forest_flux_full_extent_gross_removals_belowground__Mg_CO2',\n",
+       " 'gfw_forest_flux_full_extent_gross_removals_belowground__Mg_CO2_ha-1',\n",
+       " 'gfw_forest_flux_full_extent_net_flux__Mg_CO2e',\n",
+       " 'gfw_forest_flux_full_extent_net_flux__Mg_CO2e_ha-1',\n",
+       " 'gfw_forest_flux_full_extent_removal_factor_aboveground__Mg_C_ha-1_yr-1',\n",
+       " 'gfw_forest_flux_full_extent_removal_factor_belowground__Mg_C_ha-1_yr-1',\n",
+       " 'gfw_forest_flux_gross_emissions_node_codes__category',\n",
+       " 'gfw_forest_flux_litter_carbon_stock_in_emissions_year__Mg_C',\n",
+       " 'gfw_forest_flux_litter_carbon_stock_in_emissions_year__Mg_C_ha-1',\n",
+       " 'gfw_forest_flux_model_extent__ha',\n",
+       " 'gfw_forest_flux_removal_factor_aboveground_carbon_stdev__Mg_C_ha-1_yr-1',\n",
+       " 'gfw_forest_flux_removal_forest_type__source',\n",
+       " 'gfw_forest_flux_soil_carbon_stock_2000_stdev__Mg_C',\n",
+       " 'gfw_forest_flux_soil_carbon_stock_2000_stdev__Mg_C_ha-1',\n",
+       " 'gfw_forest_flux_soil_carbon_stock_in_emissions_year__Mg_C',\n",
+       " 'gfw_forest_flux_soil_carbon_stock_in_emissions_year__Mg_C_ha-1',\n",
+       " 'gfw_full_extent_aboveground_carbon_potential_sequestration__Mg_C',\n",
+       " 'gfw_full_extent_aboveground_carbon_potential_sequestration__Mg_C_ha_yr-1',\n",
+       " 'gfw_full_extent_belowground_carbon_potential_sequestration__Mg_C',\n",
+       " 'gfw_full_extent_belowground_carbon_potential_sequestration__Mg_C_ha_yr-1',\n",
+       " 'gfw_full_extent_co2_gross_emissions__Mg_CO2e',\n",
+       " 'gfw_full_extent_co2_gross_emissions__Mg_CO2e_ha-1',\n",
+       " 'gfw_litter_carbon__Mg_CO2',\n",
+       " 'gfw_litter_carbon__Mg_CO2_ha',\n",
+       " 'gfw_litter_carbon__Mg_CO2_ha-1',\n",
+       " 'gfw_litter_carbon_stock_2000__Mg_C',\n",
+       " 'gfw_litter_carbon_stock_2000__Mg_C_ha-1',\n",
+       " 'gfw_logging__gfw_fid',\n",
+       " 'gfw_pixel_area__m2',\n",
+       " 'gfw_plantations__type',\n",
+       " 'gfw_planted_forests__species_simp',\n",
+       " 'gfw_planted_forests__type',\n",
+       " 'gfw_primary_forests__primary_forest',\n",
+       " 'gfw_reforestable_extent_aboveground_carbon_potential_sequestration__Mg_C',\n",
+       " 'gfw_reforestable_extent_aboveground_carbon_potential_sequestration__Mg_C_ha_yr-1',\n",
+       " 'gfw_reforestable_extent_belowground_carbon_potential_sequestration__Mg_C',\n",
+       " 'gfw_reforestable_extent_belowground_carbon_potential_sequestration__Mg_C_ha_yr-1',\n",
+       " 'gfw_soil_carbon_stock_2000__Mg_C',\n",
+       " 'gfw_soil_carbon_stock_2000__Mg_C_ha-1',\n",
+       " 'gfw_soil_carbon_stocks__Mg_CO2e_ha',\n",
+       " 'gfw_west_africa_cocoa_deforestation_risk__risk',\n",
+       " 'gfw_west_africa_cocoa_plot_density__intensity',\n",
+       " 'gfwpro_forest_change_regions__bit_encoding',\n",
+       " 'gfwpro_negligible_risk_analysis__negligible_risk',\n",
+       " 'gfwpro_negligible_risk_analysis__risk',\n",
+       " 'gmw_global_mangrove_extent_2016__gfw_fid',\n",
+       " 'ibge_bra_biomes__name',\n",
+       " 'idn_forest_area__class',\n",
+       " 'idn_forest_area__class_compressed',\n",
+       " 'idn_forest_area__gfw_fid',\n",
+       " 'idn_land_cover_2017__class',\n",
+       " 'inpe_amazon_prodes__year',\n",
+       " 'inpe_amazonia_prodes__year',\n",
+       " 'inpe_cerrado_prodes__year',\n",
+       " 'inpe_prodes__year',\n",
+       " 'is__birdlife_alliance_for_zero_extinction_sites',\n",
+       " 'is__birdlife_endemic_bird_areas',\n",
+       " 'is__birdlife_key_biodiversity_areas',\n",
+       " 'is__cifor_peatlands',\n",
+       " 'is__gfw_land_rights',\n",
+       " 'is__gfw_managed_forests',\n",
+       " 'is__gfw_oil_gas',\n",
+       " 'is__gfw_oil_palm',\n",
+       " 'is__gfw_peatlands',\n",
+       " 'is__gfw_plantations',\n",
+       " 'is__gfw_resource_rights',\n",
+       " 'is__gfw_tiger_landscapes',\n",
+       " 'is__gfw_wood_fiber',\n",
+       " 'is__gfwpro_peatlands',\n",
+       " 'is__gmw_global_mangrove_extent',\n",
+       " 'is__gmw_global_mangrove_extent_1996',\n",
+       " 'is__gmw_global_mangrove_extent_2016',\n",
+       " 'is__idn_forest_moratorium',\n",
+       " 'is__ifl_intact_forest_landscapes_2000',\n",
+       " 'is__ifl_intact_forest_landscapes_2013',\n",
+       " 'is__inpe_prodes',\n",
+       " 'is__jpl_mangrove_aboveground_biomass_stock_2000',\n",
+       " 'is__osinfor_peru_permanent_production_forests',\n",
+       " 'is__pangaea_global_mining',\n",
+       " 'is__per_protected_areas',\n",
+       " 'is__umd_regional_primary_forest_2001',\n",
+       " 'is__umd_soy_planted_area_buffered_10km',\n",
+       " 'is__umd_tree_cover_gain',\n",
+       " 'is__wwf_tiger_conservation_landscapes',\n",
+       " 'jpl_mangrove_aboveground_biomass_stock_2000__Mg_CO2e',\n",
+       " 'jpl_mangrove_aboveground_biomass_stock_2000__Mg_CO2e_ha-1',\n",
+       " 'jrc_surface_water_transitions_1984_2020__Transition_Type',\n",
+       " 'landmark_icls__gfw_fid',\n",
+       " 'latitude',\n",
+       " 'longitude',\n",
+       " 'mapbiomas_bra_land_cover__class',\n",
+       " 'mapbox_river_basins__id',\n",
+       " 'nasa_umd_forest_carbon_sequestration_potential__kg_C_m2',\n",
+       " 'osinfor_per_forest_concessions__type',\n",
+       " 'per_forest_concessions__type',\n",
+       " 'rspo_oil_palm__certification_status',\n",
+       " 'rspo_oil_palm__rspocert',\n",
+       " 'rspo_southeast_asia_land_cover_2010__class',\n",
+       " 'rspo_southeast_asia_land_cover_2010__land_cover_class',\n",
+       " 'sbtn_natural_forests_map__class',\n",
+       " 'tsc_drivers__drivers',\n",
+       " 'tsc_tree_cover_loss_drivers__driver',\n",
+       " 'umd_area_2013__area_m',\n",
+       " 'umd_drivers__drivers',\n",
+       " 'umd_glad_dist_alerts__currentweek',\n",
+       " 'umd_glad_dist_alerts__default',\n",
+       " 'umd_glad_dist_alerts__intensity',\n",
+       " 'umd_glad_landsat_alerts__confidence',\n",
+       " 'umd_glad_landsat_alerts__date',\n",
+       " 'umd_glad_landsat_alerts__date_conf',\n",
+       " 'umd_land_cover__class',\n",
+       " 'umd_land_cover__ipcc_class',\n",
+       " 'umd_regional_primary_forest_2001__int16',\n",
+       " 'umd_soy_planted_area__is__year_2001',\n",
+       " 'umd_soy_planted_area__is__year_2002',\n",
+       " 'umd_soy_planted_area__is__year_2003',\n",
+       " 'umd_soy_planted_area__is__year_2004',\n",
+       " 'umd_soy_planted_area__is__year_2005',\n",
+       " 'umd_soy_planted_area__is__year_2006',\n",
+       " 'umd_soy_planted_area__is__year_2007',\n",
+       " 'umd_soy_planted_area__is__year_2008',\n",
+       " 'umd_soy_planted_area__is__year_2009',\n",
+       " 'umd_soy_planted_area__is__year_2010',\n",
+       " 'umd_soy_planted_area__is__year_2011',\n",
+       " 'umd_soy_planted_area__is__year_2012',\n",
+       " 'umd_soy_planted_area__is__year_2013',\n",
+       " 'umd_soy_planted_area__is__year_2014',\n",
+       " 'umd_soy_planted_area__is__year_2015',\n",
+       " 'umd_soy_planted_area__is__year_2016',\n",
+       " 'umd_soy_planted_area__is__year_2017',\n",
+       " 'umd_soy_planted_area__is__year_2018',\n",
+       " 'umd_soy_planted_area__is__year_2019',\n",
+       " 'umd_soy_planted_area__is__year_2020',\n",
+       " 'umd_soy_planted_area__is__year_2021',\n",
+       " 'umd_soy_planted_area__is__year_2022',\n",
+       " 'umd_soy_planted_area__year__bit_encoded',\n",
+       " 'umd_tree_cover_density_2000__percent',\n",
+       " 'umd_tree_cover_density_2000__threshold',\n",
+       " 'umd_tree_cover_density_2010__threshold',\n",
+       " 'umd_tree_cover_gain_from_height__gain',\n",
+       " 'umd_tree_cover_gain_from_height__gain_float',\n",
+       " 'umd_tree_cover_height_2000__meters',\n",
+       " 'umd_tree_cover_height_2000__tch_10',\n",
+       " 'umd_tree_cover_height_2000__tch_15',\n",
+       " 'umd_tree_cover_height_2000__tch_20',\n",
+       " 'umd_tree_cover_height_2000__tch_3',\n",
+       " 'umd_tree_cover_height_2000__tch_4',\n",
+       " 'umd_tree_cover_height_2000__tch_5',\n",
+       " 'umd_tree_cover_height_2000__tch_7',\n",
+       " 'umd_tree_cover_height_2020__meters',\n",
+       " 'umd_tree_cover_height_2020__tch_10',\n",
+       " 'umd_tree_cover_height_2020__tch_15',\n",
+       " 'umd_tree_cover_height_2020__tch_20',\n",
+       " 'umd_tree_cover_height_2020__tch_3',\n",
+       " 'umd_tree_cover_height_2020__tch_4',\n",
+       " 'umd_tree_cover_height_2020__tch_5',\n",
+       " 'umd_tree_cover_height_2020__tch_7',\n",
+       " 'umd_tree_cover_loss__year',\n",
+       " 'umd_tree_cover_loss_from_fires__year',\n",
+       " 'usgs_usa_land_cover__class',\n",
+       " 'wdpa_licensed_protected_areas__detailed_iucn_cat',\n",
+       " 'wdpa_protected_areas__iucn_cat',\n",
+       " 'whrc_aboveground_biomass_stock_2000__Mg',\n",
+       " 'whrc_aboveground_biomass_stock_2000__Mg_ha-1',\n",
+       " 'whrc_aboveground_woody_biomass_stock_2000__Mg',\n",
+       " 'whrc_aboveground_woody_biomass_stock_2000__Mg_ha-1',\n",
+       " 'whrc_aboveground_woody_biomass_stock_2000__Mg_px-1',\n",
+       " 'wri_tropical_tree_cover__decile',\n",
+       " 'wri_tropical_tree_cover__percent']"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted([d['pixel_meaning'] for d in raster_datasets])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Changes to ecosystem health"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loss\n",
+    "\"Show me tree cover loss that occurred in my area between 2013 and 2023\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_loss/v1.11/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'area_ha': 802112.87681, 'emissions_Mg_CO2e': 380371411.8263}]"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha,\n",
+    "        SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) AS emissions_Mg_CO2e\n",
+    "    FROM data \n",
+    "    WHERE umd_tree_cover_density_2000__percent > 30\n",
+    "    AND umd_tree_cover_loss__year >= 2013 \n",
+    "    AND umd_tree_cover_loss__year <= 2023\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='umd_tree_cover_loss',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"...aggregate loss by year\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_loss/v1.11/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'umd_tree_cover_loss__year': 2001,\n",
+       "  'area_ha': 100257.48624,\n",
+       "  'emissions_Mg_CO2e': 40278670.50645},\n",
+       " {'umd_tree_cover_loss__year': 2002,\n",
+       "  'area_ha': 157549.50751,\n",
+       "  'emissions_Mg_CO2e': 67764357.02075},\n",
+       " {'umd_tree_cover_loss__year': 2003,\n",
+       "  'area_ha': 225757.60157,\n",
+       "  'emissions_Mg_CO2e': 99777314.62466},\n",
+       " {'umd_tree_cover_loss__year': 2004,\n",
+       "  'area_ha': 160888.44133,\n",
+       "  'emissions_Mg_CO2e': 73607273.69579001},\n",
+       " {'umd_tree_cover_loss__year': 2005,\n",
+       "  'area_ha': 94546.42391999999,\n",
+       "  'emissions_Mg_CO2e': 43653647.645490006},\n",
+       " {'umd_tree_cover_loss__year': 2006,\n",
+       "  'area_ha': 65866.39803,\n",
+       "  'emissions_Mg_CO2e': 30227020.9946},\n",
+       " {'umd_tree_cover_loss__year': 2007,\n",
+       "  'area_ha': 77429.89739,\n",
+       "  'emissions_Mg_CO2e': 36760379.19158},\n",
+       " {'umd_tree_cover_loss__year': 2008,\n",
+       "  'area_ha': 46325.562,\n",
+       "  'emissions_Mg_CO2e': 21348410.38481},\n",
+       " {'umd_tree_cover_loss__year': 2009,\n",
+       "  'area_ha': 32814.73051,\n",
+       "  'emissions_Mg_CO2e': 15233327.451849999},\n",
+       " {'umd_tree_cover_loss__year': 2010,\n",
+       "  'area_ha': 97379.56779,\n",
+       "  'emissions_Mg_CO2e': 50477182.09031},\n",
+       " {'umd_tree_cover_loss__year': 2011,\n",
+       "  'area_ha': 54883.188949999996,\n",
+       "  'emissions_Mg_CO2e': 25164217.391799998},\n",
+       " {'umd_tree_cover_loss__year': 2012,\n",
+       "  'area_ha': 90687.41797,\n",
+       "  'emissions_Mg_CO2e': 42698582.80089},\n",
+       " {'umd_tree_cover_loss__year': 2013,\n",
+       "  'area_ha': 35111.18206,\n",
+       "  'emissions_Mg_CO2e': 13861152.52896},\n",
+       " {'umd_tree_cover_loss__year': 2014,\n",
+       "  'area_ha': 59697.69503,\n",
+       "  'emissions_Mg_CO2e': 26847213.29652},\n",
+       " {'umd_tree_cover_loss__year': 2015,\n",
+       "  'area_ha': 48503.262109999996,\n",
+       "  'emissions_Mg_CO2e': 22958091.66883},\n",
+       " {'umd_tree_cover_loss__year': 2016,\n",
+       "  'area_ha': 153437.52863,\n",
+       "  'emissions_Mg_CO2e': 70326103.23956999},\n",
+       " {'umd_tree_cover_loss__year': 2017,\n",
+       "  'area_ha': 155302.691,\n",
+       "  'emissions_Mg_CO2e': 75204100.10255},\n",
+       " {'umd_tree_cover_loss__year': 2018,\n",
+       "  'area_ha': 62236.62485,\n",
+       "  'emissions_Mg_CO2e': 30303432.85839},\n",
+       " {'umd_tree_cover_loss__year': 2019,\n",
+       "  'area_ha': 58493.75285,\n",
+       "  'emissions_Mg_CO2e': 27693852.72455},\n",
+       " {'umd_tree_cover_loss__year': 2020,\n",
+       "  'area_ha': 70979.66325,\n",
+       "  'emissions_Mg_CO2e': 34722704.27194},\n",
+       " {'umd_tree_cover_loss__year': 2021,\n",
+       "  'area_ha': 52917.70691,\n",
+       "  'emissions_Mg_CO2e': 26376812.68649},\n",
+       " {'umd_tree_cover_loss__year': 2022,\n",
+       "  'area_ha': 72148.49623,\n",
+       "  'emissions_Mg_CO2e': 35756978.8716},\n",
+       " {'umd_tree_cover_loss__year': 2023,\n",
+       "  'area_ha': 33284.273870000005,\n",
+       "  'emissions_Mg_CO2e': 16320969.5769}]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha,\n",
+    "        SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) AS emissions_Mg_CO2e\n",
+    "    FROM data \n",
+    "    WHERE umd_tree_cover_density_2000__percent > 30 \n",
+    "    GROUP BY umd_tree_cover_loss__year\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='umd_tree_cover_loss',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"how much of that loss occurred in Primary forest?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_loss/v1.11/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'area_ha': 1459176.0098299999, 'emissions_Mg_CO2e': 729762017.12657}]"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha,\n",
+    "        SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) AS emissions_Mg_CO2e\n",
+    "    FROM data \n",
+    "    WHERE umd_tree_cover_density_2000__percent > 30\n",
+    "    AND is__umd_regional_primary_forest_2001 = 'true'\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='umd_tree_cover_loss',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"...what about intact forest?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_loss/v1.11/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'area_ha': 179149.50047, 'emissions_Mg_CO2e': 86517174.50941}]"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha,\n",
+    "        SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) AS emissions_Mg_CO2e\n",
+    "    FROM data \n",
+    "    WHERE umd_tree_cover_density_2000__percent > 30\n",
+    "    AND is__ifl_intact_forest_landscapes_2000 = 1\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='umd_tree_cover_loss',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"What was the loss in different forest types?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_loss/v1.11/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'sbtn_natural_forests_map__class': 0,\n",
+       "  'area_ha': 244654.36097,\n",
+       "  'emissions_Mg_CO2e': 108816804.57236001},\n",
+       " {'sbtn_natural_forests_map__class': 1,\n",
+       "  'area_ha': 556733.01665,\n",
+       "  'emissions_Mg_CO2e': 270918812.33019},\n",
+       " {'sbtn_natural_forests_map__class': 2,\n",
+       "  'area_ha': 725.49922,\n",
+       "  'emissions_Mg_CO2e': 635794.92374}]"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha,\n",
+    "        SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) AS emissions_Mg_CO2e\n",
+    "    FROM data \n",
+    "    WHERE umd_tree_cover_density_2000__percent > 30\n",
+    "    AND umd_tree_cover_loss__year >= 2013 \n",
+    "    AND umd_tree_cover_loss__year <= 2023\n",
+    "    GROUP BY sbtn_natural_forests_map__class\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='umd_tree_cover_loss',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"how much was in protected areas?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tree cover gain\n",
+    "This dataset has no year intervals, just a single value representing the tree cover gain between 2000 and 2020"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_gain/v202206/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'area_ha': 74366.19897, 'removals_Mg_CO2e': 13358929.21051}]"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha,\n",
+    "        SUM(gfw_forest_carbon_gross_removals__Mg_CO2e) AS removals_Mg_CO2e\n",
+    "    FROM data \n",
+    "    WHERE is__umd_tree_cover_gain = 'true'\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='umd_tree_cover_gain',\n",
+    "    sql=q,\n",
+    "    geojson_dict=aoi_geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extent\n",
+    "How much forest is there (based on latest data in 2010)?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_density_2010/v1.6/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'area_ha': 1745512.64888}]"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"\"\"\n",
+    "    SELECT SUM(area__ha) AS area_ha\n",
+    "    FROM data\n",
+    "    WHERE umd_tree_cover_density_2010__threshold >= 30\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='umd_tree_cover_density_2010',\n",
+    "    sql=q,\n",
+    "    geojson_dict=aoi_geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Threats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integrated Forest Alerts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"How many alerts happened in the last month?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/gfw_integrated_alerts/v20250106/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'gfw_integrated_alerts__confidence': 'high',\n",
+       "  'count': 150899,\n",
+       "  'area_ha': 1810.82656},\n",
+       " {'gfw_integrated_alerts__confidence': 'highest',\n",
+       "  'count': 9495,\n",
+       "  'area_ha': 114.0143},\n",
+       " {'gfw_integrated_alerts__confidence': 'nominal',\n",
+       "  'count': 292477,\n",
+       "  'area_ha': 3509.71648}]"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"\"\"\n",
+    "    SELECT count(*) AS count,\n",
+    "        SUM(area__ha) AS area_ha\n",
+    "    FROM data \n",
+    "    WHERE gfw_integrated_alerts__date >= '2024-12-01'\n",
+    "    AND gfw_integrated_alerts__date <= '2025-12-31' \n",
+    "    GROUP BY gfw_integrated_alerts__confidence\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='gfw_integrated_alerts',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## VIIRS Fires"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"How many fire alerts in the last month?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/nasa_viirs_fire_alerts/v20240815/query/json\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'count': 11, 'confidence': 'h'},\n",
+       " {'count': 26, 'confidence': 'l'},\n",
+       " {'count': 298, 'confidence': 'n'}]"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(alert__count) AS count,\n",
+    "        confidence__cat AS confidence\n",
+    "    FROM data\n",
+    "    WHERE alert__date >= '2024-11-01'\n",
+    "    AND alert__date <= '2024-12-31'\n",
+    "    GROUP BY confidence__cat\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_post_query(\n",
+    "    dataset='nasa_viirs_fire_alerts',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geom,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Batch Job example for a feature collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Define feature collection\n",
+    "geoms = {\n",
+    "    'type': 'FeatureCollection',\n",
+    "             'features': [{'geometry': {'coordinates': [[[-65.37277454203024,\n",
+    "                                                                     -23.962592231630154],\n",
+    "                                                                    [-65.24569006771843,\n",
+    "                                                                     -23.963783315021942],\n",
+    "                                                                    [-65.23135233215466,\n",
+    "                                                                     -23.82256343027032],\n",
+    "                                                                    [-65.33758191837485,\n",
+    "                                                                     -23.809446597295747],\n",
+    "                                                                    [-65.39362943012263,\n",
+    "                                                                     -23.88455232152998],\n",
+    "                                                                    [-65.37277454203024,\n",
+    "                                                                     -23.962592231630154]]],\n",
+    "                                                   'type': 'Polygon'},\n",
+    "                                      'properties': {'fid': 'My First AoI'},\n",
+    "                                      'type': 'Feature'},\n",
+    "                                     {'geometry': {'coordinates': [[[-65.1889909816768,\n",
+    "                                                                     -24.07450596436658],\n",
+    "                                                                    [-65.190946127435,\n",
+    "                                                                     -24.163134208431543],\n",
+    "                                                                    [-65.05213077857164,\n",
+    "                                                                     -24.19226698759907],\n",
+    "                                                                    [-65.02084844643267,\n",
+    "                                                                     -24.062009803219865],\n",
+    "                                                                    [-65.1889909816768,\n",
+    "                                                                     -24.07450596436658]]],\n",
+    "                                                   'type': 'Polygon'},\n",
+    "                                      'properties': {'fid': 'My Second AoI'},\n",
+    "                                      'type': 'Feature'}]\n",
+    "                        }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define function\n",
+    "def execute_batch_query(api_key, dataset, geojson_dict, sql=\"SELECT * FROM data LIMIT 5\", id_field='fid', version='latest'):\n",
+    "    \"\"\"\n",
+    "    Executes a SQL query on a specified dataset against a feature collection.\n",
+    "    \n",
+    "    Parameters:\n",
+    "    - api_key (str): data-API key for authentication, if required. Defaults to None.\n",
+    "    - dataset (str): Slug identifier or name of the dataset to query.\n",
+    "    - geojson_dict (dict): A GeoJSON dictionary to use for spatially filtering the dataset.\n",
+    "    - sql (str, optional): The SQL query to execute. Defaults to simple test query.\n",
+    "    - id_field (str, optional): Specifies the id in the geometry properties to associate data against.\n",
+    "    - version (str, optional): Specifies the dataset version to query. Defaults to 'latest'.\n",
+    "    \n",
+    "    Returns:\n",
+    "    - Data object\n",
+    "    \"\"\"\n",
+    "    base_url = 'https://data-api.globalforestwatch.org/dataset/'\n",
+    "    url = base_url + dataset + f\"/{version}/query/batch\"\n",
+    "    headers = {\n",
+    "        'x-api-key': api_key,\n",
+    "        'Content-Type': 'application/json',\n",
+    "        'Cache-Control': 'no-cache'\n",
+    "    }\n",
+    "    geom_data = {\n",
+    "        \"sql\": sql,\n",
+    "        \"feature_collection\": geojson_dict,\n",
+    "        'id_field': id_field\n",
+    "    }\n",
+    "        \n",
+    "    \n",
+    "    r = requests.post(url, headers=headers, data=json.dumps(geom_data))\n",
+    "    print(r.url)\n",
+    "\n",
+    "    return r.json().get('data', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://data-api.globalforestwatch.org/dataset/umd_tree_cover_density_2010/v1.6/query/batch\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'job_id': 'bdc7bf88-7707-4dc2-b08e-e7ebe3e1275d',\n",
+       " 'job_link': 'https://data-api.globalforestwatch.org/job/bdc7bf88-7707-4dc2-b08e-e7ebe3e1275d',\n",
+       " 'status': 'pending',\n",
+       " 'message': None,\n",
+       " 'download_link': None,\n",
+       " 'failed_geometries_link': None,\n",
+       " 'progress': '0%'}"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q = \"\"\"\n",
+    "    SELECT \n",
+    "        SUM(area__ha) AS area_ha\n",
+    "    FROM data \n",
+    "    WHERE umd_tree_cover_density_2010__threshold >= 30\n",
+    "    \"\"\"\n",
+    "\n",
+    "result = execute_batch_query(\n",
+    "    dataset='umd_tree_cover_density_2010',\n",
+    "    sql=q,\n",
+    "    geojson_dict=geoms,\n",
+    "    api_key=DATA_API_KEY\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://gfw-pipelines.s3.amazonaws.com/analysis/jobs/a0704776-6333-436b-a1b5-224fce3721f9/output/efc5d1be-6f0f-4ef4-b4e0-7e1e76d6e523/analysis_results.json?AWSAccessKeyId=ASIAV3FRM4Z6IGWFJD5O&Signature=O98I1FFM1jPyIooGpMbjLz0fGuQ%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEHUaCXVzLWVhc3QtMSJIMEYCIQDwRerc7Y50U9EVWvgRltkXUOVnzYrcs7Mc0hFPgSA%2F7wIhAJy1pOey6pXys4URyGEIsWt5vcHZJjTXzp2pKAVA8mrZKv8DCF4QAxoMNDAxOTUxNDgzNTE2IgwGTHG0wKaGxa55Pjsq3AM%2BcBN51sWB8wNVbS2SztxlKeMFhZE%2BhmrWanzV3h88nfDSv%2B4d3YociudlRE%2FwEas3qSyejlzsiT7ZI8xkz7IPvhDv9nc%2FYxKXwopZaJ1RIXpuSKx7GNc9qu%2BrUpyXx4efhRJFyFQnmUvyWcUJwrpODV0hW4zvCb8%2FfiZR8rudqc1VGbWyzyfoayJN1Bg9DT03sY9Xwmpza2HQs9dL7a6nasDRbvRg72SA0HUngRmGf0rCbHxWAmrJuc9wj7nBqIENoBqLDktCqbG%2BfUI31DzwGrv%2BmtDV8RTFqaZnEuZZ1Ixe1%2BZ1qILv%2FF5ldh64H7Xk8GqL0FjyynOxpH%2FDJeRjAeeSV3exX5vrDz0Ca0D6KENgoWMzKsVDyLg8AcyOE6jFmVjlyoyleOVaHJM2irxvgQwLdXwXMERB%2FDSTlHeY7U7%2BOszElzdd39Y0kx7KJCM7wK94i0X6xzh4CIBUGaCGL5I%2BEba03cyqtDdEDRunzWvNZmz1%2FV8bVQSjOoCJLsb7NtZGrcmtH9xeb7Itht6dCsRXPrutBceFIsd77pjzgYVUgeA9yc4VjRQYzeS58vErSMy8LCvavo8I%2BFxtPesLk2MID8dPtVwbCqFNUU2CZrhw72jEvPobOZCrzDDouPS7BjqkAdR1Fawxd5Ktc6%2B2oYVD7VFSTF3HGTcpnpxWdpcDymhnldq%2BY6AW84NXkLK4bxzPycs%2ByaWAxynIbUfBq14EmUVy7GqBNNVvaZsgyYAByHesmaxE0kI32WN2UWlaTrrviC8Megt7g4CM1jwij3IWsGkpe1D7DgrLytIotEVAQvEo1Dsh0h4Eum1iGOukQ7Yvp7kcd2%2Bmre8IhBu87tsLEKf9HsqL&Expires=1736254656'"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "## Once job status = 'success'\n",
+    "job_url = result['job_link']\n",
+    "download_url = requests.get(job_url).json()['data']['download_link']\n",
+    "download_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>result</th>\n",
+       "      <th>fid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>[{'area_ha': 13074.98509}]</td>\n",
+       "      <td>My First AoI</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>[{'area_ha': 15474.68544}]</td>\n",
+       "      <td>My Second AoI</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       result            fid\n",
+       "0  [{'area_ha': 13074.98509}]   My First AoI\n",
+       "1  [{'area_ha': 15474.68544}]  My Second AoI"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "df = pd.read_json(download_url)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/nbs/09_data_api_otf_analysis_examples.ipynb
+++ b/nbs/09_data_api_otf_analysis_examples.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "## Define your DATA_API_KEY\n",
-    "DATA_API_KEY = ''"
+    "DATA_API_KEY = os.environ.get(\"DATA_API_KEY\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Adds a few examples to illustrate using the data-API OTF endpoints for the monitoring use case. Specifically:
- Querying for ecosystem health: Area, Forest Extent, Loss, Gain 
- Filtering & aggregation: forest type, land cover, year
- Querying for threats: fire and integrated deforestation alerts