### PR TITLE
Fix: eval run query over async zeno

### DIFF
--- a/experiments/eval_data_interpretation.py
+++ b/experiments/eval_data_interpretation.py
@@ -223,10 +223,12 @@ async def main():
 
         handler = CallbackHandler()
 
-        for idx, item in enumerate(active_items):
-            print(f"\n{'='*60}")
-            print(f"Processing item {idx+1}/{len(active_items)}: {item.input[:50]}...")
-            
+        for idx, item in enumerate(active_items[:1]):
+            print(f"\n{'=' * 60}")
+            print(
+                f"Processing item {idx + 1}/{len(active_items)}: {item.input[:50]}..."
+            )
+
             with item.run(run_name=run_name) as root_span:
                 # Execute
                 print(f"  Calling run_query...")
@@ -237,11 +239,13 @@ async def main():
                     thread_id=item.id,
                 )
                 print(f"  run_query completed")
-                
+
                 # Score
                 try:
                     if response is None:
-                        print(f"✗ Skipping item '{item.input}': response is None")
+                        print(
+                            f"✗ Skipping item '{item.input}': response is None"
+                        )
                         continue
 
                     print(f"  Parsing output...")
@@ -264,7 +268,9 @@ async def main():
                     )
                 except TypeError as e:
                     # Skip this item if response is not in expected format
-                    print(f"✗ TypeError processing item '{item.input}': {str(e)}")
+                    print(
+                        f"✗ TypeError processing item '{item.input}': {str(e)}"
+                    )
                     print(f"  Response type: {type(response)}")
                     if response:
                         print(f"  Response preview: {str(response)[:200]}...")
@@ -277,7 +283,7 @@ async def main():
             # LLM-based scoring with analysis helps understand evaluation reasoning
             # Check LangFuse UI for detailed trace analysis of failures
             print(f"✓ {item.input} -> {score}")
-            print(f"Item {idx+1} completed")
+            print(f"Item {idx + 1} completed")
 
     finally:
         # Clean up both database pool and checkpointer pool

--- a/experiments/eval_data_interpretation.py
+++ b/experiments/eval_data_interpretation.py
@@ -300,17 +300,6 @@ Evaluate the agent's response for environmental data hallucinations. Focus on cl
     return result
 
 
-def hallucination_severity_to_score(severity: HallucinationSeverity) -> float:
-    """Convert hallucination severity to numeric score (0.0 = worst, 1.0 = best)."""
-    severity_scores = {
-        "critical_misinfo": 0.0,
-        "significant_error": 0.33,
-        "minor_deviation": 0.67,
-        "factually_sound": 1.0,
-    }
-    return severity_scores.get(severity["severity"], 0.0)
-
-
 # Main execution
 async def main():
     """Main async function to run the evaluation."""
@@ -381,9 +370,6 @@ async def main():
                     hallucination_check = evaluate_hallucination_risk(
                         actual, item.input, item.expected_output, chat_model
                     )
-                    hallucination_score = hallucination_severity_to_score(
-                        hallucination_check
-                    )
 
                     # Upload
                     print("  Uploading trace...")
@@ -396,10 +382,12 @@ async def main():
                     )
 
                     root_span.score_trace(
-                        name="hallucination_severity_score",
-                        value=hallucination_score,
-                        comment=f"Severity: {hallucination_check['severity']} | Issues: {', '.join(hallucination_check['identified_issues'])}",
+                        name="hallucination_severity_category",
+                        value=hallucination_check["severity"],
+                        data_type="CATEGORICAL",
+                        comment=f"Issues: {', '.join(hallucination_check['identified_issues'])}",
                     )
+
                 except TypeError as e:
                     # Skip this item if response is not in expected format
                     print(

--- a/experiments/eval_data_interpretation.py
+++ b/experiments/eval_data_interpretation.py
@@ -379,12 +379,15 @@ async def main():
                         comment=f"Analysis: {evaluation['analysis']}",
                     )
 
