### PR TITLE
Remove driver option for tree cover loss

### DIFF
--- a/src/tools/analytics_datasets.yml
+++ b/src/tools/analytics_datasets.yml
@@ -563,9 +563,7 @@ datasets:
 
 - dataset_id: 4
   dataset_name: Tree cover loss
-  context_layers:
-    - value: "driver"
-      description: "Shows the primary driver of tree cover loss, including: commodity-driven deforestation, shifting agriculture, forestry, wildfire, and other drivers"
+  context_layers: null
   variables:
     - value: "primary_forest"
       description: "Shows loss within humid tropical primary forest in global pan-tropical regions"


### PR DESCRIPTION
Drivers don't have time and are thus breaking the expected schema. So to more reliably getting time series plots, this needs to be removed for now. Can add back in later.