### PR TITLE
Add dynamic model configuration via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ OLLAMA_BASE_URL=http://localhost:11434
 STREAMLIT_URL=http://localhost:8501 # URL where the Streamlit app is hosted
 COOKIE_SIGNER_SECRET_KEY="secret-cookie-key-123"
 NEXTJS_API_KEY=<nextjs-api-key>
+# Model Configuration
+# Available options: sonnet, haiku, gemini, gemini-flash, gpt, phi4, smollm2
+MODEL=sonnet

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -80,7 +80,7 @@ from src.utils.geocoding_helpers import (
     SUBREGION_TO_SUBTYPE_MAPPING,
     get_geometry_data,
 )
-from src.utils.llms import HAIKU
+from src.utils.llms import AVAILABLE_MODELS, HAIKU, get_model
 from src.utils.logging_config import bind_request_logging_context, get_logger
 
 # Load environment variables using shared utility
@@ -1863,6 +1863,10 @@ async def api_metadata(
     # Check if public signups are open
     is_signup_open = await is_public_signup_open(session)
 
+    # Get current model information
+    current_model = get_model()
+    current_model_name = APISettings.model.lower()
+
     return {
         "version": "0.1.0",
         "layer_id_mapping": {
@@ -1871,6 +1875,11 @@ async def api_metadata(
         "subregion_to_subtype_mapping": SUBREGION_TO_SUBTYPE_MAPPING,
         "gadm_subtype_mapping": GADM_SUBTYPE_MAP,
         "is_signup_open": is_signup_open,
+        "model": {
+            "current": current_model_name,
+            "available": AVAILABLE_MODELS,
+            "model_class": current_model.__class__.__name__,
+        },
     }
 
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -31,6 +31,9 @@ class _APISettings(BaseSettings):
         default=False, alias="ALLOW_PUBLIC_SIGNUPS"
     )
 
+    # Model configuration
+    model: str = Field(default="sonnet", alias="MODEL")
+
     @property
     def domains_allowlist(self) -> list[str]:
         if not self.domains_allowlist_str.strip():

--- a/src/utils/llms.py
+++ b/src/utils/llms.py
@@ -4,6 +4,8 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 
+from src.utils.config import APISettings
+
 load_dotenv()
 
 # Anthropic
@@ -55,5 +57,30 @@ SMOLLM2 = ChatOllama(
     num_predict=-1,  # num_predict is similar to max_tokens, -1 means no limit
 )
 
-# Base Model
-MODEL = SONNET
+# Model Registry for dynamic selection
+MODEL_REGISTRY = {
+    "sonnet": SONNET,
+    "haiku": HAIKU,
+    "gemini": GEMINI,
+    "gemini-flash": GEMINI_FLASH,
+    "gpt": GPT,
+    "phi4": PHI4,
+    "smollm2": SMOLLM2,
+}
+
+# Available models list for frontend
+AVAILABLE_MODELS = list(MODEL_REGISTRY.keys())
+
+
+def get_model():
+    """Get the configured model from environment or default to sonnet."""
+    model_name = APISettings.model.lower()
+    if model_name not in MODEL_REGISTRY:
+        raise ValueError(
+            f"Unknown model: {model_name}. Available models: {AVAILABLE_MODELS}"
+        )
+    return MODEL_REGISTRY[model_name]
+
+
+# Base Model - dynamically selected from environment
+MODEL = get_model()


### PR DESCRIPTION
**Update**:
- Add MODEL environment variable to config with default "sonnet"
- Update llms.py to use dynamic model selection from config
- Add model information to /api/metadata endpoint showing current and available models
- Update .env.example with MODEL configuration options

**Available models**: `sonnet, haiku, gemini, gemini-flash, gpt, phi4, smollm2`

**Usage**: Set `MODEL=gemini` in `.env` to change the default model for deployment.

Note: `generate-insights` tool will always use `sonnet` by default for now.

cc @yellowcap 