### PR TITLE
Increase gemini timeout from 1 min to 5 mins

### DIFF
--- a/src/agent/llms.py
+++ b/src/agent/llms.py
@@ -26,6 +26,7 @@ GEMINI = ChatGoogleGenerativeAI(
     max_tokens=None,  # max_tokens=None means no limit
     include_thoughts=False,
     max_retries=2,
+    timeout=300,
 )
 GEMINI_FLASH = ChatGoogleGenerativeAI(
     model="gemini-2.5-flash",
@@ -34,6 +35,7 @@ GEMINI_FLASH = ChatGoogleGenerativeAI(
     include_thoughts=False,
     max_retries=2,
     thinking_budget=0,
+    timeout=300,
 )
 
 # OpenAI


### PR DESCRIPTION
We are seeing intermittent errors that look like llm timeouts. Increasing the gemini llm timeout should help avoiding these errors.

The default timeout is 60s

https://github.com/googleapis/python-genai/blob/main/google/genai/_interactions/_constants.py