### PR TITLE
Reduce grasslands to DN 2 and update color

### DIFF
--- a/src/tools/analytics_datasets.yml
+++ b/src/tools/analytics_datasets.yml
@@ -291,7 +291,7 @@ datasets:
   dataset_name: Global natural/semi-natural grassland extent
   context_layers: null
   variables: Natural/Semi-Natural Grassland
-  tile_url: "https://eoapi.zeno-staging.ds.io/raster/collections/grasslands-v-1-1/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%220%22%3A%20%5B128%2C%20128%2C%20128%2C%20255%5D%2C%20%221%22%3A%20%5B255%2C%20194%2C%20102%2C%20255%5D%2C%20%222%22%3A%20%5B152%2C%20230%2C%2077%2C%20255%5D%2C%20%223%22%3A%20%5B102%2C%20179%2C%20102%2C%20255%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True"
+  tile_url: "https://eoapi.zeno-staging.ds.io/raster/collections/grasslands-v-1-1/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%220%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%221%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%222%22%3A%20%5B255%2C%20153%2C%2022%2C%20255%5D%2C%20%223%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True"
   license: "CC by 4.0"
   geographic_coverage: "90°N to 90°S"
   resolution: "30 x 30 meters"

--- a/stac/generate_tile_urls.py
+++ b/stac/generate_tile_urls.py
@@ -129,19 +129,19 @@ natural_lands_classes = {
 
 
 grasslands_classes = {
-    "0": {"name": "Other", "color": [128, 128, 128, 255]},  # Gray
+    "0": {"name": "Other", "color": [128, 128, 128, 255]},
     "1": {
         "name": "Cultivated grassland",
         "color": [255, 194, 102, 255],
-    },  # Light orange
+    },
     "2": {
         "name": "Natural/semi-natural grassland",
-        "color": [152, 230, 77, 255],
-    },  # Light green
+        "color": [255, 153, 22, 255],
+    },
     "3": {
         "name": "Open Shrubland",
         "color": [102, 179, 102, 255],
-    },  # Sage green
+    },
 }
 
 
@@ -284,6 +284,5 @@ print(get_natural_lands_template(enabled_natural))
 print("\n=== Only grasslands enabled ===")
 enabled_grasslands = {
     "2",
-    "3",
 }  # Natural/semi-natural grassland and open shrubland
 print(get_grasslands_template(enabled_grasslands))


### PR DESCRIPTION
Update color and replace tile url to only show DN 2 - Global natural/semi-natural grassland extent
Closes https://github.com/wri/project-zeno/issues/363