### PR TITLE
Fix distalert bugs

### DIFF
--- a/tests/test_dist_alerts.py
+++ b/tests/test_dist_alerts.py
@@ -1,25 +1,23 @@
 import datetime
-import pytest
 
-from zeno.agents.distalert.tools import dist_alerts_tool
-from zeno.tools.contextlayer.layers import layer_choices
-from zeno.tools.distalert import dist_alerts_tool
+from zeno.agents.distalert import tools
 
 
 def test_dist_alert_tool():
-    features = ["BRA.13.369_2"]
-    result = dist_alerts_tool.dist_alerts_tool.invoke(
+    result = tools.dist_alerts_tool.invoke(
         input={
-            "features": features,
-            "landcover": layer_choices[1]["dataset"],
+            "name": "BRA.13.369_2",
+            "gadm_id": "BRA.13.369_2",
+            "gadm_level": 2,
+            "context_layer_name": "WRI/SBTN/naturalLands/v1/2020",
             "threshold": 8,
             "min_date": datetime.date(2021, 8, 12),
             "max_date": datetime.date(2024, 8, 12),
         }
     )
 
-    assert len(result) == 1
-    assert "BRA.13.369_2" in result
+    assert len(result) == 7
+    assert "natural short vegetation" in result
 
 
 def test_dist_alert_tool_verified(monkeypatch):
@@ -29,13 +27,13 @@ def test_dist_alert_tool_verified(monkeypatch):
     epsilon = 0.0005
     # For this location, using GEE directly, disturbances were
     # marked as wildfire and latest disturbance was 2024-04-29,
-    # and the landcover was class 10, Wet natural short vegetation.
-    expected_natural_lands = "Wet natural short vegetation"
+    # and the context layer was class 10, Wet natural short vegetation.
+    expected_natural_lands = "wet natural short vegetation"
     expected_vegstatus = 6
     expected_vegdate = datetime.datetime(2024, 4, 29)  # 1215
     expected_driver = "wildfire"
 
-    def mockfunction(features):
+    def mockfunction(gadm_id, gadm_level):
 
         mockfeature = {
             "type": "Feature",
@@ -54,63 +52,65 @@ def test_dist_alert_tool_verified(monkeypatch):
             },
         }
 
-        return dist_alerts_tool.ee.FeatureCollection(
-            [dist_alerts_tool.ee.Feature(mockfeature)]
-        )
+        return tools.ee.FeatureCollection([tools.ee.Feature(mockfeature)])
 
-    monkeypatch.setattr(dist_alerts_tool, "get_features", mockfunction)
+    monkeypatch.setattr(tools, "get_features", mockfunction)
 
