### PR TITLE
Fix various instruction-based bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,8 @@ logs/
 
 # Notebooks
 nbs/
+PRD.md
+
+# Planning files
+planning*.md
+PLANNING*.md

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,5 @@ logs/
 
 # Notebooks
 nbs/
+PRD.md
+tests/evals/results/

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ logs/
 
 # Notebooks
 nbs/
+PRD.md
+planning/
+planning.*

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ logs/
 
 # Notebooks
 nbs/
+PRD.md
+PLAN*.md
+TODO*.md

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -5,4 +5,9 @@ WORDING_INSTRUCTIONS = """WORDING INSTRUCTIONS:
     - Use neutral, measurement-first words: decline, decrease, increase, remain stable, fluctuate.
     - Other words that need scientific justification and actual tests when used: trend (when trend wasn't actually calculated), significant (when not tied to statistical significance), validated (when not actually measured), accurate (without comparison or error bars)
 - Use markdown formatting for giving structure and increase readability of your response. Include empty lines between sections and paragraphs.
+- Never recommend or reference datasets, alert systems, or analysis capabilities
+  that are not available in GNW. Only suggest next steps that users can complete
+  within GNW using the datasets listed in your tools. If a useful dataset is not
+  available (e.g. GLAD alerts, PRODES, Hansen annual tiles outside the standard
+  pipeline), do not mention it as a recommended resource.
 """

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -5,4 +5,8 @@ WORDING_INSTRUCTIONS = """WORDING INSTRUCTIONS:
     - Use neutral, measurement-first words: decline, decrease, increase, remain stable, fluctuate.
     - Other words that need scientific justification and actual tests when used: trend (when trend wasn't actually calculated), significant (when not tied to statistical significance), validated (when not actually measured), accurate (without comparison or error bars)
 - Use markdown formatting for giving structure and increase readability of your response. Include empty lines between sections and paragraphs.
+- These wording rules apply to ALL output: response text, chart titles, axis labels,
+  legend text, code comments, and insight strings embedded in generated code.
+  Do not insert prohibited words into chart configurations, f-strings, or
+  string literals that will appear in the user interface.
 """

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -5,4 +5,11 @@ WORDING_INSTRUCTIONS = """WORDING INSTRUCTIONS:
     - Use neutral, measurement-first words: decline, decrease, increase, remain stable, fluctuate.
     - Other words that need scientific justification and actual tests when used: trend (when trend wasn't actually calculated), significant (when not tied to statistical significance), validated (when not actually measured), accurate (without comparison or error bars)
 - Use markdown formatting for giving structure and increase readability of your response. Include empty lines between sections and paragraphs.
+- Always derive dataset date ranges from the `start_date` and `end_date` fields
+  provided in the dataset state. Do not rely on memorised date ranges. If you
+  state a dataset covers a certain period, it must match the `content_date` or
+  the date range returned in the statistics.
+- If the user did not specify a year or date range, do not assume one. State
+  clearly what period the returned data covers and that no specific date was
+  requested.
 """

--- a/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -56,6 +56,20 @@ prompt_instructions: 'Use this dataset to show recent vegetation changes across 
      assessed."
   3. Always provide the LDACS metadata link alongside the DIST-ALERT metadata link.
 
