### PR TITLE
Api tests

### DIFF
--- a/api.py
+++ b/api.py
@@ -30,7 +30,12 @@ DATABASE_URL = os.environ["DATABASE_URL"]
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-DOMAINS_ALLOWLIST = os.environ.get("DOMAINS_ALLOWLIST", "").split(",")
+def get_domains_allowlist() -> tuple[str, ...]:
+    """Get allowed domains as a tuple for immutability."""
+    domains = os.environ.get("DOMAINS_ALLOWLIST", "").split(",")
+    return tuple(d.strip() for d in domains if d.strip())
+
+DOMAINS_ALLOWLIST = get_domains_allowlist()
 
 
 app = FastAPI()
@@ -43,18 +48,23 @@ app.mount("/zeno", zeno_app)
 _user_info_cache = cachetools.TTLCache(maxsize=1024, ttl=60 * 60 * 24)  # 1 day
 
 
-@cachetools.cached(_user_info_cache)
-def fetch_user_from_rw_api(
-    authorization: str = Header(...),
-    domains_allowlist: str = DOMAINS_ALLOWLIST,
-) -> UserModel:
-    if not authorization.startswith("Bearer "):
+def get_token(authorization: str = Header(..., description="Bearer token")) -> str:
+    """Extract and validate Bearer token from Authorization header."""
+    if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing Bearer token",
         )
+    return authorization.split(" ")[1]
 
