### PR TITLE
no need to migrate test db

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -51,18 +51,3 @@ services:
       - APP_DB=zeno-data
     volumes:
       - ./db:/app/db
-
-  migrate-test:
-    build:
-      context: ./db
-    depends_on:
-      test-db:
-        condition: service_healthy
-
-    environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_HOST=db
-      - APP_DB=zeno-data_test
-    volumes:
-      - ./db:/app/db


### PR DESCRIPTION
Remove migrate-test service from docker-compose because the tests creates fresh tables. cc @batpad 