### PR TITLE
Replace context_layers with config-driven params aligned to analytics API

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -46,15 +46,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
-      - name: Generate dataset embeddings
-        env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          mkdir -p data
-          uv run python src/ingest/embed_datasets.py
-
       - name: Run tools tests
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/zeno-data
@@ -82,4 +73,6 @@ jobs:
           COOKIE_SIGNER_SECRET_KEY: fake-cookie-key
           NEXTJS_API_KEY: test-nextjs-api-key
         run: |
+          mkdir -p data
+          uv run python src/ingest/embed_datasets.py
           uv run pytest tests/tools -v

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -2,9 +2,18 @@ name: Tools Tests
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: tools-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tools-tests'))
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Generate dataset embeddings
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           mkdir -p data
           uv run python src/ingest/embed_datasets.py

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -3,7 +3,7 @@ name: Tools Tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: tools-tests-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
 
+      - name: Generate dataset embeddings
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+        run: |
+          mkdir -p data
+          uv run python src/ingest/embed_datasets.py
+
       - name: Run tools tests
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/zeno-data

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,10 @@ name: Unit Tests
 on:
   pull_request:
 
+concurrency:
+  group: unit-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ ui_context = {
             "source": "GFW",
             "data_layer": "DIST-ALERT",
             "tile_url": "https://tiles.globalforestwatch.org/...",
-            "context_layer": "driver",
+            "intersection": "driver",
             "daterange": {
                 "start_date": "2024-01-01",
                 "end_date": "2024-12-31",
@@ -374,15 +374,15 @@ class AgentState(TypedDict):
     "dataset": {
         "dataset_id": 0,
         "dataset_name": "Ecosystem disturbance alerts",
-        "context_layer": null,
+        "intersection": null,
         "reason": "This dataset directly matches the query as it provides \"Global All Ecosystem Disturbance Alerts (DIST-ALERT)\" with near-real-time alerts of vegetation disturbance globally, which is exactly what the user is asking about regarding ecosystem disturbance alerts distribution.",
         "tile_url": "https://tiles.globalforestwatch.org/umd_glad_dist_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color"
     },
     "message": {
         "selected_dataset": "DIST-ALERT",
-        "context_layer": "driver",
+        "intersection": "driver",
         "threshold": null,
-        "reasoning": "The DIST-ALERT dataset is the best match as it specifically provides near-real-time alerts of vegetation disturbance at high resolution (30m), covers the 2024 timeframe (2023-2025), and includes a \"driver\" contextual layer which would help identify the main drivers of disturbances in Koraput for Q1 2024. This dataset covers all vegetation types and is designed for monitoring ecosystem changes in near-real-time."
+        "reasoning": "The DIST-ALERT dataset is the best match as it specifically provides near-real-time alerts of vegetation disturbance at high resolution (30m), covers the 2024 timeframe (2023-2025), and includes a \"driver\" intersection which would help identify the main drivers of disturbances in Koraput for Q1 2024. This dataset covers all vegetation types and is designed for monitoring ecosystem changes in near-real-time."
     }
 }
 ```

--- a/frontend/pages/3_🧪_Evaluation.py
+++ b/frontend/pages/3_🧪_Evaluation.py
@@ -78,8 +78,8 @@ def get_column_presets():
             "dataset_score",
             "expected_dataset_name",
             "actual_dataset_name",
-            "expected_context_layer",
-            "actual_context_layer",
+            "expected_params",
+            "actual_params",
         ],
         "Data Pull Evaluation": [
             "query",

--- a/frontend/utils.py
+++ b/frontend/utils.py
@@ -237,7 +237,7 @@ def render_dataset_map(dataset_data, aoi_data=None):
                 "Dataset Name": dataset_data.get("dataset_name", "N/A"),
                 "Data Layer": dataset_data.get("data_layer", "N/A"),
                 "Source": dataset_data.get("source", "N/A"),
-                "Context Layer": dataset_data.get("context_layer", "N/A"),
+                "Params": dataset_data.get("params", {}),
                 "Date Range": dataset_data.get("daterange", "N/A"),
                 "Threshold": dataset_data.get("threshold", "N/A"),
                 "Reason": dataset_data.get("reason", "N/A"),
@@ -784,8 +784,10 @@ def display_sidebar_selections():
                 "source": "GFW",
                 "dataset_name": "Tree cover loss",
                 "tile_url": "https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png?start_year=2001&end_year=2024&tree_cover_density_threshold=25&render_type=true_color",
-                "context_layer": "Primary forest",
-                "threshold": "30",
+                "params": {
+                    "forest_filter": "primary_forest",
+                    "canopy_cover": 30,
+                },
             }
         },
         "DIST_ALERT": {
@@ -794,8 +796,7 @@ def display_sidebar_selections():
                 "source": "GFW",
                 "dataset_name": "DIST-ALERT",
                 "tile_url": "https://tiles.globalforestwatch.org/umd_glad_dist_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color",
-                "context_layer": "driver",
-                "threshold": None,
+                "params": {"intersections": ["driver"]},
             }
         },
     }

--- a/src/agent/tools/code_executors/gemini_executor.py
+++ b/src/agent/tools/code_executors/gemini_executor.py
@@ -127,7 +127,10 @@ class GeminiCodeExecutor:
                             content=part.executable_code.code,
                         )
                     )
-                if part.code_execution_result:
+                if (
+                    part.code_execution_result
+                    and part.code_execution_result.output
+                ):
                     parts.append(
                         CodeActPart(
                             type=PartType.EXECUTION_OUTPUT,

--- a/src/agent/tools/data_handlers/analytics_handler.py
+++ b/src/agent/tools/data_handlers/analytics_handler.py
@@ -32,106 +32,6 @@ ADMIN_SUBTYPES = (
     "locality",
     "neighbourhood",
 )
-SLUC_GADM_LEVELS = ["country", "state-province", "district-county"]
-
-SLUC_CROPS = [
-    "Banana",
-    "Barley",
-    "Bean",
-    "Cassava",
-    "Chickpea",
-    "Coconut",
-    "Cocoa",
-    "Arabica Coffee",
-    "Robusta Coffee",
-    "Cotton",
-    "Cowpea",
-    "Groundnut",
-    "Lentil",
-    "Maize",
-    "Pearl Millet",
-    "Small Millet",
-    "Oil Palm",
-    "Pigeon Pea",
-    "Plantain",
-    "Potato",
-    "Rapeseed",
-    "Rice",
-    "Sesame Seed",
-    "Sorghum",
-    "Soybean",
-    "Sugarbeet",
-    "Sugarcane",
-    "Sunflower",
-    "Sweet Potato",
-    "Tea",
-    "Tobacco",
-    "Wheat",
-    "Yams",
-    "Other Cereals",
-    "Other Fibre Crops",
-    "Other Oil Crops",
-    "Other Pulses",
-    "Other Roots",
-    "Rest of Crops",
-    "Temperate Fruit",
-    "Tropical Fruit",
-    "Vegetables",
-]
-
-SLUC_GAS_TYPES = ["CO2e", "CO2", "CH4", "N20"]
-
-# Add dataset-specific parameters
-DIST_ALERT_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"]
-    == "Global all ecosystem disturbance alerts (DIST-ALERT)"
-][0]
-NATURAL_LANDS_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"] == "SBTN Natural Lands Map"
-][0]
-LAND_COVER_CHANGE_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"] == "Global land cover"
-][0]
-GRASSLANDS_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"] == "Global natural/semi-natural grassland extent"
-][0]
-TREE_COVER_LOSS_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"] == "Tree cover loss"
-][0]
-TREE_COVER_GAIN_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"] == "Tree cover gain"
-][0]
-FOREST_CARBON_FLUX_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"] == "Forest greenhouse gas net flux"
-][0]
-TREE_COVER_ID = [
-    ds["dataset_id"] for ds in DATASETS if ds["dataset_name"] == "Tree cover"
-][0]
-TREE_COVER_LOSS_BY_DRIVER_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"] == "Tree cover loss by dominant driver"
-][0]
-SLUC_EMISSION_FACTORS_ID = [
-    ds["dataset_id"]
-    for ds in DATASETS
-    if ds["dataset_name"]
-    == "Deforestation (sLUC) Emission Factors by Agricultural Crop"
-][0]
 
 
 class AnalyticsHandler(DataSourceHandler):
@@ -146,18 +46,13 @@ class AnalyticsHandler(DataSourceHandler):
 
     def can_handle(self, dataset: Any) -> bool:
         """Check if this handler can process the given dataset"""
-        return dataset.get("dataset_id") in [
-            DIST_ALERT_ID,
-            NATURAL_LANDS_ID,
-            LAND_COVER_CHANGE_ID,
-            GRASSLANDS_ID,
-            TREE_COVER_LOSS_ID,
-            TREE_COVER_GAIN_ID,
-            FOREST_CARBON_FLUX_ID,
-            TREE_COVER_ID,
-            TREE_COVER_LOSS_BY_DRIVER_ID,
-            SLUC_EMISSION_FACTORS_ID,
-        ]
+        dataset_id = dataset.get("dataset_id")
+        full_ds = next(
+            (ds for ds in DATASETS if ds["dataset_id"] == dataset_id), None
+        )
+        return full_ds is not None and bool(
+            full_ds.get("analytics_api_endpoint")
+        )
 
     def _get_aoi_type(self, aoi: Dict) -> str:
         """Get the type of the AOI"""
@@ -243,82 +138,38 @@ class AnalyticsHandler(DataSourceHandler):
 
         logger.debug(f"dataset: {dataset}")
 
-        if dataset.get("dataset_id") == DIST_ALERT_ID:
-            payload = {
-                **base_payload,
-                "start_date": start_date,
-                "end_date": end_date,
-                "intersections": (
-                    [dataset["context_layer"]]
-                    if dataset.get("context_layer")
-                    else []
-                ),
-            }
+        config = dataset.get("analytics_config", {})
+        payload = dict(base_payload)
 
-        elif dataset.get("dataset_id") in [
-            NATURAL_LANDS_ID,
-            LAND_COVER_CHANGE_ID,
-        ]:
-            # Natural lands and grasslands don't require date ranges
-            payload = base_payload
+        date_cfg = config.get("date_params", {})
+        date_type = date_cfg.get("type", "none")
 
-        elif dataset.get("dataset_id") == GRASSLANDS_ID:
-            payload = {
-                **base_payload,
-                "start_year": start_date[:4],  # Extract year from YYYY-MM-DD
-                "end_year": end_date[:4],
-            }
-        elif dataset.get("dataset_id") in [
-            TREE_COVER_LOSS_ID,
-            TREE_COVER_LOSS_BY_DRIVER_ID,
-        ]:
-            payload = {
-                **base_payload,
-                "start_year": start_date[:4],
-                "end_year": end_date[:4],
-                "canopy_cover": 30,
-                "forest_filter": None,
-                "intersections": (
-                    [dataset["context_layer"]]
-                    if dataset.get("context_layer")
-                    else []
-                ),
-            }
-        elif dataset.get("dataset_id") == TREE_COVER_GAIN_ID:
-            # Tree cover gain is only available in 5-year intervals
+        if date_type == "date":
+            payload[date_cfg["start_key"]] = start_date
+            payload[date_cfg["end_key"]] = end_date
+        elif date_type == "year":
+            payload[date_cfg["start_key"]] = start_date[:4]
+            payload[date_cfg["end_key"]] = end_date[:4]
+        elif date_type == "year_5yr_interval":
             start_year = int(start_date[:4]) - int(start_date[:4]) % 5
             end_year = int(end_date[:4]) - int(end_date[:4]) % 5
             if start_year == end_year:
                 end_year += 5
-            payload = {
-                **base_payload,
-                "start_year": str(max(2000, start_year)),
-                "end_year": str(max(2005, end_year)),
-                "forest_filter": None,
-            }
-        elif dataset.get("dataset_id") == FOREST_CARBON_FLUX_ID:
-            payload = {
-                **base_payload,
-                "canopy_cover": 30,
-            }
-        elif dataset.get("dataset_id") == TREE_COVER_ID:
-            payload = {
-                **base_payload,
-                "canopy_cover": 30,
-                "forest_filter": None,
-            }
-        elif dataset.get("dataset_id") == SLUC_EMISSION_FACTORS_ID:
-            payload = {
-                **base_payload,
-                "gas_types": SLUC_GAS_TYPES,
-                "crop_types": SLUC_CROPS,
-                "start_year": start_date[:4],
-                "end_year": end_date[:4],
-            }
-        else:
-            raise ValueError(
-                f"Unknown dataset ID: {dataset.get('dataset_id')}"
-            )
+            min_start = date_cfg.get("min_start", 0)
+            min_end = date_cfg.get("min_end", 0)
+            payload[date_cfg["start_key"]] = str(max(min_start, start_year))
+            payload[date_cfg["end_key"]] = str(max(min_end, end_year))
+
+        param_defs = config.get("params", {})
+        selected_params = dataset.get("params", {})
+        for param_name, param_def in param_defs.items():
+            default = param_def.get("default")
+            is_list = param_def.get("type") == "list"
+            if default == "all" and is_list:
+                default = list(param_def.get("values", []))
+            value = selected_params.get(param_name, default)
+            if value is not None:
+                payload[param_name] = value
 
         return payload
 
@@ -435,22 +286,8 @@ class AnalyticsHandler(DataSourceHandler):
         change_over_time_query: bool,
         aois: list[dict],
     ) -> DataPullResult:
-        # SLUC emission factors are only available for GADM levels 0, 1, and 2
-        if (
-            dataset.get("dataset_id") == SLUC_EMISSION_FACTORS_ID
-            and aois[0]["subtype"] not in SLUC_GADM_LEVELS
-        ):
-            msg = f"Can not pull data for aoi {aois[0].get('name', '')}. Subtype {aois[0]['subtype']} not supported for SLUC emission factors data, it is only available for GADM admin areas."
-            return DataPullResult(
-                success=False,
-                data=None,
-                message=msg,
-                data_points_count=0,
-                analytics_api_url=None,
-            )
-
         try:
-            context_layer = dataset.get("context_layer")
+            selected_params = dataset.get("params", {})
 
             dataset = [
                 ds
@@ -462,17 +299,36 @@ class AnalyticsHandler(DataSourceHandler):
                     f"Dataset not found: {dataset.get('dataset_id')}"
                 )
             dataset = dataset[0]
-            if context_layer:
-                dataset["context_layer"] = context_layer
+            if selected_params:
+                dataset["params"] = selected_params
+
+            aoi_restrictions = dataset.get("analytics_config", {}).get(
+                "aoi_restrictions"
+            )
+            if aoi_restrictions:
+                allowed = aoi_restrictions["allowed_subtypes"]
+                if aois[0]["subtype"] not in allowed:
+                    msg = (
+                        f"Can not pull data for aoi {aois[0].get('name', '')}. "
+                        f"Subtype {aois[0]['subtype']} not supported for "
+                        f"{dataset.get('dataset_name', 'this dataset')} data: "
+                        f"{aoi_restrictions['error_message']}"
+                    )
+                    return DataPullResult(
+                        success=False,
+                        data=None,
+                        message=msg,
+                        data_points_count=0,
+                        analytics_api_url=None,
+                    )
 
             # Get the appropriate endpoint URL
-            if (
-                dataset.get("dataset_id") == LAND_COVER_CHANGE_ID
-                and change_over_time_query
-            ):
+            alt_endpoints = dataset.get("analytics_config", {}).get(
+                "alternate_endpoints", {}
+            )
+            if change_over_time_query and "change_over_time" in alt_endpoints:
                 endpoint_url = (
-                    self.BASE_URL
-                    + "/v0/land_change/land_cover_composition/analytics"
+                    self.BASE_URL + alt_endpoints["change_over_time"]
                 )
             else:
                 endpoint_url = self.BASE_URL + dataset.get(

--- a/src/agent/tools/datasets/deforestation_sluc_emission_factors_by_agricultural_crop.yml
+++ b/src/agent/tools/datasets/deforestation_sluc_emission_factors_by_agricultural_crop.yml
@@ -1,6 +1,5 @@
 dataset_id: 9
 dataset_name: Deforestation (sLUC) Emission Factors by Agricultural Crop
-context_layers: null
 variables: null
 tile_url: ''
 license: CC by 4.0
@@ -23,6 +22,69 @@ keywords:
 - supply chains
 - agriculture
 analytics_api_endpoint: /v0/land_change/deforestation_luc_emissions_factor/analytics
+analytics_config:
+  date_params:
+    type: year
+    start_key: start_year
+    end_key: end_year
+  params:
+    gas_types:
+      type: list
+      values: [CO2e, CO2, CH4, N2O]
+      default: [CO2e]
+      description: "Gas types to include. CO2e is equivalent to the sum of all other gases."
+    crop_types:
+      type: list
+      values:
+      - Banana
+      - Barley
+      - Bean
+      - Cassava
+      - Chickpea
+      - Coconut
+      - Cocoa
+      - Arabica Coffee
+      - Robusta Coffee
+      - Cotton
+      - Cowpea
+      - Groundnut
+      - Lentil
+      - Maize
+      - Pearl Millet
+      - Small Millet
+      - Oil Palm
+      - Pigeon Pea
+      - Plantain
+      - Potato
+      - Rapeseed
+      - Rice
+      - Sesame Seed
+      - Sorghum
+      - Soybean
+      - Sugarbeet
+      - Sugarcane
+      - Sunflower
+      - Sweet Potato
+      - Tea
+      - Tobacco
+      - Wheat
+      - Yams
+      - Other Cereals
+      - Other Fibre Crops
+      - Other Oil Crops
+      - Other Pulses
+      - Other Roots
+      - Rest of Crops
+      - Temperate Fruit
+      - Tropical Fruit
+      - Vegetables
+      default: all
+      description: "Crop types to include. Defaults to all available crops."
+  aoi_restrictions:
+    allowed_subtypes: [country, state-province, district-county]
+    error_message: "Only available for GADM admin areas"
+tile_url_config:
+  type: none
 prompt_instructions: 'This dataset provides statistical land use change (sLUC) emission factors, total emissions, and production
   volume for 42 agricultural crops across multiple spatial scales: national (ADM0), subnational (ADM1),and local administrative
   units (ADM2). Emission factors quantify total greenhouse gas emissions in tCO2e per tonne of product from deforestation

--- a/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
+++ b/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
@@ -1,12 +1,6 @@
 dataset_id: 6
 dataset_name: Forest greenhouse gas net flux
-context_layers: null
-variables:
-- value: primary_forest
-  description: Shows loss within humid tropical primary forest in global pan-tropical regions
-- value: intact_forest_landscape
-  description: Shows gain within large, unfragmented areas of natural forest ecosystems that were free from significant human
-    disturbance as of 2000.
+variables: null
 tile_url: https://tiles.globalforestwatch.org/gfw_forest_carbon_net_flux/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30
 license: CC by 4.0
 geographic_coverage: Global
@@ -23,6 +17,16 @@ keywords:
 - carbon
 - sequestration
 analytics_api_endpoint: /v0/land_change/carbon_flux/analytics
+analytics_config:
+  date_params:
+    type: none
+  params:
+    canopy_cover:
+      values: [30, 50, 75]
+      default: 30
+      description: Minimum percent canopy cover threshold
+tile_url_config:
+  type: none
 prompt_instructions: 'DO NOT show trends over time or annual values. Caution users that this data shows net flux, gross emissions
   and removals as total values over the model period of 2001-2024, not an annual values. Show net flux as a split bar chart,
   with emissions in the positive y-axis and removals in the negative. The data is calculcated with a  30% canopy density threshold,

--- a/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -1,16 +1,5 @@
 dataset_id: 0
 dataset_name: Global all ecosystem disturbance alerts (DIST-ALERT)
-context_layers:
-- value: driver
-  description: 'Shows the primary driver or likely causes of disturbance to natural land due to: conversion, cropland dynamics,
-    fire-related, water-related, or unclassified.'
-- value: natural_lands
-  description: 'Shows intersection with natural lands classes (2020): '
-- value: grasslands
-  description: Shows disturbances to natural grasslands, shrublands, and savannas
-- value: land_cover
-  description: 'Shows disturbance within different land cover/land use classes: bare ground and sparse, vegetation, short
-    vegetation, tree cover, wetlands, water, snow/ice, cropland, cultivated grasslands, and built-up land.'
 variables: null
 tile_url: https://tiles.globalforestwatch.org/umd_glad_dist_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color
 license: CC by 4.0
@@ -27,6 +16,20 @@ keywords:
 - conversion
 - vegetation disturbance
 analytics_api_endpoint: /v0/land_change/dist_alerts/analytics
+analytics_config:
+  date_params:
+    type: date
+    start_key: start_date
+    end_key: end_date
+  params:
+    intersections:
+      type: list
+      values: [driver, natural_lands, grasslands, land_cover]
+      default: []
+      description: "Context layer: driver (LDACS driver classification), natural_lands (SBTN 2020 natural land classes), grasslands
+        (natural/semi-natural grassland extent), or land_cover (land cover/land use classes)"
+tile_url_config:
+  type: append_date_range
 prompt_instructions: 'Use this dataset to show recent vegetation changes across all ecosystems. Data is measured in hectares
   (ha), use this as the unit of analysis in all cases. Show classified alerts by driver (LDACS) by default, which is designed
   to reveal likely causes of disturbance, identify dominant drivers in a region, and support ecosystem or regional comparisons.

--- a/src/agent/tools/datasets/global_land_cover.yml
+++ b/src/agent/tools/datasets/global_land_cover.yml
@@ -1,6 +1,5 @@
 dataset_id: 1
 dataset_name: Global land cover
-context_layers: null
 variables: null
 tile_url: /raster/collections/global-land-cover-v-2/items/global-land-cover-{year}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?colormap=%7B%221%22%3A%20%5B254%2C%20254%2C%20204%2C%20255%5D%2C%20%222%22%3A%20%5B185%2C%20185%2C%2030%5D%2C%20%223%22%3A%20%5B36%2C%20110%2C%2036%5D%2C%20%224%22%3A%20%5B116%2C%20214%2C%20180%5D%2C%20%225%22%3A%20%5B107%2C%20174%2C%20214%5D%2C%20%226%22%3A%20%5B172%2C%20209%2C%20232%5D%2C%20%227%22%3A%20%5B255%2C%20241%2C%20131%5D%2C%20%228%22%3A%20%5B232%2C%20118%2C%2093%5D%2C%20%229%22%3A%20%5B255%2C%20205%2C%20115%5D%7D&assets=asset&expression=asset%2A%28asset%3C10%29%2A%28asset%3E0%29&asset_as_band=True
 license: CC by 4.0
@@ -41,6 +40,15 @@ keywords:
 - remote sensing
 - 30 m
 analytics_api_endpoint: /v0/land_change/land_cover_change/analytics
+analytics_config:
+  date_params:
+    type: none
+  alternate_endpoints:
+    change_over_time: /v0/land_change/land_cover_composition/analytics
+tile_url_config:
+  type: format_year
+  valid_year_range: [2000, 2022]
+  fallback_year: 2022
 prompt_instructions: 'This dataset contains land-cover class snapshots in 2015 and 2024, reporting pixel-level class changes,
   measured in hectares (ha). For change questions, use tables with land_cover_class_start, land_cover_class_end, and area_ha
   columns to show transitions. Warn users that the data only shows start- and end-states, not intra-annual changes. Clarify

--- a/src/agent/tools/datasets/global_natural_semi_natural_grassland_extent.yml
+++ b/src/agent/tools/datasets/global_natural_semi_natural_grassland_extent.yml
@@ -1,6 +1,5 @@
 dataset_id: 2
 dataset_name: Global natural/semi-natural grassland extent
-context_layers: null
 variables: Natural/Semi-Natural Grassland
 tile_url: /raster/collections/grasslands-v-1/items/grasslands-{year}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?colormap=%7B%220%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%221%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%222%22%3A%20%5B255%2C%20153%2C%2022%2C%20255%5D%2C%20%223%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True
 license: CC by 4.0
@@ -29,6 +28,15 @@ keywords:
 - machine learning
 - Landsat
 analytics_api_endpoint: /v0/land_change/grasslands/analytics
+analytics_config:
+  date_params:
+    type: year
+    start_key: start_year
+    end_key: end_year
+tile_url_config:
+  type: format_year
+  valid_year_range: [2000, 2022]
+  fallback_year: 2022
 prompt_instructions: 'Natural/semi-natural grassland extent and change for each year from 2000 to 2022. Quantify area of natural/semi-natural
   grasslands in a given year. Quantify gains and losses in area of natural/semi-natural grasslands through time. Use bar or
   line charts to show total area of natural/semi-natural grasslands over time where the x axis is years and the y axis is

--- a/src/agent/tools/datasets/sbtn_natural_lands_map.yml
+++ b/src/agent/tools/datasets/sbtn_natural_lands_map.yml
@@ -1,6 +1,5 @@
 dataset_id: 3
 dataset_name: SBTN Natural Lands Map
-context_layers: null
 variables: binary, classification
 tile_url: /raster/collections/natural-lands-v-1-1/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%222%22%3A%20%5B36%2C%20110%2C%2036%2C%20255%5D%2C%20%223%22%3A%20%5B185%2C%20185%2C%2030%2C%20255%5D%2C%20%224%22%3A%20%5B107%2C%20174%2C%20214%2C%20255%5D%2C%20%225%22%3A%20%5B6%2C%20162%2C%20133%2C%20255%5D%2C%20%226%22%3A%20%5B254%2C%20254%2C%20204%2C%20255%5D%2C%20%227%22%3A%20%5B172%2C%20209%2C%20232%2C%20255%5D%2C%20%228%22%3A%20%5B88%2C%20149%2C%2088%2C%20255%5D%2C%20%229%22%3A%20%5B9%2C%2061%2C%209%2C%20255%5D%2C%20%2210%22%3A%20%5B219%2C%20219%2C%20123%2C%20255%5D%2C%20%2211%22%3A%20%5B153%2C%20153%2C%2026%2C%20255%5D%2C%20%2212%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2213%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2214%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2215%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2216%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2217%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2218%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2219%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2220%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2221%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%7D&assets=asset&expression=asset%2A%28asset%3C22%29%2A%28asset%3E1%29&asset_as_band=True
 license: CC by 4.0 SA
@@ -18,6 +17,11 @@ keywords:
 - supply chains
 - natural lands
 analytics_api_endpoint: /v0/land_change/natural_lands/analytics
+analytics_config:
+  date_params:
+    type: none
+tile_url_config:
+  type: none
 prompt_instructions: 'Natural and non-natural lands in 2020. Created to see if there were natural lands within users'' production
   units in 2020, and can be used with additional monitoring data to see if change occurred on land that was natural. For questions
   around natural forests, include the following classes: 2,5,8,9. For non-natural tree cover, include the following classes:

--- a/src/agent/tools/datasets/tree_cover.yml
+++ b/src/agent/tools/datasets/tree_cover.yml
@@ -1,12 +1,6 @@
 dataset_id: 7
 dataset_name: Tree cover
-context_layers: null
-variables:
-- value: primary_forest
-  description: Shows loss within humid tropical primary forest in global pan-tropical regions
-- value: intact_forest
-  description: Shows gain within large, unfragmented areas of natural forest ecosystems that were free from significant human
-    disturbance as of 2000.
+variables: null
 tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_30/{z}/{x}/{y}.png
 license: CC by 4.0
 geographic_coverage: Global land (excluding Antarctica and Arctic islands)
@@ -21,6 +15,20 @@ keywords:
 - forest
 - canopy
 analytics_api_endpoint: /v0/land_change/tree_cover/analytics
+analytics_config:
+  date_params:
+    type: none
+  params:
+    canopy_cover:
+      values: [10, 15, 20, 25, 30, 50, 75]
+      default: 30
+      description: Minimum percent canopy cover to consider tree cover
+    forest_filter:
+      values: [primary_forest, natural_forest]
+      default: null
+      description: Filter to primary forest (humid tropical) or natural forest (intact forest landscapes)
+tile_url_config:
+  type: none
 prompt_instructions: 'Shows tree cover area (area_ha) per pixel for year 2000 with a given tree cover threshold, for woody
   vegetation greater than 5 meters in height. If combined with primary forest or IFL layers, we can use the term ''forest''
   to describe results. Otherwise, only use the term ''tree cover''. Binned % tree cover extent can be reported in bar chart

--- a/src/agent/tools/datasets/tree_cover_gain.yml
+++ b/src/agent/tools/datasets/tree_cover_gain.yml
@@ -1,12 +1,6 @@
 dataset_id: 5
 dataset_name: Tree cover gain
-context_layers: null
-variables:
-- value: primary_forest
-  description: Shows loss within humid tropical primary forest in global pan-tropical regions
-- value: intact_forest
-  description: Shows gain within large, unfragmented areas of natural forest ecosystems that were free from significant human
-    disturbance as of 2000.
+variables: null
 tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_gain_from_height/latest/default/{z}/{x}/{y}.png
 license: CC by 4.0
 geographic_coverage: Global land area (excluding Antarctica and other Arctic islands)
@@ -20,6 +14,20 @@ keywords:
 - gain
 - forest regrowth
 analytics_api_endpoint: /v0/land_change/tree_cover_gain/analytics
+analytics_config:
+  date_params:
+    type: year_5yr_interval
+    start_key: start_year
+    end_key: end_year
+    min_start: 2000
+    min_end: 2005
+  params:
+    forest_filter:
+      values: [primary_forest, natural_forest]
+      default: null
+      description: Filter to primary forest (humid tropical) or natural forest (intact forest landscapes)
+tile_url_config:
+  type: none
 prompt_instructions: 'Shows cumulative tree cover gain over the periods  2000-2020, 2005-2020, 2010-2020 or 2015-2020. Tree
   cover gain is defined as a change in tree height from under 5m to over 5m and is not necessarily the same as forest restoration.
   Avoid using the term "restoration" (other than to Use it to warn users about the differences between tree cover gain and

--- a/src/agent/tools/datasets/tree_cover_loss.yml
+++ b/src/agent/tools/datasets/tree_cover_loss.yml
@@ -1,12 +1,6 @@
 dataset_id: 4
 dataset_name: Tree cover loss
-context_layers: null
-variables:
-- value: primary_forest
-  description: Shows loss within humid tropical primary forest in global pan-tropical regions
-- value: intact_forest
-  description: Intact forest landscapes (IFL) show loss within large, unfragmented areas of natural forest ecosystems that
-    were free from significant human disturbance as of 2000.
+variables: null
 tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30&render_type=true_color
 license: CC by 4.0
 geographic_coverage: Global land area (excluding Antarctica and other Arctic islands)
@@ -21,6 +15,26 @@ keywords:
 - forest loss
 - disturbance
 analytics_api_endpoint: /v0/land_change/tree_cover_loss/analytics
+analytics_config:
+  date_params:
+    type: year
+    start_key: start_year
+    end_key: end_year
+  params:
+    canopy_cover:
+      values: [10, 15, 20, 25, 30, 50, 75]
+      default: 30
+      description: Minimum percent canopy cover. Carbon model only valid for 30% or greater.
+    forest_filter:
+      values: [primary_forest, natural_forest]
+      default: null
+      description: Filter to primary forest (humid tropical) or natural forest (intact forest landscapes)
+tile_url_config:
+  type: append_year_range
+  valid_year_range: [2001, 2024]
+  fallback:
+    start_year: 2001
+    end_year: 2024
 prompt_instructions: 'Reports gross annual loss of tree cover ≥ 5 m height (2001-2024). Show yearly loss with bar charts or
   cumulative loss with stacked-area charts; plot area_ha and drop zeros. When reporting tree cover loss, always include the
   GHG emissions associated with that loss, in MgCO2e (tonnes of CO2 equivalent). If users ask for intra-year or seasonal tree

--- a/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
+++ b/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
@@ -1,6 +1,5 @@
 dataset_id: 8
 dataset_name: Tree cover loss by dominant driver
-context_layers: null
 variables: null
 tile_url: https://tiles.globalforestwatch.org/wri_google_tree_cover_loss_drivers/v1.12/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30&render_type=true_color
 license: CC by 4.0
@@ -23,6 +22,27 @@ keywords:
 - infrastructure
 - settlements
 analytics_api_endpoint: /v0/land_change/tree_cover_loss/analytics
+analytics_config:
+  date_params:
+    type: year
+    start_key: start_year
+    end_key: end_year
+  params:
+    canopy_cover:
+      values: [10, 15, 20, 25, 30, 50, 75]
+      default: 30
+      description: Minimum percent canopy cover. Carbon model only valid for 30% or greater.
+    forest_filter:
+      values: [primary_forest, natural_forest]
+      default: null
+      description: Filter to primary forest or natural forest
+    intersections:
+      type: list
+      values: [driver]
+      default: [driver]
+      description: Driver context layer (always active for this dataset)
+tile_url_config:
+  type: none
 prompt_instructions: "Shows the delta of the primary driver or cause of tree cover loss over the entire range 2001-2024. The\
   \ data represents the change for the whole period of time, not a timeseries. IMPORTANT: If a user asks for specific time\
   \ ranges (e.g. last five years), single years (e.g. 2024), or trends over time, do not use this dataset, select Tree cover\

--- a/src/agent/tools/datasets_config.py
+++ b/src/agent/tools/datasets_config.py
@@ -21,7 +21,7 @@ def _load_datasets() -> list[dict]:
             )
         datasets.append(record)
     datasets.sort(key=lambda d: d["dataset_id"])
-    if not len(datasets) == len(set(d["dataset_id"] for d in datasets)):
+    if len(datasets) != len(set(d["dataset_id"] for d in datasets)):
         raise ValueError(
             f"duplicate dataset_id in {DATASETS_DIR}. Each dataset must have a unique dataset_id."
         )

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -124,7 +124,7 @@ def build_analysis_prompt(
     file_references: str,
     dataset_guidelines: str = "",
     code_instructions: str | None = None,
-    context_layer: str | None = None,
+    active_params: dict | None = None,
 ) -> str:
     """
     Build the analysis prompt for the code executor.
@@ -134,7 +134,7 @@ def build_analysis_prompt(
         file_references: Executor-specific file reference section
         dataset_guidelines: Dataset-specific instructions for metric selection
         code_instructions: Dataset-specific chart type and data shaping rules (tiered PoC)
-        context_layer: Active context layer name, if any (e.g. "driver")
+        active_params: Active query parameters, if any (e.g. {"intersections": ["driver"]})
 
     Returns:
         Formatted prompt string
@@ -151,8 +151,10 @@ def build_analysis_prompt(
     dataset_rules_section = ""
     if code_instructions:
         header = "### DATASET-SPECIFIC RULES (follow these strictly):\n"
-        if context_layer:
-            header += f"Active context layer: {context_layer}\n"
+        if active_params:
+            non_default = {k: v for k, v in active_params.items() if v}
+            if non_default:
+                header += f"Active params: {non_default}\n"
         dataset_rules_section = f"""
 {header}
 {code_instructions}
@@ -345,7 +347,7 @@ async def generate_insights(
         file_references,
         dataset_guidelines=dataset_guidelines,
         code_instructions=code_instructions,
-        context_layer=dataset.get("context_layer"),
+        active_params=dataset.get("params"),
     )
     logger.debug(f"Analysis prompt:\n{analysis_prompt}")
 

--- a/src/agent/tools/get_capabilities.py
+++ b/src/agent/tools/get_capabilities.py
@@ -25,14 +25,14 @@ def _load_datasets_info() -> str:
         if description != "Unknown":
             description_parts.append(f"{description}")
 
-        # Add context layers info if available
-        context_layers = dataset.get("context_layers")
-        if context_layers:
-            context_desc = ", ".join(
-                [layer.get("description", "") for layer in context_layers]
-            )
-            if context_desc:
-                description_parts.append(f"with {context_desc.lower()}")
+        config = dataset.get("analytics_config") or {}
+        param_defs = config.get("params") or {}
+        if param_defs:
+            param_names = list(param_defs.keys())
+            if param_names:
+                description_parts.append(
+                    f"configurable params: {', '.join(param_names)}"
+                )
 
         description = (
             ", ".join(description_parts)

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import pandas as pd
 from langchain_core.messages import ToolMessage
@@ -13,13 +13,6 @@ from langgraph.types import Command
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src.agent.llms import SMALL_MODEL
-from src.agent.tools.data_handlers.analytics_handler import (
-    DIST_ALERT_ID,
-    GRASSLANDS_ID,
-    LAND_COVER_CHANGE_ID,
-    TREE_COVER_LOSS_BY_DRIVER_ID,
-    TREE_COVER_LOSS_ID,
-)
 from src.agent.tools.datasets_config import DATASETS
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
@@ -64,13 +57,60 @@ async def rag_candidate_datasets(query: str, k=3):
     return pd.DataFrame(candidate_datasets)
 
 
+def _resolve_params(
+    selected: dict[str, Any], param_defs: dict
+) -> dict[str, Any]:
+    """Validate LLM-selected params against the dataset's param definitions.
+
+    For each defined param:
+    - If the LLM provided a value, validate it against allowed values.
+    - If not provided (or invalid), use the default from the definition.
+    - For list-type params, wrap scalars and filter invalid items.
+    - Unknown params (not in definitions) are silently dropped.
+    """
+    validated: dict[str, Any] = {}
+    for param_name, param_def in param_defs.items():
+        allowed = param_def.get("values", [])
+        default = param_def.get("default")
+        is_list = param_def.get("type") == "list"
+
+        if default == "all" and is_list:
+            default = list(allowed)
+
+        if param_name in selected:
+            value = selected[param_name]
+            if is_list:
+                if not isinstance(value, list):
+                    value = [value] if value else []
+                valid_items = [v for v in value if v in allowed]
+                validated[param_name] = (
+                    valid_items
+                    if valid_items
+                    else (default if default is not None else [])
+                )
+            else:
+                if value in allowed or value is None:
+                    validated[param_name] = value
+                else:
+                    validated[param_name] = default
+        else:
+            if default is not None:
+                validated[param_name] = default
+
+    return validated
+
+
 class DatasetOption(BaseModel):
     dataset_id: int = Field(
         description="ID of the dataset that best matches the user query."
     )
-    context_layer: Optional[str] = Field(
-        None,
-        description="Pick a single context layer from the dataset if relevant.",
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Selected parameter values for the dataset query. "
+            "Keys are parameter names, values are the selected values. "
+            "Only include params you want to override from their defaults."
+        ),
     )
     reason: str = Field(
         description="Short reason why the dataset is the best match."
@@ -86,28 +126,24 @@ class DatasetOption(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def validate_context_layer_for_dataset(self) -> "DatasetOption":
-        """Ensure context_layer is valid for the chosen dataset_id (runs after all fields)."""
+    def validate_params_for_dataset(self) -> "DatasetOption":
+        """Validate and normalize params against the dataset's config."""
         dataset_id = self.dataset_id
         if dataset_id is None:
-            self.context_layer = None
-            return self
-        # Hardcoded override: TCL by driver always needs "driver" intersection
-        elif dataset_id == TREE_COVER_LOSS_BY_DRIVER_ID:
-            self.context_layer = "driver"
+            self.params = {}
             return self
 
-        if self.context_layer is None:
+        selected_dataset = next(
+            (ds for ds in DATASETS if ds["dataset_id"] == dataset_id),
+            None,
+        )
+        if not selected_dataset:
+            self.params = {}
             return self
 
-        selected_dataset = [
-            ds for ds in DATASETS if ds["dataset_id"] == dataset_id
-        ][0]
-        context_layers = selected_dataset.get("context_layers") or []
-        context_layer_values = [lyr["value"] for lyr in context_layers]
-        if self.context_layer not in context_layer_values:
-            self.context_layer = None
-
+        config = selected_dataset.get("analytics_config") or {}
+        param_defs = config.get("params") or {}
+        self.params = _resolve_params(self.params, param_defs)
         return self
 
 
@@ -157,6 +193,24 @@ class DatasetSelectionResult(DatasetOption):
     )
 
 
+def _format_params_for_prompt(cfg: dict | None) -> str | None:
+    """Format params for the LLM selection prompt."""
+    if not cfg or not isinstance(cfg, dict):
+        return None
+    param_defs = cfg.get("params")
+    if not param_defs:
+        return None
+    parts = []
+    for name, defn in param_defs.items():
+        vals = defn.get("values", [])
+        default = defn.get("default")
+        desc = defn.get("description", "")
+        parts.append(
+            f"{name}: values={vals}, default={default}, description={desc}"
+        )
+    return "; ".join(parts)
+
+
 async def select_best_dataset(
     query: str, candidate_datasets: pd.DataFrame
 ) -> DatasetSelectionResult:
@@ -168,9 +222,13 @@ async def select_best_dataset(
     user query and provide reason why it is the best match. Always return at least one dataset.
     Use all information provided to decide which dataset is the best match, especially the selection hints.
 
-    Select a single context layer from the dataset if relevant for the user query. Context layers
-    allow difrenciating between different types of data within the same dataset. So if a user asks
-    to show something like "show me tree cover loss by driver", you should select a context layer
+    Select parameter values from the dataset's available_params if relevant for the user query.
+    Parameters allow filtering and configuring the dataset query. For example:
+    - If a user asks "show me primary forest loss", set forest_filter to "primary_forest".
+    - If a user asks "show me disturbance alerts by driver", set intersections to "driver".
+    - If a user asks about a specific crop emission factor, set crop_types to that crop.
+    Only include params you want to change from their defaults. The values you select MUST
+    appear in the allowed values list — do not invent values.
 
     Evaluate if the best dataset is available for the date range requested by the user,
     if not, pick the closest date range but warn the user that there
@@ -180,7 +238,7 @@ async def select_best_dataset(
     For instance, dont select tree cover loss by driver if the user requests a specific time range,
     pick tree cover loss instead.
 
-    Keep explanations concise. Do not use datset IDs to describe the dataset.
+    Keep explanations concise. Do not use dataset IDs to describe the dataset.
     For instance, instead of saying "Dataset ID: 123", say "Dataset: Tree Cover Loss".
 
     Use the language of the user query to generate the reason.
@@ -202,24 +260,28 @@ async def select_best_dataset(
         DATASET_SELECTION_PROMPT
         | SMALL_MODEL.with_structured_output(DatasetOption)
     )
+    prompt_df = candidate_datasets[
+        [
+            "dataset_id",
+            "dataset_name",
+            "description",
+            "selection_hints",
+            "content_date",
+        ]
+    ].copy()
+    prompt_df["available_params"] = candidate_datasets[
+        "analytics_config"
+    ].apply(_format_params_for_prompt)
+
     selection_result = await dataset_selection_chain.ainvoke(
         {
-            "candidate_datasets": candidate_datasets[
-                [
-                    "dataset_id",
-                    "dataset_name",
-                    "description",
-                    "selection_hints",
-                    "content_date",
-                    "context_layers",
-                ]
-            ].to_csv(index=False),
+            "candidate_datasets": prompt_df.to_csv(index=False),
             "user_query": query,
         }
     )
     logger.debug(
         f"Selected dataset ID: {selection_result.dataset_id}. "
-        f"context_layer={selection_result.context_layer!r} (type={type(selection_result.context_layer).__name__}). "
+        f"params={selection_result.params}. "
         f"Reason: {selection_result.reason}"
     )
 
@@ -230,7 +292,7 @@ async def select_best_dataset(
     return DatasetSelectionResult(
         dataset_id=selected_row.dataset_id,
         dataset_name=selected_row.dataset_name,
-        context_layer=selection_result.context_layer,
+        params=selection_result.params,
         reason=selection_result.reason,
         tile_url=selected_row.tile_url,
         analytics_api_endpoint=selected_row.analytics_api_endpoint,
@@ -272,7 +334,7 @@ async def pick_dataset(
 
     tool_message = f"""# About the selection
     Selected dataset name: {selection_result.dataset_name}
-    Selected context layer: {selection_result.context_layer}
+    Selected params: {selection_result.params}
     Reasoning for selection: {selection_result.reason}
 
     # Additional dataset information
@@ -304,26 +366,40 @@ async def pick_dataset(
             SharedSettings.eoapi_base_url + selection_result.tile_url
         )
 
-    if selection_result.dataset_id == DIST_ALERT_ID:
+    selected_dataset = [
+        ds
+        for ds in DATASETS
+        if ds["dataset_id"] == selection_result.dataset_id
+    ][0]
+    tile_cfg = selected_dataset.get("tile_url_config", {})
+    url_type = tile_cfg.get("type", "none")
+
+    if url_type == "append_date_range":
         selection_result.tile_url += (
             f"&start_date={start_date}&end_date={end_date}"
         )
-    elif selection_result.dataset_id in [LAND_COVER_CHANGE_ID, GRASSLANDS_ID]:
-        if end_date.year in range(2000, 2023):
+    elif url_type == "format_year":
+        yr_range = tile_cfg.get("valid_year_range", [])
+        fallback = tile_cfg.get("fallback_year")
+        if yr_range and end_date.year in range(yr_range[0], yr_range[1] + 1):
             selection_result.tile_url = selection_result.tile_url.format(
                 year=end_date.year
             )
         else:
             selection_result.tile_url = selection_result.tile_url.format(
-                year="2022"
+                year=fallback
             )
-    elif selection_result.dataset_id == TREE_COVER_LOSS_ID:
-        if end_date.year in range(2001, 2025):
+    elif url_type == "append_year_range":
+        yr_range = tile_cfg.get("valid_year_range", [])
+        fb = tile_cfg.get("fallback", {})
+        if yr_range and end_date.year in range(yr_range[0], yr_range[1] + 1):
             selection_result.tile_url += (
                 f"&start_year={start_date.year}&end_year={end_date.year}"
             )
         else:
-            selection_result.tile_url += "&start_year=2001&end_year=2024"
+            selection_result.tile_url += (
+                f"&start_year={fb['start_year']}&end_year={fb['end_year']}"
+            )
 
     return Command(
         update={

--- a/src/ingest/embed_datasets.py
+++ b/src/ingest/embed_datasets.py
@@ -9,7 +9,7 @@ from langchain_core.documents import Document
 from langchain_core.vectorstores import InMemoryVectorStore
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 
-from src.agent.tools.data_handlers.analytics_handler import DATASETS
+from src.agent.tools.datasets_config import DATASETS
 from src.shared.config import SharedSettings
 
 load_dotenv()
@@ -25,11 +25,12 @@ data_dir = Path("data").absolute()
 analytics_docs = []
 
 for ds in DATASETS:
+    config = ds.get("analytics_config") or {}
     content = {
         "DATA_LAYER": ds["dataset_name"],
         "DESCRIPTION": ds["description"],
         "SELECTION_HINTS": ds["selection_hints"],
-        "CONTEXTUAL_LAYERS": ds["context_layers"],
+        "PARAMS": config.get("params"),
         "DATE": ds["content_date"],
         "USAGE NOTES": ds["function_usage_notes"],
     }

--- a/tests/evals/fixture_data.py
+++ b/tests/evals/fixture_data.py
@@ -14,13 +14,13 @@ from src.agent.tools.datasets_config import DATASETS as _ALL_DATASETS
 _DS_BY_ID = {ds["dataset_id"]: ds for ds in _ALL_DATASETS}
 
 
-def _dataset_fields(dataset_id: int, context_layer=None) -> dict:
+def _dataset_fields(dataset_id: int, params=None) -> dict:
     """Extract the fields generate_insights reads from state['dataset']."""
     ds = _DS_BY_ID[dataset_id]
     result = {
         "dataset_id": ds["dataset_id"],
         "dataset_name": ds["dataset_name"],
-        "context_layer": context_layer,
+        "params": params or {},
         "tile_url": ds.get("tile_url", ""),
         "analytics_api_endpoint": ds.get("analytics_api_endpoint", ""),
         "description": ds.get("description", ""),
@@ -88,7 +88,7 @@ TCL_STATE = {
 # Dataset 8: Tree Cover Loss by Driver — driver breakdown for Indonesia
 # ---------------------------------------------------------------------------
 TCL_DRIVER_STATE = {
-    "dataset": _dataset_fields(8, context_layer="driver"),
+    "dataset": _dataset_fields(8, params={"intersections": ["driver"]}),
     "statistics": [
         Statistics(
             dataset_name="Tree cover loss by dominant driver",
@@ -136,7 +136,7 @@ TCL_DRIVER_STATE = {
 
 
 # ---------------------------------------------------------------------------
-# Dataset 0: DIST-ALERT with driver context layer — monthly alerts by driver for DRC
+# Dataset 0: DIST-ALERT with driver params — monthly alerts by driver for DRC
 # ---------------------------------------------------------------------------
 _dist_months = [
     "2024-06",
@@ -519,7 +519,7 @@ SLUC_EF_STATE = {
 
 
 DIST_ALERT_STATE = {
-    "dataset": _dataset_fields(0, context_layer="driver"),
+    "dataset": _dataset_fields(0, params={"intersections": ["driver"]}),
     "statistics": [
         Statistics(
             dataset_name="Global all ecosystem disturbance alerts (DIST-ALERT)",

--- a/tests/tools/test_generate_insights.py
+++ b/tests/tools/test_generate_insights.py
@@ -41,7 +41,7 @@ async def test_generate_insights_comparison():
     update = {
         "dataset": {
             "dataset_id": 4,
-            "context_layer": None,
+            "params": {},
             "date_request_match": True,
             "reason": "The Tree cover loss dataset is specifically designed to map annual global forest loss and monitor deforestation trends from 2001 to 2024, making it the perfect match for analyzing tree cover loss trends over time.",
             "tile_url": "https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png?start_year=2001&end_year=2024&tree_cover_density_threshold=25&render_type=true_color",
@@ -185,7 +185,7 @@ async def test_simple_line_chart():
     mock_state_line = {
         "dataset": {
             "dataset_id": 1,
-            "context_layer": None,
+            "params": {},
             "date_request_match": True,
             "reason": "Deforestation alerts dataset matches the request for analyzing alert trends.",
             "tile_url": "https://tiles.example.com/deforestation/latest/dynamic/{z}/{x}/{y}.png",
@@ -247,7 +247,7 @@ async def test_simple_bar_chart():
     mock_state_bar = {
         "dataset": {
             "dataset_id": 4,
-            "context_layer": None,
+            "params": {},
             "date_request_match": True,
             "reason": "Tree cover loss dataset matches the request for forest loss analysis.",
             "tile_url": "https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png",
@@ -255,6 +255,7 @@ async def test_simple_bar_chart():
             "analytics_api_endpoint": "/v0/land_change/tree_cover_loss/analytics",
             "description": "Tree Cover Loss (Hansen/UMD/GLAD) maps annual global forest loss.",
             "prompt_instructions": "Compare forest loss across districts",
+            "selection_hints": "Use this dataset to compare forest loss across districts.",
             "methodology": "Satellite-based detection of tree cover loss.",
             "cautions": "Tree cover includes all vegetation greater than 5 meters.",
             "function_usage_notes": "Identifies areas of gross tree cover loss\n",
@@ -317,7 +318,7 @@ async def test_stacked_bar_chart():
     mock_state_stacked = {
         "dataset": {
             "dataset_id": 5,
-            "context_layer": None,
+            "params": {},
             "date_request_match": True,
             "reason": "Forest loss causes dataset matches the request for composition analysis.",
             "tile_url": "https://tiles.example.com/forest_loss_causes/latest/dynamic/{z}/{x}/{y}.png",
@@ -325,6 +326,7 @@ async def test_stacked_bar_chart():
             "analytics_api_endpoint": "/v0/forest/loss_causes/analytics",
             "description": "Breakdown of forest loss by cause over time.",
             "prompt_instructions": "Analyze composition of forest loss causes over time",
+            "selection_hints": "Use this dataset to analyze the composition of forest loss causes over time.",
             "methodology": "Attribution of forest loss to different drivers.",
             "cautions": "Cause attribution may have uncertainty.",
             "function_usage_notes": "Identifies drivers of forest loss\n",
@@ -377,7 +379,7 @@ async def test_grouped_bar_chart():
     mock_state_grouped = {
         "dataset": {
             "dataset_id": 6,
-            "context_layer": None,
+            "params": {},
             "date_request_match": True,
             "reason": "Forest metrics dataset matches the request for comparing loss and fire incidents.",
             "tile_url": "https://tiles.example.com/forest_metrics/latest/dynamic/{z}/{x}/{y}.png",
@@ -385,6 +387,7 @@ async def test_grouped_bar_chart():
             "analytics_api_endpoint": "/v0/forest/metrics/analytics",
             "description": "Combined forest loss and fire incident metrics.",
             "prompt_instructions": "Compare forest loss and fire incidents across countries",
+            "selection_hints": "Use this dataset to compare forest loss and fire incidents across countries.",
             "methodology": "Satellite-based detection of forest loss and fire events.",
             "cautions": "Metrics may have different temporal resolutions.",
             "function_usage_notes": "Compares forest metrics across regions\n",
@@ -454,7 +457,7 @@ async def test_pie_chart():
     mock_state_pie = {
         "dataset": {
             "dataset_id": 7,
-            "context_layer": None,
+            "params": {},
             "date_request_match": True,
             "reason": "Forest loss causes dataset matches the request for global cause analysis.",
             "tile_url": "https://tiles.example.com/forest_loss_causes/latest/dynamic/{z}/{x}/{y}.png",
@@ -462,6 +465,7 @@ async def test_pie_chart():
             "analytics_api_endpoint": "/v0/forest/loss_causes/analytics",
             "description": "Global breakdown of forest loss by cause.",
             "prompt_instructions": "Analyze main causes of forest loss globally",
+            "selection_hints": "Use this dataset to analyze the main causes of forest loss globally.",
             "methodology": "Attribution of global forest loss to different drivers.",
             "cautions": "Cause attribution may have regional variations.",
             "function_usage_notes": "Identifies global drivers of forest loss\n",

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -92,7 +92,7 @@ def insight_text(update: dict) -> str:
 # ---------------------------------------------------------------------------
 GHG_FLUX_DATASET: dict[str, Any] = {
     "dataset_id": 6,
-    "context_layer": None,
+    "params": {},
     "date_request_match": True,
     "reason": "GHG flux dataset matches.",
     "tile_url": "https://tiles.globalforestwatch.org/gfw_forest_carbon_net_flux/latest/dynamic/{z}/{x}/{y}.png",
@@ -145,7 +145,7 @@ GHG_FLUX_STATS: list[dict] = [
 
 GRASSLAND_DATASET: dict[str, Any] = {
     "dataset_id": 2,
-    "context_layer": None,
+    "params": {},
     "date_request_match": True,
     "reason": "Grasslands dataset matches.",
     "tile_url": "https://tiles.globalforestwatch.org/gnsg/latest/dynamic/{z}/{x}/{y}.png",
@@ -251,7 +251,7 @@ GRASSLAND_STATS_WITH_ZEROS: list[dict] = [
 
 TREE_COVER_DATASET: dict[str, Any] = {
     "dataset_id": 7,
-    "context_layer": None,
+    "params": {},
     "date_request_match": True,
     "reason": "Tree cover dataset matches.",
     "tile_url": "https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/latest/dynamic/{z}/{x}/{y}.png",
@@ -323,7 +323,7 @@ TREE_COVER_STATS: list[dict] = [
 
 TREE_COVER_GAIN_DATASET: dict[str, Any] = {
     "dataset_id": 5,
-    "context_layer": None,
+    "params": {},
     "date_request_match": True,
     "reason": "Tree cover gain dataset matches.",
     "tile_url": "https://tiles.globalforestwatch.org/umd_tree_cover_gain/latest/dynamic/{z}/{x}/{y}.png",
@@ -380,7 +380,7 @@ TREE_COVER_GAIN_STATS: list[dict] = [
 
 LAND_COVER_DATASET: dict[str, Any] = {
     "dataset_id": 1,
-    "context_layer": None,
+    "params": {},
     "date_request_match": True,
     "reason": "Land cover dataset matches.",
     "tile_url": "https://tiles.globalforestwatch.org/wur_radd_alerts/latest/dynamic/{z}/{x}/{y}.png",
@@ -481,7 +481,7 @@ LAND_COVER_COMPOSITION_STATS: list[dict] = [
 
 NATURAL_LANDS_DATASET: dict[str, Any] = {
     "dataset_id": 3,
-    "context_layer": None,
+    "params": {},
     "date_request_match": True,
     "reason": "Natural lands dataset matches.",
     "tile_url": "https://tiles.globalforestwatch.org/sbtn_natural_lands/latest/dynamic/{z}/{x}/{y}.png",
@@ -560,7 +560,7 @@ NATURAL_LANDS_STATS: list[dict] = [
 
 SLUC_EF_DATASET: dict[str, Any] = {
     "dataset_id": 9,
-    "context_layer": None,
+    "params": {},
     "date_request_match": True,
     "reason": "sLUC EF dataset matches.",
     "tile_url": "",

--- a/tests/tools/test_intersections.py
+++ b/tests/tools/test_intersections.py
@@ -1,0 +1,124 @@
+"""Unit tests for dataset params (YAML config + pick_dataset validation).
+
+Integration pulls per (dataset, params) live in tests/tools/test_pull_data.py
+and use a hand-maintained matrix aligned with the analytics OpenAPI spec.
+"""
+
+import pytest
+
+from src.agent.tools.datasets_config import DATASETS
+from src.agent.tools.pick_dataset import DatasetOption
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+def _param_defs(dataset: dict) -> dict:
+    config = dataset.get("analytics_config") or {}
+    return config.get("params") or {}
+
+
+def dataset_param_values_from_config() -> list[tuple[int, str, str]]:
+    """Every (dataset_id, param_name, value) declared under ``params`` in dataset YAML."""
+    cases: list[tuple[int, str, str]] = []
+    for ds in DATASETS:
+        for param_name, defn in _param_defs(ds).items():
+            for val in defn.get("values", []):
+                cases.append((ds["dataset_id"], param_name, val))
+    return cases
+
+
+def dataset_intersection_values_from_config() -> list[tuple[int, str]]:
+    """Every (dataset_id, value) for intersections params — used by test_pull_data sync check."""
+    cases: list[tuple[int, str]] = []
+    for ds in DATASETS:
+        params = _param_defs(ds)
+        if "intersections" in params:
+            for val in params["intersections"].get("values", []):
+                cases.append((ds["dataset_id"], val))
+    return cases
+
+
+@pytest.mark.parametrize(
+    "dataset_id,param_name,param_value",
+    dataset_param_values_from_config(),
+)
+def test_yaml_param_accepted_by_dataset_option(
+    dataset_id: int, param_name: str, param_value: str
+):
+    """Any value in params YAML must survive DatasetOption validation."""
+    opt = DatasetOption(
+        dataset_id=dataset_id,
+        params={param_name: param_value},
+        reason="test",
+        language="en",
+    )
+    assert param_name in opt.params
+    param_def = _param_defs(
+        next(ds for ds in DATASETS if ds["dataset_id"] == dataset_id)
+    )[param_name]
+    is_list = param_def.get("type") == "list"
+    if is_list:
+        assert param_value in opt.params[param_name]
+    else:
+        assert opt.params[param_name] == param_value
+
+
+def _datasets_with_default_intersections():
+    """Dataset IDs where intersections param has a non-empty default."""
+    result = []
+    for ds in DATASETS:
+        params = _param_defs(ds)
+        inter = params.get("intersections")
+        if inter and inter.get("default"):
+            result.append(ds["dataset_id"])
+    return result
+
+
+@pytest.mark.parametrize(
+    "dataset_id",
+    _datasets_with_default_intersections(),
+)
+def test_default_intersections_applied_when_llm_omits(dataset_id: int):
+    params_def = _param_defs(
+        next(ds for ds in DATASETS if ds["dataset_id"] == dataset_id)
+    )
+    expected_default = params_def["intersections"]["default"]
+    opt = DatasetOption(
+        dataset_id=dataset_id,
+        params={},
+        reason="test",
+        language="en",
+    )
+    assert opt.params.get("intersections") == expected_default
+
+
+def test_params_config_has_valid_entries():
+    """Datasets with ``analytics_config.params`` should have valid value lists."""
+    for ds in DATASETS:
+        for param_name, defn in _param_defs(ds).items():
+            values = defn.get("values")
+            assert values, (
+                f"{ds.get('dataset_name')} (id={ds.get('dataset_id')}) has "
+                f"param '{param_name}' with no values list"
+            )
+
+
+def test_pull_data_matrix_covers_all_config_intersections():
+    """Keep tests/tools/test_pull_data.py ALL_DATASET_COMBINATIONS in sync with YAML.
+
+    When you add intersections in dataset YAML, extend ALL_DATASET_COMBINATIONS
+    (or switch that module to build cases from DATASETS) so live API pulls stay covered.
+    """
+    from tests.tools.test_pull_data import ALL_DATASET_COMBINATIONS
+
+    config_pairs = set(dataset_intersection_values_from_config())
+    pull_pairs = {
+        (c["dataset_id"], c["intersection"])
+        for c in ALL_DATASET_COMBINATIONS
+        if c.get("intersection") is not None
+    }
+    missing = config_pairs - pull_pairs
+    assert not missing, (
+        "ALL_DATASET_COMBINATIONS is missing pull tests for YAML intersections: "
+        f"{sorted(missing)}"
+    )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -122,7 +122,7 @@ lookup = {
             GRASSLANDS,  # 10
         ),
         (
-            "How much rangeland has been converted to agriculture in Mongolia since 2010?",
+            "How much grassland has been converted to agriculture in Mongolia since 2010?",
             GRASSLANDS,  # 11
         ),
         (
@@ -350,7 +350,7 @@ lookup = {
         ),  # 54
         (
             "Show the trend in natural land loss over time in Brazil",
-            TREE_COVER_LOSS,
+            DIST_ALERT,
             "2015-01-01",
             "2024-12-31",
         ),  # 55 - does not use natural lands dataset because it is not for change
@@ -396,17 +396,17 @@ async def test_queries_return_expected_dataset(
 
 
 @pytest.mark.parametrize(
-    "query,expected_dataset_id,expected_context_layer",
+    "query,expected_dataset_id,expected_intersections",
     [
-        ("Vegetation disturbances by natural lands", 0, "natural_lands"),
-        ("Vegetation disturbances over grasslands", 0, "grasslands"),
-        ("Tree cover loss by driver", 8, "driver"),
-        ("Tree  cover loss in the past decade", 4, None),
+        ("Vegetation disturbances by natural lands", 0, ["natural_lands"]),
+        ("Vegetation disturbances over grasslands", 0, ["grasslands"]),
+        ("Tree cover loss by driver", 8, ["driver"]),
+        ("Tree  cover loss in the past decade", 4, []),
         ("Most recent global land cover in storm seasons", 1, None),
     ],
 )
-async def test_query_with_context_layer(
-    query, expected_dataset_id, expected_context_layer
+async def test_query_with_params(
+    query, expected_dataset_id, expected_intersections
 ):
     tool_call_id = str(uuid.uuid4())
 
@@ -426,8 +426,9 @@ async def test_query_with_context_layer(
 
     dataset_id = command.update.get("dataset", {}).get("dataset_id")
     assert dataset_id == expected_dataset_id
-    context_layer = command.update.get("dataset", {}).get("context_layer")
-    assert context_layer == expected_context_layer
+    params = command.update.get("dataset", {}).get("params", {})
+    actual_intersections = params.get("intersections")
+    assert actual_intersections == expected_intersections
 
 
 @pytest.mark.parametrize(
@@ -476,14 +477,14 @@ async def test_tile_url_contains_date(dataset):
 
 
 def _make_fake_selection(
-    dataset_id: int, context_layer: str | None
+    dataset_id: int, params: dict | None = None
 ) -> DatasetSelectionResult:
-    """Build a DatasetSelectionResult for the given dataset with a fake context_layer."""
+    """Build a DatasetSelectionResult for the given dataset with fake params."""
     ds = next(d for d in DATASETS if d["dataset_id"] == dataset_id)
     return DatasetSelectionResult(
         dataset_id=dataset_id,
         dataset_name=ds["dataset_name"],
-        context_layer=context_layer,
+        params=params or {},
         reason="test",
         tile_url=ds["tile_url"],
         analytics_api_endpoint=ds.get("analytics_api_endpoint", ""),
@@ -499,21 +500,21 @@ def _make_fake_selection(
 
 
 @pytest.mark.parametrize(
-    "dataset_id,hallucinated_layer",
+    "dataset_id,hallucinated_params",
     [
-        (4, "Tree cover loss"),  # The exact bug from the trace
-        (4, "primary_forest"),  # variables value, not a context_layer
-        (1, "Global land cover"),
-        (7, "tree cover"),
+        (4, {"intersections": "Tree cover loss"}),
+        (4, {"forest_filter": "bogus_filter"}),
+        (1, {"intersections": "Global land cover"}),
+        (7, {"canopy_cover": 999}),
     ],
 )
-async def test_hallucinated_context_layer_is_discarded(
-    dataset_id, hallucinated_layer
+async def test_hallucinated_params_are_discarded(
+    dataset_id, hallucinated_params
 ):
-    """Verify that invalid context_layer values from LLM are set to None."""
+    """Verify that invalid param values from LLM are replaced with defaults."""
     import pandas as pd
 
-    fake_selection = _make_fake_selection(dataset_id, hallucinated_layer)
+    fake_selection = _make_fake_selection(dataset_id, hallucinated_params)
     candidate_df = pd.DataFrame(
         [d for d in DATASETS if d["dataset_id"] == dataset_id]
     )
@@ -545,18 +546,20 @@ async def test_hallucinated_context_layer_is_discarded(
 
         command = await pick_dataset.ainvoke(tool_call)
 
-    result_layer = command.update.get("dataset", {}).get("context_layer")
-    assert result_layer is None, (
-        f"Expected hallucinated layer '{hallucinated_layer}' to be discarded, "
-        f"but got '{result_layer}'"
-    )
+    result_params = command.update.get("dataset", {}).get("params", {})
+    for key, hallucinated_val in hallucinated_params.items():
+        if key in result_params:
+            assert result_params[key] != hallucinated_val, (
+                f"Expected hallucinated param '{key}={hallucinated_val}' to be replaced, "
+                f"but it was kept as '{result_params[key]}'"
+            )
 
 
-async def test_valid_context_layer_is_preserved():
-    """Verify that a valid context_layer (e.g. 'driver' for DIST-ALERT) is kept."""
+async def test_valid_params_are_preserved():
+    """Verify that valid params (e.g. intersections=['driver'] for DIST-ALERT) are kept."""
     import pandas as pd
 
-    fake_selection = _make_fake_selection(0, "driver")
+    fake_selection = _make_fake_selection(0, {"intersections": "driver"})
     candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 0])
     tool_call_id = str(uuid.uuid4())
 
@@ -586,18 +589,16 @@ async def test_valid_context_layer_is_preserved():
 
         command = await pick_dataset.ainvoke(tool_call)
 
-    result_layer = command.update.get("dataset", {}).get("context_layer")
-    assert result_layer == "driver"
+    result_params = command.update.get("dataset", {}).get("params", {})
+    assert result_params.get("intersections") == ["driver"]
 
 
-async def test_tcl_by_driver_always_gets_driver_context_layer():
-    """Dataset 8 (TCL by driver) should always have context_layer='driver',
-    even if the LLM returns None."""
+async def test_tcl_by_driver_always_gets_driver_param():
+    """Dataset 8 (TCL by driver) should always have intersections=['driver'],
+    even if the LLM returns empty params (via params.intersections.default)."""
     import pandas as pd
 
-    fake_selection = _make_fake_selection(
-        8, None
-    )  # LLM returns no context_layer
+    fake_selection = _make_fake_selection(8, {})
     candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 8])
     tool_call_id = str(uuid.uuid4())
 
@@ -627,5 +628,5 @@ async def test_tcl_by_driver_always_gets_driver_context_layer():
 
         command = await pick_dataset.ainvoke(tool_call)
 
-    result_layer = command.update.get("dataset", {}).get("context_layer")
-    assert result_layer == "driver"
+    result_params = command.update.get("dataset", {}).get("params", {})
+    assert result_params.get("intersections") == ["driver"]

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -23,83 +23,83 @@ ALL_DATASET_COMBINATIONS = [
     {
         "dataset_id": 0,
         "dataset_name": "Ecosystem disturbance alerts",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 0,
         "dataset_name": "Ecosystem disturbance alerts",
-        "context_layer": "driver",
+        "intersection": "driver",
     },
     {
         "dataset_id": 0,
         "dataset_name": "Ecosystem disturbance alerts",
-        "context_layer": "natural_lands",
+        "intersection": "natural_lands",
     },
     {
         "dataset_id": 0,
         "dataset_name": "Ecosystem disturbance alerts",
-        "context_layer": "grasslands",
+        "intersection": "grasslands",
     },
     {
         "dataset_id": 0,
         "dataset_name": "Ecosystem disturbance alerts",
-        "context_layer": "land_cover",
+        "intersection": "land_cover",
     },
     {
         "dataset_id": 1,
         "dataset_name": "Global land cover",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 1,
         "dataset_name": "Global land cover",
-        "context_layer": None,
+        "intersection": None,
         "check_composition": True,
     },
     {
         "dataset_id": 2,
         "dataset_name": "Grassland",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 3,
         "dataset_name": "Natural lands",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 4,
         "dataset_name": "Tree cover loss",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 4,
         "dataset_name": "Tree cover loss",
-        "context_layer": "driver",
+        "intersection": "driver",
     },
     {
         "dataset_id": 5,
         "dataset_name": "Tree cover gain",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 6,
         "dataset_name": "Forest greenhouse gas net flux",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 7,
         "dataset_name": "Tree cover",
-        "context_layer": None,
+        "intersection": None,
     },
     {
         "dataset_id": 8,
         "dataset_name": "Tree cover loss by driver",
-        "context_layer": "driver",
+        "intersection": "driver",
     },
     {
         "dataset_id": 9,
         "dataset_name": "Deforestation (sLUC) Emission Factors by Agricultural Crop",
-        "context_layer": None,
+        "intersection": None,
     },
 ]
 
@@ -153,6 +153,10 @@ TEST_AOIS = [
 async def test_pull_data_queries(aoi_data, dataset):
     print(f"Testing {dataset['dataset_name']} with {aoi_data['name']}")
 
+    intersection = dataset.get("intersection")
+    params = {}
+    if intersection:
+        params["intersections"] = [intersection]
     update = {
         "aoi_selection": {
             "name": aoi_data["name"],
@@ -163,7 +167,7 @@ async def test_pull_data_queries(aoi_data, dataset):
             "dataset_name": dataset["dataset_name"],
             "reason": "",
             "tile_url": "",
-            "context_layer": dataset["context_layer"],
+            "params": params,
         },
     }
     if dataset.get("check_composition"):
@@ -196,13 +200,12 @@ async def test_pull_data_queries(aoi_data, dataset):
     }
     command = await pull_data.ainvoke(tool_call)
     statistics = command.update.get("statistics", {})
-    if dataset["dataset_id"] in [5, 9] and aoi_data["src_id"] in [
+    if dataset["dataset_id"] == 9 and aoi_data["src_id"] in [
         "6072",
         "148322",
         "MEX9713",
+        "CHE.6.3_1",
     ]:
-        assert len(statistics) == 0
-    elif dataset["dataset_id"] == 9 and aoi_data["src_id"] == "CHE.6.3_1":
         assert len(statistics) == 0
     else:
         assert len(statistics) == 1
@@ -220,7 +223,7 @@ async def test_tree_cover_loss_date_range_clamped_to_2024():
             "dataset_name": "Tree cover loss",
             "reason": "",
             "tile_url": "",
-            "context_layer": None,
+            "params": {},
         },
     }
     tool_call = {
@@ -340,7 +343,7 @@ async def test_pull_data_custom_area(auth_override, client, structlog_context):
             "dataset_name": "Global land cover",
             "reason": "",
             "tile_url": "",
-            "context_layer": None,
+            "params": {},
         },
     }
     query = f"find commodities in {aoi_data['query_description']}"


### PR DESCRIPTION
## Summary

Replaces the `context_layers` abstraction with a generic, config-driven `params` system that mirrors the actual filter parameters accepted by the [analytics API](https://analytics.globalnaturewatch.org/openapi.json). Previously, each dataset had bespoke handling in Python code -- hardcoded dataset ID constants, per-dataset `if/elif` chains for payload construction, and a `context_layer` field that flattened fundamentally different API parameters (intersections, canopy cover, forest filters, crop types, gas types) into a single string. This PR moves all of that into declarative `analytics_config` blocks in each dataset's YAML file, and makes the handler logic fully data-driven.

### What changed

- **Dataset YAML configs** now declare `analytics_config` with:
  - `date_params` -- how date ranges map to API fields (`date`, `year`, `year_5yr_interval`, or `none`)
  - `params` -- typed parameter definitions with allowed values, defaults, and descriptions (e.g. `canopy_cover`, `forest_filter`, `intersections`, `crop_types`, `gas_types`)
  - `aoi_restrictions` -- allowed AOI subtypes per dataset (replaces hardcoded sLUC GADM check)
  - `alternate_endpoints` -- e.g. land cover composition endpoint for change-over-time queries
  - `tile_url_config` -- how tile URLs are constructed (`append_date_range`, `format_year`, `append_year_range`, or `none`)

- **`analytics_handler.py`**: removed ~200 lines of hardcoded dataset ID constants and per-dataset `if/elif` branches. `can_handle()` now checks for the presence of `analytics_api_endpoint` instead of matching against a list of IDs. Payload construction iterates over config-defined params.

- **`pick_dataset.py`**: the LLM now selects `params: dict` instead of `context_layer: str`. A new `_resolve_params()` function validates LLM-selected values against allowed values and falls back to defaults for invalid/hallucinated selections. The selection prompt shows `available_params` per candidate dataset so the LLM can make informed choices.

- **`generate_insights.py`**: passes `active_params` dict instead of a single `context_layer` string to the code executor prompt.

- **`get_capabilities.py`** / **`embed_datasets.py`**: updated to read from `analytics_config.params` instead of `context_layers`.

- **Frontend**: `context_layer` references replaced with `params` dict in the evaluation page, map renderer, and sidebar fixtures.

- **Docs**: updated state schema examples in `docs/README.md`.

### Known limitation

Tree cover loss (dataset 4) and tree cover loss by dominant driver (dataset 8) hit the same API endpoint (`/v0/land_change/tree_cover_loss/analytics`) with different filter configurations. Ideally these would be separate API endpoints since they have quite different semantics (e.g. time-slice coverage). This works correctly with the current API, but is a candidate for a future API review.

### Smaller changes

- **Gemini executor**: added null check for `code_execution_result.output` to avoid passing empty output parts.
- **`datasets_config.py`**: minor lint fix (`!=` instead of `not len(...) ==`).

## Separate: CI workflow for tools tests

The tools-tests workflow can now be triggered on PRs by adding the `run-tools-tests` label (in addition to the existing `workflow_dispatch` trigger). Includes concurrency control to cancel in-progress runs.

