### PR TITLE
Agent: Add support for User Selection from UI to define agent flow

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,26 +1,33 @@
-import uuid
-import requests
-import json
 import argparse
-from typing import Dict, Optional, Iterator, Any
+import json
+import uuid
+from typing import Any, Dict, Iterator, Optional
+
+import requests
 
 
 class ZenoClient:
-    def __init__(self, base_url: str = "http://localhost:8000", token: Optional[str] = None):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        token: Optional[str] = None,
+    ):
         """
         Initialize the Zeno API client.
-        
+
         Args:
             base_url: The base URL of the Zeno API server
             token: The bearer token for authentication
         """
         self.base_url = base_url
         self.token = token
-        
+
     def chat(
-        self, 
-        query: str, 
-        user_persona: Optional[str] = None, 
+        self,
+        query: str,
+        user_persona: Optional[str] = None,
+        ui_context: Optional[Dict] = None,
+        ui_action_only: Optional[bool] = False,
         thread_id: Optional[str] = None,
         metadata: Optional[Dict] = None,
         session_id: Optional[str] = None,
@@ -29,81 +36,94 @@ class ZenoClient:
     ) -> Iterator[Dict[str, Any]]:
         """
         Send a chat request to the Zeno API and stream the responses.
-        
+
         Args:
             query: The query to send
             user_persona: Optional user persona
+            ui_context: Optional UI context
             thread_id: Optional thread ID
             metadata: Optional metadata
-            
+            session_id: Optional session ID
+            user_id: Optional user ID
+            tags: Optional tags
         Returns:
             An iterator of response messages
         """
         url = f"{self.base_url}/api/chat"
-        
+
         payload = {
             "query": query,
+            "ui_action_only": ui_action_only,
         }
-        
+
+        if ui_context:
+            payload["ui_context"] = ui_context
+
         if user_persona:
             payload["user_persona"] = user_persona
-            
+
         if thread_id:
             payload["thread_id"] = thread_id
-        
+
         if metadata:
             payload["metadata"] = metadata
-        
+
         if session_id:
             payload["session_id"] = session_id
-        
+
         if user_id:
             payload["user_id"] = user_id
-        
+
         if tags:
             payload["tags"] = tags
-        
+
         headers = {}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
 
-        with requests.post(url, json=payload, stream=True, headers=headers) as response:
+        with requests.post(
+            url, json=payload, stream=True, headers=headers
+        ) as response:
             if response.status_code != 200:
-                raise Exception(f"Request failed with status code {response.status_code}: {response.text}")
+                raise Exception(
+                    f"Request failed with status code {response.status_code}: {response.text}"
+                )
             for update in response.iter_lines():
                 if update:
                     # Decode the line and parse the JSON
-                    decoded_update = update.decode('utf-8')
+                    decoded_update = update.decode("utf-8")
                     yield json.loads(decoded_update)
 
 
 def main():
     """
     Simple command-line interface to test the Zeno API.
-    
+
     Usage:
         python client.py [query] [--persona PERSONA] [--thread-id THREAD_ID]
     """
-    
-    parser = argparse.ArgumentParser(description='Test the Zeno API')
-    parser.add_argument('query', nargs='?', help='The query to send')
-    parser.add_argument('--persona', '-p', help='User persona')
-    parser.add_argument('--thread-id', '-t', help='Thread ID')
-    parser.add_argument('--metadata', '-m', help='Metadata')
-    parser.add_argument('--session-id', '-s', help='Session ID')
-    parser.add_argument('--user-id', '-i', help='User ID')
-    parser.add_argument('--tags', '-a', help='Tags')
-    parser.add_argument('--url', '-u', default='http://localhost:8000', help='API server URL')
-    
+
+    parser = argparse.ArgumentParser(description="Test the Zeno API")
+    parser.add_argument("query", nargs="?", help="The query to send")
+    parser.add_argument("--persona", "-p", help="User persona")
+    parser.add_argument("--thread-id", "-t", help="Thread ID")
+    parser.add_argument("--metadata", "-m", help="Metadata")
+    parser.add_argument("--session-id", "-s", help="Session ID")
+    parser.add_argument("--user-id", "-i", help="User ID")
+    parser.add_argument("--tags", "-a", help="Tags")
+    parser.add_argument(
+        "--url", "-u", default="http://localhost:8000", help="API server URL"
+    )
+
     args = parser.parse_args()
