### PR TITLE
remove trailing slash from custom_areas endpoints

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1295,7 +1295,7 @@ async def api_metadata() -> dict:
     }
 
 
-@app.post("/api/custom_areas/", response_model=CustomAreaModel)
+@app.post("/api/custom_areas", response_model=CustomAreaModel)
 async def create_custom_area(
     area: CustomAreaCreate,
     user: UserModel = Depends(require_auth),
@@ -1321,7 +1321,7 @@ async def create_custom_area(
     )
 
 
-@app.get("/api/custom_areas/", response_model=list[CustomAreaModel])
+@app.get("/api/custom_areas", response_model=list[CustomAreaModel])
 async def list_custom_areas(
     user: UserModel = Depends(require_auth),
     session: AsyncSession = Depends(get_async_session),


### PR DESCRIPTION
Related to #333 

Let's be consistent on the API and either require trailing slashes for endpoints or not. This removes the trailing slash from the `custom_areas` endpoints as none of the other endpoints require a trailing slash.

We should also fix #333, but for now let's merge this in to have consistency on the API layer.

cc @sunu @kamicut @srmsoumya - @srmsoumya is this API being called internally anywhere where we need to make sure it's being called without a trailing slash?

@kamicut we should modify the frontend to always strip trailing slash when making requests to the API.