+  When the user asks WHY there are so many unclassified alerts (this rule applies
+  whether or not the driver context layer is currently active) (e.g. "why is so
+  much unclassified?", "what does unclassified mean?", "why aren''t these classified?"):
+  - The ONLY correct explanation is: LDACS is updated quarterly and cannot classify
+    the most recent ~90 days of alerts. Alerts in that window appear as "Unclassified"
+    because they have not yet been assessed — not because the driver is genuinely unknown
+    or because of any inherent limitation of the detection algorithm.
+  - Do NOT attribute unclassified alerts to "the way the classification system works",
+    cloud cover, image quality, detection uncertainty, or any other technical reason.
+    Those explanations are incorrect for this dataset. The unclassified category here
+    reflects a data-lag in the quarterly LDACS assessment, nothing more.
+  - State clearly: once LDACS is next updated, these alerts will receive a driver
+    classification.
+
   '
 selection_hints: 'Best dataset for near-real-time vegetation disturbance across ALL ecosystems (not just forests). Covers
   Dec 2023 to present at 30m resolution, measured in hectares. Prefer when user asks about recent disturbance, clearing, or
@@ -89,6 +103,13 @@ presentation_instructions: 'Describe results as vegetation disturbance alerts, n
   completed quarter, state that alerts not yet assessed by LDACS will appear as Unclassified and this reflects an assessment
   gap, not an unknown driver. This covers all vegetation, not just forest — relevant for non-conversion of natural ecosystems
   monitoring.
+
+  When explaining why alerts are unclassified: the answer is ALWAYS the quarterly
+  LDACS update lag (~90-day delay). Do NOT attribute unclassified alerts to cloud
+  cover, image quality, detection uncertainty, or "the way the classification system
+  works" — those are factually incorrect. The correct framing is: these alerts have
+  not yet been assessed by LDACS; once the next quarterly update runs they will
+  receive a driver classification.
 
   When DIST-ALERT is used in response to a query that explicitly mentions forest loss, deforestation, or tree cover, always
   include the following caveat in the response:

--- a/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -51,6 +51,10 @@ selection_hints: 'Best dataset for near-real-time vegetation disturbance across 
   12 months, classification NOT available for last 90 days. For historical or long-term tree cover change, prefer Tree Cover
   Loss instead. For driver attribution of tree cover loss specifically, prefer Tree Cover Loss by Dominant Driver.
 
+  Avoid selecting this dataset as the primary source when a user asks specifically about forest loss or deforestation — prefer
+  Tree Cover Loss. Only use DIST-ALERT for forest queries when the user explicitly requests near-real-time data and understands
+  this limitation.
+
   '
 code_instructions: "CHART TYPES: - Recent trends over time → line chart (x=alert month, y=area in hectares) - Distribution\
   \ by driver → pie chart (one slice per driver class) - Distribution by land cover class or natural land type → pie chart\
@@ -63,11 +67,21 @@ code_instructions: "CHART TYPES: - Recent trends over time → line chart (x=ale
   \ - LDACS classification NOT available for last 90 days — omit driver breakdown for that period - Potential conversion requires\
   \ ≥75 days of sustained loss — recent clearing may not appear - Conversion may be undercounted when fire is used for clearing\
   \ or near rivers - Severe boreal fires may be misclassified as conversion - Always interpret alerts as indicators, not definitive\
-  \ outcomes\n"
+  \ outcomes\n- NEVER label DIST-ALERT data as \"deforestation\" or \"forest loss\" in code output, print statements, chart\
+  \ titles, or axis labels — always use \"vegetation disturbance alerts\" or \"disturbance alerts\" instead\n"
 presentation_instructions: 'Describe results as vegetation disturbance alerts, not confirmed deforestation or conversion.
   Clarify if user cares about temporary disturbance vs permanent conversion; recommend annual land cover or tree cover loss
   datasets for historical changes. Note LDACS is updated quarterly, covers most recent 12 months, no classification for last
   90 days. This covers all vegetation, not just forest — relevant for non-conversion of natural ecosystems monitoring.
+
+  When DIST-ALERT is used in response to a query that explicitly mentions forest loss, deforestation, or tree cover, always
+  include the following caveat in the response:
+
+  "DIST-ALERT monitors disturbances across ALL vegetation types (forests, grasslands, croplands, etc.) and does not apply a
+  forest mask. Results therefore include disturbances to non-forest vegetation such as crop harvesting or grassland disturbance.
+  For confirmed forest-specific loss, use the Tree Cover Loss dataset."
+
+  Do not omit this caveat even if other datasets were also used in the same response.
 
   '
 description: 'Global All Ecosystem Disturbance Alerts (DIST-ALERT) provides near-real-time alerts of vegetation disturbance

--- a/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -44,6 +44,18 @@ prompt_instructions: 'Use this dataset to show recent vegetation changes across 
   when it occurs near rivers. Severe boreal fires may be misclassified as conversion. Always interpret alerts as indicators,
   not definitive outcomes.
 
+  When driver classification data is shown (i.e. when the context_layer is "driver"),
+  you MUST:
+  1. Name the driver classification product as "LDACS (Land Disturbance Alert
+     Classification System)" and explain it is updated quarterly.
+  2. Include the following caveat if the requested time period extends beyond
+     the most recently completed quarter: "The LDACS driver classifications may
+     not cover all of the requested time period. Alerts in periods not yet
+     assessed by LDACS will appear as ''Unclassified'' — this does not mean
+     the cause of disturbance is unknown, only that it has not yet been
+     assessed."
+  3. Always provide the LDACS metadata link alongside the DIST-ALERT metadata link.
+
   '
 selection_hints: 'Best dataset for near-real-time vegetation disturbance across ALL ecosystems (not just forests). Covers
   Dec 2023 to present at 30m resolution, measured in hectares. Prefer when user asks about recent disturbance, clearing, or
@@ -66,8 +78,12 @@ code_instructions: "CHART TYPES: - Recent trends over time → line chart (x=ale
   \ outcomes\n"
 presentation_instructions: 'Describe results as vegetation disturbance alerts, not confirmed deforestation or conversion.
   Clarify if user cares about temporary disturbance vs permanent conversion; recommend annual land cover or tree cover loss
-  datasets for historical changes. Note LDACS is updated quarterly, covers most recent 12 months, no classification for last
-  90 days. This covers all vegetation, not just forest — relevant for non-conversion of natural ecosystems monitoring.
+  datasets for historical changes. When the driver context layer is active, you MUST explicitly name "LDACS (Land Disturbance
+  Alert Classification System)" as the source of the driver classifications in your insight text. Note LDACS is updated quarterly,
+  covers most recent 12 months, no classification for last 90 days. If the requested period extends beyond the most recently
+  completed quarter, state that alerts not yet assessed by LDACS will appear as Unclassified and this reflects an assessment
+  gap, not an unknown driver. This covers all vegetation, not just forest — relevant for non-conversion of natural ecosystems
+  monitoring.
 
   '
 description: 'Global All Ecosystem Disturbance Alerts (DIST-ALERT) provides near-real-time alerts of vegetation disturbance

