### PR TITLE
Add GADM country disambiguation for exact name matches

### DIFF
--- a/src/frontend/pages/1_🦎_Uni_Guana.py
+++ b/src/frontend/pages/1_🦎_Uni_Guana.py
@@ -87,7 +87,7 @@ for message in st.session_state.messages:
 
 client = ZenoClient(base_url=API_BASE_URL, token=st.session_state.token)
 quota_info = client.get_quota_info()
-remaining_prompts = quota_info["prompt_quota"] - quota_info["prompts_used"]
+remaining_prompts = quota_info["promptQuota"] - quota_info["promptsUsed"]
 
 if user_input := st.chat_input(
     f"Type your message here... (remaining prompts: {remaining_prompts})"

--- a/src/tools/pick_aoi.py
+++ b/src/tools/pick_aoi.py
@@ -383,6 +383,64 @@ async def pick_aoi(
         name = selected_aoi.name
         subtype = selected_aoi.subtype
 
+        # Check if NAME of selected AOI is an exact match of any of the names in the results, then ask the user for clarification
+        short_name = name.split(",")[0]
+
+        # For GADM sources, check for exact name matches from different countries
+        if source == "gadm":
+            # Extract country code from selected AOI's src_id (e.g., "IND.12.26_1" -> "IND")
+            selected_country = src_id.split(".")[0] if "." in src_id else None
+
+            if selected_country:
+                # Filter results to only include AOIs from different countries
+                different_country_results = results[
+                    (results.source == "gadm")
+                    & (~results.src_id.str.startswith(selected_country + "."))
+                ]
+
+                # Find exact matches of the short name in different countries
+                exact_matches_different_countries = different_country_results[
+                    different_country_results.name.str.lower().str.startswith(
+                        short_name.lower()
+                    )
+                ]
+
+                # If we have exact matches from different countries, ask for clarification
+                if len(exact_matches_different_countries) > 0:
+                    # Include the selected AOI and the matches from other countries
+                    all_matches = results[
+                        (
+                            results.name.str.lower().str.startswith(
+                                short_name.lower()
+                            )
+                        )
+                        & (results.source == "gadm")
+                    ]
+
+                    candidate_names = all_matches[
+                        ["name", "subtype", "src_id"]
+                    ].to_dict(orient="records")
+                    candidate_names = "\n".join(
+                        [
+                            f"{candidate['name']} - ({candidate['subtype']}) [{candidate['src_id'].split('.')[0]}]"
+                            for candidate in candidate_names
+                        ]
+                    )
+                    return Command(
+                        update={
+                            "messages": [
+                                ToolMessage(
+                                    f"I found multiple locations named '{short_name}' in different countries. Please tell me which one you meant:\n\n{candidate_names}\n\nWhich location are you looking for?",
+                                    tool_call_id=tool_call_id,
+                                    status="success",
+                                    response_metadata={
+                                        "msg_type": "human_feedback"
+                                    },
+                                )
+                            ],
+                        },
+                    )
+
         # todo: this is redundant with the one in helpers.py, consider refactoring
         source_table_map = {
             "gadm": GADM_TABLE,


### PR DESCRIPTION
Addresses #301 

**Enhanced AOI selection**:
Added logic to detect when GADM locations with identical names exist across different countries
Example: When user searches for "Paris", if both "Paris, France" and "Paris, Texas" are found, the system now asks: "I found multiple locations named 'Paris' in different countries. Please tell me which one you meant: ..."

@leothomas `Streamlit Frontend fix`: Updated quota info field names from snake_case to camelCase (`promptQuota`, `promptsUsed`)

@kamicut this will impact FE (breaking change) - `pick-aoi` tool response can now return both an `aoi` update & request user feedback when exact matches are found across countries. Frontend needs to handle this new response pattern where disambiguation is required.
