### PR TITLE
Update langfuse version to 3.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "langchain-community==0.3.27",
     "langchain-ollama==0.3.6",
     "langchain-openai==0.3.28",
-    "langfuse==3.2.1",
+    "langfuse==3.3.3",
     "langchain-chroma==0.2.5",
     "fastapi[standard]==0.116.1",
     "watchdog==6.0.0",


### PR DESCRIPTION
Tested this locally and the upgrade fixes the issue of langfuse traces not reporting token usage and cost 