### PR TITLE
add endpoint to GET ratings for a thread

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1195,7 +1195,7 @@ async def get_thread_ratings(
     **Response**: Returns an array of ratings with metadata
 
     **Error Responses**:
-    - 401: Missing or invalid authentication  
+    - 401: Missing or invalid authentication
     - 404: Thread not found or access denied
     """
     # Verify if the thread exists and belongs to the user
@@ -1208,9 +1208,11 @@ async def get_thread_ratings(
         )
 
     # Get all ratings for this thread by the user
-    stmt = select(RatingOrm).filter_by(
-        user_id=user.id, thread_id=thread_id
-    ).order_by(RatingOrm.created_at)
+    stmt = (
+        select(RatingOrm)
+        .filter_by(user_id=user.id, thread_id=thread_id)
+        .order_by(RatingOrm.created_at)
+    )
     result = await session.execute(stmt)
     ratings = result.scalars().all()
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1170,6 +1170,60 @@ async def create_or_update_rating(
         return RatingModel.model_validate(new_rating)
 
 
+@app.get("/api/threads/{thread_id}/rating", response_model=list[RatingModel])
+async def get_thread_ratings(
+    thread_id: str,
+    user: UserModel = Depends(require_auth),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """
+    Get all ratings for traces in a thread.
+
+    This endpoint allows authenticated users to retrieve all ratings they have
+    provided for traces within a specific conversation thread.
+
+    **Authentication**: Requires Bearer token in Authorization header.
+
+    **Path Parameters**:
+    - thread_id (str): The unique identifier of the thread
+
+    **Behavior**:
+    - Returns all ratings created by the authenticated user for the specified thread
+    - Returns empty array if no ratings exist for the thread
+    - The thread must exist and belong to the authenticated user
+
+    **Response**: Returns an array of ratings with metadata
+
+    **Error Responses**:
+    - 401: Missing or invalid authentication  
+    - 404: Thread not found or access denied
+    """
+    # Verify if the thread exists and belongs to the user
+    stmt = select(ThreadOrm).filter_by(id=thread_id, user_id=user.id)
+    result = await session.execute(stmt)
+    thread = result.scalars().first()
+    if not thread:
+        raise HTTPException(
+            status_code=404, detail="Thread not found or access denied"
+        )
+
+    # Get all ratings for this thread by the user
+    stmt = select(RatingOrm).filter_by(
+        user_id=user.id, thread_id=thread_id
+    ).order_by(RatingOrm.created_at)
+    result = await session.execute(stmt)
+    ratings = result.scalars().all()
+
+    logger.info(
+        "Thread ratings retrieved",
+        user_id=user.id,
+        thread_id=thread_id,
+        count=len(ratings),
+    )
+
+    return [RatingModel.model_validate(rating) for rating in ratings]
+
+
 @app.get("/api/auth/me", response_model=UserWithQuotaModel)
 async def auth_me(
     user: UserModel = Depends(require_auth),

--- a/tests/api/test_ratings.py
+++ b/tests/api/test_ratings.py
@@ -305,7 +305,7 @@ async def test_get_thread_ratings_nonexistent_thread(
 ):
     """Test getting ratings for a thread that doesn't exist."""
     auth_override("test-user-wri")
-    
+
     response = await client.get(
         "/api/threads/nonexistent-thread/rating",
         headers={"Authorization": "Bearer test-user-wri-token"},
@@ -416,4 +416,6 @@ async def test_full_flow_create_and_get_ratings(
     assert final_ratings[0]["trace_id"] == "test-trace-flow"
     assert final_ratings[0]["rating"] == -1
     assert final_ratings[0]["comment"] == "Updated rating"
-    assert final_ratings[0]["id"] == created_rating["id"]  # Same ID (updated, not created new)
+    assert (
+        final_ratings[0]["id"] == created_rating["id"]
+    )  # Same ID (updated, not created new)

--- a/tests/api/test_ratings.py
+++ b/tests/api/test_ratings.py
@@ -224,3 +224,196 @@ async def test_create_update_rating_with_comment(
     assert response.status_code == 200
     data = response.json()
     assert data["comment"] == "Updated comment"
+
+
+@pytest.mark.asyncio
+async def test_get_thread_ratings_empty(
+    thread_factory, user: UserOrm, client: AsyncClient, auth_override
+):
+    """Test getting ratings for a thread with no ratings."""
+    thread = await thread_factory(user.id)
+    auth_override(user.id)
+
+    response = await client.get(
+        f"/api/threads/{thread.id}/rating",
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == []
+
+
+@pytest.mark.asyncio
+async def test_get_thread_ratings_with_ratings(
+    thread_factory, user: UserOrm, client: AsyncClient, auth_override
+):
+    """Test getting ratings for a thread that has ratings."""
+    thread = await thread_factory(user.id)
+    auth_override(user.id)
+
+    # Create multiple ratings for different traces in the thread
+    rating_data = [
+        {"trace_id": "trace-1", "rating": 1, "comment": "Good response"},
+        {"trace_id": "trace-2", "rating": -1, "comment": "Bad response"},
+        {"trace_id": "trace-3", "rating": 1},  # No comment
+    ]
+
+    created_ratings = []
+    for data in rating_data:
+        response = await client.post(
+            f"/api/threads/{thread.id}/rating",
+            json=data,
+            headers={"Authorization": "Bearer test-user-wri-token"},
+        )
+        assert response.status_code == 200
+        created_ratings.append(response.json())
+
+    # Get all ratings for the thread
+    response = await client.get(
+        f"/api/threads/{thread.id}/rating",
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+
+    # Verify all ratings are returned and ordered by created_at
+    trace_ids = [rating["trace_id"] for rating in data]
+    assert "trace-1" in trace_ids
+    assert "trace-2" in trace_ids
+    assert "trace-3" in trace_ids
+
+    # Check specific rating details
+    rating_1 = next(r for r in data if r["trace_id"] == "trace-1")
+    assert rating_1["rating"] == 1
+    assert rating_1["comment"] == "Good response"
+
+    rating_2 = next(r for r in data if r["trace_id"] == "trace-2")
+    assert rating_2["rating"] == -1
+    assert rating_2["comment"] == "Bad response"
+
+    rating_3 = next(r for r in data if r["trace_id"] == "trace-3")
+    assert rating_3["rating"] == 1
+    assert rating_3["comment"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_thread_ratings_nonexistent_thread(
+    client: AsyncClient, auth_override
+):
+    """Test getting ratings for a thread that doesn't exist."""
+    auth_override("test-user-wri")
+    
+    response = await client.get(
+        "/api/threads/nonexistent-thread/rating",
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+
+    assert response.status_code == 404
+    assert "Thread not found or access denied" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_thread_ratings_thread_belongs_to_other_user(
+    thread_factory,
+    user: UserOrm,
+    user_ds: UserOrm,
+    client: AsyncClient,
+    auth_override,
+):
+    """Test getting ratings for a thread that belongs to another user."""
+    thread = await thread_factory(user_ds.id)
+    auth_override(user.id)
+
+    response = await client.get(
+        f"/api/threads/{thread.id}/rating",
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+
+    assert response.status_code == 404
+    assert "Thread not found or access denied" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_get_thread_ratings_unauthorized(
+    user: UserOrm, thread_factory, client: AsyncClient
+):
+    """Test getting ratings without authorization."""
+    thread = await thread_factory(user.id)
+
+    response = await client.get(
+        f"/api/threads/{thread.id}/rating",
+        # No Authorization header
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_full_flow_create_and_get_ratings(
+    thread_factory, user: UserOrm, client: AsyncClient, auth_override
+):
+    """Test the full flow: create ratings then retrieve them."""
+    thread = await thread_factory(user.id)
+    auth_override(user.id)
+
+    # Initially, thread should have no ratings
+    response = await client.get(
+        f"/api/threads/{thread.id}/rating",
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+    # Create a rating
+    create_response = await client.post(
+        f"/api/threads/{thread.id}/rating",
+        json={
+            "trace_id": "test-trace-flow",
+            "rating": 1,
+            "comment": "Initial rating",
+        },
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+    assert create_response.status_code == 200
+    created_rating = create_response.json()
+
+    # Get ratings - should now have one rating
+    get_response = await client.get(
+        f"/api/threads/{thread.id}/rating",
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+    assert get_response.status_code == 200
+    ratings = get_response.json()
+    assert len(ratings) == 1
+    assert ratings[0]["trace_id"] == "test-trace-flow"
+    assert ratings[0]["rating"] == 1
+    assert ratings[0]["comment"] == "Initial rating"
+    assert ratings[0]["id"] == created_rating["id"]
+
+    # Update the rating
+    update_response = await client.post(
+        f"/api/threads/{thread.id}/rating",
+        json={
+            "trace_id": "test-trace-flow",
+            "rating": -1,
+            "comment": "Updated rating",
+        },
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+    assert update_response.status_code == 200
+
+    # Get ratings again - should still have one rating but updated
+    final_get_response = await client.get(
+        f"/api/threads/{thread.id}/rating",
+        headers={"Authorization": "Bearer test-user-wri-token"},
+    )
+    assert final_get_response.status_code == 200
+    final_ratings = final_get_response.json()
+    assert len(final_ratings) == 1
+    assert final_ratings[0]["trace_id"] == "test-trace-flow"
+    assert final_ratings[0]["rating"] == -1
+    assert final_ratings[0]["comment"] == "Updated rating"
+    assert final_ratings[0]["id"] == created_rating["id"]  # Same ID (updated, not created new)


### PR DESCRIPTION
We had endpoints to create and update ratings for traces in a thread but there was no way for the frontend to retrieve current ratings for a thread. This adds a GET endpoint - /api/threads/{thread_id}/rating to fetch all ratings for the existing thread.

This is fairly straightforward and there's tests that pass, so I'm going to go ahead and merge..
