### PR TITLE
Migrate AOI tool from local database to s3

### DIFF
--- a/scripts/dump_basemaps_tables.py
+++ b/scripts/dump_basemaps_tables.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""
+dump_basemaps_tables.py
+---------------------
+Export every table in a Basemaps database to its own Parquet file.
+• Geometry columns are preserved; DuckDB writes valid GeoParquet metadata.
+• Output directory is created automatically.
+Usage:
+    python dump_basemaps_tables.py path/to/basemaps.duckdb [-o exports]
+"""
+import duckdb
+import argparse
+from pathlib import Path
+
+def main(db_path: str, outdir: str):
+    outdir = Path(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    con = duckdb.connect(db_path)
+    con.execute("INSTALL spatial; LOAD spatial;")          # Needed once
+
+    # list only user‑visible tables in the default schema
+    tables = [r[0] for r in con.execute("SHOW TABLES").fetchall()]
+
+    for t in tables:
+        outfile = outdir / f"{t}.parquet"
+        con.execute(f"COPY {t} TO '{outfile}' (FORMAT PARQUET, COMPRESSION ZSTD);")
+        print(f"✓ {t}  →  {outfile}")
+
+    con.close()
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("db", help="Path to .duckdb database file")
+    p.add_argument("-o", "--outdir", default="data/geocode/exports", help="Directory for Parquet files")
+    args = p.parse_args()
+    main(args.db, args.outdir)


### PR DESCRIPTION
**What Changed**

- Data source migration: changed `pick_aoi` tool to read data from S3 parquet files instead of local DuckDB database
- S3 configuration: Added AWS credentials setup for cloud data access
- New export script: Added `scripts/dump_basemaps_tables.py` to convert DuckDB tables to parquet files

**Key Updates**

- Updated all table references to use S3 paths (gadm, kba, wdpa, landmark)
- Enhanced AOI selection model to include `source` and `src_id` fields
- Improved logging and removed redundant database queries

**Requirements**

- AWS credentials must be configured in environment
- Pull data from s3 bucker `zeno-agent-data` to `data/`