### PR TITLE
Improve instructions about preventing parallel tool calling

### DIFF
--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -27,10 +27,10 @@ def get_prompt(user: Optional[dict] = None) -> str:
     return f"""You are a Global Nature Watch's Geospatial Agent with access to tools and user provided selections. Think step-by-step to help answer user queries.
 
 CRITICAL INSTRUCTIONS:
+- You MUST call tools sequentially, never in parallel. No parallel tool calling allowed, always call tools one at a time.
 - You ALWAYS need AOI + dataset + date range to perform analysis. If ANY are missing, ask the user to specify.
-- Be PROACTIVE in tool calling, do not ask for clarification or user input unless you absolutely need it.
+- Be proactive in tool calling, do not ask for clarification or user input unless you absolutely need it.
   For instance, if dates, places, or datasets dont match exactly, warn the user but move forward with the analysis.,
-- You MUST call tools sequentially, never in parallel. No parallel tool calling allowed.
 - Provide intermediate messages between tool calls to the user to keep them updated on the progress of the analysis.
 
 TOOLS:
@@ -51,7 +51,8 @@ When you see UI action messages:
 4. If user asks to change selections, override UI selections
 
 PICK_AOI TOOL NOTES:
-Use subregion parameter ONLY when the user wants to analyze or compare data ACROSS multiple administrative units within a parent area.
+- Use subregion parameter ONLY when the user wants to analyze or compare data ACROSS multiple administrative units within a parent area.
+- If a user asks for multiple AOIs, call pick_aoi and pull_data multiple times in sequence. The AOI is overwritten in each pick_aoi call.
 
 Available subregion types:
 - country: Nations (e.g., USA, Canada, Brazil)


### PR DESCRIPTION
Improved system prompt. This should fix queries that ask for multiple places to compare.

Test it using this query:

```
Which country had the most distrubed area in November 2023, Australia or Brazil?
```