-                    root_span.score_trace(
-                        name="hallucination_severity_category",
-                        value=hallucination_check["severity"],
-                        data_type="CATEGORICAL",
-                        comment=f"Issues: {', '.join(hallucination_check['identified_issues'])}",
-                    )
+                    # TODO: factually_sound prognosis seem buggy. i.e. answre is outright wrong but
+                    # it's marked as factually_sound
+                    if hallucination_check["severity"] != "factually_sound":
+                        root_span.score_trace(
+                            name="hallucination_severity_category",
+                            value=hallucination_check["severity"],
+                            data_type="CATEGORICAL",
+                            comment=f"Issues: {', '.join(hallucination_check['identified_issues'])}",
+                        )
 
                 except TypeError as e:
                     # Skip this item if response is not in expected format
@@ -397,7 +400,7 @@ async def main():
                     print(f"  Traceback:\n{traceback.format_exc()}")
                     continue
                 finally:
-                    print(f"  Flushing langfuse...")
+                    print("  Flushing langfuse...")
                     langfuse.flush()
 
             # LLM-based scoring with analysis helps understand evaluation reasoning

--- a/experiments/eval_dataset_identification.py
+++ b/experiments/eval_dataset_identification.py
@@ -23,6 +23,7 @@ from langgraph.types import StateSnapshot
 from typing_extensions import Annotated, Literal, TypedDict
 
 from experiments.eval_utils import get_langfuse, get_run_name, run_query
+from src.utils.database import initialize_global_pool, close_global_pool
 
 
 # Data structures
@@ -189,72 +190,83 @@ def evaluation_to_score(evaluation: EvaluationResult) -> float:
 
 
 def main(dataset_name: str):
-    langfuse = get_langfuse()
-    run_name = get_run_name()
-    dataset = langfuse.get_dataset(dataset_name)
-    chat_model = ChatAnthropic(
-        model="claude-opus-4-20250514",
-        max_tokens=20000,
-        thinking={"type": "enabled", "budget_tokens": 10000},
-    )
+    # Initialize the database pool for tools
+    asyncio.run(initialize_global_pool())
 
