### PR TITLE
Switch grasslands to v1 instead of v1.1

### DIFF
--- a/src/tools/analytics_datasets.yml
+++ b/src/tools/analytics_datasets.yml
@@ -298,7 +298,7 @@ datasets:
   dataset_name: Global natural/semi-natural grassland extent
   context_layers: null
   variables: Natural/Semi-Natural Grassland
-  tile_url: "/raster/collections/grasslands-v-1-1/items/grasslands-{year}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?colormap=%7B%220%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%221%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%222%22%3A%20%5B255%2C%20153%2C%2022%2C%20255%5D%2C%20%223%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True"
+  tile_url: "/raster/collections/grasslands-v-1/items/grasslands-{year}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?colormap=%7B%220%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%221%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%222%22%3A%20%5B255%2C%20153%2C%2022%2C%20255%5D%2C%20%223%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True"
   license: "CC by 4.0"
   geographic_coverage: "90°N to 90°S"
   resolution: "30 x 30 meters"

--- a/stac/datasets/grasslands.py
+++ b/stac/datasets/grasslands.py
@@ -17,16 +17,11 @@ from stac.datasets.utils import (
     load_stac_data_to_db,
 )
 
-S3_URLS = [
-    f"s3://gfw-data-lake/gfw_grasslands/v1.1/geotiff/grasslands_{year}.tif"
-    for year in range(2000, 2025)
-]
-
 dotenv.load_dotenv("stac/env/.env_staging")
 
 set_stac_version("1.1.0")
 
-COLLECTION_ID = "grasslands-v-1-1"
+COLLECTION_ID = "grasslands-v-1"
 
 CLASSIFICATION_VALUES = {
     0: "Other",
@@ -38,9 +33,9 @@ CLASSIFICATION_VALUES = {
 
 def create_grasslands_items() -> Item:
     items = []
-    for year in range(2000, 2025):
+    for year in range(2000, 2023):
         print(f"Creating item for {year}")
-        url = f"s3://gfw-data-lake/gfw_grasslands/v1.1/geotiff/grasslands_{year}.tif"
+        url = f"s3://gfw-data-lake/gfw_grasslands/v1/geotiff/grasslands_{year}.tif"
         item = create_stac_item(
             source=url,
             id=f"grasslands-{year}",


### PR DESCRIPTION
The analytics api is relying on v1, so we are switching the tile urls to v1.

Our STAC api hosts both versions v1 and v1.1.