### PR TITLE
Fix user validation error on missing name field

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -442,17 +442,18 @@ def fetch_user_from_rw_api(
         )
     if resp.status_code != 200:
         raise HTTPException(status_code=resp.status_code, detail=resp.text)
-
+    
     user_info = resp.json()
-    # cache user info
-    _user_info_cache[token] = UserModel.model_validate(user_info)
-
+    
     if "name" not in user_info:
         logger.warning(
             "User info does not contain the 'name' field, using email account name as fallback",
             email=user_info.get("email", None),
         )
         user_info["name"] = user_info["email"].split("@")[0]
+    
+    # cache user info
+    _user_info_cache[token] = UserModel.model_validate(user_info)
 
     domains_allowlist = APISettings.domains_allowlist
 


### PR DESCRIPTION
This PR fixes a `pydantic.ValidationError` that occurs during user authentication when the user data from the Resource Watch API is missing the name field.

The fix ensures the name field is populated with a fallback value (the email prefix) before the `UserModel` is validated, preventing the API from crashing on login for affected accounts.

cc @geohacker 