--- a/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
+++ b/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
@@ -25,8 +25,8 @@ keywords:
 analytics_api_endpoint: /v0/land_change/tree_cover_loss/analytics
 prompt_instructions: "Shows the delta of the primary driver or cause of tree cover loss over the entire range 2001-2024. The\
   \ data represents the change for the whole period of time, not a timeseries. IMPORTANT: If a user asks for specific time\
-  \ ranges (e.g. last five years), single years (e.g. 2024), or trends over time, do not use this dataset, select Tree cover\
-  \ loss instead. Classes are defined as follows: - Permanent agriculture: Long-term, permanent tree cover loss for small-\
+  \ ranges (e.g. last five years), single years (e.g. 2024), or trends over time, do not use this dataset — explicitly tell\
+  \ the user to use the \"Tree cover loss\" dataset for annual breakdowns instead. Classes are defined as follows: - Permanent agriculture: Long-term, permanent tree cover loss for small-\
   \ to large-scale agriculture. - Hard commodities: Loss due to the establishment or expansion of mining or energy infrastructure.\
   \ - Shifting cultivation: Tree cover loss due to small- to medium-scale clearing for temporary\n  cultivation that is later\
   \ abandoned and followed by subsequent regrowth of secondary forest or\n  vegetation.\n- Logging: Forest management and\
@@ -51,10 +51,21 @@ selection_hints: 'Use when user asks WHY tree cover was lost — attributes loss
   analysis. Drivers: permanent agriculture, hard commodities, shifting cultivation, logging, wildfire, settlements & infrastructure,
   other natural disturbances.
 
