### PR TITLE
Fix empty subregion result error

### DIFF
--- a/src/agent/tools/pick_aoi.py
+++ b/src/agent/tools/pick_aoi.py
@@ -397,6 +397,12 @@ async def check_multiple_matches(
 
 
 async def check_aoi_selection(aois: list[dict]) -> str:
+    if not aois:
+        return (
+            "No matching AOIs were found for your request. "
+            "Try a broader place name or choose a different subregion type."
+        )
+
     aoi_sources = set([aoi["source"] for aoi in aois])
     if len(aoi_sources) > 1:
         return "Found multiple sources of AOIs, which is not supported. Please select only one source."

--- a/tests/tools/test_pick_aoi.py
+++ b/tests/tools/test_pick_aoi.py
@@ -1,5 +1,7 @@
 import uuid
+from importlib import import_module
 
+import pandas as pd
 import pytest
 import structlog
 from sqlalchemy import select
@@ -188,4 +190,64 @@ async def test_custom_area_selection(auth_override, client, structlog_context):
 
     assert (
         command.update.get("aoi_selection", {}).get("name") == "My custom area"
+    )
+
+
+async def test_pick_aoi_handles_empty_subregion_results(
+    monkeypatch, structlog_context
+):
+    pick_aoi_module = import_module("src.agent.tools.pick_aoi")
+
+    async def fake_query_aoi_database(place_name: str, result_limit: int = 10):
+        return pd.DataFrame(
+            [
+                {
+                    "src_id": "USA.6_1",
+                    "name": "Colorado, United States",
+                    "subtype": "state-province",
+                    "source": "gadm",
+                }
+            ]
+        )
+
+    async def fake_select_best_aoi(question, candidate_aois):
+        return {
+            "src_id": "USA.6_1",
+            "name": "Colorado, United States",
+            "subtype": "state-province",
+            "source": "gadm",
+        }
+
+    async def fake_query_subregion_database(
+        subregion_name: str, source: str, src_id: int
+    ):
+        return pd.DataFrame(columns=["name", "subtype", "src_id", "source"])
+
+    monkeypatch.setattr(
+        pick_aoi_module, "query_aoi_database", fake_query_aoi_database
+    )
+    monkeypatch.setattr(
+        pick_aoi_module, "select_best_aoi", fake_select_best_aoi
+    )
+    monkeypatch.setattr(
+        pick_aoi_module,
+        "query_subregion_database",
+        fake_query_subregion_database,
+    )
+
+    command = await pick_aoi.ainvoke(
+        {
+            "args": {
+                "question": "How much land changed to short vegetation in protected areas in Colorado in the past decade?",
+                "places": ["Colorado"],
+                "subregion": "wdpa",
+            },
+            "id": str(uuid.uuid4()),
+            "type": "tool_call",
+        }
+    )
+
+    assert "aoi_selection" not in command.update
+    assert str(command.update["messages"][0].content).startswith(
+        "No matching AOIs were found for your request."
     )


### PR DESCRIPTION
## Summary
- Fixes a `pick_aoi` crash path where empty subregion results caused `StopIteration` (`next(iter(aoi_sources))`) and surfaced in Langfuse as `coroutine raised StopIteration`.
- Adds an explicit empty-AOI guard in `check_aoi_selection` to return a user-facing fallback message: “No matching AOIs were found for your request...”.
- Adds a regression test that mocks an empty `query_subregion_database` response and verifies `pick_aoi` returns feedback instead of erroring.

## Why
`pick_aoi` could fail when a valid place is selected but the requested subregion filter returns no matches. This produced noisy tool errors and unnecessary retries in the agent loop.

## Test plan
- [x] `uv run pytest tests/tools/test_pick_aoi.py::test_pick_aoi_handles_empty_subregion_results -q`
- [x] `uv run pytest tests/tools/test_pick_aoi.py -q`
- [x] Confirmed `pick_aoi` suite passes: `10 passed, 1 warning`

## Notes

[Langfuse trace with error](https://langfuse.staging.globalnaturewatch.org/project/wri_lcl/traces/d503b248c8f8af0df12d75ad35d0b61d)