### PR TITLE
Avoid empty human messages

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -348,8 +348,9 @@ async def stream_chat(
                     content = f"User performed action in UI: {action_type}\n\n"
             ui_action_message.append(content)
 
-    ui_message = HumanMessage(content="\n".join(ui_action_message))
-    messages.append(ui_message)
+    ui_action_content = "\n".join(ui_action_message).strip()
+    if ui_action_content:
+        messages.append(HumanMessage(content=ui_action_content))
 
     if not ui_action_only and query:
         messages.append(HumanMessage(content=query))


### PR DESCRIPTION
This raises errors on the api. They are caught but we should avoid them nonetheless, this has not been a problem until now but might be one on gemini 3. Trying to solve for 500 errors on gemini api.