-    
+
     # If query wasn't provided as a positional argument, prompt for it
     query = args.query
     if not query:
         query = input("Enter your query: ")
-    
+
     client = ZenoClient(base_url=args.url)
-    
+
     print(f"Sending query: {query}")
     if args.persona:
         print(f"User persona: {args.persona}")
@@ -126,13 +146,21 @@ def main():
     else:
         tags = ["zeno-default-tag"]
     print("Streaming response:")
-    
+
     try:
-        for stream in client.chat(query, user_persona=args.persona, thread_id=args.thread_id, metadata=metadata, session_id=session_id, user_id=user_id, tags=tags):
-            node = stream['node']
-            update = json.loads(stream['update'])
-            for msg in update['messages']:
-                content = msg['kwargs']['content']
+        for stream in client.chat(
+            query,
+            user_persona=args.persona,
+            thread_id=args.thread_id,
+            metadata=metadata,
+            session_id=session_id,
+            user_id=user_id,
+            tags=tags,
+        ):
+            node = stream["node"]
+            update = json.loads(stream["update"])
+            for msg in update["messages"]:
+                content = msg["kwargs"]["content"]
                 print(f"Node: {node}")
                 if isinstance(content, list):
                     for msg in content:

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,94 @@ The reasoning behind this is the following:
 - Minimal middle layer between the agent and the frontend
 - Focus on a synced state on frontend and backend
 
+## Chat API Endpoint
+
+The main chat endpoint is `/api/chat` which accepts POST requests with the following schema:
+
+```python
+class ChatRequest(BaseModel):
+    query: str = Field(..., description="The query")
+    user_persona: Optional[str] = Field(None, description="The user persona")
+    
+    # UI Context - can include multiple selections
+    ui_context: Optional[dict] = None  # {"aoi_selected": {...}, "dataset_selected": {...}, "daterange_selected": {...}}
+    
+    # Pure UI actions - no query
+    ui_action_only: Optional[bool] = False
+    
+    # Chat info
+    thread_id: Optional[str] = Field(None, description="The thread ID")
+    metadata: Optional[dict] = Field(None, description="The metadata")
+    session_id: Optional[str] = Field(None, description="The session ID")
+    user_id: Optional[str] = Field(None, description="The user ID")
+    tags: Optional[list] = Field(None, description="The tags")
+```
+
+### UI Context
+
+The `ui_context` parameter allows the frontend to pass pre-selected data (AOI, dataset, date range) directly to the agent, enabling a hybrid approach where users can either:
+1. Use natural language queries to let the agent select data
+2. Use UI dropdowns to pre-select data and then ask questions
+3. Mix both approaches in the same conversation
+
+#### UI Context Schema
+
+```python
+ui_context = {
+    "aoi_selected": {
+        "aoi": {  # Full AOI geojson and metadata
+            "geometry": {...},  # GeoJSON geometry
+            "name": "Location Name",
+            "gadm_id": 12345,
+            # ... other AOI fields
+        },
+        "aoi_name": "Location Name",
+        "subregion_aois": None,  # or DataFrame data
+        "subregion": None,
+        "subtype": "district-county"
+    },
+    "dataset_selected": {
+        "dataset": {
+            "dataset_id": 14,
+            "source": "GFW",
+            "data_layer": "DIST-ALERT",
+            "tile_url": "https://tiles.globalforestwatch.org/...",
+            "context_layer": "driver",
+            "daterange": {
+                "start_date": "2024-01-01",
+                "end_date": "2024-12-31",
+                "years": [2024],
+                "period": "2024",
+                "original_text": "2024"
+            },
+            "threshold": None
+        }
+    },
+    "daterange_selected": {
+        "start_date": "2024-01-01",
+        "end_date": "2024-12-31",
+        "years": None,
+        "period": "2024-01-01 to 2024-12-31",
+        "original_text": "2024-01-01 to 2024-12-31"
+    }
+}
+```
+
+### Frontend UI Components
+
+The Streamlit frontend now includes UI selection components that work in conjunction with the chat interface:
+
+1. **AOI Dropdown**: Pre-defined areas of interest (e.g., "Koraput" district)
+2. **Dataset Dropdown**: Pre-configured datasets (e.g., "Tree Cover Loss", "DIST_ALERT")
+3. **Date Range Picker**: Interactive date selection with start/end date inputs
+
+When users make selections via these UI components, the selections are automatically passed to the chat API via the `ui_context` parameter. This enables a seamless hybrid experience where users can:
+- Pre-select data via UI and then ask natural language questions
+- Override UI selections with natural language ("actually, show me data for Brazil instead")
+- Mix UI selections and natural language queries in the same conversation
+
+The UI selections are acknowledged once per conversation to avoid repetitive confirmations.
+
 ## Type of updates
 
 We have two main types of updates: AI messages and tool updates. Both are state updates, they are not different from that perspective. However, AI messages operate only on the "messages" list in the state (appending new messages), while the tool updates add to "messages" but also update other state varaibles such as aoi, chart data, dataset picked, etc.

