### PR TITLE
Fix/anonymous cookie key

### DIFF
--- a/client.py
+++ b/client.py
@@ -125,6 +125,18 @@ class ZenoClient:
                 )
             return response.json()
 
+    def get_quota_info(self):
+        url = f"{self.base_url}/api/quota"
+        headers = (
+            {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        )
+        with requests.get(url, headers=headers) as response:
+            if response.status_code != 200:
+                raise Exception(
+                    f"Request for quota information failed with status code {response.status_code}: {response.text}"
+                )
+            return response.json()
+
     def chat(
         self,
         query: str,

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -576,7 +576,7 @@ async def check_quota(
     # 1. Get calling user and set quota
     if not user:
         daily_quota = APISettings.anonymous_user_daily_quota
-        if anon := request.cookies.get("anon_id"):
+        if anon := request.cookies.get("anonymous_id"):
             identity = f"anon:{anon}"
         else:
             identity = f"anon:{request.state.anonymous_id}"

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -44,6 +44,7 @@ from src.api.schemas import (
     CustomAreaModel,
     CustomAreaNameRequest,
     GeometryResponse,
+    QuotaModel,
     RatingCreateRequest,
     RatingModel,
     ThreadModel,
@@ -673,7 +674,7 @@ async def generate_thread_name(query: str) -> str:
         return "Unnamed Thread"  # Fallback to default name
 
 
-@app.get("/api/quota")
+@app.get("/api/quota", response_model=QuotaModel)
 async def get_quota(
     quota_info: Dict = Depends(check_quota),
 ):

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -169,6 +169,14 @@ signer = TimestampSigner(os.environ["COOKIE_SIGNER_SECRET_KEY"])
 
 @app.middleware("http")
 async def anonymous_id_middleware(request: Request, call_next):
+    # Check auth headers if user is logged in, and if
+    # so proceed to the request without generating an
+    # anonymous user session cookie
+    auth = await security(request)
+    if auth and auth.scheme.lower() == "bearer" and auth.credentials:
+        response: Response = await call_next(request)
+        return response
+
     anon_cookie = request.cookies.get("anonymous_id")
     need_new = True
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -178,6 +178,7 @@ async def anonymous_id_middleware(request: Request, call_next):
         return response
 
     anon_cookie = request.cookies.get("anonymous_id")
+
     need_new = True
 
     if anon_cookie:
@@ -573,14 +574,10 @@ async def fetch_user(
     return await optional_auth(user_info, session)
 
 
-async def check_quota(
+async def get_user_identity_and_daily_quota(
     request: Request,
     user: Optional[UserModel] = Depends(fetch_user_from_rw_api),
-    session: AsyncSession = Depends(get_async_session),
 ):
-    if not APISettings.enable_quota_checking:
-        return {}
-
     # 1. Get calling user and set quota
     if not user:
         daily_quota = APISettings.anonymous_user_daily_quota
@@ -596,13 +593,44 @@ async def check_quota(
             else APISettings.regular_user_daily_quota
         )
         identity = f"user:{user.id}"
+    return {"identity": identity, "prompt_quota": daily_quota}
+
+
+async def check_quota(
+    identity_and_quota: Dict = Depends(get_user_identity_and_daily_quota),
+    session: AsyncSession = Depends(get_async_session),
+):
+    if not APISettings.enable_quota_checking:
+        return {}
+
+    today = date.today()
+
+    stmt = select(DailyUsageOrm).filter_by(
+        id=identity_and_quota["identity"], date=today
+    )
+    result = await session.execute(stmt)
+    daily_usage = result.scalars().first()
+
+    # TODO: is the conditional check necessary here?
+    identity_and_quota["prompts_used"] = (
+        daily_usage.usage_count if daily_usage else 0
+    )
+    return identity_and_quota
+
+
+async def enforce_quota(
+    identity_and_quota: Dict = Depends(get_user_identity_and_daily_quota),
+    session: AsyncSession = Depends(get_async_session),
+):
+    if not APISettings.enable_quota_checking:
+        return {}
 
     today = date.today()
 
     # 2. Atomically "insert or increment" with ON CONFLICT
     stmt = (
         insert(DailyUsageOrm)
-        .values(id=identity, date=today, usage_count=1)
+        .values(id=identity_and_quota["identity"], date=today, usage_count=1)
         # Composite PK = (id, date)
         .on_conflict_do_update(
             index_elements=["id", "date"],
@@ -615,13 +643,15 @@ async def check_quota(
     await session.commit()  # commit the upsert
 
     # 3. Enforce the quota
-    if count > daily_quota:
+    if count > identity_and_quota["prompt_quota"]:
         raise HTTPException(
             status_code=429,
-            detail=f"Daily free limit of {daily_quota} exceeded; please try again tomorrow.",
+            detail=f"Daily free limit of {identity_and_quota['prompt_quota']} exceeded; please try again tomorrow.",
         )
 
-    return {"prompts_used": count, "prompt_quota": daily_quota}
+    identity_and_quota["prompts_used"] = count
+
+    return identity_and_quota
 
 
 async def generate_thread_name(query: str) -> str:
@@ -644,7 +674,9 @@ async def generate_thread_name(query: str) -> str:
 
 
 @app.get("/api/quota")
-async def get_quota(quota_info: dict = Depends(check_quota)):
+async def get_quota(
+    quota_info: Dict = Depends(check_quota),
+):
     return quota_info
 
 
@@ -652,7 +684,7 @@ async def get_quota(quota_info: dict = Depends(check_quota)):
 async def chat(
     request: ChatRequest,
     user: Optional[UserModel] = Depends(optional_auth),
-    quota_info: dict = Depends(check_quota),
+    quota_info: dict = Depends(enforce_quota),
     session: AsyncSession = Depends(get_async_session),
 ):
     """

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -644,10 +644,7 @@ async def generate_thread_name(query: str) -> str:
 
 
 @app.get("/api/quota")
-async def get_quota(
-    user: UserModel = Depends(require_auth),
-    quota_info: dict = Depends(check_quota),
-):
+async def get_quota(quota_info: dict = Depends(check_quota)):
     return quota_info
 
 

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -58,8 +58,8 @@ class UserModel(BaseModel):
         return value
 
 
-class UserWithQuotaModel(UserModel):
-    """User model with quota information."""
+class QuotaModel(BaseModel):
+    """Quota information"""
 
     model_config = ConfigDict(
         alias_generator=alias_generators.to_camel,
@@ -72,6 +72,20 @@ class UserWithQuotaModel(UserModel):
     prompt_quota: Optional[int] = Field(
         None, description="Prompt quota for the user"
     )
+
+
+class UserWithQuotaModel(UserModel, QuotaModel):
+    """User model with quota information."""
+
+    # model_config = ConfigDict(
+    #     alias_generator=alias_generators.to_camel,
+    #     from_attributes=True,
+    #     populate_by_name=True,
+    # )
+    # prompts_used: Optional[int] = Field(
+    #     None, description="Number of prompts used today"
+    # )
+    # prompt_quota: Optional[int] = Field(None, description="Prompt quota for the user")
 
 
 class GeometryResponse(BaseModel):

--- a/src/frontend/pages/1_🦎_Uni_Guana.py
+++ b/src/frontend/pages/1_🦎_Uni_Guana.py
@@ -85,7 +85,13 @@ for message in st.session_state.messages:
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
 
-if user_input := st.chat_input("Type your message here..."):
+client = ZenoClient(base_url=API_BASE_URL, token=st.session_state.token)
+quota_info = client.get_quota_info()
+remaining_prompts = quota_info["prompt_quota"] - quota_info["prompts_used"]
+
+if user_input := st.chat_input(
+    f"Type your message here... (remaining prompts: {remaining_prompts})"
+):
     ui_context = {}
 
     if selected_aoi and not st.session_state.get("aoi_acknowledged"):
@@ -105,9 +111,6 @@ if user_input := st.chat_input("Type your message here..."):
         st.markdown(user_input)
 
     with st.chat_message("assistant"):
-        client = ZenoClient(
-            base_url=API_BASE_URL, token=st.session_state.token
-        )
         for stream in client.chat(
             query=user_input,
             user_persona="Researcher",


### PR DESCRIPTION
The PR: 
- Updates the key under which the session cookie is stored for anonymous users
- Separates quota _checking_ and quota _enforcing_ into two separate dependencies so that checking the quota outside of a chat request won't increment the usage
- Enables quota checking for anonymous users (previously quota checking relied on the get_user dependency)