### PR TITLE
Fix: Streamlit chat input not responding after first message

### DIFF
--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime
 from typing import Optional
-from typing import Optional
 
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.graph.state import CompiledStateGraph

--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from typing import Optional
+from typing import Optional
 
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.graph.state import CompiledStateGraph

--- a/src/frontend/pages/1_🦎_Uni_Guana.py
+++ b/src/frontend/pages/1_🦎_Uni_Guana.py
@@ -89,9 +89,30 @@ client = ZenoClient(base_url=API_BASE_URL, token=st.session_state.token)
 quota_info = client.get_quota_info()
 remaining_prompts = quota_info["promptQuota"] - quota_info["promptsUsed"]
 
-if user_input := st.chat_input(
-    f"Type your message here... (remaining prompts: {remaining_prompts})"
-):
+# Initialize pending input state
+if "pending_input" not in st.session_state:
+    st.session_state.pending_input = None
+
+
+def handle_input():
+    # Get the current input value from the widget
+    current_input = st.session_state.get("user_input", "")
+    if current_input and current_input.strip():
+        st.session_state.pending_input = current_input.strip()
+
+
+user_input = st.chat_input(
+    f"Type your message here... (remaining prompts: {remaining_prompts})",
+    key="user_input",
+    on_submit=handle_input,
+)
+
+# Check for pending input from session state
+if st.session_state.pending_input:
+    user_input = st.session_state.pending_input
+    st.session_state.pending_input = None  # Clear after use
+
+if user_input:
     ui_context = {}
 
     if selected_aoi and not st.session_state.get("aoi_acknowledged"):


### PR DESCRIPTION
**Problem** 
`st.chat_input()` returns `None` on subsequent submissions due to Streamlit widget state bug.

**Solution** 
Capture input via `on_submit` callback and session state instead of relying on widget return value.

cc @batpad @yellowcap 