-    # This iterates through dataset items automatically like unit tests.
-    # Run locally for development, but use staging for accurate latency/cost measurements.
-    # Future: Integrate with CI/CD pipeline for automated testing on code changes.
-    active_items = [item for item in dataset.items if item.status == "ACTIVE"]
-    print(
-        f"Evaluating {len(active_items)} active items (out of {len(dataset.items)} total)..."
-    )
-
-    handler = CallbackHandler()
-
-    for item in active_items:
-        with item.run(run_name=run_name) as root_span:
-            # Execute
-            response = asyncio.run(
-                run_query(
-                    query=item.input,
-                    handler=handler,
-                    user_persona="researcher",
-                    thread_id=item.id,
-                )
-            )
-            # Score
-            try:
-                actual = parse_output_state_snapshot(response)
-                evaluation = evaluate_answer(
-                    actual, item.input, item.expected_output, chat_model
-                )
-                score = evaluation_to_score(evaluation)
-
-                # Upload
-                root_span.update_trace(input=item.input, output=actual)
-
-                root_span.score_trace(
-                    name="dataset_identification_score",
-                    value=score,
-                    comment=f"Analysis: {evaluation['analysis']}",
-                )
-            except TypeError as e:
-                # Skip this item if response is not in expected format
-                print(f"✗ TypeError processing item '{item.input}': {str(e)}")
-                print(f"  Response type: {type(response)}")
-                if response:
-                    print(f"  Response preview: {str(response)[:200]}...")
-                print(f"  Traceback:\n{traceback.format_exc()}")
-                continue
-            finally:
-                langfuse.flush()
-
-        # LLM-based scoring with analysis helps understand evaluation reasoning
-        # Check LangFuse UI for detailed trace analysis of failures
-        print(f"✓ {item.input} -> {score}")
-
-    if hasattr(sys, "flags") and sys.flags.interactive:
-        print(
-            "\nEvaluation complete. Starting interactive console to inspect variables (e.g., 'item', 'response', 'evaluation')."
+    try:
+        langfuse = get_langfuse()
+        run_name = get_run_name()
+        dataset = langfuse.get_dataset(dataset_name)
+        chat_model = ChatAnthropic(
+            model="claude-opus-4-20250514",
+            max_tokens=20000,
+            thinking={"type": "enabled", "budget_tokens": 10000},
         )
-        code.interact(local=locals())
+
+        # This iterates through dataset items automatically like unit tests.
+        # Run locally for development, but use staging for accurate latency/cost measurements.
+        # Future: Integrate with CI/CD pipeline for automated testing on code changes.
+        active_items = [
+            item for item in dataset.items if item.status == "ACTIVE"
+        ]
+        print(
+            f"Evaluating {len(active_items)} active items (out of {len(dataset.items)} total)..."
+        )
+
+        handler = CallbackHandler()
+
+        for item in active_items:
+            with item.run(run_name=run_name) as root_span:
+                # Execute
+                response = asyncio.run(
+                    run_query(
+                        query=item.input,
+                        handler=handler,
+                        user_persona="researcher",
+                        thread_id=item.id,
+                    )
+                )
+                # Score
+                try:
+                    actual = parse_output_state_snapshot(response)
+                    evaluation = evaluate_answer(
+                        actual, item.input, item.expected_output, chat_model
+                    )
+                    score = evaluation_to_score(evaluation)
+
+                    # Upload
+                    root_span.update_trace(input=item.input, output=actual)
+
+                    root_span.score_trace(
+                        name="dataset_identification_score",
+                        value=score,
+                        comment=f"Analysis: {evaluation['analysis']}",
+                    )
+                except TypeError as e:
+                    # Skip this item if response is not in expected format
+                    print(
+                        f"✗ TypeError processing item '{item.input}': {str(e)}"
+                    )
+                    print(f"  Response type: {type(response)}")
+                    if response:
+                        print(f"  Response preview: {str(response)[:200]}...")
+                    print(f"  Traceback:\n{traceback.format_exc()}")
+                    continue
+                finally:
+                    langfuse.flush()
+
+            # LLM-based scoring with analysis helps understand evaluation reasoning
+            # Check LangFuse UI for detailed trace analysis of failures
+            print(f"✓ {item.input} -> {score}")
+
+            if hasattr(sys, "flags") and sys.flags.interactive:
+                print(
+                    "\nEvaluation complete. Starting interactive console to inspect variables (e.g., 'item', 'response', 'evaluation')."
+                )
+                code.interact(local=locals())
+    finally:
+        # Clean up database pool
+        asyncio.run(close_global_pool())
 
 
 if __name__ == "__main__":

--- a/experiments/eval_dataset_identification.py
+++ b/experiments/eval_dataset_identification.py
@@ -8,6 +8,7 @@ This evaluates high-level questions (e.g., deforestation in Amazon) with expert-
 Unlike GADM evaluation, this uses LLM-based scoring to compare non-exact matches.
 """
 
+import asyncio
 import argparse
 import code
 import json
@@ -210,11 +211,13 @@ def main(dataset_name: str):
     for item in active_items:
         with item.run(run_name=run_name) as root_span:
             # Execute
-            response = run_query(
-                query=item.input,
-                handler=handler,
-                user_persona="researcher",
-                thread_id=item.id,
+            response = asyncio.run(
+                run_query(
+                    query=item.input,
+                    handler=handler,
+                    user_persona="researcher",
+                    thread_id=item.id,
+                )
             )
             # Score
             try:

--- a/experiments/eval_gadm.py
+++ b/experiments/eval_gadm.py
@@ -44,9 +44,19 @@ def normalize_gadm_id(gadm_id: str) -> str:
     return gadm_id
 
 
-def parse_expected_output(gadm_id: str) -> List[GadmLocation]:
+def parse_expected_output(expected_data) -> List[GadmLocation]:
     """Convert list of dicts to list of GadmLocation objects."""
-    return [GadmLocation(gadm_id=gadm_id)]
+    if isinstance(expected_data, list):
+        return [
+            GadmLocation(gadm_id=item["gadm_id"], name=item["name"])
+            for item in expected_data
+            if "gadm_id" in item
+        ]
+    elif isinstance(expected_data, str):
+        # Handle legacy case if it's just a string
+        return [GadmLocation(gadm_id=expected_data)]
+    else:
+        return []
 
 
 def parse_gadm_from_json(json_str: str) -> List[GadmLocation]:
@@ -123,7 +133,6 @@ def extract_gadm_from_state(state):
 
             if aoi_gadm_id:
                 return [GadmLocation(name=aoi_name, gadm_id=aoi_gadm_id)]
-
         return []
 
     return []

--- a/experiments/eval_gadm.py
+++ b/experiments/eval_gadm.py
@@ -58,8 +58,11 @@ def normalize_gadm_id(gadm_id: str) -> str:
     Returns:
         Normalized GADM ID string
     """
-    gadm_id = gadm_id.split("_")[0].replace("-", ".").lower()
-    return gadm_id
+    try:
+        return gadm_id.split("_")[0].replace("-", ".").lower()
+    except AttributeError:
+        # If gadm_id is not a string (e.g., int), return as-is
+        return gadm_id
 
 
 def parse_expected_output(expected_data) -> List[GadmLocation]:

--- a/experiments/eval_gadm.py
+++ b/experiments/eval_gadm.py
@@ -14,7 +14,6 @@ from typing import List, Optional
 from langfuse.langchain import CallbackHandler
 
 from experiments.eval_utils import get_langfuse, get_run_name, run_query
-from src.utils.geocoding_helpers import GADM_LEVELS
 from src.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -120,9 +119,7 @@ def extract_gadm_from_state(state):
         aoi = state.values.get("aoi")
 
         if aoi is not None and aoi_name:
-            subtype = state.values.get("subtype")
-            gadm_level = GADM_LEVELS.get(subtype, {})
-            aoi_gadm_id = aoi.get(gadm_level.get("col_name", ""))
+            aoi_gadm_id = aoi.get("gadm_id")
 
             if aoi_gadm_id:
                 return [GadmLocation(name=aoi_name, gadm_id=aoi_gadm_id)]

--- a/experiments/eval_gadm.py
+++ b/experiments/eval_gadm.py
@@ -40,6 +40,24 @@ class GadmLocation:
 
 # Parsing utilities
 def normalize_gadm_id(gadm_id: str) -> str:
+    """Normalize GADM IDs to enable consistent comparison between different formats.
+
+    Normalization steps:
+    1. Remove suffix after underscore (e.g., CUB.7_1 → CUB.7)
+    2. Replace hyphens with dots (e.g., CUB-7 → CUB.7)
+    3. Convert to lowercase (e.g., CUB.7 → cub.7)
+
+    Examples:
+        CUB.7_1 → cub.7
+        CUB-7 → cub.7
+        CUB.7 → cub.7
+
+    Args:
+        gadm_id: The GADM ID to normalize
+
+    Returns:
+        Normalized GADM ID string
+    """
     gadm_id = gadm_id.split("_")[0].replace("-", ".").lower()
     return gadm_id
 

--- a/experiments/eval_gadm.py
+++ b/experiments/eval_gadm.py
@@ -5,6 +5,7 @@ Results are published to LangFuse (either localhost or staging instance).
 See experiments/upload_dataset.py for how to add new test data.
 """
 
+import asyncio
 import json
 from collections import Counter
 from dataclasses import dataclass
@@ -151,7 +152,9 @@ for item in dataset.items:
         run_name=run_name,
     ) as span:
         # Execute
-        state = run_query(item.input, handler, "researcher", item.id)
+        state = asyncio.run(
+            run_query(item.input, handler, "researcher", item.id)
+        )
 
         # Score
         actual = extract_gadm_from_state(state)

--- a/experiments/eval_utils.py
+++ b/experiments/eval_utils.py
@@ -1,13 +1,18 @@
 import os
 import subprocess
 from datetime import datetime
+from typing import Type, TypeVar
 
 import langgraph.errors
+from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage
 from langfuse import Langfuse
 from langfuse.langchain import CallbackHandler
+from pydantic import BaseModel
 
 from src.agents import fetch_zeno
+
+T = TypeVar("T", bound=BaseModel)
 
 
 def get_langfuse():
@@ -33,6 +38,55 @@ def get_run_name():
     return f"eval_{date}_{git_hash}"
 
 
+# This is a workaround for Anthropic+Langchain API's lack of thinking+structured_output
+# https://gist.github.com/donbr/aef4488082a0a25c7b829c3bec7445d2
+def reason_and_structure(
+    prompt: str,
+    schema: Type[T],
+    reasoning_model: str = "claude-opus-4-1-20250805",
+    structuring_model: str = "claude-sonnet-4-20250514",
+) -> T:
+    """Two-stage process: reason with thinking, then structure the output.
+
+    Args:
+        prompt: The prompt to send to the reasoning model
+        schema: The Pydantic model or TypedDict to structure the output
+        reasoning_model: Model to use for reasoning stage (with thinking)
+        structuring_model: Model to use for structuring stage (without thinking)
+        thinking_budget: Token budget for thinking in reasoning stage
+
+    Returns:
+        Structured output matching the provided schema
+    """
+    # Stage 1: Reasoning with thinking enabled
+    reasoning_llm = ChatAnthropic(
+        model=reasoning_model,
+        max_tokens=32000,
+        thinking={"type": "enabled", "budget_tokens": 20000},
+    )
+
+    reasoning_response = reasoning_llm.invoke([HumanMessage(content=prompt)])
+
+    # Stage 2: Structuring with a fast model (no thinking)
+    structuring_llm = ChatAnthropic(
+        model=structuring_model,
+        max_tokens=8000,
+        thinking={"type": "disabled"},
+    )
+
+    structured_llm = structuring_llm.with_structured_output(schema)
+
+    # Create a prompt that asks the structuring model to extract structured data
+    structuring_prompt = f"""Based on the following analysis, provide a structured response.
+
+    Analysis:
+    {reasoning_response.content}
+
+    Extract the key information and structure it according to the required format."""
+
+    return structured_llm.invoke([HumanMessage(content=structuring_prompt)])
+
+
 async def run_query(
     query: str,
     handler: CallbackHandler,
@@ -41,10 +95,10 @@ async def run_query(
 ):
     """Run a query through Zeno and return the final state."""
     import uuid
-    
+
     # Use a unique thread_id for each evaluation to avoid locking issues
     eval_thread_id = f"eval_{thread_id}_{uuid.uuid4().hex[:8]}"
-    
+
     config = {
         "configurable": {"thread_id": eval_thread_id},  # Unique thread ID
         "callbacks": [handler],
@@ -74,7 +128,7 @@ async def run_query(
         async for update in stream:
             update_count += 1
             print(f"    Update {update_count} received")
-            
+
         print(f"  Stream completed with {update_count} updates")
 
         # Now get the final state after execution
@@ -91,12 +145,19 @@ async def run_query(
         return None
     except ValueError as e:
         # Handle the specific case of missing ToolMessages
-        if "AIMessages with tool_calls that do not have a corresponding ToolMessage" in str(e):
-            print(f"Incomplete execution for query '{query}': Tool calls without responses detected")
+        if (
+            "AIMessages with tool_calls that do not have a corresponding ToolMessage"
+            in str(e)
+        ):
+            print(
+                f"Incomplete execution for query '{query}': Tool calls without responses detected"
+            )
             # Try to get the state anyway with a different approach
             try:
                 # Get the state with snapshot=True to get whatever state is available
-                state = await zeno_async.aget_state(config=config, subgraphs=True)
+                state = await zeno_async.aget_state(
+                    config=config, subgraphs=True
+                )
                 if state:
                     print(f"  Retrieved partial state for query '{query}'")
                     return state
@@ -114,6 +175,7 @@ async def run_query(
             f"Unexpected error for query '{query}': {type(e).__name__}: {str(e)}"
         )
         import traceback
+
         traceback.print_exc()
         # Return None to indicate error
         return None


### PR DESCRIPTION
Converted the evaluation pipeline to use async/await patterns with proper database connection pooling, requiring initialization and cleanup of global pools. Added hallucination severity detection for environmental data responses, implementing a two-stage LLM processing approach (reasoning + structuring) to work around Anthropic API limitations with thinking and structured outputs.