### PR TITLE
Fix created_at and updated_at timestamps on models

### DIFF
--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -32,8 +32,8 @@ class UserOrm(Base):
     id = Column(String, primary_key=True, unique=True, nullable=False)
     name = Column(String, nullable=False)
     email = Column(String, unique=True, nullable=False)
-    created_at = Column(DateTime, nullable=False, default=datetime.now())
-    updated_at = Column(DateTime, nullable=False, default=datetime.now())
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(DateTime, nullable=False, default=datetime.now)
     user_type = Column(String, nullable=False, default=UserType.REGULAR.value)
     threads = relationship("ThreadOrm", back_populates="user")
     custom_areas = relationship("CustomAreaOrm", back_populates="user")
@@ -46,12 +46,12 @@ class ThreadOrm(Base):
     id = Column(String, primary_key=True, unique=True, nullable=False)
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     agent_id = Column(String, nullable=False)
-    created_at = Column(DateTime, nullable=False, default=datetime.now())
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=datetime.now(),
-        onupdate=datetime.now(),
+        default=datetime.now,
+        onupdate=datetime.now,
     )
     name = Column(String, nullable=False, default="Unnamed Thread")
     is_public = Column(Boolean, nullable=False, default=False)
@@ -78,12 +78,12 @@ class RatingOrm(Base):
     trace_id = Column(String, nullable=False)
     rating = Column(Integer, nullable=False)
     comment = Column(String, nullable=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.now())
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=datetime.now(),
-        onupdate=datetime.now(),
+        default=datetime.now,
+        onupdate=datetime.now,
     )
     user = relationship(
         "UserOrm", back_populates="ratings", foreign_keys=[user_id]
@@ -112,12 +112,12 @@ class CustomAreaOrm(Base):
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     name = Column(String, nullable=False)
     geometries = Column(JSONB, nullable=False)
-    created_at = Column(DateTime, nullable=False, default=datetime.now())
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=datetime.now(),
-        onupdate=datetime.now(),
+        default=datetime.now,
+        onupdate=datetime.now,
     )
 
     user = relationship("UserOrm", back_populates="custom_areas")

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -33,7 +33,9 @@ class UserOrm(Base):
     name = Column(String, nullable=False)
     email = Column(String, unique=True, nullable=False)
     created_at = Column(DateTime, nullable=False, default=datetime.now)
-    updated_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(
+        DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
+    )
     user_type = Column(String, nullable=False, default=UserType.REGULAR.value)
     threads = relationship("ThreadOrm", back_populates="user")
     custom_areas = relationship("CustomAreaOrm", back_populates="user")

--- a/tests/api/test_threads.py
+++ b/tests/api/test_threads.py
@@ -1,6 +1,8 @@
 """Tests for thread-related endpoints and sharing functionality."""
 
+import asyncio
 import uuid
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -385,3 +387,63 @@ async def test_partial_update_preserves_other_fields(
     assert updated_thread["is_public"] is True
     assert updated_thread["name"] == original_name  # Name should be unchanged
     assert updated_thread["user_id"] == user_id  # Other fields unchanged
+
+
+@pytest.mark.asyncio
+async def test_thread_timestamps_behavior(client, auth_override, thread_factory):
+    """Test that created_at and updated_at timestamps behave correctly."""
+    user_id = "test-user-timestamps"
+    auth_override(user_id)
+
+    # Record time before creating thread
+    before_create = datetime.now()
+    
+    # Create a thread
+    thread = await thread_factory(user_id)
+    
+    # Record time after creating thread  
+    after_create = datetime.now()
+
+    # Verify created_at is set to approximately current time
+    created_at = datetime.fromisoformat(thread.created_at.isoformat())
+    updated_at = datetime.fromisoformat(thread.updated_at.isoformat())
+    
+    # created_at should be between before_create and after_create
+    assert before_create <= created_at <= after_create
+    
+    # Initially, created_at and updated_at should be the same (or very close)
+    time_diff = abs((updated_at - created_at).total_seconds())
+    assert time_diff < 1  # Should be within 1 second
+    
+    # Store original timestamps
+    original_created_at = created_at
+    original_updated_at = updated_at
+    
+    # Wait a small amount to ensure timestamp difference
+    await asyncio.sleep(0.1)
+    
+    # Update the thread via API
+    before_update = datetime.now()
+    response = await client.patch(
+        f"/api/threads/{thread.id}",
+        headers={"Authorization": "Bearer test-token"},
+        json={"name": "Updated Thread Name"}
+    )
+    after_update = datetime.now()
+    
+    assert response.status_code == 200
+    updated_thread_data = response.json()
+    
+    # Parse updated timestamps
+    new_created_at = datetime.fromisoformat(updated_thread_data["created_at"])
+    new_updated_at = datetime.fromisoformat(updated_thread_data["updated_at"])
+    
+    # created_at should NOT have changed
+    assert new_created_at == original_created_at
+    
+    # updated_at should have changed and be recent
+    assert new_updated_at != original_updated_at
+    assert before_update <= new_updated_at <= after_update
+    
+    # updated_at should be after created_at
+    assert new_updated_at > new_created_at


### PR DESCRIPTION
Fixes #318 

We were using `default` and `onupdate` a little bit wrong - they needed to be callables so the datetime.now() function is called every time while saving - the way we had it, they were called only when the app instantiated and then that datetime value was cached, leading to all sorts of weirdness with timestamps.

This should fix the issue and includes a test for the thread timestamps.

cc @leothomas 