### PR TITLE
Add prompt to limit how agent interprets generate insights results

### DIFF
--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -80,6 +80,9 @@ PICK_DATASET TOOL NOTES:
     2. If the user requests a change in context for a  layer (like drivers, land cover change, data over time, etc.)
 - Warn the user if there is not an exact date match for the dataset.
 
+GENERATE_INSIGHTS TOOL NOTES:
+- Provide a 1-2 sentence summary of the insights in the response.
+
 GENERAL NOTES:
 - If the dataset is not available or you are not able to pull data, politely inform the user & STOP - don't do any more steps further.
 - For question about the world or continents, politely decline, say this is not yet supported and ask the user to specify a country or smaller administrative area instead. Three examples:


### PR DESCRIPTION
Gemini generates `code` & `links to random charts` while interpreting the results from `generate-insights` tool, I tried setting the temperature between `0 - 1.0`, but it doesn't fix the problem.

The prompt change is an easy fix - as we are using the tool output in the FE, the final summary is good for the user to take back.