### PR TITLE
Allow admins to render any thread

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1158,14 +1158,15 @@ async def get_thread(
     if thread.is_public:
         logger.debug("Accessing public thread", thread_id=thread_id)
     else:
-        # For private threads, require authentication and ownership
+        # For private threads, require authentication and ownership (or admin access)
         if not user:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Missing Bearer token",
             )
 
-        if thread.user_id != user.id:
+        # Allow access if user is admin or owns the thread
+        if thread.user_id != user.id and user.user_type != UserType.ADMIN:
             logger.warning(
                 "Unauthorized access to private thread",
                 thread_id=thread_id,
@@ -1174,9 +1175,19 @@ async def get_thread(
             )
             raise HTTPException(status_code=404, detail="Thread not found")
 
-        logger.debug(
-            "Accessing private thread", thread_id=thread_id, user_id=user.id
-        )
+        if user.user_type == UserType.ADMIN:
+            logger.debug(
+                "Admin accessing private thread",
+                thread_id=thread_id,
+                admin_user_id=user.id,
+                owner_id=thread.user_id,
+            )
+        else:
+            logger.debug(
+                "Accessing private thread",
+                thread_id=thread_id,
+                user_id=user.id,
+            )
     try:
         logger.debug("Replaying thread", thread_id=thread_id)
         return StreamingResponse(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from src.api.app import app, fetch_user_from_rw_api
-from src.api.data_models import Base, ThreadOrm, UserOrm
+from src.api.data_models import Base, ThreadOrm, UserOrm, UserType
 from src.api.schemas import UserModel
 from src.utils.database import (
     close_global_pool,
@@ -248,3 +248,24 @@ async def test_db_pool():
     await initialize_global_pool()
     yield
     await close_global_pool()
+
+
+@pytest_asyncio.fixture(scope="function")
+async def admin_user_factory():
+    """Create admin user fixture."""
+
+    async def _admin_user(email: str):
+        async with async_session_maker() as session:
+            # Create admin user
+            admin_user = UserOrm(
+                id=f"admin-{email.split('@')[0]}",
+                name=f"Admin {email.split('@')[0]}",
+                email=email,
+                user_type=UserType.ADMIN.value,
+            )
+            session.add(admin_user)
+            await session.commit()
+            await session.refresh(admin_user)
+            return admin_user
+
+    return _admin_user


### PR DESCRIPTION
This change allows admin users to see any tread in read-only mode. 

This would help the WRI admin team a lot to understand bug reports and feature requests. The rendered thread is much easier to read than the langfuse trace.