+  NEVER select this dataset when the user asks about a specific year, a date range
+  shorter than the full 2001-2024 period, or asks for a trend or timeseries.
+  These queries require the base "Tree cover loss" dataset. Examples of queries
+  that must NOT use this dataset:
+  - "deforestation over the past 5 years"
+  - "forest loss in 2023"
+  - "how has deforestation changed over time"
+  If you have already retrieved driver data, do not suggest timeseries follow-up
+  analysis — it is not possible with this dataset.
+
   '
 code_instructions: "CHART TYPES: - Driver breakdown → pie chart or table ONLY - DO NOT attempt a timeseries — this is a single-period\
   \ aggregate (2001-2024) DATA RULES: - Exclude the \"Unknown\" driver class from analysis - Show area_ha or emissions (MgCO2e)\
-  \ per driver class for the full period 2001-2024 - 7 driver classes:\n  1. Permanent agriculture — long-term, permanent\
+  \ per driver class for the full period 2001-2024 - If user asks for annual trends or specific years, REFUSE and in your\
+  \ feedback explicitly recommend the \"Tree cover loss\" dataset for annual breakdowns - 7 driver classes:\n  1. Permanent agriculture — long-term, permanent\
   \ tree cover loss for agriculture\n  2. Hard commodities — loss due to mining or energy infrastructure\n  3. Shifting cultivation\
   \ — small/medium-scale temporary cultivation, later abandoned\n  4. Logging — forest management within managed/natural/semi-natural\
   \ forests and plantations\n  5. Wildfire — fire with no visible human conversion afterward\n  6. Settlements and infrastructure\
@@ -66,6 +77,10 @@ code_instructions: "CHART TYPES: - Driver breakdown → pie chart or table ONLY 
 presentation_instructions: 'Use "tree cover loss" not "deforestation." Driver = dominant driver in each ~1km cell over full
   period 2001-2024, not per-event attribution. Does not distinguish natural forest from plantations. Classification is an
   approximation — does not monitor regrowth or permanence.
+
+  Do not suggest next steps that imply a timeseries analysis using this dataset.
+  If you recommend further analysis, direct the user to the Tree Cover Loss dataset
+  for annual breakdowns.
 
   '
 description: "Shows the dominant driver of tree cover loss over the time period 2001-2024. A driver is defined as the direct\

