### PR TITLE
This will allow using zeno from anywhere in the virtualenv.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,10 @@ ignore = ["E501"]
 
 [tool.ruff.format]
 quote-style = "double"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["zeno"]

--- a/uv.lock
+++ b/uv.lock
@@ -3214,7 +3214,7 @@ wheels = [
 [[package]]
 name = "project-zeno"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "earthengine-api" },
     { name = "elevenlabs" },


### PR DESCRIPTION
This removes pain when it comes to pythonpaths. Basically uv will install the package in a n "editable" mode into the venv and 🎉 no more path problems.
