### PR TITLE
Add `trace_url` to end of streaming response

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -414,11 +414,14 @@ async def stream_chat(
 
         # Send trace ID after stream completes
         trace_id = getattr(langfuse_handler, "last_trace_id", None)
+        trace_url = langfuse_client.get_trace_url(trace_id=trace_id)
         if trace_id:
             yield pack(
                 {
                     "node": "trace_info",
-                    "update": dumps({"trace_id": trace_id}),
+                    "update": dumps(
+                        {"trace_id": trace_id, "trace_url": trace_url}
+                    ),
                 }
             )
 

--- a/tests/agent/e2e/runners/api.py
+++ b/tests/agent/e2e/runners/api.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 
 import httpx
 from langchain_core.load import loads
-from langfuse import get_client
 
 from ..types import ExpectedData, TestResult
 from .base import BaseTestRunner
@@ -36,7 +35,6 @@ class APITestRunner(BaseTestRunner):
             TestResult with evaluation scores and metadata
         """
         thread_id = uuid4().hex
-        langfuse = get_client()
         trace_url = None
 
         try:
@@ -79,8 +77,7 @@ class APITestRunner(BaseTestRunner):
                                     stream_data.get("update", "{}")
                                 )
                                 trace_id = update_data.get("trace_id")
-
-                trace_url = langfuse.get_trace_url(trace_id=trace_id)
+                                trace_url = update_data.get("trace_url")
 
                 # Get final agent state using the state endpoint
                 state_response = await client.get(


### PR DESCRIPTION
This helps to include langfuse traces in the eval runs even when they are run on remote environments.

- Include `trace_url` alongside `trace_id` in the streaming chat response `trace_info` node. 
- Update API test runner to read `trace_url` directly from response instead of generating it separately.

