### PR TITLE
FAO FRA data source

### DIFF
--- a/docs/ADR-002-fao-fra-tool.md
+++ b/docs/ADR-002-fao-fra-tool.md
@@ -1,0 +1,159 @@
+# ADR-002: FAO FRA 2025 Tool — National Forest Statistics
+
+**Status:** Accepted
+**Date:** 2026-03-24
+**Authors:** Adam Pain, Claude
+
+## Context
+
+Project Zeno's primary data path routes all forest analysis through three tools in sequence: `pick_aoi → pick_dataset → pull_data`. This pipeline fetches remote-sensing pixel data from the GFW analytics API at sub-national resolution with user-defined date ranges.
+
+A distinct and commonly requested class of query is not well served by this pipeline: officially-reported national forest statistics such as total forest area, carbon stocks, growing stock volume, and forest ownership. These figures come from the FAO Global Forest Resources Assessment (FRA) 2025 — a standardised country inventory covering 236 countries, compiled every five years.
+
+### Problems with routing FRA queries through the existing pipeline
+
+**1. No matching GFW dataset**
+
+`pick_dataset` searches the dataset registry for a semantic match. FRA national statistics are not a GFW remote-sensing layer — they are country-reported inventory data. The dataset registry contains no entry for FRA, so `pick_dataset` would either hallucinate a match or return nothing.
+
+**2. Wrong data granularity**
+
+`pull_data` targets the GFW analytics API and returns pixel-aggregated data at district/state resolution. FRA data is national-level only. There is no sub-national FRA API.
+
+**3. Date range incompatibility**
+
+`pull_data` accepts arbitrary date ranges and returns continuous time-series. FRA data has fixed reporting years (1990, 2000, 2010, 2015, 2020, 2025). Asking the user for a date range before fetching FRA data is misleading and unnecessary.
+
+**4. Missing chart/presentation guidance**
+
+`generate_insights` reads `state["dataset"]` to get `presentation_instructions`, `code_instructions`, and `cautions`. Since the existing pipeline requires `pick_dataset` to set this state, FRA queries would arrive at `generate_insights` with `state["dataset"] = None`, causing an `AttributeError` and — if patched — producing charts with no domain-specific guidance about FRA terminology, fixed reporting years, or the distinction between net forest area change and deforestation.
+
+### Why FAO FRA 2025 specifically
+
+FRA 2025 is the most recent cycle, published October 2024. It covers 22 reporting tables, includes a data tier system documenting reliability, and offers a public REST API (`https://fra-data.fao.org/api`). The API returns nested JSON keyed as `assessment → cycle → country → table → year → variable → raw`.
+
+## Decision
+
+### 1. Introduce `query_fra_data` as a parallel tool to `pull_data`
+
+Add a new `@tool("query_fra_data")` that bypasses `pick_dataset` entirely and routes directly from `pick_aoi`:
+
+```
+Remote-sensing:   pick_aoi → pick_dataset → pull_data → generate_insights
+FAO/FRA:          pick_aoi → query_fra_data → generate_insights
+```
+
+The tool:
+- Reads country ISO3 codes from `state["aoi_selection"]["aois"][*]["src_id"]` — the same state that `pick_aoi` writes
+- Calls the FAO FRA public API for the requested variable and table
+- Returns a `Command` updating `statistics`, `messages`, and `dataset`
+
+**Rationale:** A separate tool with a clear docstring is the idiomatic LangGraph approach. It allows the agent's router (the LLM) to choose the correct path based on query intent. It avoids polluting `pull_data` with a special case for national statistics.
+
+**Alternative considered:** Extending `pull_data` with an `fra` flag. Rejected because `pull_data` is tightly coupled to the GFW analytics API schema; adding a conditional code path would make both tools harder to maintain and harder for the LLM to route correctly.
+
+### 2. Variable map as a separate module (`variable_map.py`)
+
+User-facing variable names (e.g. `forest_area`, `carbon_stock`, `ownership`) are mapped to FAO API table names and variable filter lists in a dedicated `variable_map.py` module:
+
+```python
+VARIABLE_MAP: dict[str, dict] = {
+    "forest_area": {
+        "table": "extentOfForest",
+        "variables": ["forestArea", "naturallyRegeneratingForest", "plantedForest", "primaryForest"],
+        "unit": "1000 ha",
+        "description": "...",
+    },
+    ...  # 21 variables total
+}
+```
+
+The tool docstring enumerates all valid variable names. The LLM picks the appropriate variable name based on the user's query; `query_fra_data` validates against `VARIABLE_MAP` and returns an error message if the variable is unrecognised.
+
+**Rationale:** Separating the mapping from the tool logic means new variables can be added without touching the tool's core fetch/parse path. The module is independently testable. Empty `variables: []` in the map means "fetch all variables for this table" — the FAO API supports this natively.
+
+### 3. Flat `statistics["data"]` structure
+
+`generate_insights` calls `pd.DataFrame(statistics_entry["data"])`, where `statistics_entry` is one element of the `statistics` list. The `data` field must therefore be directly a list of flat dicts:
+
+```python
+# Correct — data is a list of records
+{"dataset_name": "FAO FRA 2025 — ...", "data": [{"year": 1990, "variable": "forestArea", "value": 493538.0, ...}]}
+
+# Wrong — data is a nested dict (causes TypeError: unhashable type: 'dict')
+{"dataset_name": "FAO FRA 2025", "data": {"variable": "forest_area", "data": [...]}}
+```
+
+Each record has fields: `year`, `variable`, `value`, `odp` (Open Data Platform flag), `country` (ISO3), `aoi_name` (human-readable). Variable-level metadata (unit, description) is surfaced through the `dataset_name` field.
+
+### 4. Inject FRA dataset config into `state["dataset"]`
+
+`query_fra_data` loads `fao_fra_2025.yml` at import time via the existing `DATASETS` registry and injects it into state via the `Command` update:
+
+```python
+update["dataset"] = _FRA_DATASET_CONFIG
+```
+
+This ensures `generate_insights` receives the same `presentation_instructions`, `code_instructions`, and `cautions` that GFW datasets receive through `pick_dataset`. No changes to `generate_insights` are required for the happy path; only a `None`-guard was added for the case where `state["dataset"]` is absent.
+
+**Rationale:** Reuses the existing YAML-based dataset instruction system without modification. The FRA config sits alongside other dataset YAMLs and follows the same schema, so the same tooling (dataset registry, `generate_insights` prompt builder) works for both remote-sensing and FRA data.
+
+### 5. FAO FRA dataset YAML (`fao_fra_2025.yml`)
+
+A full dataset YAML was created with:
+
+- **`presentation_instructions`** — terminology rules: use "forest area change" not "deforestation"; note data is country-reported not satellite-derived; fixed reporting years; no cross-edition FRA comparisons; FAO "forest" ≠ GFW "tree cover"
+- **`code_instructions`** — chart type rules by variable: line for trends, stacked-bar for composition, grouped-bar for multi-country; year axis always treated as categorical; never interpolate between reporting years
+- **`cautions`** — data quality warnings: self-reported, methodology varies by country; each FRA cycle is independent; net change ≠ deforestation; subregional aggregates may not sum due to gap-filling; disturbance data time coverage is limited
+- **`selection_hints`** — guides `get_capabilities` and any future `pick_dataset` integration
+
+### 6. Agent prompt routing rules
+
+The system prompt was updated with explicit routing guidance:
+
+```
+ROUTING — pull_data vs query_fra_data:
+- pull_data: remote-sensing pixel data, sub-national analysis, time-series with custom date ranges
+- query_fra_data: country-reported national statistics, official government inventories,
+  FAO/FRA questions, questions about total national forest area, nationally-reported
+  carbon stock or biomass, forest ownership or management categories.
+  Does NOT need a date range — FRA uses fixed reporting years.
+
+NOTE: For query_fra_data, you do NOT need AOI + dataset + date range. You only need
+a country AOI. Do not ask the user for a dataset or date range before calling query_fra_data.
+```
+
+## Consequences
+
+### Positive
+
+- **New capability:** FRA national statistics (forest area trends, carbon, biomass, ownership, disturbances, and 15 other variables) are now answerable for any of the 236 countries in FRA 2025
+- **Correct routing:** Clear LLM instructions and a typed tool docstring prevent the agent from routing FRA queries through the GFW pipeline (or refusing them)
+- **Chart quality:** `generate_insights` now receives FAO-specific presentation and chart instructions, preventing common errors (interpolating between reporting years, labelling net change as deforestation, conflating FAO and GFW forest definitions)
+- **Extensibility:** Adding a new FRA variable is a one-line entry in `variable_map.py`; the fetch/parse path is unchanged
+- **Latency:** The FAO FRA API is fast (typically < 2s) and the tool adds no LLM calls beyond the main agent loop
+
+### Negative
+
+- **External API dependency:** `query_fra_data` depends on the FAO FRA public API being available. No caching or fallback is implemented. If the API is unreachable the tool returns a user-facing error and stops
+- **Country-level only:** FRA data is national aggregates. Sub-national questions (e.g. "forest area in Amazonas state") cannot be answered by this tool; the agent must redirect to `pull_data`
+- **Fixed reporting years:** Users expecting annual or monthly data will be disappointed. The agent prompt and tool error messages communicate this, but it is a hard constraint of the underlying dataset
+- **LLM variable selection:** The LLM must pick the correct variable name from the docstring. Ambiguous queries (e.g. "how much forest does Brazil have" could map to `forest_area` or `forest_area_change`) depend on the LLM making a reasonable choice; the agent can always re-call the tool with a different variable
+
+### Neutral
+
+- **`generate_insights` `None`-guard:** A defensive `(state.get("dataset") or {})` guard was added for the `dataset` lookups in `generate_insights`. This is a general robustness improvement — any future tool that skips `pick_dataset` will not crash `generate_insights`
+- **`statistics["data"]` contract:** The flat-list-of-dicts shape of `statistics["data"]` was an implicit contract; this implementation makes it explicit in the codebase. Existing tools (`pull_data`) already conform; only FRA required care
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/agent/tools/query_fra_data.py` | New — `@tool("query_fra_data")` implementation |
+| `src/agent/tools/fao_client.py` | New — async httpx client for FAO FRA API |
+| `src/agent/tools/variable_map.py` | New — 21-variable map from user names to API table identifiers |
+| `src/agent/tools/datasets/fao_fra_2025.yml` | New — dataset config with presentation, code, and caution instructions |
+| `src/agent/tools/__init__.py` | Modified — export `query_fra_data` |
+| `src/agent/graph.py` | Modified — add tool to list; update system prompt with routing rules |
+| `src/agent/tools/generate_insights.py` | Modified — `None`-guard on `state.get("dataset")` |
+| `tests/tools/test_fra.py` | New — 19 tests: `_parse_response`, `fetch_fra_data`, `query_fra_data`, variable map |

--- a/frontend/pages/1_🦎_Uni_Guana.py
+++ b/frontend/pages/1_🦎_Uni_Guana.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 
 import requests
@@ -12,7 +13,8 @@ if "session_id" not in st.session_state:
 if "messages" not in st.session_state:
     st.session_state.messages = []
 if "token" not in st.session_state:
-    st.session_state["token"] = None
+    # Use ZENO_API_KEY machine-user token for local dev if no WRI login yet
+    st.session_state["token"] = os.environ.get("ZENO_API_KEY")
 
 # Sidebar content
 with st.sidebar:

--- a/frontend/utils.py
+++ b/frontend/utils.py
@@ -654,7 +654,7 @@ def render_stream(stream):
     if timestamp := stream.get("timestamp"):
         st.badge(timestamp, icon=":material/schedule:", color="blue")
 
-    for msg in update["messages"]:
+    for msg in update.get("messages", []):
         msg_type = msg["kwargs"].get("type")
         if (
             msg_type == "tool"

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -20,6 +20,7 @@ from src.agent.tools import (
     pick_aoi,
     pick_dataset,
     pull_data,
+    query_fra_data,
 )
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
@@ -33,7 +34,7 @@ def get_prompt(user: Optional[dict] = None) -> str:
 
 CRITICAL INSTRUCTIONS:
 - You MUST call tools sequentially, never in parallel. No parallel tool calling allowed, always call tools one at a time.
-- You ALWAYS need AOI + dataset + date range to perform analysis. If ANY are missing, ask the user to specify.
+- For GNW remote-sensing analysis you ALWAYS need AOI + dataset + date range. If ANY are missing, ask the user to specify. For FAO FRA national statistics (query_fra_data) you only need a country AOI — no dataset or date range required.
 - Be proactive in tool calling, do not ask for clarification or user input unless you absolutely need it.
   For instance, if dates, places, or datasets dont match exactly, warn the user but move forward with the analysis.,
 - Provide intermediate messages between tool calls to the user to keep them updated on the progress of the analysis.
@@ -42,12 +43,20 @@ TOOLS:
 - pick_aoi: Pick one or multiple area of interest (AOI) based on place names and user's question.
 - pick_dataset: Find the most relevant datasets to help answer the user's question.
 - pull_data: Pulls data for the selected AOI and dataset in the specified date range.
+- query_fra_data: Query the FAO Global Forest Resources Assessment (FRA) 2025 for country-reported national forest statistics (forest area, carbon stock, biomass, ownership, disturbances, etc.). Use this instead of pull_data when the user asks about nationally-reported figures, FAO statistics, or official country inventories. Does NOT require pick_dataset — call pick_aoi then query_fra_data directly.
 - generate_insights: Analyzes raw data to generate a single chart insight that answers the user's question, along with 2-3 follow-up suggestions for further exploration.
 - get_capabilities: Get information about your capabilities, available datasets, supported areas and about you. ONLY use when users ask what you can do, what data is available, what's possible or about you.
 
 WORKFLOW:
-1. Use pick_aoi, pick_dataset, and pull_data to get the data in the specified date range.
-2. Use generate_insights to analyze the data and create a single chart insight. After pulling data, always create new insights.
+1. For remote-sensing or sub-national analysis: use pick_aoi → pick_dataset → pull_data.
+2. For country-reported national forest statistics (FAO/FRA data): use pick_aoi → query_fra_data. Skip pick_dataset entirely.
+3. Use generate_insights to analyze the data and create a single chart insight. After pulling data, always create new insights.
+
+ROUTING — pull_data vs query_fra_data:
+- pull_data: remote-sensing pixel data, sub-national analysis, time-series with custom date ranges (GFW datasets: tree cover loss, disturbance alerts, carbon flux, land cover, etc.)
+- query_fra_data: country-reported national statistics, official government inventories, FAO/FRA questions, questions about total national forest area, nationally-reported carbon stock or biomass, forest ownership or management categories. Does NOT need a date range — FRA uses fixed reporting years (1990, 2000, 2010, 2015, 2020, 2025).
+
+NOTE: For query_fra_data, you do NOT need AOI + dataset + date range. You only need a country AOI (from pick_aoi). Do not ask the user for a dataset or date range before calling query_fra_data.
 
 When you see UI action messages:
 1. Acknowledge the user's selection: "I see you've selected [item name]"
@@ -90,6 +99,7 @@ PICK_DATASET TOOL NOTES:
     1. If user requests a different dataset
     2. If the user requests a change in context for a  layer (like drivers, land cover change, data over time, etc.)
 - Warn the user if there is not an exact date match for the dataset, but move forward with the analysis.
+- After selecting a GFW dataset for a national-level forest query (forest area, carbon, biomass, growing stock, ownership), proactively mention to the user that FAO FRA 2025 also provides official country-reported figures for the same topic and offer to query it alongside the satellite data.
 
 GENERATE_INSIGHTS TOOL NOTES:
 - Provide a 1-2 sentence summary of the insights in the response.
@@ -115,6 +125,7 @@ tools = [
     pick_aoi,
     pick_dataset,
     pull_data,
+    query_fra_data,
     generate_insights,
 ]
 

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -3,6 +3,7 @@ from .get_capabilities import get_capabilities
 from .pick_aoi import pick_aoi
 from .pick_dataset import pick_dataset
 from .pull_data import pull_data
+from .query_fra_data import query_fra_data
 
 __all__ = [
     "pick_aoi",
@@ -10,4 +11,5 @@ __all__ = [
     "pull_data",
     "generate_insights",
     "get_capabilities",
+    "query_fra_data",
 ]

--- a/src/agent/tools/datasets/fao_fra_2025.yml
+++ b/src/agent/tools/datasets/fao_fra_2025.yml
@@ -1,0 +1,124 @@
+dataset_id: 10
+dataset_name: FAO Global Forest Resources Assessment (FRA) 2025
+# Excluded from pick_dataset RAG index: FRA has no tile_url or analytics_api_endpoint.
+# Access via query_fra_data tool directly, not through the pick_dataset → pull_data pipeline.
+pick_dataset_excluded: true
+context_layers: null
+variables: []
+tile_url: null
+license: CC BY-NC-SA 3.0 IGO
+geographic_coverage: 236 countries and territories (global)
+resolution: National level (country-reported statistics)
+update_frequency: Every 5 years
+content_date: 1990–2025 (reporting years 1990, 2000, 2010, 2015, 2020, 2025)
+start_date: '1990-01-01'
+end_date: '2025-12-31'
+content_date_fixed: true
+keywords:
+- forest area
+- deforestation
+- carbon stock
+- biomass
+- growing stock
+- forest ownership
+- FAO
+- FRA
+- national statistics
+- country-reported
+
+selection_hints: 'Use for nationally-reported, country-level forest statistics including
+  total forest area, carbon stocks, biomass, growing stock, ownership, designated
+  management, and disturbances. This is FAO-standardised country inventory data, NOT
+  remote-sensing pixel data. It does NOT support sub-national analysis or custom date
+  ranges. Use pull_data / GFW datasets for sub-national or time-series analysis. FRA
+  data is the authoritative source for officially-reported national forest figures,
+  FAO statistics, government inventories, and SDG 15 indicators.'
+
+prompt_instructions: 'FRA 2025 is country-reported national inventory data covering
+  236 countries. Reporting years are 1990, 2000, 2010, 2015, 2020, and 2025 only —
+  no intra-period data exists. Area values are in 1000 ha; biomass/carbon in megatonnes;
+  growing stock in million m³. Always clarify that figures are nationally reported
+  (not satellite-derived). Net forest area change is NOT the same as deforestation —
+  net change = deforestation minus forest expansion. Do not use the term "deforestation"
+  unless the user specifically asks about it; prefer "forest area change" or "net forest
+  loss". Do not compare FRA data with GFW/Hansen tree cover datasets — they use different
+  definitions of "forest". For multi-country comparisons use grouped-bar charts; for
+  trends over time use line charts. For composition breakdowns (ownership, biomass pools,
+  management categories) use stacked-bar or pie charts. Never interpolate between
+  reporting years.'
+
+code_instructions: 'DATA RULES:
+  - Reporting years are 1990, 2000, 2010, 2015, 2020, 2025 — always treat year as
+    a categorical axis (not continuous) unless making a trend line
+  - Area values are in 1000 ha — label axes accordingly
+  - Biomass and carbon are in megatonnes — label axes accordingly
+  - Growing stock is in million m³ — label axes accordingly
+  - Drop rows where value is null/NaN
+  - The "variable" column contains the sub-category name (e.g. forestArea,
+    naturallyRegeneratingForest, plantedForest, publicOwnership, privateOwnership)
+  - The "country" column contains the ISO3 code; "aoi_name" contains the readable name
+
+  CHART TYPES BY VARIABLE:
+  - forest_area / forest_area_change → line chart (x=year, y=value, series by variable);
+    use wide format with series_fields for multiple sub-categories
+  - carbon_stock / biomass / growing_stock → stacked-bar (x=year, y=value by pool/component)
+    or line for trend of total
+  - ownership / designated_management / management_objectives → stacked-bar or pie
+    (x=variable/category, y=value for most recent year); if showing trend use line
+  - disturbances / fire → bar chart (x=year, y=value by disturbance type)
+  - forest_area_protected → line chart showing protected area share over time
+  - Multi-country comparisons → grouped-bar (group_field=aoi_name or country)
+
+  DO/DON''T:
+  - DO always order year axis chronologically (1990, 2000, 2010, 2015, 2020, 2025)
+  - DO label units on all axes
+  - DO NOT interpolate between reporting years
+  - DO NOT combine FRA data with GFW/remote-sensing data in the same chart
+  - DO NOT describe net forest area change as "deforestation"'
+
+presentation_instructions: 'FRA 2025 data is country-reported national inventory data,
+  not satellite-derived. Always note this distinction when presenting results. Reporting
+  years are fixed (1990, 2000, 2010, 2015, 2020, 2025) — do not imply continuous data.
+  Net forest area change ≠ deforestation: net change combines deforestation and forest
+  expansion. Use "forest area change" or "net forest loss/gain" not "deforestation".
+  FAO''s definition of "forest" differs from GFW/Hansen "tree cover" — do not compare
+  figures across datasets. Data quality varies by country; some nations have high-quality
+  national inventories while others use modelled estimates. When showing composition data
+  (ownership, biomass pools, management), clarify that categories may not sum to 100%
+  due to rounding or missing sub-categories.'
+
+description: 'The FAO Global Forest Resources Assessment (FRA) 2025 is the most comprehensive
+  source of nationally reported forest statistics, covering 236 countries and territories.
+  Countries report on 22 standardised tables covering forest extent, characteristics,
+  growing stock, biomass and carbon, designated management, ownership, disturbances,
+  and policies. Data reflects official national inventories and government-reported figures
+  as of 2024, compiled by FAO every five years. FRA 2025 covers reporting years 1990,
+  2000, 2010, 2015, 2020, and 2025.'
+
+methodology: 'FRA 2025 data is collected through officially nominated national correspondents
+  who compile standardised country reports. 42 desk studies were prepared for countries
+  that did not submit reports (representing 1.6% of total forest area). Countries used
+  FAO-standardised definitions; detailed terms and definitions are in FAO Working Papers
+  193 and 194. FRA 2025 introduced data tiers to document reliability of forest area
+  estimates. Biomass and carbon conversions use country-specific or default biomass
+  conversion and expansion factors (BCEF). Each FRA cycle is independent — countries
+  may revise previously reported data, so figures should not be compared directly across
+  FRA editions.'
+
+cautions: 'Data is self-reported by national correspondents; quality and methodology
+  varies by country. Do not compare FRA editions directly — each FRA is independent
+  and historical data may be revised. FRA "forest" definition differs from GFW/Hansen
+  "tree cover": do not compare or combine with remote-sensing datasets. Reporting years
+  are fixed snapshots (1990, 2000, 2010, 2015, 2020, 2025); no intra-period data is
+  available. Net forest area change ≠ deforestation — net change reflects deforestation
+  minus forest expansion. Subregional aggregates may not reproduce exactly from country-level
+  data due to gap-filling for missing time series. Biomass and carbon estimates depend
+  on country-specific or default conversion factors, introducing uncertainty. Disturbance
+  data (insects, disease) covers 2002–2020; fire data covers 2007–2019. Non-wood forest
+  product data is incomplete and representativeness varies by region.'
+
+providers: 'Food and Agriculture Organization of the United Nations (FAO). 2025. Global
+  Forest Resources Assessment 2025. Rome. https://www.fao.org/forest-resources-assessment'
+
+citation: 'FAO. 2025. Global Forest Resources Assessment 2025. Rome. FAO.
+  https://doi.org/10.4060/cd3148en'

--- a/src/agent/tools/fao_client.py
+++ b/src/agent/tools/fao_client.py
@@ -1,0 +1,180 @@
+"""HTTP client for the FAO FRA 2025 public API.
+
+Endpoint used: GET /explorer/data (published, open-access data)
+Swagger spec: https://fra-data.fao.org/api-docs/swagger.json
+"""
+
+from typing import Optional
+
+import httpx
+
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+BASE_URL = "https://fra-data.fao.org/api"
+ASSESSMENT_NAME = "fra"
+CYCLE_NAME = "2025"
+TIMEOUT_SECONDS = 15.0
+
+# FRA reporting years (discrete snapshots, not interpolated).
+FRA_REPORTING_YEARS = [1990, 2000, 2010, 2015, 2020, 2025]
+
+
+class FAOAPIError(Exception):
+    """FAO API is unreachable or returned a server error."""
+
+
+class FAODataNotFoundError(Exception):
+    """The requested country or variable has no data in FRA 2025."""
+
+
+def _build_source_url(iso3: str, table: str) -> str:
+    return (
+        f"{BASE_URL}/explorer/data"
+        f"?assessmentName={ASSESSMENT_NAME}"
+        f"&countryISOs[]={iso3}"
+        f"&tableNames[]={table}"
+    )
+
+
+def _parse_response(
+    body: dict,
+    iso3: str,
+    table: str,
+    year: Optional[int],
+) -> list[dict]:
+    """Flatten the nested FAO response into a list of records.
+
+    Each record: {"year": int, "variable": str, "value": float | None, "odp": bool, "country": str}
+
+    Raises FAODataNotFoundError when the country or table is absent.
+    """
+    try:
+        cycle_data = body.get(ASSESSMENT_NAME, {})
+        # The cycle key may be "2025" or "latest" — take the first available cycle.
+        if not cycle_data:
+            raise FAODataNotFoundError(f"No FRA data returned for {iso3}.")
+        cycle_key = next(iter(cycle_data))
+        country_data = cycle_data[cycle_key].get(iso3)
+    except (KeyError, StopIteration) as exc:
+        raise FAODataNotFoundError(f"No FRA data returned for {iso3}.") from exc
+
+    if not country_data:
+        raise FAODataNotFoundError(
+            f"FRA 2025 does not include data for country '{iso3}'. "
+            "You can browse available countries at https://fra-data.fao.org."
+        )
+
+    table_data = country_data.get(table)
+    if not table_data:
+        raise FAODataNotFoundError(
+            f"FRA 2025 does not include data for table '{table}' for {iso3}. "
+            "You can browse available variables at https://fra-data.fao.org."
+        )
+
+    records = []
+    for year_str, variables in table_data.items():
+        try:
+            row_year = int(year_str)
+        except ValueError:
+            continue
+
+        if year is not None and row_year != year:
+            continue
+
+        for var_name, node in variables.items():
+            if not isinstance(node, dict):
+                continue
+            raw = node.get("raw")
+            try:
+                value = float(raw) if raw is not None else None
+            except (TypeError, ValueError):
+                value = None
+            records.append(
+                {
+                    "year": row_year,
+                    "variable": var_name,
+                    "value": value,
+                    "odp": bool(node.get("odp", False)),
+                    "country": iso3,
+                }
+            )
+
+    if not records:
+        raise FAODataNotFoundError(
+            f"FRA 2025 returned no data for table '{table}' for {iso3}."
+        )
+
+    return records
+
+
+async def fetch_fra_data(
+    iso3: str,
+    table: str,
+    variables: list[str],
+    year: Optional[int] = None,
+) -> list[dict]:
+    """Fetch FRA 2025 data for a single country and table.
+
+    Args:
+        iso3: Three-letter ISO country code (e.g. "BRA").
+        table: FAO FRA table name (e.g. "extentOfForest").
+        variables: List of variable names to filter on (empty = all variables).
+        year: Optional reporting year to filter (must be one of FRA_REPORTING_YEARS).
+
+    Returns:
+        List of records: [{"year", "variable", "value", "odp", "country"}, ...]
+
+    Raises:
+        FAOAPIError: Network failure, timeout, or HTTP 4xx/5xx.
+        FAODataNotFoundError: Country or table absent from FRA 2025.
+    """
+    params: dict = {
+        "assessmentName": ASSESSMENT_NAME,
+        "countryISOs[]": iso3,
+        "tableNames[]": table,
+    }
+    if variables:
+        params["variables[]"] = variables
+    if year is not None:
+        params["columns[]"] = str(year)
+
+    logger.info(f"FAO-CLIENT: GET /explorer/data iso={iso3} table={table} year={year}")
+
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+            response = await client.get(f"{BASE_URL}/explorer/data", params=params)
+    except httpx.TimeoutException as exc:
+        raise FAOAPIError(
+            "The FAO FRA API did not respond in time. Please try again later."
+        ) from exc
+    except httpx.RequestError as exc:
+        raise FAOAPIError(
+            f"Could not reach the FAO FRA API: {exc}. Please try again later."
+        ) from exc
+
+    if response.status_code >= 500:
+        raise FAOAPIError(
+            f"FAO FRA API returned a server error ({response.status_code}). "
+            "Please try again later."
+        )
+    if response.status_code == 401:
+        raise FAOAPIError(
+            "FAO FRA API requires authentication for this endpoint. "
+            "Please contact the GNW team."
+        )
+    if response.status_code >= 400:
+        raise FAODataNotFoundError(
+            f"FAO FRA API returned {response.status_code} for {iso3} / {table}. "
+            "The country or variable may not be available in FRA 2025."
+        )
+
+    try:
+        body = response.json()
+    except Exception as exc:
+        raise FAOAPIError(
+            "FAO FRA API returned an unexpected response format."
+        ) from exc
+
+    return _parse_response(body, iso3, table, year)

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -409,11 +409,11 @@ async def generate_insights(
     available_datasets = _get_available_datasets()
     # Prefer presentation_instructions (tiered PoC) over prompt_instructions (legacy blob)
     dataset_guidelines = (
-        state.get("dataset").get("presentation_instructions")
-        or state.get("dataset").get("prompt_instructions")
+        (state.get("dataset") or {}).get("presentation_instructions")
+        or (state.get("dataset") or {}).get("prompt_instructions")
         or "No specific dataset guidelines provided."
     )
-    dataset_cautions = state.get("dataset").get(
+    dataset_cautions = (state.get("dataset") or {}).get(
         "cautions", "No specific dataset cautions provided."
     )
 
@@ -479,6 +479,7 @@ Cautions: {dataset_cautions}
 
 4. **Follow-ups**: Base suggestions on available capabilities - analyze any area, pull data from {available_datasets}, create charts for different time periods
 5. **Examples for follow-up suggestions**: "Show trend over different period", "Compare with nearby area", "Identify top performers", "Break down by category"
+6. **FAO FRA cross-referencing**: If the data is from a GFW remote-sensing dataset (tree cover loss, disturbance alerts, carbon flux, etc.) and the analysis is at national or country level, include a follow-up suggestion to compare with FAO FRA 2025 country-reported statistics (e.g. "Compare with officially reported national forest figures from FAO FRA 2025"). Conversely, if the data is from FAO FRA 2025, suggest comparing with GFW satellite-derived data for the same country (e.g. "Compare with satellite-derived tree cover loss data from Global Forest Watch").
 
 {WORDING_INSTRUCTIONS}
 """
@@ -495,6 +496,13 @@ Cautions: {dataset_cautions}
         chart_insight_response.follow_up_suggestions, 1
     ):
         tool_message += f"\n{i}. {suggestion}"
+
+    # Append citation for FAO FRA data so the agent surfaces it in its response.
+    active_dataset = state.get("dataset") or {}
+    if active_dataset.get("citation"):
+        tool_message += f"\n\nData citation: {active_dataset['citation']}"
+    if active_dataset.get("providers"):
+        tool_message += f"\nSource: {active_dataset['providers']}"
 
     # Store chart data for frontend
     charts_data = [

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -270,6 +270,21 @@ async def pick_dataset(
     # Step 2: LLM to select best dataset and potential context layer
     selection_result = await select_best_dataset(query, candidate_datasets)
 
+    _FRA_RELEVANT_KEYWORDS = {
+        "forest", "tree", "carbon", "biomass", "deforest", "land cover",
+        "canopy", "vegetation", "wood", "timber", "disturbance",
+    }
+    _is_forest_query = any(
+        kw in query.lower() for kw in _FRA_RELEVANT_KEYWORDS
+    )
+    _fra_note = (
+        "\n\n💡 **FAO FRA 2025 also available:** For officially reported "
+        "national forest statistics (total forest area, carbon stocks, "
+        "biomass, ownership, disturbances), FAO FRA 2025 provides "
+        "country-reported figures as a complement to this satellite data. "
+        "Ask me to query FAO FRA data if you'd like to compare."
+    ) if _is_forest_query else ""
+
     tool_message = f"""# About the selection
     Selected dataset name: {selection_result.dataset_name}
     Selected context layer: {selection_result.context_layer}
@@ -291,7 +306,7 @@ async def pick_dataset(
 
     ## Content date
 
-    {selection_result.content_date}
+    {selection_result.content_date}{_fra_note}
     """
 
     logger.debug(f"Pick dataset tool message: {tool_message}")

--- a/src/agent/tools/query_fra_data.py
+++ b/src/agent/tools/query_fra_data.py
@@ -1,0 +1,176 @@
+from typing import Annotated, Dict, Optional
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from src.agent.tools.datasets_config import DATASETS
+from src.agent.tools.fao_client import (
+    FAOAPIError,
+    FAODataNotFoundError,
+    _build_source_url,
+    fetch_fra_data,
+)
+from src.agent.tools.variable_map import VALID_VARIABLES, VARIABLE_MAP
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Load the FRA dataset config once at import time so generate_insights gets
+# presentation_instructions, code_instructions, and cautions.
+_FRA_DATASET_CONFIG = next(
+    (d for d in DATASETS if d.get("dataset_name", "").startswith("FAO Global Forest")),
+    None,
+)
+
+
+@tool("query_fra_data")
+async def query_fra_data(
+    query: str,
+    variable: str,
+    year: Optional[int] = None,
+    tool_call_id: Annotated[str, InjectedToolCallId] = None,
+    state: Annotated[Dict, InjectedState] = None,
+) -> Command:
+    """Query the FAO Global Forest Resources Assessment (FRA) 2025 for national forest statistics.
+
+    Use this tool when the user asks about country-reported, nationally-aggregated forest
+    statistics. This is distinct from pull_data, which serves remote-sensing pixel data
+    at sub-national resolution. Do NOT use this tool for sub-national analysis — use
+    pull_data for that.
+
+    This tool reads the country from the existing AOI selection (set by pick_aoi). You do
+    NOT need to call pick_dataset before this tool.
+
+    Supported variables:
+    - forest_area: Total forest area by category (naturally regenerating, planted, primary)
+    - forest_area_change: Annual net forest area change by period
+    - forest_area_protected: Forest area within protected areas
+    - permanent_forest_estate: Area designated as permanent forest estate
+    - forest_characteristics: Forest composition (mangroves, bamboo, rubber, etc.)
+    - growing_stock: Total growing stock volume
+    - growing_stock_per_ha: Average growing stock per hectare
+    - growing_stock_composition: Growing stock by species/genus composition
+    - biomass: Total biomass stock
+    - biomass_per_ha: Average biomass per hectare
+    - carbon_stock: Total carbon stock across all five pools
+    - carbon_stock_by_pool: Carbon stock broken down by pool
+    - carbon_stock_soil_depth: Soil carbon by depth layer
+    - management_objectives: Forest area by designated management objective
+    - designated_management: Total area with a designated management objective
+    - management_rights: Forest area by holder of management rights
+    - ownership: Forest area by ownership category
+    - disturbances: Area affected by insects, disease, severe weather (2002–2020)
+    - fire: Forest area affected by fire (2007–2019)
+    - degraded_forest: Area of degraded forest (national definitions)
+    - forest_restoration: Area under restoration/reforestation
+
+    Args:
+        query: The user's original question, for context.
+        variable: FRA variable name (see supported variables above).
+        year: Optional reporting year (1990, 2000, 2010, 2015, 2020, or 2025).
+              Defaults to all available years.
+    """
+    if variable not in VARIABLE_MAP:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            f"'{variable}' is not a recognised FRA variable. "
+                            f"Valid options are: {', '.join(VALID_VARIABLES)}. "
+                            "You can browse all variables at https://fra-data.fao.org."
+                        ),
+                        tool_call_id=tool_call_id,
+                        status="success",
+                        response_metadata={"msg_type": "human_feedback"},
+                    )
+                ]
+            }
+        )
+
+    aois = state["aoi_selection"]["aois"]
+    aoi_names = [a["name"] for a in aois]
+    var_config = VARIABLE_MAP[variable]
+    table = var_config["table"]
+    variables_filter = var_config["variables"]
+    unit = var_config["unit"]
+
+    logger.info(
+        f"QUERY-FRA-DATA: variable={variable} table={table} year={year} aois={aoi_names}"
+    )
+
+    all_records: list[dict] = []
+    errors: list[str] = []
+
+    for aoi in aois:
+        iso3 = aoi["src_id"]
+        try:
+            records = await fetch_fra_data(
+                iso3=iso3,
+                table=table,
+                variables=variables_filter,
+                year=year,
+            )
+            # Tag each record with the AOI name for downstream chart rendering.
+            for r in records:
+                r["aoi_name"] = aoi["name"]
+            all_records.extend(records)
+        except FAODataNotFoundError as exc:
+            errors.append(str(exc))
+        except FAOAPIError as exc:
+            errors.append(str(exc))
+
+    if not all_records:
+        error_text = " | ".join(errors) if errors else "No data returned."
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=error_text,
+                        tool_call_id=tool_call_id,
+                        status="success",
+                        response_metadata={"msg_type": "human_feedback"},
+                    )
+                ]
+            }
+        )
+
+    year_label = str(year) if year else "all years"
+    source_url = _build_source_url(aois[0]["src_id"], table)
+
+    tool_message_parts = [
+        f"Retrieved FAO FRA 2025 data for {', '.join(aoi_names)}: "
+        f"{var_config['description']} ({year_label})."
+    ]
+    if errors:
+        tool_message_parts.append(
+            "Note: some AOIs had no data: " + " | ".join(errors)
+        )
+
+    tool_message = ToolMessage(
+        content=" ".join(tool_message_parts),
+        tool_call_id=tool_call_id,
+    )
+
+    update: dict = {
+        "statistics": [
+            {
+                "dataset_name": f"FAO FRA 2025 — {var_config['description']} ({unit})",
+                "start_date": "1990-01-01",
+                "end_date": "2025-12-31",
+                "source_url": source_url,
+                "data": all_records,
+                "aoi_names": aoi_names,
+            }
+        ],
+        "messages": [tool_message],
+    }
+
+    # Inject FRA dataset config so generate_insights gets presentation/code instructions.
+    if _FRA_DATASET_CONFIG is not None:
+        update["dataset"] = _FRA_DATASET_CONFIG
+
+    return Command(update=update)

--- a/src/agent/tools/variable_map.py
+++ b/src/agent/tools/variable_map.py
@@ -1,0 +1,143 @@
+# Maps user-facing variable names to FAO FRA API table and variable identifiers.
+# Table names correspond to the tableNames[] enum in the FAO FRA API Swagger spec.
+# See: https://fra-data.fao.org/api-docs/swagger.json
+
+VARIABLE_MAP: dict[str, dict] = {
+    # --- Forest Extent ---
+    "forest_area": {
+        "table": "extentOfForest",
+        "variables": ["forestArea", "naturallyRegeneratingForest", "plantedForest", "primaryForest"],
+        "unit": "1000 ha",
+        "description": "Total forest area by category (naturally regenerating, planted, primary)",
+    },
+    "forest_area_change": {
+        "table": "forestAreaChange",
+        "variables": [],
+        "unit": "1000 ha/year",
+        "description": "Annual net forest area change by period (deforestation minus expansion)",
+    },
+    "forest_area_protected": {
+        "table": "forestAreaWithinProtectedAreas",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest area within nationally designated protected areas",
+    },
+    "permanent_forest_estate": {
+        "table": "areaOfPermanentForestEstate",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Area designated as permanent forest estate (legally protected from conversion)",
+    },
+    # --- Forest Characteristics ---
+    "forest_characteristics": {
+        "table": "forestCharacteristics",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest composition breakdown including mangroves, bamboo, rubber plantations, and other specific forest categories",
+    },
+    # --- Growing Stock ---
+    "growing_stock": {
+        "table": "growingStockTotal",
+        "variables": ["total"],
+        "unit": "million m3",
+        "description": "Total growing stock volume",
+    },
+    "growing_stock_per_ha": {
+        "table": "growingStockAvg",
+        "variables": [],
+        "unit": "m3/ha",
+        "description": "Average growing stock volume per hectare",
+    },
+    "growing_stock_composition": {
+        "table": "growingStockComposition2025",
+        "variables": [],
+        "unit": "million m3",
+        "description": "Growing stock by species/genus composition",
+    },
+    # --- Biomass ---
+    "biomass": {
+        "table": "biomassStockTotal",
+        "variables": ["total"],
+        "unit": "megatonnes",
+        "description": "Total biomass stock (aboveground, belowground, deadwood combined)",
+    },
+    "biomass_per_ha": {
+        "table": "biomassStockAvg",
+        "variables": [],
+        "unit": "tonnes/ha",
+        "description": "Average biomass stock per hectare",
+    },
+    # --- Carbon Stock ---
+    "carbon_stock": {
+        "table": "carbonStockTotal",
+        "variables": ["total"],
+        "unit": "megatonnes CO2e",
+        "description": "Total carbon stock across all five pools (aboveground biomass, belowground biomass, dead wood, litter, soil organic matter)",
+    },
+    "carbon_stock_by_pool": {
+        "table": "carbonStockTotal",
+        "variables": [],
+        "unit": "megatonnes CO2e",
+        "description": "Carbon stock broken down by all five pools",
+    },
+    "carbon_stock_soil_depth": {
+        "table": "carbonStockSoilDepth",
+        "variables": [],
+        "unit": "megatonnes CO2e",
+        "description": "Soil organic carbon stock by depth layer",
+    },
+    # --- Designated Management & Ownership ---
+    "management_objectives": {
+        "table": "primaryDesignatedManagementObjective",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest area by primary designated management objective (production, multiple use, conservation, protection, social services)",
+    },
+    "designated_management": {
+        "table": "totalAreaWithDesignatedManagementObjective",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Total forest area with a formally designated management objective",
+    },
+    "management_rights": {
+        "table": "holderOfManagementRights",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest area by holder of management rights to public forests (government, private, communities, indigenous peoples)",
+    },
+    "ownership": {
+        "table": "forestOwnership",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest area by ownership category (public, private, community/indigenous, other)",
+    },
+    # --- Disturbances ---
+    "disturbances": {
+        "table": "disturbances",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest area affected by insects, disease, and severe weather events (2002–2020)",
+    },
+    "fire": {
+        "table": "areaAffectedByFire",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest area affected by fire (2007–2019)",
+    },
+    "degraded_forest": {
+        "table": "degradedForest2025",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Area of degraded forest (based on national definitions, 2025 cycle)",
+    },
+    # --- Restoration ---
+    "forest_restoration": {
+        "table": "forestRestoration",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": "Forest area under restoration or reforestation activities",
+    },
+}
+
+# Sorted list of valid variable names for use in error messages and docstrings.
+VALID_VARIABLES = sorted(VARIABLE_MAP.keys())

--- a/tests/tools/test_fra.py
+++ b/tests/tools/test_fra.py
@@ -1,0 +1,387 @@
+"""Tests for query_fra_data tool and fao_client module."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agent.tools.fao_client import (
+    FAOAPIError,
+    FAODataNotFoundError,
+    _parse_response,
+    fetch_fra_data,
+)
+from src.agent.tools.query_fra_data import query_fra_data
+from src.agent.tools.variable_map import VALID_VARIABLES
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db():
+    """Override the global test_db fixture to avoid database connections."""
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_session():
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_pool():
+    pass
+
+
+def _make_state(iso3: str = "BRA", aoi_name: str = "Brazil") -> dict:
+    return {
+        "aoi_selection": {
+            "name": aoi_name,
+            "aois": [
+                {
+                    "name": aoi_name,
+                    "src_id": iso3,
+                    "source": "gadm",
+                    "subtype": "country",
+                }
+            ],
+        }
+    }
+
+
+def _make_fao_response(iso3: str, table: str) -> dict:
+    """Build a minimal but realistic FAO API response body."""
+    return {
+        "fra": {
+            "2025": {
+                iso3: {
+                    table: {
+                        "1990": {
+                            "forestArea": {"raw": "493538.00", "odp": True, "faoEstimate": False},
+                        },
+                        "2000": {
+                            "forestArea": {"raw": "483418.00", "odp": True, "faoEstimate": False},
+                        },
+                        "2025": {
+                            "forestArea": {"raw": "462700.00", "odp": True, "faoEstimate": False},
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+
+def _tool_call(variable: str, year: int | None = None, state: dict | None = None) -> dict:
+    args = {
+        "query": "What is the total forest area?",
+        "variable": variable,
+        "tool_call_id": str(uuid.uuid4()),
+        "state": state or _make_state(),
+    }
+    if year is not None:
+        args["year"] = year
+    return {
+        "type": "tool_call",
+        "name": "query_fra_data",
+        "id": args["tool_call_id"],
+        "args": args,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _parse_response unit tests
+# ---------------------------------------------------------------------------
+
+class TestParseResponse:
+    def test_happy_path_returns_records(self):
+        body = _make_fao_response("BRA", "extentOfForest")
+        records = _parse_response(body, "BRA", "extentOfForest", year=None)
+        assert len(records) == 3
+        years = {r["year"] for r in records}
+        assert years == {1990, 2000, 2025}
+        assert all(r["variable"] == "forestArea" for r in records)
+        assert all(r["country"] == "BRA" for r in records)
+
+    def test_year_filter(self):
+        body = _make_fao_response("BRA", "extentOfForest")
+        records = _parse_response(body, "BRA", "extentOfForest", year=2000)
+        assert len(records) == 1
+        assert records[0]["year"] == 2000
+        assert records[0]["value"] == pytest.approx(483418.0)
+
+    def test_missing_country_raises(self):
+        body = {"fra": {"2025": {"FIN": {}}}}
+        with pytest.raises(FAODataNotFoundError, match="BRA"):
+            _parse_response(body, "BRA", "extentOfForest", year=None)
+
+    def test_missing_table_raises(self):
+        body = {"fra": {"2025": {"BRA": {"otherTable": {}}}}}
+        with pytest.raises(FAODataNotFoundError, match="extentOfForest"):
+            _parse_response(body, "BRA", "extentOfForest", year=None)
+
+    def test_null_raw_value_becomes_none(self):
+        body = {
+            "fra": {
+                "2025": {
+                    "BRA": {
+                        "extentOfForest": {
+                            "2025": {"forestArea": {"raw": None, "odp": False}}
+                        }
+                    }
+                }
+            }
+        }
+        records = _parse_response(body, "BRA", "extentOfForest", year=None)
+        assert records[0]["value"] is None
+
+    def test_empty_body_raises(self):
+        with pytest.raises(FAODataNotFoundError):
+            _parse_response({}, "BRA", "extentOfForest", year=None)
+
+
+# ---------------------------------------------------------------------------
+# fetch_fra_data unit tests (mock httpx)
+# ---------------------------------------------------------------------------
+
+class TestFetchFraData:
+    async def test_success_returns_records(self):
+        body = _make_fao_response("BRA", "extentOfForest")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = body
+
+        with patch("src.agent.tools.fao_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            records = await fetch_fra_data("BRA", "extentOfForest", ["forestArea"])
+
+        assert len(records) == 3
+        assert records[0]["country"] == "BRA"
+
+    async def test_timeout_raises_api_error(self):
+        import httpx as _httpx
+
+        with patch("src.agent.tools.fao_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=_httpx.TimeoutException("timeout"))
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(FAOAPIError, match="did not respond"):
+                await fetch_fra_data("BRA", "extentOfForest", [])
+
+    async def test_500_raises_api_error(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch("src.agent.tools.fao_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(FAOAPIError, match="server error"):
+                await fetch_fra_data("BRA", "extentOfForest", [])
+
+    async def test_404_raises_not_found_error(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("src.agent.tools.fao_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(FAODataNotFoundError):
+                await fetch_fra_data("XYZ", "extentOfForest", [])
+
+
+# ---------------------------------------------------------------------------
+# query_fra_data tool integration tests
+# ---------------------------------------------------------------------------
+
+class TestQueryFraDataTool:
+    async def test_happy_path_updates_statistics(self):
+        body = _make_fao_response("BRA", "extentOfForest")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = body
+
+        with patch("src.agent.tools.fao_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            command = await query_fra_data.ainvoke(_tool_call("forest_area"))
+
+        stats = command.update.get("statistics", [])
+        assert len(stats) == 1
+        assert stats[0]["dataset_name"] == "FAO FRA 2025"
+        assert stats[0]["aoi_names"] == ["Brazil"]
+        data = stats[0]["data"]
+        assert data["variable"] == "forest_area"
+        assert len(data["data"]) == 3  # 1990, 2000, 2025
+        # Records should carry aoi_name
+        assert all(r["aoi_name"] == "Brazil" for r in data["data"])
+
+    async def test_invalid_variable_returns_error_tool_message(self):
+        command = await query_fra_data.ainvoke(_tool_call("nonexistent_variable"))
+
+        assert "statistics" not in command.update
+        messages = command.update.get("messages", [])
+        assert len(messages) == 1
+        content = messages[0].content
+        assert "nonexistent_variable" in content
+        assert "Valid options" in content
+
+    async def test_fao_api_error_returns_error_tool_message(self):
+        with patch(
+            "src.agent.tools.query_fra_data.fetch_fra_data",
+            new=AsyncMock(side_effect=FAOAPIError("API down")),
+        ):
+            command = await query_fra_data.ainvoke(_tool_call("forest_area"))
+
+        assert "statistics" not in command.update
+        messages = command.update.get("messages", [])
+        assert messages[0].content == "API down"
+
+    async def test_data_not_found_returns_error_tool_message(self):
+        with patch(
+            "src.agent.tools.query_fra_data.fetch_fra_data",
+            new=AsyncMock(side_effect=FAODataNotFoundError("Country not in FRA")),
+        ):
+            command = await query_fra_data.ainvoke(_tool_call("forest_area"))
+
+        assert "statistics" not in command.update
+        assert "Country not in FRA" in command.update["messages"][0].content
+
+    async def test_iso_code_read_from_state(self):
+        """Tool should use src_id from aoi_selection, not a separate parameter."""
+        body = _make_fao_response("IDN", "extentOfForest")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = body
+
+        state = _make_state(iso3="IDN", aoi_name="Indonesia")
+
+        with patch("src.agent.tools.fao_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            command = await query_fra_data.ainvoke(_tool_call("forest_area", state=state))
+
+        stats = command.update["statistics"]
+        assert stats[0]["aoi_names"] == ["Indonesia"]
+        assert all(r["country"] == "IDN" for r in stats[0]["data"]["data"])
+
+    async def test_multi_aoi_combines_records(self):
+        """Multiple AOIs should each be fetched and combined into one statistics entry."""
+        def make_response(iso3):
+            body = _make_fao_response(iso3, "extentOfForest")
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = body
+            return r
+
+        state = {
+            "aoi_selection": {
+                "name": "Brazil + Indonesia",
+                "aois": [
+                    {"name": "Brazil", "src_id": "BRA", "source": "gadm", "subtype": "country"},
+                    {"name": "Indonesia", "src_id": "IDN", "source": "gadm", "subtype": "country"},
+                ],
+            }
+        }
+
+        responses = [make_response("BRA"), make_response("IDN")]
+        call_count = 0
+
+        async def mock_get(*args, **kwargs):
+            nonlocal call_count
+            r = responses[call_count]
+            call_count += 1
+            return r
+
+        with patch("src.agent.tools.fao_client.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = mock_get
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            command = await query_fra_data.ainvoke(_tool_call("forest_area", state=state))
+
+        stats = command.update["statistics"]
+        assert len(stats) == 1
+        all_records = stats[0]["data"]["data"]
+        countries = {r["country"] for r in all_records}
+        assert countries == {"BRA", "IDN"}
+        assert stats[0]["aoi_names"] == ["Brazil", "Indonesia"]
+
+    async def test_partial_aoi_failure_returns_partial_statistics(self):
+        """If one AOI fails and another succeeds, return data for the successful one."""
+        body = _make_fao_response("BRA", "extentOfForest")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = body
+
+        call_count = 0
+
+        async def mock_fetch(iso3, table, variables, year=None):
+            nonlocal call_count
+            call_count += 1
+            if iso3 == "IDN":
+                raise FAODataNotFoundError("IDN not found")
+            from src.agent.tools.fao_client import _parse_response
+            return _parse_response(body, iso3, table, year)
+
+        state = {
+            "aoi_selection": {
+                "name": "Brazil + Indonesia",
+                "aois": [
+                    {"name": "Brazil", "src_id": "BRA", "source": "gadm", "subtype": "country"},
+                    {"name": "Indonesia", "src_id": "IDN", "source": "gadm", "subtype": "country"},
+                ],
+            }
+        }
+
+        with patch("src.agent.tools.query_fra_data.fetch_fra_data", new=mock_fetch):
+            command = await query_fra_data.ainvoke(_tool_call("forest_area", state=state))
+
+        # Statistics should exist for BRA
+        stats = command.update.get("statistics", [])
+        assert len(stats) == 1
+        countries = {r["country"] for r in stats[0]["data"]["data"]}
+        assert countries == {"BRA"}
+        # Tool message should mention the IDN failure
+        msg = command.update["messages"][0].content
+        assert "IDN not found" in msg
+
+
+# ---------------------------------------------------------------------------
+# variable_map sanity checks
+# ---------------------------------------------------------------------------
+
+class TestVariableMap:
+    def test_all_valid_variables_are_strings(self):
+        for v in VALID_VARIABLES:
+            assert isinstance(v, str)
+
+    def test_each_entry_has_required_keys(self):
+        from src.agent.tools.variable_map import VARIABLE_MAP
+        for name, config in VARIABLE_MAP.items():
+            assert "table" in config, f"{name} missing 'table'"
+            assert "variables" in config, f"{name} missing 'variables'"
+            assert "unit" in config, f"{name} missing 'unit'"
+            assert "description" in config, f"{name} missing 'description'"


### PR DESCRIPTION
## Add FAO FRA 2025 as a national forest statistics source

Introduces `query_fra_data` — a new tool that routes country-level forest questions to the FAO Global Forest Resources Assessment (FRA) 2025 API instead of the GFW remote-sensing pipeline.

## Why

The existing `pick_dataset → pull_data` pipeline serves sub-national, satellite-derived data. Users asking nationally-reported questions ("What is Brazil's total forest area?", "How has carbon stock changed nationally?") had no good path — `pick_dataset` had no matching dataset, and GFW pixel data can't answer FAO-level inventory questions.

## What changed

**New data source** (commits 1–2)
- Async HTTP client for the FAO FRA public API (`fao_client.py`)
- 21-variable map from user-facing names to FRA API table identifiers (`variable_map.py`)
- `query_fra_data` tool: reads country ISO from AOI selection, fetches FRA data, returns flat
records compatible with `generate_insights`
- `fao_fra_2025.yml`: full dataset config with chart/presentation/caution instructions derived
from the FAO methodology doc

**Agent routing** (commit 3)
- New tool registered and added to the agent tool list
- System prompt updated with explicit `pull_data` vs `query_fra_data` routing rules — FRA path
skips `pick_dataset` and date range entirely

**Proactive discovery** (commit 4)
- `pick_dataset` surfaces FAO as a complementary option when a GFW forest dataset is selected
- `generate_insights` follow-up suggestions cross-reference FRA ↔ GFW depending on the active
data source
- Citations and data providers from the dataset YAML are appended to insight tool messages

## Routing

Remote-sensing:  pick_aoi → pick_dataset → pull_data → generate_insights
FAO/FRA:         pick_aoi → query_fra_data → generate_insights

## Supported variables (21)
`forest_area`, `forest_area_change`, `forest_area_protected`, `permanent_forest_estate`,
`forest_characteristics`, `growing_stock`, `growing_stock_per_ha`, `growing_stock_composition`,
`biomass`, `biomass_per_ha`, `carbon_stock`, `carbon_stock_by_pool`, `carbon_stock_soil_depth`,
`management_objectives`, `designated_management`, `management_rights`, `ownership`,
`disturbances`, `fire`, `degraded_forest`, `forest_restoration`

## Test plan
- [ ] Unit tests: `tests/tools/test_fra.py` (19 tests — API client, response parsing, tool
integration, variable map)
- [ ] Manual: "What are trends in Brazil's forest area using FAO data?" → `pick_aoi →
query_fra_data → generate_insights` with line chart
- [ ] Manual: "Show tree cover loss in Colombia" → `pick_dataset` tool message surfaces FAO FRA
note
- [ ] Manual: GFW insight follow-ups include FAO cross-reference suggestion
- [ ] Manual: FRA insight includes FAO citation in response

See `docs/ADR-002-fao-fra-tool.md` for full decision rationale.