### PR TITLE
refactor: replace DO block with \gexec for database creation in init …

### DIFF
--- a/db/init-multiple-dbs.sh
+++ b/db/init-multiple-dbs.sh
@@ -4,16 +4,17 @@ set -e
 # Set password for psql
 export PGPASSWORD="${POSTGRES_PASSWORD}"
 
+# Define effective database names with defaults
+APP_DB_EFFECTIVE="${APP_DB:-zeno-data}"
+LANGFUSE_DB_EFFECTIVE="${LANGFUSE_DB:-langfuse}"
+
 # Create additional databases if they do not exist
-psql -h "${POSTGRES_HOST}" -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-    DO \$\$
-    BEGIN
-        IF NOT EXISTS (SELECT FROM pg_database WHERE datname = '${APP_DB:-zeno-data}') THEN
-            CREATE DATABASE "${APP_DB:-zeno-data}";
-        END IF;
-        IF NOT EXISTS (SELECT FROM pg_database WHERE datname = '${LANGFUSE_DB:-langfuse}') THEN
-            CREATE DATABASE "${LANGFUSE_DB:-langfuse}";
-        END IF;
-    END
-    \$\$;
+psql -h "${POSTGRES_HOST}" -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" \
+    -v app_db_name="$APP_DB_EFFECTIVE" \
+    -v langfuse_db_name="$LANGFUSE_DB_EFFECTIVE" <<-EOSQL
+    SELECT 'CREATE DATABASE "' || :'app_db_name' || '"'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'app_db_name')\gexec
+
+    SELECT 'CREATE DATABASE "' || :'langfuse_db_name' || '"'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'langfuse_db_name')\gexec
 EOSQL


### PR DESCRIPTION
this PR fixes error from `migrate` docker container

```
migrate-1          | ERROR:  CREATE DATABASE cannot be executed from a function
db-1               |    PL/pgSQL function inline_code_block line 4 at SQL statement
migrate-1          | CONTEXT:  SQL statement "CREATE DATABASE "zeno-data""
db-1               | 2025-05-19 20:38:42.491 UTC [41] STATEMENT:  DO $$
migrate-1          | PL/pgSQL function inline_code_block line 4 at SQL statement
db-1               |        BEGIN
db-1               |            IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'zeno-data') THEN
db-1               |                CREATE DATABASE "zeno-data";
db-1               |            END IF;
db-1               |            IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'langfuse') THEN
db-1               |                CREATE DATABASE "langfuse";
db-1               |            END IF;
db-1               |        END
db-1               |        $$;
migrate-1 exited with code 3
```