-    token = authorization.split(" ")[1]
+def fetch_user_from_rw_api(
+    token: str = Depends(get_token),
+    domains_allowlist: tuple[str, ...] = DOMAINS_ALLOWLIST,
+) -> UserModel:
+    # Use cache key that only includes the token
+    cache_key = token
+    if cache_key in _user_info_cache:
+        return _user_info_cache[cache_key]
 
     try:
         resp = requests.get(
@@ -73,13 +83,17 @@ def fetch_user_from_rw_api(
         raise HTTPException(status_code=resp.status_code, detail=resp.text)
 
     user_info = resp.json()
-    if user_info["email"].split("@")[-1].lower() not in domains_allowlist:
+    domain = user_info["email"].split("@")[-1]
+    allowed_domains = {d.lower() for d in domains_allowlist}
+    if domain.lower() not in allowed_domains:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User not allowed to access this API",
         )
 
-    return UserModel.model_validate(resp.json())
+    user = UserModel.model_validate(resp.json())
+    _user_info_cache[cache_key] = user
+    return user
 
 
 def fetch_user(user_info: UserModel = Depends(fetch_user_from_rw_api)):

--- a/db/alembic/env.py
+++ b/db/alembic/env.py
@@ -19,6 +19,14 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
+import sys
+from pathlib import Path
+
+# Add the base directory to the Python path
+base_dir = str(Path(__file__).resolve().parent.parent)
+if base_dir not in sys.path:
+    sys.path.append(base_dir)
+
 from models import Base
 
 target_metadata = Base.metadata

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the API endpoints."""

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -118,28 +118,6 @@ def test_missing_bearer_token(db_session: Session):
         assert response.status_code == 401
         assert "Missing Bearer token" in response.json()["detail"]
 
-def test_case_insensitive_domain_check(db_session: Session):
-    """Test that email domain checking is case-insensitive."""
-    with domain_allowlist("developmentseed.org,wri.org"):
-        mock_mixed_case_user = {
-            "id": "test-user-4",
-            "name": "Mixed Case User",
-            "email": "test@DevElopmentSeed.org",  # Mixed case domain
-            "createdAt": "2024-01-01T00:00:00Z",
-            "updatedAt": "2024-01-01T00:00:00Z"
-        }
-        
-        with patch('requests.get') as mock_get:
-            mock_get.return_value = mock_rw_api_response(mock_mixed_case_user)
-            
-            response = client.get(
-                "/auth/me",
-                headers={"Authorization": "Bearer test-token"}
-            )
-            
-            assert response.status_code == 200
-            user_response = response.json()
-            assert user_response["email"] == mock_mixed_case_user["email"]
 
 def test_missing_authorization_header(db_session: Session):
     """Test that requests without an Authorization header are rejected."""

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,148 @@
+"""Tests for authentication-related endpoints."""
+import os
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+import importlib.util
+from pathlib import Path
+
+from fastapi import FastAPI
+from contextlib import contextmanager
+
+# Import api.py from the project root
+api_path = Path(__file__).resolve().parent.parent.parent / "api.py"
+spec = importlib.util.spec_from_file_location("api", api_path)
+api = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(api)
+
+# Use the original app with its dependencies and middleware
+client = TestClient(api.app)
+
+@contextmanager
+def domain_allowlist(domains: str):
+    """Context manager to set and reset DOMAINS_ALLOWLIST."""
+    domain_list = domains.split(",")
+    original = os.environ.get("DOMAINS_ALLOWLIST")
+    os.environ["DOMAINS_ALLOWLIST"] = ",".join(domain_list)
+    try:
+        with patch.object(api, "DOMAINS_ALLOWLIST", domain_list):
+            yield domain_list
+    finally:
+        if original is not None:
+            os.environ["DOMAINS_ALLOWLIST"] = original
+        else:
+            del os.environ["DOMAINS_ALLOWLIST"]
+
+# Mock user responses for different scenarios
+MOCK_AUTHORIZED_USER = {
+    "id": "test-user-1",
+    "name": "Test User",
+    "email": "test@developmentseed.org",
+    "createdAt": "2024-01-01T00:00:00Z",
+    "updatedAt": "2024-01-01T00:00:00Z"
+}
+
+MOCK_ALTERNATE_DOMAIN_USER = {
+    "id": "test-user-2",
+    "name": "WRI User",
+    "email": "test@wri.org",
+    "createdAt": "2024-01-01T00:00:00Z",
+    "updatedAt": "2024-01-01T00:00:00Z"
+}
+
+MOCK_UNAUTHORIZED_USER = {
+    "id": "test-user-3",
+    "name": "Unauthorized User",
+    "email": "test@unauthorized.com",
+    "createdAt": "2024-01-01T00:00:00Z",
+    "updatedAt": "2024-01-01T00:00:00Z"
+}
+
+def mock_rw_api_response(user_data):
+    """Helper to create a mock response object."""
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+            self.text = str(json_data)
+
+        def json(self):
+            return self.json_data
+
+    return MockResponse(user_data, 200)
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the user info cache before each test."""
+    api._user_info_cache.clear()
+
+@pytest.mark.parametrize("user_data,expected_status,expected_error", [
+    (MOCK_AUTHORIZED_USER, 200, None),  # developmentseed.org user should succeed
+    (MOCK_ALTERNATE_DOMAIN_USER, 200, None),  # wri.org user should succeed
+    (MOCK_UNAUTHORIZED_USER, 403, "User not allowed to access this API"),  # unauthorized domain should fail
+])
+def test_email_domain_authorization(user_data, expected_status, expected_error, db_session: Session):
+    """Test that only users with allowed email domains can access the API."""
+    with domain_allowlist("developmentseed.org,wri.org"):
+        with patch('requests.get') as mock_get:
+            # Mock the RW API response
+            mock_response = mock_rw_api_response(user_data)
+            mock_get.return_value = mock_response
+            
+            # Test the auth endpoint
+            response = client.get(
+                "/auth/me",
+                headers={"Authorization": "Bearer test-token"}
+            )
+        
+        assert response.status_code == expected_status
+        
+        if expected_error:
+            assert expected_error in response.json()["detail"]
+        else:
+            # For successful requests, verify the user data is returned correctly
+            user_response = response.json()
+            assert user_response["id"] == user_data["id"]
+            assert user_response["email"] == user_data["email"]
+            assert user_response["name"] == user_data["name"]
+
+def test_missing_bearer_token(db_session: Session):
+    """Test that requests without a Bearer token are rejected."""
+    with domain_allowlist("developmentseed.org,wri.org"):
+        response = client.get(
+            "/auth/me",
+            headers={"Authorization": "test-token"}  # Missing "Bearer" prefix
+        )
+        assert response.status_code == 401
+        assert "Missing Bearer token" in response.json()["detail"]
+
+def test_case_insensitive_domain_check(db_session: Session):
+    """Test that email domain checking is case-insensitive."""
+    with domain_allowlist("developmentseed.org,wri.org"):
+        mock_mixed_case_user = {
+            "id": "test-user-4",
+            "name": "Mixed Case User",
+            "email": "test@DevElopmentSeed.org",  # Mixed case domain
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:00:00Z"
+        }
+        
+        with patch('requests.get') as mock_get:
+            mock_get.return_value = mock_rw_api_response(mock_mixed_case_user)
+            
+            response = client.get(
+                "/auth/me",
+                headers={"Authorization": "Bearer test-token"}
+            )
+            
+            assert response.status_code == 200
+            user_response = response.json()
+            assert user_response["email"] == mock_mixed_case_user["email"]
+
+def test_missing_authorization_header(db_session: Session):
+    """Test that requests without an Authorization header are rejected."""
+    os.environ["DOMAINS_ALLOWLIST"] = "developmentseed.org,wri.org"
+    response = client.get("/auth/me")  # No Authorization header
+    assert response.status_code == 422  # FastAPI validation error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+"""Test configuration and fixtures."""
+import os
+from sqlalchemy import create_engine, text
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from alembic.config import Config
+from alembic import command
+from pathlib import Path
+
+# Test database settings
+TEST_DB_NAME = "zeno_test"
+DEFAULT_DB_URL = "postgresql://postgres@localhost:5432/postgres"
+TEST_DB_URL = f"postgresql://postgres@localhost:5432/{TEST_DB_NAME}"
+
+def run_migrations(database_url: str) -> None:
+    """Run all alembic migrations."""
+    alembic_cfg = Config()
+    alembic_cfg.set_main_option("script_location", "db/alembic")
+    alembic_cfg.set_main_option("sqlalchemy.url", database_url)
+    command.upgrade(alembic_cfg, "head")
+
+def create_test_database() -> None:
+    """Create a test database."""
+    # Connect to default postgres database
+    engine = create_engine(DEFAULT_DB_URL)
+    
+    # Need to be outside a transaction for database drop/create
+    with engine.connect() as conn:
+        conn.execution_options(isolation_level="AUTOCOMMIT")
+        # Drop test database if it exists and create it fresh
+        conn.execute(text(f"DROP DATABASE IF EXISTS {TEST_DB_NAME}"))
+        conn.execute(text(f"CREATE DATABASE {TEST_DB_NAME}"))
+    
+    engine.dispose()
+    
+    # Run migrations on test database
+    run_migrations(TEST_DB_URL)
+
+def drop_test_database() -> None:
+    """Drop the test database."""
+    engine = create_engine(DEFAULT_DB_URL)
+    
+    with engine.connect() as conn:
+        conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(text(f"DROP DATABASE IF EXISTS {TEST_DB_NAME}"))
+    
+    engine.dispose()
+
+@pytest.fixture(scope="session", autouse=True)
+def test_db():
+    """Create test database and run migrations."""
+    # Save original DATABASE_URL
+    original_db_url = os.environ.get("DATABASE_URL")
+    
+    # Set up test database
+    create_test_database()
+    os.environ["DATABASE_URL"] = TEST_DB_URL
+    
+    yield  # Run the tests
+    
+    # Clean up
+    if original_db_url:
+        os.environ["DATABASE_URL"] = original_db_url
+    drop_test_database()
+
+@pytest.fixture(scope="function")
+def db_session():
+    """Create a new database session for a test."""
+    engine = create_engine(TEST_DB_URL)
+    Session = sessionmaker(bind=engine)
+    
+    with Session() as session:
+        with session.begin():  # Automatic transaction management
+            yield session
+            session.rollback()  # Rollback any changes after test


### PR DESCRIPTION
This is a first pass at adding some scaffolding to run API tests that involve the database, and adds tests for user authentication.

This:

 - Makes some small changes to the user cache and reading of the DOMAINS_ALLOWLIST var to fix small bugs and work well with passing in mocks for tests
 - Adds a conftest.py to do db creation and teardown
 - Creates a separate tests/api/ folder for these kinds of more deterministic API tests (as opposed to the agent tests) with a test_auth.py, that will grow to test the CRUD API end-points, etc

TODO: I'll wire up CI to run these tests as part of CI - I'd really like things like testing our auth and basic db CRUD functions to have tests that run in CI

I have not really written tests for a FastAPI application before, and some of the import stuff got a little weird - @leothomas I might appreciate talking that through with you. My understanding is we might want to change the application structure a little bit to make it work better as a python module, but will run it by you.

You should be able to run the tests added here with `pytest tests/api` and you should see 5 tests pass.