--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -2,7 +2,6 @@ import contextlib
 import os
 from datetime import datetime
 
-from langchain_anthropic import ChatAnthropic
 from langgraph.checkpoint.postgres import PostgresSaver
 from langgraph.prebuilt import create_react_agent
 
@@ -15,7 +14,7 @@ from src.tools import (
 )
 from src.utils.llms import SONNET
 
-prompt = f"""You are a geospatial agent that has access to tools to help answer user queries. Plan your actions carefully and use the tools to answer the user's question.
+prompt = f"""You are a geospatial agent that has access to tools and user provided selections to help answer user queries. Plan your actions carefully and use the tools to answer the user's question.
 
 Tools:
 - pick-aoi: Pick the best area of interest (AOI) based on a place name and user's question.
@@ -26,6 +25,12 @@ Tools:
 Workflow:
 1. Use pick-aoi, pick-dataset, and pull-data to get the data
 2. Use generate-insights to analyze the data and create 1-2 compelling visualizations.
+
+When you see UI action messages:
+1. Acknowledge the user's selection: "I see you've selected [item name]"
+2. Check if you have all needed components (AOI + dataset) before proceeding
+3. Use tools only for missing components
+4. If user asks to change selections, override UI selections
 
 Notes: 
 - If the dataset is not available or you are not able to pull data, politely inform the user & STOP - don't do any more steps further. 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -46,6 +46,16 @@ langfuse_handler = CallbackHandler()
 class ChatRequest(BaseModel):
     query: str = Field(..., description="The query")
     user_persona: Optional[str] = Field(None, description="The user persona")
+
+    # UI Context - can include multiple selections
+    ui_context: Optional[dict] = (
+        None  # {"aoi_selected": {...}, "dataset_selected": {...}, "daterange_selected": {...}}
+    )
+
+    # Pure UI actions - no query
+    ui_action_only: Optional[bool] = False
+
+    # Chat info
     thread_id: Optional[str] = Field(None, description="The thread ID")
     metadata: Optional[dict] = Field(None, description="The metadata")
     session_id: Optional[str] = Field(None, description="The session ID")
@@ -81,6 +91,8 @@ def replay_chat(thread_id):
 def stream_chat(
     query: str,
     user_persona: Optional[str] = None,
+    ui_context: Optional[dict] = None,
+    ui_action_only: Optional[bool] = False,
     thread_id: Optional[str] = None,
     metadata: Optional[Dict] = None,
     session_id: Optional[str] = None,
@@ -103,14 +115,57 @@ def stream_chat(
         },
         "callbacks": [langfuse_handler],
     }
