### PR TITLE
use q.first instead of scalar.first while querying geometry

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -821,7 +821,7 @@ async def get_geometry(
 
     try:
         q = await session.execute(text(sql_query), {"src_id": src_id})
-        result = q.scalars().fetchone()
+        result = q.first()
 
         if not result:
             raise HTTPException(


### PR DESCRIPTION
q.scalars() is useful if we expect multiple results but in this case, we are quering a single id. So a q.first is enough.

cc @batpad @sunu 