### PR TITLE
Add buffer option to distalert tool

### DIFF
--- a/tests/test_context_layer_tool.py
+++ b/tests/test_context_layer_tool.py
@@ -1,6 +1,4 @@
-from zeno.tools.contextlayer.context_layer_retriever_tool import (
-    context_layer_tool,
-)
+from zeno.tools.contextlayer.context_layer_retriever_tool import context_layer_tool
 
 
 def test_context_layer_tool_cereal():

--- a/tests/test_dist_alerts.py
+++ b/tests/test_dist_alerts.py
@@ -39,13 +39,13 @@ def test_dist_alert_tool_no_landcover():
 
 
 def test_dist_alert_tool_verified(monkeypatch):
-
+    # Target location and small buffer size.
     lon = -54.180643732357765
     lat = -24.047038901203194
     epsilon = 0.0005
-    # For this location, disturbances were marked as wildfire
-    # and latest disturbance was 2024-04-29, and the landcover
-    # was class 10, Wet natural short vegetation
+    # For this location, using GEE directly, disturbances were
+    # marked as wildfire and latest disturbance was 2024-04-29,
+    # and the landcover was class 10, Wet natural short vegetation.
     expected_natural_lands = "Wet natural short vegetation"
     expected_vegstatus = 6
     expected_vegdate = datetime.datetime(2024, 4, 29)  # 1215

--- a/tests/test_dist_alerts.py
+++ b/tests/test_dist_alerts.py
@@ -128,5 +128,5 @@ def test_dist_alert_tool_verified(monkeypatch):
             "max_date": expected_vegdate,
         }
     )
-    # Threshold is out of range, no results
+    # Landcover type is as expected
     assert list(result["IND.26.12_1"].keys()) == [exppected_natural_lands]

--- a/tests/test_dist_alerts.py
+++ b/tests/test_dist_alerts.py
@@ -1,13 +1,13 @@
 import datetime
 
 from zeno.tools.contextlayer.layers import layer_choices
-from zeno.tools.distalert.dist_alerts_tool import dist_alerts_tool
+from zeno.tools.distalert import dist_alerts_tool
 
 
 def test_dist_alert_tool():
 