--- a/tests/evals/test_date_range_accuracy.py
+++ b/tests/evals/test_date_range_accuracy.py
@@ -1,0 +1,35 @@
+"""
+Eval: Stated dataset date ranges match fixture data, not memorised values.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+RUBRIC_GRASSLAND_DATES = """
+The fixture data covers grassland extent from 2000 to 2022. The response must
+state that data is available up to 2022 (not 2023 or any later date). It must
+not report figures for years beyond 2022.
+"""
+
+RUBRIC_NO_ASSUMED_YEAR = """
+The user did not specify a year. The response must NOT state or imply that
+the user requested a specific year (e.g. "as requested for 2023"). It should
+instead describe the full period covered by the data returned.
+"""
+
+
+@pytest.mark.asyncio
+async def test_grassland_dates_match_fixture(grasslands_state, run_insights, judge):
+    query = "What is the grassland extent in Kenya up to the latest available year?"
+    tool_output = await run_insights(query, grasslands_state)
+    verdict = await judge(query, RUBRIC_GRASSLAND_DATES, tool_output)
+    assert verdict.passed, verdict.comment
+
+
+@pytest.mark.asyncio
+async def test_no_assumed_year_in_tcl_response(tcl_state, run_insights, judge):
+    query = "Show me tree cover loss data for Pará, Brazil."
+    tool_output = await run_insights(query, tcl_state)
+    verdict = await judge(query, RUBRIC_NO_ASSUMED_YEAR, tool_output)
+    assert verdict.passed, verdict.comment

--- a/tests/evals/test_dist_forest_caveat.py
+++ b/tests/evals/test_dist_forest_caveat.py
@@ -1,0 +1,35 @@
+"""
+Eval: DIST-ALERT forest caveat
+Verifies that when DIST alert data is presented for a forest-loss query,
+the response includes a caveat that alerts cover all vegetation, not just forest.
+"""
+
+import pytest
+from tests.evals.judge import run_generate_insights, judge_output
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+RUBRIC = """
+The response MUST include a caveat explaining that DIST-ALERT covers ALL
+vegetation types and is not limited to forest. It should state that results
+may include non-forest disturbances such as crop harvesting or grassland change.
+The caveat must appear even if the analysis data looks plausible.
+The response must NOT present the alert numbers as confirmed forest loss.
+"""
+
+
+@pytest.mark.asyncio
+async def test_dist_forest_query_includes_vegetation_caveat(dist_alert_state, run_insights, judge):
+    query = "How much forest was lost in the Democratic Republic of Congo in the last 6 months?"
+    tool_output = await run_insights(query, dist_alert_state)
+    verdict = await judge(query, RUBRIC, tool_output)
+    assert verdict.passed, verdict.comment
+
+
+@pytest.mark.asyncio
+async def test_dist_deforestation_query_includes_caveat(dist_alert_state, run_insights, judge):
+    query = "Show me deforestation alerts in DRC from June to November 2024."
+    tool_output = await run_insights(query, dist_alert_state)
+    verdict = await judge(query, RUBRIC, tool_output)
+    assert verdict.passed, verdict.comment

--- a/tests/evals/test_ldacs_disclosure.py
+++ b/tests/evals/test_ldacs_disclosure.py
@@ -1,0 +1,41 @@
+"""
+Eval: LDACS citation and temporal caveat
+Verifies that LDACS is named and its temporal limitations are disclosed
+whenever driver breakdown data is shown.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+RUBRIC_NAMED = """
+The response MUST mention LDACS (or Land Disturbance Alert Classification System)
+by name. It should explain that LDACS classifies alert drivers.
+The response must not present driver classes without attribution.
+"""
+
+RUBRIC_TEMPORAL = """
+The response MUST include a caveat that LDACS may not have classified alerts
+for the most recent period, and that 'Unclassified' alerts reflect this
+assessment gap rather than an unknown driver.
+"""
+
+
+@pytest.mark.asyncio
+async def test_ldacs_named_in_driver_response(dist_alert_state, run_insights, judge):
+    query = "What are the main drivers of vegetation disturbance in DRC from June to November 2024? How is the driver classification done?"
+    tool_output = await run_insights(query, dist_alert_state)
+    verdict = await judge(query, RUBRIC_NAMED, tool_output)
+    assert verdict.passed, verdict.comment
+
+
+@pytest.mark.asyncio
+async def test_ldacs_unclassified_explained(dist_alert_state, run_insights, judge):
+    query = (
+        "Show me a breakdown of disturbance drivers in DRC for 2024. "
+        "Why is such a large proportion unclassified?"
+    )
+    tool_output = await run_insights(query, dist_alert_state)
+    verdict = await judge(query, RUBRIC_TEMPORAL, tool_output)
+    assert verdict.passed, verdict.comment

