### PR TITLE
Fix bug for gadm levels above 1

### DIFF
--- a/tests/tools/test_agent.py
+++ b/tests/tools/test_agent.py
@@ -1,5 +1,4 @@
 import uuid
-import asyncio
 
 import pytest
 
@@ -103,4 +102,21 @@ async def test_full_agent_for_datasets(dataset):
             has_raw_data = True
 
     assert has_insights
+    assert has_raw_data
+
+
+@pytest.mark.asyncio
+async def test_full_agent_for_disturbance_alerts_in_brazil():
+    query = "What is the distribution of disturbance alerts in Belem, Pará, Brazil July 2024?"
+    steps = await run_agent(query)
+
+    assert len(steps) > 0
+
+    has_raw_data = False
+
+    for tool_step in [dat["tools"] for dat in steps if "tools" in dat]:
+        if "raw_data" in tool_step:
+            if len(tool_step["raw_data"]["value"]) > 0:
+                has_raw_data = True
+
     assert has_raw_data


### PR DESCRIPTION
Fix bug in pull data when gadm ids of higher levels are requested.

The `_2` (or higher) part of the ID was not stripped off, we were only checking for `_1`