### PR TITLE
Simplify aoi selection

### DIFF
--- a/tests/tools/test_pick_aoi.py
+++ b/tests/tools/test_pick_aoi.py
@@ -55,9 +55,12 @@ async def whitelist_test_user():
 async def test_query_aoi_multiple_matches(structlog_context):
     command = await pick_aoi.ainvoke(
         {
-            "question": "Measure deforestation in Puri",
-            "place": "Puri",
-            "tool_call_id": str(uuid.uuid4()),
+            "args": {
+                "question": "Measure deforestation in Puri",
+                "place": "Puri",
+            },
+            "id": str(uuid.uuid4()),
+            "type": "tool_call",
         }
     )
     assert str(command.update.get("messages")[0].content).startswith(


### PR DESCRIPTION
# What I am changing

I am simplifying the AOI selection. This is a preparation for multi area selection.

1. Removes try/except, since we have the middleware now
2. Remove explicit translation. Put instructions for translation into tool call docstring.

Closes https://github.com/wri/project-zeno/issues/551

# How you can test it

Run the agent tests with queries in different languages and with typos in the place names.
