### PR TITLE
Update chart instructions

### DIFF
--- a/src/tools/analytics_datasets.yml
+++ b/src/tools/analytics_datasets.yml
@@ -604,6 +604,8 @@ datasets:
     includes plantations as well as natural forest meaning loss is not automatically
     deforestation or carbon loss.
     The product measures canopy loss only; it doesn't track regrowth or permanence. Use 30% threshold.
+    If a user asks for net gain/loss, refuse and explain that the methodologies for the two datasets differ
+    and thus they cannot be combined directly to calculate net change.
   description: >
     Tree Cover Loss (Hansen/UMD/GLAD) maps annual global forest loss from 2001 to 2024 at
     30-meter resolution using Landsat satellite imagery. It detects stand-replacement
@@ -722,6 +724,8 @@ datasets:
     Area [Year1 to Year2] = Area [Year1 to 2020] - Area [Year2 to 2020].
     Warn that these are estimates that can be used as indicators of tree gain but are not suitable for
     precise verification of restoration activities at local scales.
+    If a user asks for net gain/loss, refuse and explain that the methodologies for the two datasets differ
+    and thus they cannot be combined directly to calculate net change.
   description: >
     Tree Cover Gain (Hansen/UMD/GLAD) identifies areas where new tree canopy was established
     between 2000 and 2012 at 30-meter resolution, using Landsat 7 imagery. It captures both

--- a/src/tools/analytics_datasets.yml
+++ b/src/tools/analytics_datasets.yml
@@ -606,6 +606,7 @@ datasets:
     The product measures canopy loss only; it doesn't track regrowth or permanence. Use 30% threshold.
     If a user asks for net gain/loss, refuse and explain that the methodologies for the two datasets differ
     and thus they cannot be combined directly to calculate net change.
+    DO NOT show emissions and loss in the same chart, use separate charts.
   description: >
     Tree Cover Loss (Hansen/UMD/GLAD) maps annual global forest loss from 2001 to 2024 at
     30-meter resolution using Landsat satellite imagery. It detects stand-replacement

--- a/src/tools/analytics_datasets.yml
+++ b/src/tools/analytics_datasets.yml
@@ -802,6 +802,8 @@ datasets:
     in the negative.
     DO NOT show trends over time and caution users that net flux represents totals over
     the the period 2001-2024, not an annual time series.
+    Use the term "net sink" for net-negative flux values (removals/sequestration) and "net source"
+    for net-positive (emissions)
   description: >
     Maps the balance between emissions from forest disturbances and carbon removals from forest growth
     between 2001 and 2024, using a globally consistent model. Negative values indicate forest areas


### PR DESCRIPTION
A couple of instruction changes to address bugs reported by internal researchers. These should _hopefully_ ensure that the LLM doesn't:
- Show emissions and loss on the same bar chart
- Calculate net forest change using TCL and Gain
- use confusing terms for net carbon flux