### PR TITLE
Make temporal exclusion stronger

### DIFF
--- a/src/agent/tools/analytics_datasets.yml
+++ b/src/agent/tools/analytics_datasets.yml
@@ -978,12 +978,10 @@ datasets:
     - settlements
   analytics_api_endpoint: "/v0/land_change/tree_cover_loss/analytics"
   prompt_instructions: >
-    Shows the primary driver or cause of tree cover loss over the entire range 2001-2024.
-    DO NOT use when asked for 'forest loss', 'deforestation', 'tree cover loss' for:
-    - specific time ranges (e.g. last five years)
-    - single years (e.g. 2024)
-    - trends over time
-    Instead, refuse and select Tree cover loss instead.
+    Shows the delta of the primary driver or cause of tree cover loss over the entire range 2001-2024.
+    The data represents the change for the whole period of time, not a timeseries.
+    IMPORTANT: If a user asks for specific time ranges (e.g. last five years), single years (e.g. 2024),
+    or trends over time, do not use this dataset, select Tree cover loss instead.
     Classes are defined as follows:
     - Permanent agriculture: Long-term, permanent tree cover loss for small- to large-scale agriculture.
     - Hard commodities: Loss due to the establishment or expansion of mining or energy infrastructure.
@@ -1003,7 +1001,7 @@ datasets:
       followed by salvage or sanitation logging, it is classified as logging.
     DO NOT include the 'Unknown' class in analysis.
     Show total area of loss (ha) or total emissions (MgCO2e) due to loss per driver class
-    over the entire time period 2001-2024. 
+    over the entire time period 2001-2024.
     Data should be represented in a pie chart or table with each segment representing loss area
     or emissions due per driver class.
     DO NOT use the term "deforestation", use "tree cover loss" instead since "Tree cover"

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -70,10 +70,13 @@ class DatasetOption(BaseModel):
     )
     context_layer: Optional[str] = Field(
         None,
-        description="Pick a single context layer from the dataset if useful.",
+        description="Pick a single context layer from the dataset if relevant.",
     )
     reason: str = Field(
         description="Short reason why the dataset is the best match."
+    )
+    language: str = Field(
+        description="Language of the user query.",
     )
 
     @field_validator("dataset_id")
@@ -151,17 +154,22 @@ async def select_best_dataset(
                 """Based on the query, return the ID of the dataset that can best answer the
                 user query and provide reason why it is the best match.
 
-    Select a single context layer from the dataset if useful. Context layers allow difrenciating
-    between different types of data within the same dataset.
+    Select a single context layer from the dataset if relevant for the user query. Context layers
+    allow difrenciating between different types of data within the same dataset. So if a user asks
+    to show something like "show me tree cover loss by driver", you should select a context layer
 
     Evaluate if the best dataset is available for the date range requested by the user,
     if not, pick the closest date range but warn the user that there
     is not an exact match with the query requested by the user in the reason field.
 
-    IMPORTANT:
-    Provide the selection reason in the same language used in the user query,
-    but keep explanations concise. Do not use datset IDs to describe the dataset.
+    Pick the most granular dataset that matches the query and requested time range if specified.
+    For instance, dont select tree cover loss by driver if the user requests a specific time range,
+    pick tree cover loss instead.
+
+    Keep explanations concise. Do not use datset IDs to describe the dataset.
     For instance, instead of saying "Dataset ID: 123", say "Dataset: Tree Cover Loss".
+
+    Use the language of the user query to generate the reason.
 
     Candidate datasets:
 
@@ -220,6 +228,7 @@ async def select_best_dataset(
         function_usage_notes=selected_row.function_usage_notes,
         citation=selected_row.citation,
         content_date=selected_row.content_date,
+        language=selection_result.language,
     )
 
 

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -354,6 +354,7 @@ def _make_fake_selection(
         function_usage_notes=ds.get("function_usage_notes", ""),
         citation=ds.get("citation", ""),
         content_date=ds.get("content_date", ""),
+        language="en",
     )
 
 


### PR DESCRIPTION
```
  prompt_instructions: >
    Shows the primary driver or cause of tree cover loss over the entire range 2001-2024.
    DO NOT use when asked for 'forest loss', 'deforestation', 'tree cover loss' for:
    - specific time ranges (e.g. last five years)
    - single years (e.g. 2024)
    - trends over time
    Instead, refuse and select Tree cover loss instead.
```