### PR TITLE
Implement MAX_USER_SIGNUPS

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1810,7 +1810,9 @@ async def get_profile_config():
 
 
 @app.get("/api/metadata")
-async def api_metadata(session: AsyncSession = Depends(get_async_session)) -> dict:
+async def api_metadata(
+    session: AsyncSession = Depends(get_async_session),
+) -> dict:
     """
     Returns API metadata that's helpful for instantiating the frontend.
 
@@ -1835,7 +1837,7 @@ async def api_metadata(session: AsyncSession = Depends(get_async_session)) -> di
     For example, if the user selects a GADM level 2 geometry,
     the ID will look something like `IND.26.2_1` and should be available in
     the gid_2 field on the vector tile layer.
-    
+
     For `is_signup_open`, this indicates whether new public user signups are
     currently allowed. This is based on the ALLOW_PUBLIC_SIGNUPS setting and
     whether the current user count is below the MAX_USER_SIGNUPS limit.
@@ -1843,7 +1845,7 @@ async def api_metadata(session: AsyncSession = Depends(get_async_session)) -> di
     """
     # Check if public signups are open
     is_signup_open = await is_public_signup_open(session)
-    
+
     return {
         "version": "0.1.0",
         "layer_id_mapping": {

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -453,13 +453,13 @@ async def is_user_whitelisted(user_email: str, session: AsyncSession) -> bool:
     """
     user_email_lower = user_email.lower()
     user_domain = user_email_lower.split("@")[-1]
-    
+
     # Check email whitelist first
     stmt = select(WhitelistedUserOrm).filter_by(email=user_email_lower)
     result = await session.execute(stmt)
     if result.scalars().first():
         return True
-    
+
     # Check domain whitelist
     domains_allowlist = APISettings.domains_allowlist
     normalized_domains = [domain.lower() for domain in domains_allowlist]
@@ -477,23 +477,23 @@ async def check_signup_limit_allows_new_user(
     # Whitelisted users always bypass limits
     if await is_user_whitelisted(user_email, session):
         return True
-    
+
     # If public signups disabled, non-whitelisted users can't sign up
     if not APISettings.allow_public_signups:
         return False
-    
+
     # For public users, check signup limit
     max_signups = APISettings.max_user_signups
-    
+
     # -1 means unlimited
     if max_signups < 0:
         return True
-    
+
     # Check user count vs limit
     stmt = select(func.count(UserOrm.id))
     result = await session.execute(stmt)
     current_user_count = result.scalar()
-    
+
     return current_user_count < max_signups
 
 
@@ -574,16 +574,16 @@ async def fetch_user_from_rw_api(
     _user_info_cache[token] = UserModel.model_validate(user_info)
 
     user_email = user_info["email"]
-    
+
     # Check 3-tier access model:
     # Tier 1: Email whitelist (always allowed)
-    # Tier 2: Domain whitelist (always allowed) 
+    # Tier 2: Domain whitelist (always allowed)
     # Tier 3: Public users (allowed only if ALLOW_PUBLIC_SIGNUPS=true)
-    
+
     if await is_user_whitelisted(user_email, session):
         # User is whitelisted (email or domain), allow access
         return UserModel.model_validate(user_info)
-    
+
     if not APISettings.allow_public_signups:
         # Public signups disabled, only whitelisted users allowed
         raise HTTPException(
@@ -612,7 +612,9 @@ async def require_auth(
     user = result.scalars().first()
     if not user:
         # Check signup limits for new users
-        if not await check_signup_limit_allows_new_user(user_info.email, session):
+        if not await check_signup_limit_allows_new_user(
+            user_info.email, session
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="User signups are currently closed",
@@ -660,7 +662,9 @@ async def optional_auth(
     user = result.scalars().first()
     if not user:
         # Check signup limits for new users
-        if not await check_signup_limit_allows_new_user(user_info.email, session):
+        if not await check_signup_limit_allows_new_user(
+            user_info.email, session
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="User signups are currently closed",

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -446,6 +446,57 @@ async def stream_chat(
 _user_info_cache = cachetools.TTLCache(maxsize=1024, ttl=60 * 60 * 24)  # 1 day
 
 
+async def is_user_whitelisted(user_email: str, session: AsyncSession) -> bool:
+    """
+    Check if user is whitelisted via email or domain.
+    Returns True if user is in email whitelist or domain whitelist.
+    """
+    user_email_lower = user_email.lower()
+    user_domain = user_email_lower.split("@")[-1]
+    
+    # Check email whitelist first
+    stmt = select(WhitelistedUserOrm).filter_by(email=user_email_lower)
+    result = await session.execute(stmt)
+    if result.scalars().first():
+        return True
+    
+    # Check domain whitelist
+    domains_allowlist = APISettings.domains_allowlist
+    normalized_domains = [domain.lower() for domain in domains_allowlist]
+    return user_domain in normalized_domains
+
+
+async def check_signup_limit_allows_new_user(
+    user_email: str, session: AsyncSession
+) -> bool:
+    """
+    Check if signup limits allow a new user to be created.
+    Only applies to non-whitelisted users when public signups are enabled.
+    Returns True if user can sign up, False if blocked by limits.
+    """
+    # Whitelisted users always bypass limits
+    if await is_user_whitelisted(user_email, session):
+        return True
+    
+    # If public signups disabled, non-whitelisted users can't sign up
+    if not APISettings.allow_public_signups:
+        return False
+    
+    # For public users, check signup limit
+    max_signups = APISettings.max_user_signups
+    
+    # -1 means unlimited
+    if max_signups < 0:
+        return True
+    
+    # Check user count vs limit
+    stmt = select(func.count(UserOrm.id))
+    result = await session.execute(stmt)
+    current_user_count = result.scalar()
+    
+    return current_user_count < max_signups
+
+
 async def fetch_user_from_rw_api(
     request: Request,
     authorization: Optional[str] = Depends(security),
@@ -522,25 +573,19 @@ async def fetch_user_from_rw_api(
     # cache user info
     _user_info_cache[token] = UserModel.model_validate(user_info)
 
-    user_email = user_info["email"].lower()
-    user_domain = user_email.split("@")[-1]
-
-    # Check email whitelist first
-    stmt = select(WhitelistedUserOrm).filter_by(email=user_email)
-    result = await session.execute(stmt)
-    whitelisted_user = result.scalars().first()
-
-    if whitelisted_user:
-        # User is on email whitelist, allow access
+    user_email = user_info["email"]
+    
+    # Check 3-tier access model:
+    # Tier 1: Email whitelist (always allowed)
+    # Tier 2: Domain whitelist (always allowed) 
+    # Tier 3: Public users (allowed only if ALLOW_PUBLIC_SIGNUPS=true)
+    
+    if await is_user_whitelisted(user_email, session):
+        # User is whitelisted (email or domain), allow access
         return UserModel.model_validate(user_info)
-
-    # Check domain whitelist as fallback
-    domains_allowlist = APISettings.domains_allowlist
-
-    # Normalize domains for comparison (lowercase)
-    normalized_domains = [domain.lower() for domain in domains_allowlist]
-
-    if user_domain not in normalized_domains:
+    
+    if not APISettings.allow_public_signups:
+        # Public signups disabled, only whitelisted users allowed
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User not allowed to access this API",
@@ -566,6 +611,12 @@ async def require_auth(
     result = await session.execute(stmt)
     user = result.scalars().first()
     if not user:
+        # Check signup limits for new users
+        if not await check_signup_limit_allows_new_user(user_info.email, session):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User signups are currently closed",
+            )
         user = UserOrm(**user_info.model_dump())
         session.add(user)
         await session.commit()
@@ -608,6 +659,12 @@ async def optional_auth(
     result = await session.execute(stmt)
     user = result.scalars().first()
     if not user:
+        # Check signup limits for new users
+        if not await check_signup_limit_allows_new_user(user_info.email, session):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User signups are currently closed",
+            )
         user = UserOrm(**user_info.model_dump())
         session.add(user)
         await session.commit()

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -20,7 +20,9 @@ class _APISettings(BaseSettings):
 
     nextjs_api_key: str = Field(..., alias="NEXTJS_API_KEY")
     max_user_signups: int = Field(default=-1, alias="MAX_USER_SIGNUPS")
-    allow_public_signups: bool = Field(default=False, alias="ALLOW_PUBLIC_SIGNUPS")
+    allow_public_signups: bool = Field(
+        default=False, alias="ALLOW_PUBLIC_SIGNUPS"
+    )
 
     @property
     def domains_allowlist(self) -> list[str]:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -19,6 +19,8 @@ class _APISettings(BaseSettings):
     enable_quota_checking: bool = True
 
     nextjs_api_key: str = Field(..., alias="NEXTJS_API_KEY")
+    max_user_signups: int = Field(default=-1, alias="MAX_USER_SIGNUPS")
+    allow_public_signups: bool = Field(default=False, alias="ALLOW_PUBLIC_SIGNUPS")
 
     @property
     def domains_allowlist(self) -> list[str]:

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -627,3 +627,77 @@ async def test_authentication_priority_order(client):
                 )  # Should succeed due to email whitelist
                 user_data = response.json()
                 assert user_data["email"] == "priority@blocked.com"
+
+
+@pytest.mark.asyncio
+async def test_metadata_signup_open_when_under_limit(client):
+    """Test that metadata shows is_signup_open as True when under user limit."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate with users below limit
+    async with async_session_maker() as session:
+        for i in range(2):
+            user = UserOrm(id=f"user-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        await session.commit()
+    
+    with patch.object(api.APISettings, "allow_public_signups", True):
+        with patch.object(api.APISettings, "max_user_signups", 5):  # Limit of 5, have 2
+            response = await client.get("/api/metadata")
+            
+            assert response.status_code == 200
+            metadata = response.json()
+            assert metadata["is_signup_open"] is True
+
+
+@pytest.mark.asyncio
+async def test_metadata_signup_closed_when_at_limit(client):
+    """Test that metadata shows is_signup_open as False when at user limit."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate to reach limit
+    async with async_session_maker() as session:
+        for i in range(3):
+            user = UserOrm(id=f"user-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        await session.commit()
+    
+    with patch.object(api.APISettings, "allow_public_signups", True):
+        with patch.object(api.APISettings, "max_user_signups", 3):  # Limit of 3, have 3
+            response = await client.get("/api/metadata")
+            
+            assert response.status_code == 200
+            metadata = response.json()
+            assert metadata["is_signup_open"] is False
+
+
+@pytest.mark.asyncio
+async def test_metadata_signup_closed_when_public_disabled(client):
+    """Test that metadata shows is_signup_open as False when public signups disabled."""
+    from unittest.mock import patch
+    
+    with patch.object(api.APISettings, "allow_public_signups", False):
+        with patch.object(api.APISettings, "max_user_signups", 100):  # High limit
+            response = await client.get("/api/metadata")
+            
+            assert response.status_code == 200
+            metadata = response.json()
+            assert metadata["is_signup_open"] is False
+
+
+@pytest.mark.asyncio
+async def test_metadata_signup_open_unlimited_users(client):
+    """Test that metadata shows is_signup_open as True when user limit is unlimited."""
+    from unittest.mock import patch
+    
+    with patch.object(api.APISettings, "allow_public_signups", True):
+        with patch.object(api.APISettings, "max_user_signups", -1):  # Unlimited
+            response = await client.get("/api/metadata")
+            
+            assert response.status_code == 200
+            metadata = response.json()
+            assert metadata["is_signup_open"] is True

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -632,21 +632,26 @@ async def test_authentication_priority_order(client):
 @pytest.mark.asyncio
 async def test_metadata_signup_open_when_under_limit(client):
     """Test that metadata shows is_signup_open as True when under user limit."""
-    from tests.conftest import async_session_maker
-    from src.api.data_models import UserOrm
     from unittest.mock import patch
-    
+
+    from src.api.data_models import UserOrm
+    from tests.conftest import async_session_maker
+
     # Pre-populate with users below limit
     async with async_session_maker() as session:
         for i in range(2):
-            user = UserOrm(id=f"user-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            user = UserOrm(
+                id=f"user-{i}", name=f"User {i}", email=f"user{i}@test.com"
+            )
             session.add(user)
         await session.commit()
-    
+
     with patch.object(api.APISettings, "allow_public_signups", True):
-        with patch.object(api.APISettings, "max_user_signups", 5):  # Limit of 5, have 2
+        with patch.object(
+            api.APISettings, "max_user_signups", 5
+        ):  # Limit of 5, have 2
             response = await client.get("/api/metadata")
-            
+
             assert response.status_code == 200
             metadata = response.json()
             assert metadata["is_signup_open"] is True
@@ -655,21 +660,26 @@ async def test_metadata_signup_open_when_under_limit(client):
 @pytest.mark.asyncio
 async def test_metadata_signup_closed_when_at_limit(client):
     """Test that metadata shows is_signup_open as False when at user limit."""
-    from tests.conftest import async_session_maker
-    from src.api.data_models import UserOrm
     from unittest.mock import patch
-    
+
+    from src.api.data_models import UserOrm
+    from tests.conftest import async_session_maker
+
     # Pre-populate to reach limit
     async with async_session_maker() as session:
         for i in range(3):
-            user = UserOrm(id=f"user-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            user = UserOrm(
+                id=f"user-{i}", name=f"User {i}", email=f"user{i}@test.com"
+            )
             session.add(user)
         await session.commit()
-    
+
     with patch.object(api.APISettings, "allow_public_signups", True):
-        with patch.object(api.APISettings, "max_user_signups", 3):  # Limit of 3, have 3
+        with patch.object(
+            api.APISettings, "max_user_signups", 3
+        ):  # Limit of 3, have 3
             response = await client.get("/api/metadata")
-            
+
             assert response.status_code == 200
             metadata = response.json()
             assert metadata["is_signup_open"] is False
@@ -679,11 +689,13 @@ async def test_metadata_signup_closed_when_at_limit(client):
 async def test_metadata_signup_closed_when_public_disabled(client):
     """Test that metadata shows is_signup_open as False when public signups disabled."""
     from unittest.mock import patch
-    
+
     with patch.object(api.APISettings, "allow_public_signups", False):
-        with patch.object(api.APISettings, "max_user_signups", 100):  # High limit
+        with patch.object(
+            api.APISettings, "max_user_signups", 100
+        ):  # High limit
             response = await client.get("/api/metadata")
-            
+
             assert response.status_code == 200
             metadata = response.json()
             assert metadata["is_signup_open"] is False
@@ -693,11 +705,13 @@ async def test_metadata_signup_closed_when_public_disabled(client):
 async def test_metadata_signup_open_unlimited_users(client):
     """Test that metadata shows is_signup_open as True when user limit is unlimited."""
     from unittest.mock import patch
-    
+
     with patch.object(api.APISettings, "allow_public_signups", True):
-        with patch.object(api.APISettings, "max_user_signups", -1):  # Unlimited
+        with patch.object(
+            api.APISettings, "max_user_signups", -1
+        ):  # Unlimited
             response = await client.get("/api/metadata")
-            
+
             assert response.status_code == 200
             metadata = response.json()
             assert metadata["is_signup_open"] is True

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -47,36 +47,51 @@ async def test_email_domain_authorization(
 ):
     """Test that only users with allowed email domains can access the API."""
     with domain_allowlist("developmentseed.org,wri.org"):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            # Mock the AsyncClient context manager and get method
-            mock_client = (
-                mock_client_class.return_value.__aenter__.return_value
-            )
-            mock_client.get.return_value = mock_rw_api_response(username)
+        with patch.object(api.APISettings, "allow_public_signups", False):  # Disable public signups for original behavior
+            with patch("httpx.AsyncClient") as mock_client_class:
+                # Mock the AsyncClient context manager and get method
+                mock_client = (
+                    mock_client_class.return_value.__aenter__.return_value
+                )
+                mock_client.get.return_value = mock_rw_api_response(username)
 
-            # Test the auth endpoint
-            response = await client.get(
-                "/api/auth/me", headers={"Authorization": "Bearer test-token"}
-            )
+                # Test the auth endpoint
+                response = await client.get(
+                    "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                )
 
-        assert response.status_code == expected_status
+            assert response.status_code == expected_status
 
-        if expected_error:
-            assert expected_error in response.json()["detail"]
-        else:
-            # For successful requests, verify the user data is returned correctly
-            user_response = response.json()
-            assert user_response["name"] == username
+            if expected_error:
+                assert expected_error in response.json()["detail"]
+            else:
+                # For successful requests, verify the user data is returned correctly
+                user_response = response.json()
+                assert user_response["name"] == username
 
 
 @pytest.mark.asyncio
 async def test_missing_bearer_token(client):
     """Test that requests without a Bearer token are rejected."""
     with domain_allowlist("developmentseed.org,wri.org"):
-        response = await client.get(
-            "/api/auth/me",
-            headers={"Authorization": "test-token"},  # Missing "Bearer" prefix
-        )
+        with patch.object(api.APISettings, "allow_public_signups", False):  # Ensure consistent behavior
+            response = await client.get(
+                "/api/auth/me",
+                headers={"Authorization": "test-token"},  # Missing "Bearer" prefix
+            )
+            assert response.status_code == 401
+            assert (
+                "Missing Bearer token in Authorization header"
+                in response.json()["detail"]
+            )
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header(client):
+    """Test that requests without an Authorization header are rejected."""
+    with patch.object(api.APISettings, "allow_public_signups", False):  # Ensure consistent behavior
+        os.environ["DOMAINS_ALLOWLIST"] = "developmentseed.org,wri.org"
+        response = await client.get("/api/auth/me")  # No Authorization header
         assert response.status_code == 401
         assert (
             "Missing Bearer token in Authorization header"
@@ -85,40 +100,29 @@ async def test_missing_bearer_token(client):
 
 
 @pytest.mark.asyncio
-async def test_missing_authorization_header(client):
-    """Test that requests without an Authorization header are rejected."""
-    os.environ["DOMAINS_ALLOWLIST"] = "developmentseed.org,wri.org"
-    response = await client.get("/api/auth/me")  # No Authorization header
-    assert response.status_code == 401
-    assert (
-        "Missing Bearer token in Authorization header"
-        in response.json()["detail"]
-    )
-
-
-@pytest.mark.asyncio
 async def test_user_cant_override_email_domain_authorization(client):
     """Test that only users cant override email domain authorization through query params."""
     with domain_allowlist("developmentseed.org,wri.org"):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            # Mock the AsyncClient context manager and get method
-            mock_client = (
-                mock_client_class.return_value.__aenter__.return_value
-            )
-            mock_client.get.return_value = mock_rw_api_response(
-                "Unauthorized User"
-            )
+        with patch.object(api.APISettings, "allow_public_signups", False):  # Disable public signups for original behavior
+            with patch("httpx.AsyncClient") as mock_client_class:
+                # Mock the AsyncClient context manager and get method
+                mock_client = (
+                    mock_client_class.return_value.__aenter__.return_value
+                )
+                mock_client.get.return_value = mock_rw_api_response(
+                    "Unauthorized User"
+                )
 
-            # Test the auth endpoint
-            response = await client.get(
-                "/api/auth/me?domains_allowlist=unauthorized.com",
-                headers={"Authorization": "Bearer test-token"},
-            )
+                # Test the auth endpoint
+                response = await client.get(
+                    "/api/auth/me?domains_allowlist=unauthorized.com",
+                    headers={"Authorization": "Bearer test-token"},
+                )
 
-        assert response.status_code == 403
-        assert (
-            "User not allowed to access this API" in response.json()["detail"]
-        )
+            assert response.status_code == 403
+            assert (
+                "User not allowed to access this API" in response.json()["detail"]
+            )
 
 
 @pytest.mark.asyncio
@@ -215,22 +219,326 @@ async def test_domain_whitelist_still_works_with_email_feature(client):
 
 @pytest.mark.asyncio
 async def test_user_blocked_when_not_in_domain_or_email_whitelist(client):
-    """Test that users are blocked when not in either domain or email whitelist."""
+    """Test that users are blocked when not in either domain or email whitelist and public signups disabled."""
     with domain_allowlist("developmentseed.org,wri.org"):
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = (
-                mock_client_class.return_value.__aenter__.return_value
-            )
-            # Mock user with unauthorized domain and not in email whitelist
-            mock_response = mock_rw_api_response("Unauthorized User")
-            mock_response.json_data["email"] = "test@blocked.com"
-            mock_client.get.return_value = mock_response
+        with patch.object(api.APISettings, "allow_public_signups", False):  # Disable public signups
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = (
+                    mock_client_class.return_value.__aenter__.return_value
+                )
+                # Mock user with unauthorized domain and not in email whitelist
+                mock_response = mock_rw_api_response("Unauthorized User")
+                mock_response.json_data["email"] = "test@blocked.com"
+                mock_client.get.return_value = mock_response
 
-            response = await client.get(
-                "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                response = await client.get(
+                    "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                )
+
+            assert response.status_code == 403
+            assert (
+                "User not allowed to access this API" in response.json()["detail"]
             )
+
+
+@pytest.mark.asyncio
+async def test_public_signup_allowed_when_under_limit(client):
+    """Test that public users can sign up when under the limit and public signups enabled."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate with 2 users 
+    async with async_session_maker() as session:
+        user1 = UserOrm(id="existing-1", name="User 1", email="user1@test.com")
+        user2 = UserOrm(id="existing-2", name="User 2", email="user2@test.com")
+        session.add_all([user1, user2])
+        await session.commit()
+    
+    with domain_allowlist(""):  # No domain whitelist
+        with patch.object(api.APISettings, "allow_public_signups", True):
+            with patch.object(api.APISettings, "max_user_signups", 5):  # Limit of 5, currently have 2
+                with patch("httpx.AsyncClient") as mock_client_class:
+                    mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                    # Mock public user (not in whitelist)
+                    mock_response = mock_rw_api_response("Test User")
+                    mock_response.json_data = {
+                        "id": "public-user-123",
+                        "name": "Public User",
+                        "email": "publicuser@gmail.com", 
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "updatedAt": "2024-01-01T00:00:00Z",
+                    }
+                    mock_client.get.return_value = mock_response
+
+                    response = await client.get(
+                        "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                    )
+
+            assert response.status_code == 200
+            user_data = response.json()
+            assert user_data["id"] == "public-user-123"
+
+
+@pytest.mark.asyncio
+async def test_signup_limit_blocks_new_user_when_at_limit(client):
+    """Test that new users are blocked when signup limit is reached."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate to reach the limit (2 users)
+    async with async_session_maker() as session:
+        for i in range(2):
+            user = UserOrm(id=f"existing-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        await session.commit()
+    
+    with domain_allowlist(""):  # No domain whitelist
+        with patch.object(api.APISettings, "allow_public_signups", True):
+            with patch.object(api.APISettings, "max_user_signups", 2):  # Limit of 2, currently have 2
+                with patch("httpx.AsyncClient") as mock_client_class:
+                    mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                    # Mock public user trying to sign up
+                    mock_response = mock_rw_api_response("Test User")
+                    mock_response.json_data = {
+                        "id": "blocked-user-456",
+                        "name": "Blocked User",
+                        "email": "blocked@gmail.com",
+                        "createdAt": "2024-01-01T00:00:00Z", 
+                        "updatedAt": "2024-01-01T00:00:00Z",
+                    }
+                    mock_client.get.return_value = mock_response
+
+                    response = await client.get(
+                        "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                    )
 
         assert response.status_code == 403
-        assert (
-            "User not allowed to access this API" in response.json()["detail"]
-        )
+        assert "signups are currently closed" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_public_signup_blocked_when_disabled(client):
+    """Test that public users are blocked when public signups are disabled."""
+    from unittest.mock import patch
+    
+    with domain_allowlist(""):  # No domain whitelist  
+        with patch.object(api.APISettings, "allow_public_signups", False):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                # Mock public user
+                mock_response = mock_rw_api_response("Test User")
+                mock_response.json_data = {
+                    "id": "public-user-456", 
+                    "name": "Public User",
+                    "email": "public@gmail.com",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "updatedAt": "2024-01-01T00:00:00Z",
+                }
+                mock_client.get.return_value = mock_response
+
+                response = await client.get(
+                    "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                )
+
+        assert response.status_code == 403
+        assert "User not allowed to access this API" in response.json()["detail"]
+
+
+@pytest.mark.asyncio 
+async def test_signup_limit_unlimited_when_negative(client):
+    """Test that negative MAX_USER_SIGNUPS means unlimited signups."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate with many users
+    async with async_session_maker() as session:
+        for i in range(100):
+            user = UserOrm(id=f"existing-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        await session.commit()
+    
+    with domain_allowlist(""):  # No domain whitelist
+        with patch.object(api.APISettings, "allow_public_signups", True):
+            with patch.object(api.APISettings, "max_user_signups", -1):  # Unlimited
+                with patch("httpx.AsyncClient") as mock_client_class:
+                    mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                    mock_response = mock_rw_api_response("Test User")
+                    mock_response.json_data = {
+                        "id": "new-unlimited-user",
+                        "name": "New User",
+                        "email": "newuser@gmail.com",
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "updatedAt": "2024-01-01T00:00:00Z", 
+                    }
+                    mock_client.get.return_value = mock_response
+
+                    response = await client.get(
+                        "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                    )
+
+            assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_whitelisted_user_bypasses_signup_limit(client):
+    """Test that whitelisted users can sign up even when limit is reached."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm, WhitelistedUserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate to reach limit and add user to email whitelist
+    async with async_session_maker() as session:
+        # Add users to reach limit
+        for i in range(2):
+            user = UserOrm(id=f"existing-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        # Add email to whitelist
+        whitelisted = WhitelistedUserOrm(email="whitelisted@gmail.com")
+        session.add(whitelisted)
+        await session.commit()
+    
+    with domain_allowlist("developmentseed.org"):  # gmail.com not in domain list
+        with patch.object(api.APISettings, "max_user_signups", 2):  # Limit of 2, currently have 2
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                # Mock whitelisted user
+                mock_response = mock_rw_api_response("Test User")
+                mock_response.json_data = {
+                    "id": "whitelisted-user-789",
+                    "name": "Whitelisted User", 
+                    "email": "whitelisted@gmail.com",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "updatedAt": "2024-01-01T00:00:00Z",
+                }
+                mock_client.get.return_value = mock_response
+
+                response = await client.get(
+                    "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                )
+
+        assert response.status_code == 200
+        user_data = response.json()
+        assert user_data["email"] == "whitelisted@gmail.com"
+
+
+@pytest.mark.asyncio
+async def test_domain_whitelisted_user_bypasses_signup_limit(client):
+    """Test that domain whitelisted users can sign up even when limit is reached."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate to reach limit
+    async with async_session_maker() as session:
+        for i in range(3):
+            user = UserOrm(id=f"existing-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        await session.commit()
+    
+    with domain_allowlist("developmentseed.org,wri.org"):
+        with patch.object(api.APISettings, "max_user_signups", 3):  # Limit of 3, currently have 3
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                # Mock user from whitelisted domain
+                mock_response = mock_rw_api_response("Test User")
+                mock_response.json_data = {
+                    "id": "domain-user-456",
+                    "name": "Domain User",
+                    "email": "domainuser@wri.org",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "updatedAt": "2024-01-01T00:00:00Z",
+                }
+                mock_client.get.return_value = mock_response
+
+                response = await client.get(
+                    "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                )
+
+        assert response.status_code == 200
+        user_data = response.json()
+        assert user_data["email"] == "domainuser@wri.org"
+
+
+@pytest.mark.asyncio
+async def test_existing_user_can_login_when_over_limit(client):
+    """Test that existing users can always login even when over the signup limit."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate with existing user and others to exceed limit
+    async with async_session_maker() as session:
+        existing_user = UserOrm(id="existing-user", name="Existing User", email="existing@developmentseed.org")
+        session.add(existing_user)
+        for i in range(5):
+            user = UserOrm(id=f"other-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        await session.commit()
+    
+    with domain_allowlist("developmentseed.org"):
+        with patch.object(api.APISettings, "max_user_signups", 3):  # Limit of 3, currently have 6
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                # Mock existing user logging back in
+                mock_response = mock_rw_api_response("Test User")
+                mock_response.json_data = {
+                    "id": "existing-user",
+                    "name": "Existing User",
+                    "email": "existing@developmentseed.org",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "updatedAt": "2024-01-01T00:00:00Z",
+                }
+                mock_client.get.return_value = mock_response
+
+                response = await client.get(
+                    "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                )
+
+        assert response.status_code == 200
+        user_data = response.json()
+        assert user_data["id"] == "existing-user"
+
+
+@pytest.mark.asyncio
+async def test_authentication_priority_order(client):
+    """Test that authentication priority is: email whitelist > domain whitelist > public signup settings."""
+    from tests.conftest import async_session_maker
+    from src.api.data_models import UserOrm, WhitelistedUserOrm
+    from unittest.mock import patch
+    
+    # Pre-populate to reach signup limit
+    async with async_session_maker() as session:
+        for i in range(2):
+            user = UserOrm(id=f"existing-{i}", name=f"User {i}", email=f"user{i}@test.com")
+            session.add(user)
+        # Add email to whitelist but not domain
+        whitelisted = WhitelistedUserOrm(email="priority@blocked.com") 
+        session.add(whitelisted)
+        await session.commit()
+    
+    # Test: Email whitelist beats blocked domain + signup limit + disabled public
+    with domain_allowlist("developmentseed.org,wri.org"):  # blocked.com not in list
+        with patch.object(api.APISettings, "allow_public_signups", False):
+            with patch.object(api.APISettings, "max_user_signups", 2):  # At limit
+                with patch("httpx.AsyncClient") as mock_client_class:
+                    mock_client = (mock_client_class.return_value.__aenter__.return_value)
+                    mock_response = mock_rw_api_response("Test User")
+                    mock_response.json_data = {
+                        "id": "priority-test",
+                        "name": "Priority User",
+                        "email": "priority@blocked.com",  # Not in domain list but in email whitelist
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "updatedAt": "2024-01-01T00:00:00Z",
+                    }
+                    mock_client.get.return_value = mock_response
+
+                    response = await client.get(
+                        "/api/auth/me", headers={"Authorization": "Bearer test-token"}
+                    )
+
+                assert response.status_code == 200  # Should succeed due to email whitelist
+                user_data = response.json()
+                assert user_data["email"] == "priority@blocked.com"


### PR DESCRIPTION
As per #373 - allows a MAX_USER_SIGNUPS after which new users are no longer allowed to signup.

Also adds an ALLOW_PUBLIC_SIGNUPS config parameter. If that is set to False, only users that are whitelisted are allowed. If ALLOW_PUBIC_SIGNUPS is set to True, then users are allowed to signup until the MAX_USER_SIGNUPS threshhold is reached. If MAX_USER_SIGNUPS is set to `-1`, then there is no maximum number of users and all users are allowed to signup via the WRI login.

cc @leothomas @yellowcap 