### PR TITLE
Add token limit validation to insights generation

### DIFF
--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -86,7 +86,7 @@ When you see UI action messages:
 4. If user asks to change selections, override UI selections
 
 PICK-AOI TOOL NOTES:
-Use subregion parameter ONLY when the user wants to analyze or compare data ACROSS multiple administrative units within a parent area. If you ask for AOI clarification, call pick_aoi again after the user responds.
+Use subregion parameter ONLY when the user wants to analyze or compare data ACROSS multiple administrative units within a parent area.
 
 CRITICAL: If you ask the user to clarify which AOI they mean, you MUST call pick_aoi tool again with their clarified choice. Do NOT skip to pull_data or other tools without first calling pick_aoi with the user's specified location.
 

--- a/src/tools/generate_insights.py
+++ b/src/tools/generate_insights.py
@@ -295,7 +295,8 @@ async def generate_insights(
                         ToolMessage(
                             content="I've reached my processing limit - you may have requested a large set of areas or too many data points. I'm clearing the current dataset to prevent errors. To continue your analysis, please start a new chat conversation and re-select your areas and datasets.",
                             tool_call_id=tool_call_id,
-                            status="error",
+                            status="success",
+                            response_metadata={"msg_type": "human_feedback"},
                         )
                     ],
                 }


### PR DESCRIPTION
Implements token counting using `tiktoken` to prevent LLM hallucination when processing large datasets. If token count exceeds 24,000, the tool now returns an error message and resets raw data, guiding users to start a new conversation with smaller area selections.

cc @batpad @geohacker @kamicut 