### PR TITLE
Add checkpoint specific csv data download

### DIFF
--- a/client.py
+++ b/client.py
@@ -125,8 +125,14 @@ class ZenoClient:
                 )
             return response.json()
 
-    def download_data(self, thread_id, mime_type: str = "text/csv"):
-        url = f"{self.base_url}/api/threads/{thread_id}/raw_data"
+    def download_data(
+        self, thread_id, checkpoint_id, mime_type: str = "text/csv"
+    ):
+        print("PINGPONG!")
+        url = (
+            f"{self.base_url}/api/threads/{thread_id}/{checkpoint_id}/raw_data"
+        )
+        print("URL: ", url)
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": mime_type,

--- a/client.py
+++ b/client.py
@@ -128,7 +128,6 @@ class ZenoClient:
     def download_data(
         self, thread_id, checkpoint_id, mime_type: str = "text/csv"
     ):
-        print("PINGPONG!")
         url = (
             f"{self.base_url}/api/threads/{thread_id}/{checkpoint_id}/raw_data"
         )

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1676,11 +1676,14 @@ async def get_raw_data(
     content_type: str = Header(default="text/csv", alias="Content-Type"),
 ):
     """
-    Get insights data for a specific thread. The data returned will reflect the
-    latest state of the `raw_data` key - meaning that if, during a multi-turn
-    conversation, the user has generated insights multiple time (eg: for
-    different locations or different time ranges) only the latest insights will
-    be downloadable.
+    Get insights data for a specific thread and checkpoint. The data returned
+    will reflect the state of the `raw_data` key at that point in time,
+    meaning that users can download the data for generated insights at
+    any point during a multi-turn conversation.
+
+    Note: should we make the checkpoint_id optional? (in this case we would
+    return the latest state of the `raw_data` insights when the checkpoint_id
+    is not provided).
 
     **Authentication**: Requires Bearer token in Authorization header.
     **Content-Type**: Accepts an OPTIONAL Content-Type header to specify

--- a/src/frontend/pages/2_🧵_Threads.py
+++ b/src/frontend/pages/2_🧵_Threads.py
@@ -70,26 +70,19 @@ def update_thread_name_dialog(thread_id):
 # Fetch a single thread
 def fetch_thread(thread_id):
     client = ZenoClient(base_url=API_BASE_URL, token=st.session_state.token)
-    st.header(f"{thread_options[thread_id]['name']}")
 
-    col1, col2, col3 = st.columns([0.1, 0.1, 0.8], gap=None)
+    col1, col2, col3 = st.columns([0.8, 0.1, 0.1], gap=None)
 
     with col1:
+        st.header(f"{thread_options[thread_id]['name']}")
+
+    with col2:
         if st.button(":pencil2:", key=f"save-{thread_id}"):
             update_thread_name_dialog(thread_id)
 
-    with col2:
-        if col2.button(":wastebasket:", key=f"delete-{thread_id}"):
-            delete_dialog(thread_id)
-
     with col3:
-        st.download_button(
-            label="Download data CSV",
-            data=client.download_data(thread_id),
-            file_name=f"raw_data_thread_{thread_id}.csv",
-            mime="text/csv",
-        )
-
+        if col3.button(":wastebasket:", key=f"delete-{thread_id}"):
+            delete_dialog(thread_id)
     st.text(f"Created: {thread_options[thread_id]['created_at']}")
 
     return client.fetch(thread_id)

--- a/src/frontend/utils.py
+++ b/src/frontend/utils.py
@@ -584,7 +584,22 @@ def render_stream(stream):
     # Render charts if this is a tool node with charts_data
     if "charts_data" in update:
         charts_data = update["charts_data"]
+        thread_id = stream["thread_id"]
+        checkpoint_id = stream["checkpoint_id"]
+        client = ZenoClient(
+            base_url=API_BASE_URL, token=st.session_state.token
+        )
+
         render_charts(charts_data)
+
+        st.download_button(
+            label="Download data CSV",
+            data=client.download_data(
+                thread_id=thread_id, checkpoint_id=checkpoint_id
+            ),
+            file_name=f"thread_{thread_id}_checkpoint_{checkpoint_id}_raw_data.csv",
+            mime="text/csv",
+        )
 
     with st.expander("State Updates"):
         for key, value in update.items():


### PR DESCRIPTION
I've added the thread_id and checkpoint_id to the output of the thread replay response to enable this feature. 

The CSV download endpoint now accepts both parameters, loads the corresponding checkpoint and returns the CSV data. See the demo video below to see it live in action!


https://github.com/user-attachments/assets/3792901b-b08c-48b3-9161-c38aa0471d25

