### PR TITLE
add hasProfile field for user profile for fronted to set and gete

### DIFF
--- a/db/alembic/versions/8f636b664598_add_has_profile_field_to_users_table.py
+++ b/db/alembic/versions/8f636b664598_add_has_profile_field_to_users_table.py
@@ -5,22 +5,30 @@ Revises: 95d9d8ca3bf1
 Create Date: 2025-09-02 16:57:45.873121
 
 """
+
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = '8f636b664598'
-down_revision: Union[str, None] = '95d9d8ca3bf1'
+revision: str = "8f636b664598"
+down_revision: Union[str, None] = "95d9d8ca3bf1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.add_column("users", sa.Column("has_profile", sa.Boolean(), nullable=False, server_default=sa.text("false")))
+    op.add_column(
+        "users",
+        sa.Column(
+            "has_profile",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
 
 
 def downgrade() -> None:

--- a/db/alembic/versions/8f636b664598_add_has_profile_field_to_users_table.py
+++ b/db/alembic/versions/8f636b664598_add_has_profile_field_to_users_table.py
@@ -1,0 +1,28 @@
+"""add has_profile field to users table
+
+Revision ID: 8f636b664598
+Revises: 95d9d8ca3bf1
+Create Date: 2025-09-02 16:57:45.873121
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8f636b664598'
+down_revision: Union[str, None] = '95d9d8ca3bf1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("users", sa.Column("has_profile", sa.Boolean(), nullable=False, server_default=sa.text("false")))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("users", "has_profile")

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -655,6 +655,7 @@ async def require_auth(
         preferred_language_code=user.preferred_language_code,
         gis_expertise_level=user.gis_expertise_level,
         areas_of_interest=user.areas_of_interest,
+        has_profile=user.has_profile,
     )
 
 
@@ -706,6 +707,7 @@ async def optional_auth(
         preferred_language_code=user.preferred_language_code,
         gis_expertise_level=user.gis_expertise_level,
         areas_of_interest=user.areas_of_interest,
+        has_profile=user.has_profile,
     )
 
 
@@ -1605,6 +1607,7 @@ async def auth_me(
         - preferredLanguageCode: ISO language code (optional, see /api/profile/config)
         - gisExpertiseLevel: GIS expertise level (optional, see /api/profile/config)
         - areasOfInterest: Free text areas of interest (optional)
+        - hasProfile: Whether the user has completed their profile (boolean, set by frontend)
 
         **Quota Information:**
         - promptsUsed: Number of prompts used today (null if quota disabled)
@@ -1664,6 +1667,7 @@ async def update_user_profile(
       - Valid values: GET /api/profile/config → gisExpertiseLevels
       - Examples: "beginner", "intermediate", "advanced", "expert"
     - areasOfInterest: Free text areas of interest (string, optional)
+    - hasProfile: Whether the user has completed their profile (boolean, optional, set by frontend)
 
     **Request Body Example:**
     ```json
@@ -1678,7 +1682,8 @@ async def update_user_profile(
       "countryCode": "US",
       "preferredLanguageCode": "en",
       "gisExpertiseLevel": "intermediate",
-      "areasOfInterest": "Deforestation monitoring, Biodiversity conservation"
+      "areasOfInterest": "Deforestation monitoring, Biodiversity conservation",
+      "hasProfile": true
     }
     ```
 
@@ -1735,6 +1740,7 @@ async def update_user_profile(
         "preferred_language_code": db_user.preferred_language_code,
         "gis_expertise_level": db_user.gis_expertise_level,
         "areas_of_interest": db_user.areas_of_interest,
+        "has_profile": db_user.has_profile,
     }
 
     return UserModel(**response_data)

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -56,6 +56,7 @@ class UserOrm(Base):
     preferred_language_code = Column(String, nullable=True)
     gis_expertise_level = Column(String, nullable=True)
     areas_of_interest = Column(String, nullable=True)
+    has_profile = Column(Boolean, nullable=False, default=False)
 
     # Machine user fields
     machine_description = Column(String, nullable=True)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -68,6 +68,7 @@ class UserModel(BaseModel):
     preferred_language_code: Optional[str] = None
     gis_expertise_level: Optional[str] = None
     areas_of_interest: Optional[str] = None
+    has_profile: bool = False
 
     @field_validator("created_at", "updated_at", mode="before")
     def parse_dates(cls, value):
@@ -135,6 +136,7 @@ class UserProfileUpdateRequest(BaseModel):
     preferred_language_code: Optional[str] = None
     gis_expertise_level: Optional[str] = None
     areas_of_interest: Optional[str] = None
+    has_profile: Optional[bool] = None
 
     @field_validator("sector_code")
     def validate_sector_code(cls, v):


### PR DESCRIPTION
Adds a `hasProfile` field to the user profile endpoint as a boolean which indicates whether the user has filled in their profile. Must be set by the frontend.

cc @kamicut 