### PR TITLE
fix sending rating to langfuse

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1456,7 +1456,7 @@ async def send_rating_to_langfuse(
         user_id: User ID for context
     """
     try:
-        langfuse_client.score(
+        langfuse_client.create_score(
             trace_id=trace_id,
             name="user-feedback",
             value=rating,


### PR DESCRIPTION
Fixes sending rating information to langfuse, use `create_score` and not `score` as per https://langfuse.com/docs/evaluation/evaluation-methods/custom-scores

cc @srmsoumya @leothomas 