-    features = ["IND.26.12_1"]
-    result = dist_alerts_tool.dist_alerts_tool.invoke(
+    result = tools.dist_alerts_tool.invoke(
         input={
-            "features": features,
-            "landcover": "distalert-drivers",
+            "name": "IND.26.12_1",
+            "gadm_id": "IND.26.12_1",
+            "gadm_level": 2,
+            "context_layer_name": "distalert-drivers",
             "threshold": expected_vegstatus,
             "min_date": expected_vegdate,
             "max_date": expected_vegdate,
         }
     )
     # Change is wildfire
-    assert list(result["IND.26.12_1"].keys()) == [expected_driver]
+    assert list(result.keys()) == [expected_driver]
 
     # Test for date range
-    features = ["IND.26.12_1"]
-    result = dist_alerts_tool.dist_alerts_tool.invoke(
+    result = tools.dist_alerts_tool.invoke(
         input={
-            "features": features,
-            "landcover": "distalert-drivers",
+            "name": "IND.26.12_1",
+            "gadm_id": "IND.26.12_1",
+            "gadm_level": 2,
+            "context_layer_name": "distalert-drivers",
             "threshold": expected_vegstatus,
             "min_date": expected_vegdate + datetime.timedelta(days=1),
             "max_date": expected_vegdate + datetime.timedelta(days=1),
         }
     )
     # Date is out of range, no results
-    assert result["IND.26.12_1"] == {}
+    assert result == {}
 
     # Test for threshold
-    features = ["IND.26.12_1"]
-    result = dist_alerts_tool.dist_alerts_tool.invoke(
+    result = tools.dist_alerts_tool.invoke(
         input={
-            "features": features,
-            "landcover": "distalert-drivers",
+            "name": "IND.26.12_1",
+            "gadm_id": "IND.26.12_1",
+            "gadm_level": 2,
+            "context_layer_name": "distalert-drivers",
             "threshold": expected_vegstatus + 1,
             "min_date": expected_vegdate,
             "max_date": expected_vegdate,
         }
     )
     # Threshold is out of range, no results
-    assert result["IND.26.12_1"] == {}
+    assert result == {}
 
-    # Test for landcover type
-    features = ["IND.26.12_1"]
-    result = dist_alerts_tool.dist_alerts_tool.invoke(
+    # Test for context_layer_name type
+    result = tools.dist_alerts_tool.invoke(
         input={
-            "features": features,
-            "landcover": "WRI/SBTN/naturalLands/v1/2020",
+            "name": "IND.26.12_1",
+            "gadm_id": "IND.26.12_1",
+            "gadm_level": 2,
+            "context_layer_name": "WRI/SBTN/naturalLands/v1/2020",
             "threshold": expected_vegstatus,
             "min_date": expected_vegdate,
             "max_date": expected_vegdate,
         }
     )
-    # Landcover type is as expected
-    assert list(result["IND.26.12_1"].keys()) == [expected_natural_lands]
+    # Context layer type is as expected
+    assert list(result.keys()) == [expected_natural_lands]

--- a/zeno/agents/distalert/tools.py
+++ b/zeno/agents/distalert/tools.py
@@ -1,6 +1,7 @@
 import datetime
+import json
 from pathlib import Path
-from typing import Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Tuple
 
 import ee
 import geopandas as gpd
@@ -9,16 +10,12 @@ from dotenv import load_dotenv
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from zeno.agents.contextfinder.tools import table as contextfinder_table
 from zeno.agents.distalert.drivers import DRIVER_VALUEMAP, get_drivers
 from zeno.agents.distalert.gee import init_gee
-from zeno.tools.contextlayer.layers import layer_choices
 
-# Load environment variables
 load_dotenv(".env")
-
-# Initialize gee
 init_gee()
-data_dir = Path("data")
 
 DIST_ALERT_REF_DATE = datetime.date(2020, 12, 31)
 DIST_ALERT_STATS_SCALE = 30
@@ -39,52 +36,16 @@ class DistAlertsInput(BaseModel):
     max_date: datetime.date = Field(
         description="Cutoff date for alerts. Alerts after that date will be excluded.",
     )
-    landcover: Optional[str] = Field(
+    context_layer_name: Optional[str] = Field(
         default=None,
-        description="Landcover layer name to group zonal statistics by",
+        description="Context layer name to group zonal statistics by.",
     )
     threshold: Optional[Literal[1, 2, 3, 4, 5, 6, 7, 8]] = Field(
         default=5, description="Threshold for disturbance alert scale"
     )
 
 
-def print_meta(
-    layer: Union[ee.image.Image, ee.imagecollection.ImageCollection],
-) -> None:
-    """Print layer metadata"""
-    # Get all metadata as a dictionary
-    metadata = layer.getInfo()
-
-    # Print metadata
-    print("Image Metadata:")
-    for key, value in metadata.items():
-        print(f"{key}: {value}")
-
-
-def get_class_table(
-    band_name: str,
-    layer: Union[ee.image.Image, ee.imagecollection.ImageCollection],
-) -> dict:
-    band_info = layer.select(band_name).getInfo()
-
-    names = band_info["features"][0]["properties"][f"{band_name}_class_names"]
-    values = band_info["features"][0]["properties"][
-        f"{band_name}_class_values"
-    ]
-    colors = band_info["features"][0]["properties"][
-        f"{band_name}_class_palette"
-    ]
-
-    pairs = []
-    for name, color in zip(names, colors):
-        pairs.append({"name": name, "color": color})
-
-    return {val: pair for val, pair in zip(values, pairs)}
-
-
-def get_date_mask(
-    min_date: datetime.date, max_date: datetime.date
-) -> ee.image.Image:
+def get_date_mask(min_date: datetime.date, max_date: datetime.date) -> ee.image.Image:
     today = datetime.date.today()
     date_mask = None
     if min_date and min_date > DIST_ALERT_REF_DATE and min_date < today:
@@ -116,41 +77,52 @@ def get_date_mask(
     return date_mask
 
 
-def get_alerts_by_landcover(
+def get_context_layer_info(dataset: str) -> dict:
+    data = contextfinder_table.search().where(f"dataset = '{dataset}'").to_list()
+    if not data:
+        return {}
+    data.reverse()
+    data = data[0]
+    data["visualization_parameters"] = json.loads(data["visualization_parameters"])
+    data["metadata"] = json.loads(data["metadata"])
+    data.pop("vector")
+
+    return data
+
+
+def get_alerts_by_context_layer(
     name: str,
     distalerts: ee.Image,
-    landcover: ee.Image,
+    context_layer_name: ee.Image,
     gee_features: ee.FeatureCollection,
     date_mask: ee.Image,
     threshold: int,
 ) -> Tuple[dict, ee.Image]:
-    choice = [dat for dat in layer_choices if dat["dataset"] == landcover]
-    if choice:
-        choice = choice[0]
-        if choice["type"] == "ImageCollection":
-            landcover_layer = ee.ImageCollection(landcover)
-        else:
-            landcover_layer = ee.Image(landcover)
 
-        if "class_table" in choice:
-            class_table = choice["class_table"]
-        else:
-            class_table = get_class_table(choice["band"], landcover_layer)
+    choice = get_context_layer_info(context_layer_name)
+
+    if not choice:
+        context_layer = get_drivers()
+        # TODO: replace this with layer in DB, this is currently a patch to make the tests work
+        choice["resolution"] = DIST_ALERT_STATS_SCALE
+        choice["band"] = "driver"
+        choice["metadata"] = {
+            "value_mappings": [
+                {"value": val, "description": key}
+                for key, val in DRIVER_VALUEMAP.items()
+            ]
+        }
+    elif choice["type"] == "ImageCollection":
+        context_layer = (
+            ee.ImageCollection(context_layer_name).mosaic().select(choice["band"])
+        )
     else:
-        # TODO: replace this with a better selection. For now
-        # assumes if the choice did not exist that the drivers are requested.
-        landcover_layer = get_drivers()
-        class_table = {val: key for key, val in DRIVER_VALUEMAP.items()}
-
-    if choice["type"] == "ImageCollection":
-        landcover_layer = landcover_layer.mosaic()
-
-    landcover_layer = landcover_layer.select(choice["band"])
+        context_layer = ee.Image(context_layer_name).select(choice["band"])
 
     zone_stats_img = (
         distalerts.pixelArea()
         .divide(M2_TO_HA)
-        .addBands(landcover_layer)
+        .addBands(context_layer)
         .updateMask(distalerts.gte(threshold))
     )
     if date_mask:
@@ -164,15 +136,16 @@ def get_alerts_by_landcover(
         scale=choice["resolution"],
     ).getInfo()
 
-    zone_stats_result = {"landcover": landcover}
-    for feat in zone_stats["features"]:
-        zone_stats_result[name] = {
-            class_table[dat[choice["band"]]]["name"]: dat["sum"]
-            for dat in feat["properties"]["groups"]
-        }
-    vectorize = landcover_layer.updateMask(distalerts.gte(threshold))
+    zone_stats = zone_stats["features"][0]["properties"]["groups"]
 
-    return zone_stats_result, vectorize
+    value_mappings = {
+        dat["value"]: dat["description"] for dat in choice["metadata"]["value_mappings"]
+    }
+    zone_stats = {value_mappings[dat[choice["band"]]]: dat["sum"] for dat in zone_stats}
+
+    vectorize = context_layer.updateMask(distalerts.gte(threshold))
+
+    return zone_stats, vectorize
 
 
 def get_distalerts_unfiltered(
@@ -183,9 +156,7 @@ def get_distalerts_unfiltered(
     threshold: int,
 ) -> Tuple[dict, ee.Image]:
     zone_stats_img = (
-        distalerts.pixelArea()
-        .divide(M2_TO_HA)
-        .updateMask(distalerts.gte(threshold))
+        distalerts.pixelArea().divide(M2_TO_HA).updateMask(distalerts.gte(threshold))
     )
     if date_mask:
         zone_stats_img = zone_stats_img.updateMask(
@@ -198,16 +169,23 @@ def get_distalerts_unfiltered(
         scale=DIST_ALERT_STATS_SCALE,
     ).getInfo()
 
-    zone_stats_result = {"landcover": None}
+    zone_stats_result = {"context_layer_name": None}
     for feat in zone_stats["features"]:
         zone_stats_result[name] = {"disturbances": feat["properties"]["sum"]}
 
     vectorize = (
-        distalerts.gte(threshold)
-        .updateMask(distalerts.gte(threshold))
-        .selfMask()
+        distalerts.gte(threshold).updateMask(distalerts.gte(threshold)).selfMask()
     )
     return zone_stats_result, vectorize
+
+
+def get_features(gadm_id: str, gadm_level: int) -> ee.FeatureCollection:
+    aoi_df = gpd.read_file(
+        Path("data") / f"gadm_410_level_{gadm_level}.gpkg",
+        where=f"GID_{gadm_level} like '{gadm_id}'",
+    )
+    aoi = aoi_df.geometry.iloc[0]
+    return ee.FeatureCollection([ee.Feature(aoi.__geo_interface__)])
 
 
 @tool(
@@ -222,36 +200,27 @@ def dist_alerts_tool(
     gadm_level: int,
     min_date: datetime.date,
     max_date: datetime.date,
-    landcover: Optional[str] = None,
+    context_layer_name: Optional[str] = None,
     threshold: Optional[Literal[1, 2, 3, 4, 5, 6, 7, 8]] = 5,
 ) -> dict:
     """
     Dist alerts tool
 
     This tool quantifies vegetation disturbance alerts over an area of interest
-    and summarizes the alerts in statistics by landcover types.
+    and summarizes the alerts in statistics by context layer types.
     """
-    # import pdb
-
-    # pdb.set_trace()
     print("---DIST ALERTS TOOL---")
 
-    aoi_df = gpd.read_file(
-        data_dir / f"gadm_410_level_{gadm_level}.gpkg",
-        where=f"GID_{gadm_level} like '{gadm_id}'",
-    )
-    aoi = aoi_df.geometry.iloc[0]
-    gee_features = ee.FeatureCollection([ee.Feature(aoi.__geo_interface__)])
-
+    gee_features = get_features(gadm_id=gadm_id, gadm_level=gadm_level)
     distalerts = ee.ImageCollection(GEE_FOLDER + "VEG-DIST-STATUS").mosaic()
 
     date_mask = get_date_mask(min_date, max_date)
 
-    if landcover:
-        zone_stats_result, vectorize = get_alerts_by_landcover(
+    if context_layer_name:
+        zone_stats_result, vectorize = get_alerts_by_context_layer(
             name=name,
             distalerts=distalerts,
-            landcover=landcover,
+            context_layer_name=context_layer_name,
             gee_features=gee_features,
             date_mask=date_mask,
             threshold=threshold,

--- a/zeno/agents/distalert/tools.py
+++ b/zeno/agents/distalert/tools.py
@@ -21,7 +21,8 @@ init_gee()
 data_dir = Path("data")
 
 DIST_ALERT_REF_DATE = datetime.date(2020, 12, 31)
-DIST_ALERT_SCALE = 30
+DIST_ALERT_STATS_SCALE = 30
+DIST_ALERT_VECTORIZATION_SCALE = 150
 M2_TO_HA = 10000
 GEE_FOLDER = "projects/glad/HLSDIST/backend/"
 
@@ -194,7 +195,7 @@ def get_distalerts_unfiltered(
     zone_stats = zone_stats_img.reduceRegions(
         collection=gee_features,
         reducer=ee.Reducer.sum(),
-        scale=DIST_ALERT_SCALE,
+        scale=DIST_ALERT_STATS_SCALE,
     ).getInfo()
 
     zone_stats_result = {"landcover": None}
@@ -267,7 +268,7 @@ def dist_alerts_tool(
     # Vectorize the masked classification
     vectors = vectorize.reduceToVectors(
         geometryType="polygon",
-        scale=DIST_ALERT_SCALE,
+        scale=DIST_ALERT_VECTORIZATION_SCALE,
         maxPixels=1e8,
         geometry=gee_features,
         eightConnected=True,


### PR DESCRIPTION
- Fix error of "too many polygons to vectorize" by reducing the resolution of the vectorization to 150m.
- Fix valuemap lookups and other small distalert issues. This now uses the lancedb data for the valuemaps etc. Except for drivers, where its still hard coded. We might want to add that data as a new layer to the context layer table.
