### PR TITLE
Set forest_filter to null in analytics api queries

### DIFF
--- a/src/tools/data_handlers/analytics_handler.py
+++ b/src/tools/data_handlers/analytics_handler.py
@@ -239,7 +239,7 @@ class AnalyticsHandler(DataSourceHandler):
                 "start_year": start_date[:4],
                 "end_year": end_date[:4],
                 "canopy_cover": 30,
-                "forest_filter": "primary_forest",
+                "forest_filter": None,
                 "intersections": (
                     [dataset["context_layer"]]
                     if dataset.get("context_layer")
@@ -256,7 +256,7 @@ class AnalyticsHandler(DataSourceHandler):
                 **base_payload,
                 "start_year": str(max(2000, start_year)),
                 "end_year": str(max(2005, end_year)),
-                "forest_filter": "primary_forest",
+                "forest_filter": None,
             }
         elif dataset.get("dataset_id") == FOREST_CARBON_FLUX_ID:
             payload = {
@@ -267,7 +267,7 @@ class AnalyticsHandler(DataSourceHandler):
             payload = {
                 **base_payload,
                 "canopy_cover": 30,
-                "forest_filter": "primary_forest",
+                "forest_filter": None,
             }
         else:
             raise ValueError(


### PR DESCRIPTION
We need to fetch the tree cover loss/gain data for all forest types

Fixes the inaccurate numbers issue reported in https://gfw.atlassian.net/browse/PZB-419. Now it correctly reports the total tree cover loss / gain for all types of forests.

eg for the query `tree cover loss in Indonesia from 2021 to 2024` it now returns this:

<img width="571" height="469" alt="image" src="https://github.com/user-attachments/assets/3406b3f5-5ee0-4928-b140-0dab6497a46c" />

which matches the expected numbers mentioned in the issue https://gfw.atlassian.net/browse/PZB-419:

> Correct results:
>
> 2024: 1.12 Mha
> 
> 2023: 1.4 Mha
> 
> 2022: 885,000 ha
> 
> 2021: 841,000 ha

cc @srmsoumya @yellowcap 