### PR TITLE
Add langfuse trace ID to streaming response

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -116,8 +116,21 @@ The chat API returns a streaming response with `application/x-ndjson` media type
 }
 ```
 
-- `node`: Can be "agent", "tools", or "error"
+- `node`: Can be "agent", "tools", "trace_info", or "error"
 - `update`: JSON-serialized string containing the state update data
+
+### Trace Information
+
+At the end of each conversation, a `trace_info` node is sent containing the Langfuse trace ID:
+
+```json
+{
+    "node": "trace_info",
+    "update": "{\"trace_id\": \"langfuse-trace-id\"}"
+}
+```
+
+This trace ID can be used for feedback collection and conversation analytics.
 
 ### Error Handling
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -252,6 +252,16 @@ def stream_chat(
                 )
                 # Continue processing other updates if possible
                 continue
+        
+        # Send trace ID after stream completes
+        trace_id = getattr(langfuse_handler, 'last_trace_id', None)
+        if trace_id:
+            yield pack(
+                {
+                    "node": "trace_info",
+                    "update": dumps({"trace_id": trace_id}),
+                }
+            )
 
     except Exception as e:
         logger.exception("Error during chat streaming: %s", e)

--- a/src/frontend/pages/1_🦎_Uni_Guana.py
+++ b/src/frontend/pages/1_🦎_Uni_Guana.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from datetime import datetime
 
@@ -116,5 +117,12 @@ if user_input := st.chat_input(
             ui_context=ui_context,
             thread_id=st.session_state.session_id,
         ):
-
+            # Handle trace_info node to capture trace ID
+            if stream.get("node") == "trace_info":
+                update = json.loads(stream["update"])
+                if "trace_id" in update:
+                    st.session_state.current_trace_id = update["trace_id"]
+                    st.success(f"🔍 Trace ID: {update['trace_id']}")
+                continue
+            
             render_stream(stream)

--- a/src/frontend/utils.py
+++ b/src/frontend/utils.py
@@ -451,6 +451,8 @@ def render_stream(stream):
         charts_data = update["charts_data"]
         render_charts(charts_data)
 
+
+
     with st.expander("State Updates"):
         for key, value in update.items():
             if key == "messages" or key == "aoi":


### PR DESCRIPTION
Addresses #236 (partially)

Send trace ID at end of chat stream for feedback integration:
- Frontend captures and displays trace ID
- Updated API documentation

This enables future thumbs up/down feedback functionality by making trace IDs available to the frontend.

cc @kamicut @LanesGood @geohacker 