### PR TITLE
Add migration to remove unique key constraint on daily usage table

### DIFF
--- a/db/alembic/versions/d1d3e7357b26_remove_unique_key_constraint_on_daily_usage.py
+++ b/db/alembic/versions/d1d3e7357b26_remove_unique_key_constraint_on_daily_usage.py
@@ -17,8 +17,25 @@ depends_on = None
 
 
 def upgrade():
-    # Drop the unique constraint on 'id' column
-    op.drop_constraint("daily_usage_id_key", "daily_usage", type_="unique")
+    # Drop the unique constraint on 'id' column if it exists
+    # op.drop_constraint("daily_usage_id_key", "daily_usage", type_="unique")
+
+    op.execute(
+        """
+    DO $$
+    BEGIN
+        IF EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conname = 'daily_usage_id_key'
+              AND conrelid = 'daily_usage'::regclass
+        ) THEN
+            ALTER TABLE daily_usage DROP CONSTRAINT daily_usage_id_key;
+        END IF;
+    END
+    $$;
+    """
+    )
 
 
 def downgrade():

--- a/db/alembic/versions/d1d3e7357b26_remove_unique_key_constraint_on_daily_usage.py
+++ b/db/alembic/versions/d1d3e7357b26_remove_unique_key_constraint_on_daily_usage.py
@@ -1,0 +1,26 @@
+"""Remove unique constraint on id column from daily_usage table
+
+Revision ID: d1d3e7357b26
+Revises: 14bd7b5fb4a1
+Create Date: 2025-07-30 09:34:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "d1d3e7357b26"
+down_revision = "14bd7b5fb4a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop the unique constraint on 'id' column
+    op.drop_constraint("daily_usage_id_key", "daily_usage", type_="unique")
+
+
+def downgrade():
+    # Recreate the unique constraint on 'id' column
+    op.create_unique_constraint("daily_usage_id_key", "daily_usage", ["id"])

--- a/db/alembic/versions/d1d3e7357b26_remove_unique_key_constraint_on_daily_usage.py
+++ b/db/alembic/versions/d1d3e7357b26_remove_unique_key_constraint_on_daily_usage.py
@@ -18,7 +18,6 @@ depends_on = None
 
 def upgrade():
     # Drop the unique constraint on 'id' column if it exists
-    # op.drop_constraint("daily_usage_id_key", "daily_usage", type_="unique")
 
     op.execute(
         """


### PR DESCRIPTION
The daily usage table uses a composite primary key: `user_id + date`. 

Since these two fields are defined a composite primary key, uniqueness of their combination will be automatically enforced. There is currently an uniqueness constrain on `user_id` which blocks new values being added, whereas we write a new record per user/date, so I'm removing the `user_id` uniqueness constraint