### PR TITLE
Fix pick aoi when custom table not present

### DIFF
--- a/src/tools/pick_aoi.py
+++ b/src/tools/pick_aoi.py
@@ -62,6 +62,8 @@ async def query_aoi_database(
         await conn.execute(text("SET pg_trgm.similarity_threshold = 0.2;"))
         await conn.commit()
 
+        user_id = structlog.contextvars.get_contextvars().get("user_id")
+
         # Check which tables exist first
         existing_tables = []
 
@@ -157,10 +159,8 @@ async def query_aoi_database(
 
         if "custom" in existing_tables:
             src_id = SOURCE_ID_MAPPING["custom"]["id_column"]
-            user_id = structlog.contextvars.get_contextvars().get("user_id")
             if not user_id:
                 raise ValueError("user_id required for custom areas")
-
             union_parts.append(
                 f"""
                 SELECT CAST({src_id} as TEXT) as src_id,

--- a/tests/tools/test_agent.py
+++ b/tests/tools/test_agent.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+import structlog
 
 from src.agents.agents import fetch_zeno_anonymous
 
@@ -99,8 +100,10 @@ async def run_agent(query: str, thread_id: str | None = None):
 )
 @pytest.mark.asyncio
 async def test_full_agent_for_datasets(dataset):
-    query = f"What is the distribution of {dataset} in the municipality of Bern, Switzerland for July 2024?"
-    steps = await run_agent(query)
+    query = f"What are the trends of {dataset} in the municipality of Bern, Switzerland for July 2024?"
+
+    with structlog.contextvars.bound_contextvars(user_id="test-user-123"):
+        steps = await run_agent(query)
 
     assert len(steps) > 0
 
@@ -120,7 +123,9 @@ async def test_full_agent_for_datasets(dataset):
 @pytest.mark.asyncio
 async def test_full_agent_for_disturbance_alerts_in_brazil():
     query = "What is the distribution of disturbance alerts in Belem, Pará, Brazil July 2024?"
-    steps = await run_agent(query)
+
+    with structlog.contextvars.bound_contextvars(user_id="test-user-123"):
+        steps = await run_agent(query)
 
     assert len(steps) > 0
 


### PR DESCRIPTION
The `user_id` is needed for this function, but it is currently only set if custom table is present.

I moved the user id retrieval out of that if clause.


I noticed because I dont have this table in my localhost, so there was an error in the agent test.