### PR TITLE
Remove ::text cast to fix ingestion

### DIFF
--- a/src/ingest/ingest_kba.py
+++ b/src/ingest/ingest_kba.py
@@ -58,7 +58,7 @@ def ingest_kba() -> None:
     create_id_index_if_not_exists(
         table_name="geometries_kba",
         index_name="idx_geometries_kba_sitrecid_text",
-        column="sitrecid::text",
+        column="sitrecid",
     )
 
     print("✓ KBA ingestion completed successfully!")


### PR DESCRIPTION
Getting error on ingestion of KBA data

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near "::"
LINE 1: ...etries_kba_sitrecid_text ON geometries_kba (sitrecid::text);
```

This worked for me on localhost ingesting against the services in docker.

Not sure if the cast was essential, but if not this worked for me.

Thanks @Quantisan for reporting.