--- a/tests/evals/test_no_unavailable_datasets.py
+++ b/tests/evals/test_no_unavailable_datasets.py
@@ -1,0 +1,38 @@
+"""
+Eval: GNW does not suggest unavailable datasets in next steps.
+Verifies that follow-up recommendations only reference datasets
+that exist within the GNW platform.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+UNAVAILABLE_DATASETS = [
+    "GLAD alert",
+    "PRODES",
+    "Hansen annual",
+    "Global Forest Change",
+    "FORMA",
+    "Terra-i",
+]
+
+RUBRIC = """
+The response must NOT recommend or reference any dataset or monitoring system
+that is not available within Global Nature Watch. Specifically, it must not
+mention: GLAD alerts, PRODES, Hansen annual tiles (outside the standard TCL
+pipeline), FORMA, Terra-i, or any other external forest monitoring system as
+a suggested next step. All recommended next steps must use datasets available
+in the GNW platform.
+"""
+
+
+@pytest.mark.asyncio
+async def test_next_steps_only_reference_gnw_datasets(tcl_state, run_insights, judge):
+    query = (
+        "Which regions in Pará, Brazil should I prioritise for biodiversity monitoring? "
+        "What should I look at next?"
+    )
+    tool_output = await run_insights(query, tcl_state)
+    verdict = await judge(query, RUBRIC, tool_output)
+    assert verdict.passed, verdict.comment

--- a/tests/evals/test_tcl_driver_selection.py
+++ b/tests/evals/test_tcl_driver_selection.py
@@ -1,0 +1,40 @@
+"""
+Eval: TCL drivers dataset not used for annual/trend queries.
+Verifies the response refuses to produce a timeseries from drivers data
+and correctly explains the limitation.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+RUBRIC_NO_TIMESERIES = """
+The response MUST NOT present the driver data as a year-by-year breakdown.
+It should clearly state that the drivers dataset covers the aggregate period
+2001-2024 only and cannot show annual trends.
+If a timeseries was requested, the response should suggest using the Tree Cover
+Loss dataset instead.
+"""
+
+RUBRIC_DEFAULT_RANGE = """
+When no date range is specified and drivers data is shown, the response MUST
+use the full 2001-2024 range and must NOT assume a shorter default range such
+as 2001-2023.
+"""
+
+
+@pytest.mark.asyncio
+async def test_driver_dataset_refuses_annual_query(tcl_driver_state, run_insights, judge):
+    query = "Show me deforestation trends by driver for Colombia over the past 5 years."
+    tool_output = await run_insights(query, tcl_driver_state)
+    verdict = await judge(query, RUBRIC_NO_TIMESERIES, tool_output)
+    assert verdict.passed, verdict.comment
+
+
+@pytest.mark.asyncio
+async def test_driver_dataset_uses_full_range_by_default(tcl_driver_state, run_insights, judge):
+    query = "What are the main drivers of tree cover loss in Indonesia?"
+    tool_output = await run_insights(query, tcl_driver_state)
+    verdict = await judge(query, RUBRIC_DEFAULT_RANGE, tool_output)
+    assert verdict.passed, verdict.comment

