### PR TITLE
FIX: Fix max tokens error for Claude SONNET

### DIFF
--- a/src/utils/llms.py
+++ b/src/utils/llms.py
@@ -5,8 +5,28 @@ from langchain_openai import ChatOpenAI
 
 load_dotenv()
 
-SONNET = ChatAnthropic(model="claude-sonnet-4-20250514", temperature=0)
-HAIKU = ChatAnthropic(model="claude-3-5-haiku-latest", temperature=0)
-GPT = ChatOpenAI(model="gpt-4o", temperature=0)
-PHI4 = ChatOllama(model="phi4-mini", temperature=0)
-SMOLLM2 = ChatOllama(model="smollm2", temperature=0)
+SONNET = ChatAnthropic(
+    model="claude-sonnet-4-20250514",
+    temperature=0,
+    max_tokens=64_000,  # Sonnet has a limit of max 64000 tokens
+)
+HAIKU = ChatAnthropic(
+    model="claude-3-5-haiku-latest",
+    temperature=0,
+    max_tokens=8_192,  # Haiku has a limit of max 8192 tokens
+)
+GPT = ChatOpenAI(
+    model="gpt-4o",
+    temperature=0,
+    max_tokens=None,  # max_tokens=None means no limit
+)
+PHI4 = ChatOllama(
+    model="phi4-mini",
+    temperature=0,
+    num_predict=-1,  # num_predict is similar to max_tokens, -1 means no limit
+)
+SMOLLM2 = ChatOllama(
+    model="smollm2",
+    temperature=0,
+    num_predict=-1,  # num_predict is similar to max_tokens, -1 means no limit
+)


### PR DESCRIPTION
- Sonnet: Set `max_tokens=64_000` (model limit: 64K tokens)
- Haiku: Set `max_tokens=8_192` (model limit: 8K tokens)
- GPT-4o: Set `max_tokens=None` (no limit for OpenAI models)
- Ollama models (Phi4, SmolLM2): Use `num_predict=-1` (Ollama's equivalent to max_tokens, -1 = no limit)

This resolves the `max_tokens` parameter error when using Claude Sonnet while properly configuring token limits for all supported LLM models.

Fixes #315 