### PR TITLE
Set upadate node_type based on message type of messages in update

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -142,7 +142,15 @@ def replay_chat(thread_id):
 
                 update[key] = value
 
-            yield pack({"node": "agent", "update": dumps(update)})
+            mtypes = set(m.type for m in update["messages"])
+
+            node_type = (
+                "agent"
+                if mtypes == {"ai"} or len(mtypes) > 1
+                else "tools" if mtypes == {"tool"} else "human"
+            )
+
+            yield pack({"node": node_type, "update": dumps(update)})
 
     except Exception as e:
         logger.exception("Error during chat replay: %s", e)

--- a/src/frontend/utils.py
+++ b/src/frontend/utils.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import json
 import altair as alt
-import datetime
+from datetime import datetime
 import folium
 import pandas as pd
 from shapely.geometry import shape


### PR DESCRIPTION
I noticed that all message appear to have the same type for any single checkpoint. Since we yield one update per checkpoint, we can set the `node_type` for that update based on the message type from the messages in the update. 

If message type == "tool" , `node_type` is set to `tools`
If message type == "human", `node_type` is set to `human`
if message type == "ai" or there are more than 1 message types in the messages, `node_type` is set to `agent`