### PR TITLE
Add tms url generation to context layer tool

### DIFF
--- a/tests/test_context_layer_tool.py
+++ b/tests/test_context_layer_tool.py
@@ -4,14 +4,13 @@ from zeno.tools.contextlayer.context_layer_retriever_tool import (
 
 
 def test_context_layer_tool_cereal():
-    result = context_layer_tool.invoke(
-        input={"question": "Summarize disturbance alerts by type of cereal"}
+    msg = context_layer_tool.invoke(
+        {
+            "name": "context-layer-tool",
+            "args": {"question": "Summarize disturbance alerts by type of cereal"},
+            "id": "42",
+            "type": "tool_call",
+        }
     )
-    assert result == "ESA/WorldCereal/2021/MODELS/v100"
-
-
-def test_context_layer_tool_null():
-    result = context_layer_tool.invoke(
-        input={"question": "Provide disturbances for Aveiro Portugal"}
-    )
-    assert result == ""
+    assert msg.content == "ESA/WorldCereal/2021/MODELS/v100"
+    assert "{z}/{x}/{y}" in msg.artifact["tms_url"]


### PR DESCRIPTION
This adds a dynamically generated TMS url to the context layer output. It also adds the rest of the metadata to the output through an `artifact`. 

Closes #90 

The only thing missing is a better viz parameter styling. This is currently using the default, which will look nice if the default is set. For instance, the NatrualLands one has a palette built in and will look nice. The world cereal will simply be a grayscale, so that one should be changed. We can make this dynamic in a later step.
