### PR TITLE
fix some issues with config handling, tests and add tests for anonymo…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "elevenlabs>=1.50.5",
     "cachetools>=5.5.2",
     "pydantic>=2",
+    "pydantic-settings>=2.6.0",
     "alembic>=1.15.2",
     "sqlalchemy>=2.0.35",
     "pypgstac>=0.9.6",

--- a/tests/api/test_anonymous_users.py
+++ b/tests/api/test_anonymous_users.py
@@ -1,0 +1,98 @@
+"""Tests for anonymous user access and quota enforcement."""
+import pytest
+from unittest.mock import patch
+from src.utils.config import APISettings
+
+
+@pytest.fixture
+def anonymous_client(client):
+    """Client without authentication headers."""
+    return client
+
+
+class TestAnonymousUserAccess:
+    """Test anonymous user access to various endpoints."""
+    
+    def test_anonymous_user_can_access_chat_endpoint(self, anonymous_client):
+        """Test that anonymous users can access the /api/chat endpoint."""
+        chat_request = {
+            "query": "Hello, world!",
+            "thread_id": "test-thread-123"
+        }
+        
+        # Mock the stream_chat function to avoid actual LLM calls
+        with patch('src.api.app.stream_chat') as mock_stream:
+            mock_stream.return_value = iter([b'{"response": "Hello!"}\\n'])
+            
+            response = anonymous_client.post("/api/chat", json=chat_request)
+            
+            # Should succeed for anonymous users
+            assert response.status_code == 200
+            assert response.headers["content-type"] == "application/x-ndjson"
+
+    def test_anonymous_user_cannot_access_protected_endpoints(self, anonymous_client):
+        """Test that anonymous users cannot access protected endpoints."""
+        protected_endpoints = [
+            ("/api/auth/me", "GET"),
+            ("/api/threads", "GET"), 
+            ("/api/custom_areas/", "GET"),
+            ("/api/custom_areas/", "POST")
+        ]
+        
+        for endpoint, method in protected_endpoints:
+            if method == "GET":
+                response = anonymous_client.get(endpoint)
+            elif method == "POST":
+                response = anonymous_client.post(endpoint, json={})
+            
+            # Should return 422 (validation error) for missing auth
+            assert response.status_code == 422
+            assert "Authorization header is required" in response.json()["detail"]
+
+    def test_quota_disabled_allows_chat_access(self, anonymous_client):
+        """Test that disabling quotas allows unlimited chat access."""
+        # Disable quota checking
+        original_setting = APISettings.enable_quota_checking
+        APISettings.enable_quota_checking = False
+        
+        try:
+            chat_request = {
+                "query": "Test message",
+                "thread_id": "test-thread-123"
+            }
+            
+            with patch('src.api.app.stream_chat') as mock_stream:
+                mock_stream.return_value = iter([b'{"response": "OK"}\\n'])
+                
+                response = anonymous_client.post("/api/chat", json=chat_request)
+                
+                assert response.status_code == 200                
+        finally:
+            APISettings.enable_quota_checking = original_setting
+
+    def test_anonymous_thread_continuity_via_thread_id(self, anonymous_client):
+        """Test that anonymous users can maintain conversation continuity via thread_id."""
+        thread_id = "continuous-thread-456"
+        
+        with patch('src.api.app.stream_chat') as mock_stream:
+            mock_stream.return_value = iter([b'{"response": "OK"}\\n'])
+            
+            # First message
+            response1 = anonymous_client.post("/api/chat", json={
+                "query": "First message",
+                "thread_id": thread_id
+            })
+            assert response1.status_code == 200
+            
+            # Second message with same thread_id
+            response2 = anonymous_client.post("/api/chat", json={
+                "query": "Second message", 
+                "thread_id": thread_id
+            })
+            assert response2.status_code == 200
+            
+            # Verify stream_chat was called with correct thread_id both times
+            calls = mock_stream.call_args_list
+            assert len(calls) == 2
+            assert calls[0][1]['thread_id'] == thread_id
+            assert calls[1][1]['thread_id'] == thread_id

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -14,16 +14,11 @@ from .mock import mock_rw_api_response
 def domain_allowlist(domains: str):
     """Context manager to set and reset DOMAINS_ALLOWLIST."""
     domain_list = domains.split(",")
-    original = os.environ.get("DOMAINS_ALLOWLIST")
-    os.environ["DOMAINS_ALLOWLIST"] = ",".join(domain_list)
     try:
-        with patch.object(api, "DOMAINS_ALLOWLIST", domain_list):
+        with patch.object(api.APISettings, "domains_allowlist_str", domains):
             yield domain_list
     finally:
-        if original is not None:
-            os.environ["DOMAINS_ALLOWLIST"] = original
-        else:
-            del os.environ["DOMAINS_ALLOWLIST"]
+        pass
 
 
 @pytest.fixture(autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -3726,6 +3725,7 @@ dependencies = [
     { name = "psycopg-pool" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pylate" },
     { name = "pypgstac" },
     { name = "pystac" },
@@ -3788,6 +3788,7 @@ requires-dist = [
     { name = "psycopg-pool", specifier = ">=3.2.6" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pydantic", specifier = ">=2" },
+    { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "pylate", specifier = ">=1.2.0" },
     { name = "pypgstac", specifier = ">=0.9.6" },
     { name = "pystac", specifier = ">=1.11.0" },


### PR DESCRIPTION
This fixes some issues with the `feature/usage-tracking` PR that were causing tests to fail, and tries to make a bit clearer the distinction between endpoints that require auth and where auth is optional (anon users can access).

 - Fix some issues with the typing of domains_allowlist and handling in the new config.py setup
 - Separate out `require_auth` and `optional_auth` clearly, fixes small bugs where some code paths that could be hit by anonymous users were trying to access `user.id` etc.
 - Ensure the existing `test_auth.py` tests all pass
 - Add additional tests for anonymous user access

@leothomas Could you review and if it looks good, we can merge into your `feature/usage-tracking` branch and then get that merged in?

cc @willemarcel 
