### PR TITLE
add db migrations for new profile fields

### DIFF
--- a/db/alembic/versions/ab07f4a240eb_add_topics_receive_news_emails_and_help_.py
+++ b/db/alembic/versions/ab07f4a240eb_add_topics_receive_news_emails_and_help_.py
@@ -5,15 +5,15 @@ Revises: e092075cb11b
 Create Date: 2025-09-10 15:08:17.650795
 
 """
+
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = 'ab07f4a240eb'
-down_revision: Union[str, None] = 'e092075cb11b'
+revision: str = "ab07f4a240eb"
+down_revision: Union[str, None] = "e092075cb11b"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -21,16 +21,32 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Upgrade schema."""
     # Add topics field as String (JSON array of selected topic codes)
-    op.add_column('users', sa.Column('topics', sa.String(), nullable=True))
-    
+    op.add_column("users", sa.Column("topics", sa.String(), nullable=True))
+
     # Add boolean fields for user preferences
-    op.add_column('users', sa.Column('receive_news_emails', sa.Boolean(), nullable=False, server_default='false'))
-    op.add_column('users', sa.Column('help_test_features', sa.Boolean(), nullable=False, server_default='false'))
+    op.add_column(
+        "users",
+        sa.Column(
+            "receive_news_emails",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "help_test_features",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     # Remove the added columns
-    op.drop_column('users', 'help_test_features')
-    op.drop_column('users', 'receive_news_emails')
-    op.drop_column('users', 'topics')
+    op.drop_column("users", "help_test_features")
+    op.drop_column("users", "receive_news_emails")
+    op.drop_column("users", "topics")

--- a/db/alembic/versions/ab07f4a240eb_add_topics_receive_news_emails_and_help_.py
+++ b/db/alembic/versions/ab07f4a240eb_add_topics_receive_news_emails_and_help_.py
@@ -1,0 +1,36 @@
+"""add topics, receive_news_emails, and help_test_features fields to users table
+
+Revision ID: ab07f4a240eb
+Revises: e092075cb11b
+Create Date: 2025-09-10 15:08:17.650795
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ab07f4a240eb'
+down_revision: Union[str, None] = 'e092075cb11b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Add topics field as String (JSON array of selected topic codes)
+    op.add_column('users', sa.Column('topics', sa.String(), nullable=True))
+    
+    # Add boolean fields for user preferences
+    op.add_column('users', sa.Column('receive_news_emails', sa.Boolean(), nullable=False, server_default='false'))
+    op.add_column('users', sa.Column('help_test_features', sa.Boolean(), nullable=False, server_default='false'))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove the added columns
+    op.drop_column('users', 'help_test_features')
+    op.drop_column('users', 'receive_news_emails')
+    op.drop_column('users', 'topics')


### PR DESCRIPTION
I missed adding the db migrations for the new user profile fields. This adds them.