### PR TITLE
add workflow to build and push image for db container

### DIFF
--- a/.github/workflows/docker-build-db.yml
+++ b/.github/workflows/docker-build-db.yml
@@ -4,10 +4,8 @@ on:
   push:
     branches:
       - main
-      - docker-build-publish
-      - publish-docker-db
-    # paths:
-    #   - 'db/**'
+    paths:
+      - 'db/**'
 
 env:
   REGISTRY: public.ecr.aws/b7u8b0a6

--- a/.github/workflows/docker-build-db.yml
+++ b/.github/workflows/docker-build-db.yml
@@ -1,0 +1,46 @@
+name: Build and Publish DB Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - docker-build-publish
+      - publish-docker-db
+    paths:
+      - 'db/**'
+
+env:
+  REGISTRY: public.ecr.aws/b7u8b0a6
+  IMAGE_NAME: project-zeno/zeno-db
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./db
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/docker-build-db.yml
+++ b/.github/workflows/docker-build-db.yml
@@ -34,7 +34,6 @@ jobs:
         run: |
           aws ecr-public create-repository \
             --repository-name ${{ env.IMAGE_NAME }} \
-            --registry-alias b7u8b0a6 \
             --region us-east-1 || true
 
       - name: Login to Amazon ECR Public

--- a/.github/workflows/docker-build-db.yml
+++ b/.github/workflows/docker-build-db.yml
@@ -6,8 +6,8 @@ on:
       - main
       - docker-build-publish
       - publish-docker-db
-    paths:
-      - 'db/**'
+    # paths:
+    #   - 'db/**'
 
 env:
   REGISTRY: public.ecr.aws/b7u8b0a6
@@ -34,6 +34,7 @@ jobs:
         run: |
           aws ecr-public create-repository \
             --repository-name ${{ env.IMAGE_NAME }} \
+            --registry-alias b7u8b0a6 \
             --region us-east-1 || true
 
       - name: Login to Amazon ECR Public

--- a/.github/workflows/docker-build-db.yml
+++ b/.github/workflows/docker-build-db.yml
@@ -30,6 +30,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      - name: Create ECR repository if not exists
+        run: |
+          aws ecr-public create-repository \
+            --repository-name ${{ env.IMAGE_NAME }} \
+            --region us-east-1 || true
+
       - name: Login to Amazon ECR Public
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -8,8 +8,8 @@ RUN pip install --no-cache-dir alembic psycopg2-binary pydantic
 # Copy migration scripts and models
 COPY . /app/db
 
-RUN chmod +x /app/db/init-multiple-dbs.sh
-
+RUN chmod +x /app/db/init-multiple-dbs.sh && \
+    chmod +x /app/db/entrypoint.sh
 
 # Default command (can be overridden)
-CMD ["alembic", "upgrade", "head"]
+CMD ["./entrypoint.sh"]

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.11-slim
 
 WORKDIR /app/db
 
+# Install PostgreSQL client and Alembic
+RUN apt-get update && \
+    apt-get install -y postgresql-client
+
 # Install Alembic
 RUN pip install --no-cache-dir alembic psycopg2-binary pydantic
 

--- a/db/entrypoint.sh
+++ b/db/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+./init-multiple-dbs.sh && \
+alembic upgrade head

--- a/db/entrypoint.sh
+++ b/db/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+export DATABASE_URL="postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${APP_DB}"
 ./init-multiple-dbs.sh && \
 alembic upgrade head

--- a/db/init-multiple-dbs.sh
+++ b/db/init-multiple-dbs.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e
 
+# Set password for psql
+export PGPASSWORD="${POSTGRES_PASSWORD}"
+
 # Create additional databases if they do not exist
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+psql -h "${POSTGRES_HOST}" -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
     CREATE DATABASE "${APP_DB:-zeno-data}";
     CREATE DATABASE "${LANGFUSE_DB:-langfuse}";
 EOSQL

--- a/db/init-multiple-dbs.sh
+++ b/db/init-multiple-dbs.sh
@@ -6,6 +6,14 @@ export PGPASSWORD="${POSTGRES_PASSWORD}"
 
 # Create additional databases if they do not exist
 psql -h "${POSTGRES_HOST}" -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-    CREATE DATABASE "${APP_DB:-zeno-data}";
-    CREATE DATABASE "${LANGFUSE_DB:-langfuse}";
+    DO \$\$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_database WHERE datname = '${APP_DB:-zeno-data}') THEN
+            CREATE DATABASE "${APP_DB:-zeno-data}";
+        END IF;
+        IF NOT EXISTS (SELECT FROM pg_database WHERE datname = '${LANGFUSE_DB:-langfuse}') THEN
+            CREATE DATABASE "${LANGFUSE_DB:-langfuse}";
+        END IF;
+    END
+    \$\$;
 EOSQL

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,6 +77,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+      - POSTGRES_HOST=db
       - APP_DB=zeno-data
       - LANGFUSE_DB=langfuse
     ports:
@@ -92,7 +93,10 @@ services:
       db:
         condition: service_healthy
     environment:
-      - DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/zeno-data
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_HOST=db
+      - APP_DB=zeno-data
 
 volumes:
   database_data:


### PR DESCRIPTION
Refs https://github.com/wri/project-zeno-deploy/issues/16

To deploy the latest changes, we need to publish the new `db` container to pull and run it in the cluster.

This PR adds a Github workflow to publish the db image to the same ECR we use for the main image.

I'm not super happy with this as this will mean two different commit hashes that we need to keep track of between `project-zeno` and `project-zeno-deploy`. I'll work with @sunu to outline a plan to do this a bit better, but I think this is the most straightforward way to deploy these changes right now and unblock / move ahead.

cc @sunu @yellowcap 