-    messages = [HumanMessage(content=query)]
+
+    messages = []
+    ui_action_message = []
+    state_updates = {}
+    import pdb
+
+    pdb.set_trace()
+
+    if ui_context:
+        for action_type, action_data in ui_context.items():
+            match action_type:
+                case "aoi_selected":
+                    content = (
+                        f"User selected AOI in UI: {action_data['aoi_name']}"
+                    )
+                    state_updates["aoi"] = action_data["aoi"]
+                    state_updates["aoi_name"] = action_data["aoi_name"]
+                    state_updates["subregion_aois"] = action_data[
+                        "subregion_aois"
+                    ]
+                    state_updates["subregion"] = action_data["subregion"]
+                    state_updates["subtype"] = action_data["subtype"]
+                case "dataset_selected":
+                    content = f"User selected dataset in UI: {action_data['dataset']['data_layer']}"
+                    state_updates["dataset"] = action_data["dataset"]
+                case "daterange_selected":
+                    content = f"User selected daterange in UI: start_date:  {action_data['start_date']}, end_date: {action_data['end_date']}"
+                    # state_updates["daterange"] = action_data["daterange"]
+                case _:
+                    content = f"User performed action in UI: {action_type}"
+            ui_action_message.append(content)
+
+    ui_message = HumanMessage(content="\n".join(ui_action_message))
+    messages.append(ui_message)
+
+    if not ui_action_only and query:
+        messages.append(HumanMessage(content=query))
+    else:
+        # UI action only, no query, agent should acknowledge the UI updates & ask what's next
+        messages.append(
+            HumanMessage(
+                content="User performed UI action only. Acknowledge the updates and ask what they would like to do next with their selections."
+            )
+        )
 
     try:
+        state_updates["messages"] = messages
+        state_updates["user_persona"] = user_persona
+
         stream = zeno.stream(
-            {
-                "messages": messages,
-                "user_persona": user_persona,
-            },
+            state_updates,
             config=config,
             stream_mode="updates",
             subgraphs=False,
@@ -166,7 +221,7 @@ def fetch_user_from_rw_api(
         raise HTTPException(status_code=resp.status_code, detail=resp.text)
 
     user_info = resp.json()
-    if not "name" in user_info:
+    if "name" not in user_info:
         logger.warning(
             "User info does not contain 'name' field, using email account name as fallback"
         )
@@ -231,6 +286,8 @@ async def chat(request: ChatRequest, user: UserModel = Depends(fetch_user)):
             stream_chat(
                 query=request.query,
                 user_persona=request.user_persona,
+                ui_context=request.ui_context,
+                ui_action_only=request.ui_action_only,
                 thread_id=request.thread_id,
                 metadata=request.metadata,
                 session_id=request.session_id,

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -119,9 +119,6 @@ def stream_chat(
     messages = []
     ui_action_message = []
     state_updates = {}
-    import pdb
-
-    pdb.set_trace()
 
     if ui_context:
         for action_type, action_data in ui_context.items():


### PR DESCRIPTION
Add initial support for direct UI selection of AOI and datasets, bypassing agent tool calls for user-selected items.

**Changes**
Frontend: Add dropdown selectors for AOI (Odisha & Koraput) and datasets (Tree Cover Loss, DIST-ALERT) with date range picker
API: Extended ChatRequest with ui_context field to pass UI selections to agent state
Agent Integration: Modified stream_chat() to inject UI selections directly into agent state, skipping tool execution for pre-selected items

**Current Limitations**
Only supports 2 hardcoded AOI (Odisha, Koraput) and 2 datasets (Tree Cover Loss & DIST-ALERTS)
Need to expand to full AOI/dataset catalog

**Next Steps**
~- [ ] Connect to actual AOI database for full location support~
~- [ ] Integrate complete dataset catalog~
~- [ ] Integrate DateRange Selection~
~- [ ] Add validation and error handling~

Update: Merge this now, will be adding support for daterange & support complete AOIs/datasets in separate PRs.

This enables users to make selections via UI (fallback) instead of natural language, improving UX for known selections while maintaining conversational flow for complex queries.

cc @batpad @kamicut @oliverroick @yellowcap 