--- a/tests/evals/test_wording_in_code.py
+++ b/tests/evals/test_wording_in_code.py
@@ -1,0 +1,38 @@
+"""
+Eval: Prohibited wording does not appear in generated code or chart labels.
+Verifies WORDING_INSTRUCTIONS are applied to chart titles, axis labels,
+and code comments, not just the prose response.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+PROHIBITED = [
+    "significant", "critical", "alarming", "substantial", "considerable",
+    "remarkable", "crucial", "dramatic", "problematic", "concerning",
+]
+
+RUBRIC = (
+    "The generated code, chart titles, axis labels, and insight text must NOT "
+    "contain any of the following words: "
+    + ", ".join(f'"{w}"' for w in PROHIBITED)
+    + ". This applies to string literals, f-strings, comments, and any text "
+    "that will appear in the chart or UI."
+)
+
+
+@pytest.mark.asyncio
+async def test_prohibited_words_absent_from_code(land_cover_state, run_insights, judge):
+    query = "What are the most significant land cover changes in Brazil between 2015 and 2024?"
+    tool_output = await run_insights(query, land_cover_state)
+    verdict = await judge(query, RUBRIC, tool_output)
+    assert verdict.passed, verdict.comment
+
+
+@pytest.mark.asyncio
+async def test_prohibited_words_absent_from_tcl_insight(tcl_state, run_insights, judge):
+    query = "Summarise tree cover loss in Pará, Brazil. How alarming is the trend?"
+    tool_output = await run_insights(query, tcl_state)
+    verdict = await judge(query, RUBRIC, tool_output)
+    assert verdict.passed, verdict.comment


### PR DESCRIPTION
## Summary                                                                                        
                                                                                                 
Six bug-fix branches merged as a single batch — all YAML and prompts.py changes, no Python logic 
altered in graph.py or generate_insights.py. Safe to merge before Batch 2 (PRs 4/7/8).

Focusing (mostly) on TCL/Driver related issues with the upcoming release in mind
                                                                                                 
Bugs fixed: PZB-617, PZB-691, PZB-595, PZB-660, PZB-694, PZB-653, PZB-708, PZB-705, PZB-619,     
PZB-601, PZB-709, PZB-618
                                                                                                 
## Changes                                                                                          

DIST-ALERT forest caveat (PZB-617, PZB-691, PZB-595)                                             
Adds mandatory caveat when DIST-ALERT is used for forest-loss queries: covers ALL vegetation   
types, not confirmed deforestation. selection_hints prefers Tree Cover Loss for forest-specific  
queries. code_instructions blocks "deforestation"/"forest loss" labels in generated code and
charts.                                                                                          
                                                                                               
LDACS temporal disclosure + unclassified explanation (PZB-660, PZB-694)                          
When the driver context layer is active, responses must name "LDACS (Land Disturbance Alert
Classification System)", explain its quarterly update cadence, and caveat that unclassified      
alerts reflect an assessment gap — not an unknown driver. Adds an explicit prohibition on      
hallucinated explanations for unclassified alerts (cloud cover, image quality, "the way the      
system works") — the only correct answer is the 90-day quarterly lag.                          

TCL drivers dataset — block trend/annual queries (PZB-653, PZB-708, PZB-705)                     
Strengthened selection_hints to explicitly forbid dataset selection for trend, timeseries,
single-year, or sub-range queries, with concrete examples. Directs agent to the base Tree Cover  
Loss dataset instead. Also blocks timeseries follow-up suggestions when driver data is returned.
                                                                                                 
No unavailable dataset suggestions (PZB-619)                                                     
Adds restriction to WORDING_INSTRUCTIONS: never recommend GLAD alerts, PRODES, Hansen annual
tiles outside the standard TCL pipeline, FORMA, Terra-i, or similar external systems as next     
steps.                                                    
                                                                                                 
Wording rules apply to code/charts (PZB-601)                                                     
Extends existing prohibited-words rules to ALL output: chart titles, axis labels, legend text,
code comments, f-strings, and any string that appears in the UI.                                 
                                                          
Date range accuracy (PZB-709, PZB-618)                                                           
Two new instructions in WORDING_INSTRUCTIONS: always derive date ranges from start_date/end_date
in dataset state (not memorised values); if the user didn't specify a year, don't assume one.    

Files changed                                                                                    
                                                          
- src/agent/tools/datasets/global_all_ecosystem_disturbance_alerts_dist_alert.yml                
- src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
- src/agent/prompts.py                                                                           
- tests/evals/test_dist_forest_caveat.py (new — 2/2 passing)
- tests/evals/test_ldacs_disclosure.py (new — 2/2 passing)                                       
- tests/evals/test_tcl_driver_selection.py (new — 2/2 passing)
- tests/evals/test_no_unavailable_datasets.py (new — 1/1 passing)                                
- tests/evals/test_wording_in_code.py (new — 2/2 passing) 
- tests/evals/test_date_range_accuracy.py (new — 2/2 passing)                                    
                                                                                                 
Test plan                                                                                        
                                                                                                 
- uv run pytest tests/evals/ -k "dist_forest_caveat or ldacs_disclosure or tcl_driver_selection  
or no_unavailable or wording_in_code or date_range_accuracy" -v
- "Why is so much of the disturbance unclassified?" — must cite LDACS quarterly lag, not cloud   
cover or algorithm behaviour                                                                     
- "Show me deforestation trends by driver over 5 years" — must redirect to Tree Cover Loss
- "What should I look at next for deforestation monitoring in Pará?" — must not mention          
GLAD/PRODES                 