-    features = ["2323"]
-    result = dist_alerts_tool.invoke(
+    features = ["BRA.13.369_2"]
+    result = dist_alerts_tool.dist_alerts_tool.invoke(
         input={
             "features": features,
             "landcover": layer_choices[1]["dataset"],
@@ -18,13 +18,13 @@ def test_dist_alert_tool():
     )
 
     assert len(result) == 1
-    assert "AGO.1.3.4_1" in result
+    assert "BRA.13.369_2" in result
 
 
 def test_dist_alert_tool_no_landcover():
 
-    features = ["2323"]
-    result = dist_alerts_tool.invoke(
+    features = ["IND.26.12_1"]
+    result = dist_alerts_tool.dist_alerts_tool.invoke(
         input={
             "features": features,
             "landcover": None,
@@ -35,4 +35,98 @@ def test_dist_alert_tool_no_landcover():
     )
 
     assert len(result) == 1
-    assert "AGO.1.3.4_1" in result
+    assert "IND.26.12_1" in result
+
+
+def test_dist_alert_tool_verified(monkeypatch):
+
+    lon = -54.180643732357765
+    lat = -24.047038901203194
+    epsilon = 0.0005
+    # For this location, disturbances were marked as wildfire
+    # and latest disturbance was 2024-04-29, and the landcover
+    # was class 10, Wet natural short vegetation
+    exppected_natural_lands = "Wet natural short vegetation"
+    expected_vegstatus = 6
+    expected_vegdate = datetime.datetime(2024, 4, 29)  # 1215
+    expected_driver = "wildfire"
+
+    def mockfunction(features):
+
+        mockfeature = {
+            "type": "Feature",
+            "properties": {"GID_2": "IND.26.12_1"},
+            "geometry": {
+                "coordinates": [
+                    [
+                        [lon, lat],
+                        [lon + epsilon, lat],
+                        [lon + epsilon, lat + epsilon],
+                        [lon, lat + epsilon],
+                        [lon, lat],
+                    ]
+                ],
+                "type": "Polygon",
+            },
+        }
+
+        return dist_alerts_tool.ee.FeatureCollection(
+            [dist_alerts_tool.ee.Feature(mockfeature)]
+        )
+
+    monkeypatch.setattr(dist_alerts_tool, "get_features", mockfunction)
+
+    features = ["IND.26.12_1"]
+    result = dist_alerts_tool.dist_alerts_tool.invoke(
+        input={
+            "features": features,
+            "landcover": "distalert-drivers",
+            "threshold": expected_vegstatus,
+            "min_date": expected_vegdate,
+            "max_date": expected_vegdate,
+        }
+    )
+    # Change is wildfire
+    assert list(result["IND.26.12_1"].keys()) == [expected_driver]
+
+    # Test for date range
+    features = ["IND.26.12_1"]
+    result = dist_alerts_tool.dist_alerts_tool.invoke(
+        input={
+            "features": features,
+            "landcover": "distalert-drivers",
+            "threshold": expected_vegstatus,
+            "min_date": expected_vegdate + datetime.timedelta(days=1),
+            "max_date": expected_vegdate + datetime.timedelta(days=1),
+        }
+    )
+    # Date is out of range, no results
+    assert result["IND.26.12_1"] == {}
+
+    # Test for threshold
+    features = ["IND.26.12_1"]
+    result = dist_alerts_tool.dist_alerts_tool.invoke(
+        input={
+            "features": features,
+            "landcover": "distalert-drivers",
+            "threshold": expected_vegstatus + 1,
+            "min_date": expected_vegdate,
+            "max_date": expected_vegdate,
+        }
+    )
+    # Threshold is out of range, no results
+    assert result["IND.26.12_1"] == {}
+
+    # Test for landcover type
+    features = ["IND.26.12_1"]
+    result = dist_alerts_tool.dist_alerts_tool.invoke(
+        input={
+            "features": features,
+            "landcover": "WRI/SBTN/naturalLands/v1/2020",
+            "threshold": expected_vegstatus,
+            "min_date": expected_vegdate,
+            "max_date": expected_vegdate,
+        }
+    )
+    # Threshold is out of range, no results
+    assert list(result["IND.26.12_1"].keys()) == [exppected_natural_lands]

--- a/tests/test_dist_alerts.py
+++ b/tests/test_dist_alerts.py
@@ -46,7 +46,7 @@ def test_dist_alert_tool_verified(monkeypatch):
     # For this location, disturbances were marked as wildfire
     # and latest disturbance was 2024-04-29, and the landcover
     # was class 10, Wet natural short vegetation
-    exppected_natural_lands = "Wet natural short vegetation"
+    expected_natural_lands = "Wet natural short vegetation"
     expected_vegstatus = 6
     expected_vegdate = datetime.datetime(2024, 4, 29)  # 1215
     expected_driver = "wildfire"
@@ -129,4 +129,4 @@ def test_dist_alert_tool_verified(monkeypatch):
         }
     )
     # Landcover type is as expected
-    assert list(result["IND.26.12_1"].keys()) == [exppected_natural_lands]
+    assert list(result["IND.26.12_1"].keys()) == [expected_natural_lands]

--- a/zeno/tools/distalert/drivers.py
+++ b/zeno/tools/distalert/drivers.py
@@ -12,7 +12,7 @@ DRIVER_VALUEMAP = {
 
 
 def get_drivers():
-    folder = "projects/glad/HLSDIST/current"
+    folder = "projects/glad/HLSDIST/backend"
     natural_lands = ee.Image("WRI/SBTN/naturalLands/v1/2020").select("natural")
     vegdistcount = ee.ImageCollection(folder + "/VEG-DIST-COUNT").mosaic()
     veganommax = ee.ImageCollection(folder + "/VEG-ANOM-MAX").mosaic()


### PR DESCRIPTION
Adds a buffer input parameter to the distalert tool. This could also be externalized. But like this we don't have to store the buffered geoms. But we can split later if that is better.

This estimates the UTM zone of the GADM area, converts the geom to UTM and buffers in meters in that projection. This should guarantee consistent buffers.

Has simple test to run buffers.

Requires / Contains #102 