### PR TITLE
Dynamic canopy cover threshold selection  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ logs/
 
 # Notebooks
 nbs/
+tests/evals/results/

--- a/docs/adr-canopy-cover-threshold-resolution.md
+++ b/docs/adr-canopy-cover-threshold-resolution.md
@@ -1,0 +1,110 @@
+# ADR: Deterministic Canopy Cover Threshold Resolution
+
+**Date:** 2026-04-06
+**Status:** Accepted
+**Branch:** feat/canopy-cover-threshold
+**PR:** wri/project-zeno#597
+
+---
+
+## Context
+
+Tree cover loss datasets on Global Forest Watch support a `canopy_cover` threshold
+parameter (valid values: 10, 15, 20, 25, 30, 50, 75%) that filters which pixels
+are counted as "forest". Different countries define forest using different minimum
+canopy densities in their national legislation and UNFCCC submissions.
+
+The previous implementation encoded the country→threshold mapping as a large
+`TREE COVER THRESHOLD SELECTION` block inside the base system prompt. This block
+listed ~30 countries and their thresholds and instructed the LLM to infer the
+correct threshold from the query context and pass it as the `canopy_cover`
+argument to `pull_data`.
+
+### Problems
+
+1. **System prompt bloat.** The block was sent with every query, regardless of
+   whether tree cover analysis was involved. This increases token cost and
+   prompt complexity for all queries (raised by @yellowcap and @soumya).
+
+2. **LLM inference is unreliable.** Threshold selection based on country context
+   is a deterministic lookup; delegating it to LLM inference introduces
+   non-determinism and occasional errors.
+
+3. **Maintenance coupling.** Adding a new country required editing the system
+   prompt, touching a high-traffic file with broad blast radius.
+
+4. **Separation of concerns.** The base system prompt is meant to describe the
+   agent's workflow and tools, not to encode dataset-specific lookup tables.
+
+---
+
+## Decision
+
+Move the country→threshold mapping out of the system prompt and into a dedicated
+Python module (`src/agent/tools/canopy_cover.py`). Apply the mapping
+deterministically at data fetch time inside `pull_data`, using the country AOI
+already stored in state.
+
+### Resolution priority
+
+```
+1. Explicit user override  →  user said "use 20% canopy cover"
+2. Country lookup          →  first gadm country-level AOI in state["aoi_selection"]
+3. GFW default             →  30%
+```
+
+Only country-level (`subtype="country"`, `source="gadm"`) AOIs are matched.
+Sub-national AOIs (states, districts) and non-gadm sources (wdpa, kba, landmark)
+fall through to the GFW default.
+
+### System prompt change
+
+The 27-line `TREE COVER THRESHOLD SELECTION` block was removed entirely. No
+replacement was needed — the `pull_data` tool docstring already instructs the LLM
+to only set `canopy_cover` when the user explicitly requests a threshold. A
+system prompt note on top would have been redundant.
+
+### Citation and justification in responses
+
+The citation language ("10% — India's national forest definition per the
+[Forest Survey of India (FSI)](https://fsi.nic.in/)") has always lived in
+`presentation_instructions` inside `tree_cover_loss.yml`. This is unchanged.
+`presentation_instructions` is injected only by `generate_insights` when the
+Tree Cover Loss dataset is active — it is never in the base system prompt.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `src/agent/tools/canopy_cover.py` | **New.** Lookup table + `resolve_canopy_cover()` |
+| `src/agent/tools/pull_data.py` | Uses `resolve_canopy_cover()` instead of `canopy_cover or 30` |
+| `src/agent/graph.py` | Removed 27-line system prompt block |
+| `tests/tools/test_canopy_cover_lookup.py` | **New.** Unit tests for lookup table and resolver |
+
+---
+
+## Consequences
+
+### Positive
+
+- **Cheaper and simpler.** ~25 lines removed from the base system prompt; every
+  query saves those tokens regardless of dataset.
+- **Deterministic.** Country→threshold mapping is a pure function; identical
+  inputs always produce identical outputs with no LLM inference step.
+- **Easier to extend.** Adding a new country means adding one dict entry to
+  `COUNTRY_THRESHOLDS` — no prompt editing required.
+- **Better separation of concerns.** System prompt describes workflow; dataset
+  YAML describes presentation; Python code handles data logic.
+
+### Trade-offs
+
+- **Only country-level AOIs are auto-resolved.** Sub-national queries (e.g.,
+  "show deforestation in Maharashtra") default to 30% even though India's
+  national threshold is 10%. The user can still override explicitly. This is a
+  known limitation and can be improved by adding parent-country resolution later.
+- **Unknown countries default to 30%.** Any country not in `COUNTRY_THRESHOLDS`
+  silently uses the GFW default. The table covers the countries listed in the
+  original system prompt; gaps should be filled as new country support is added.
+- **Explicit overrides still go through the LLM.** The `canopy_cover` parameter
+  on `pull_data` remains LLM-settable for cases where the user explicitly names
+  a threshold. The system prompt note keeps the LLM aware of this path.

--- a/docs/adr-canopy-cover-threshold-resolution.md
+++ b/docs/adr-canopy-cover-threshold-resolution.md
@@ -1,6 +1,6 @@
 # ADR: Deterministic Canopy Cover Threshold Resolution
 
-**Date:** 2026-04-06
+**Date:** 2026-04-07
 **Status:** Accepted
 **Branch:** feat/canopy-cover-threshold
 **PR:** wri/project-zeno#597
@@ -11,74 +11,76 @@
 
 Tree cover loss datasets on Global Forest Watch support a `canopy_cover` threshold
 parameter (valid values: 10, 15, 20, 25, 30, 50, 75%) that filters which pixels
-are counted as "forest". Different countries define forest using different minimum
-canopy densities in their national legislation and UNFCCC submissions.
+are counted as "forest". The GFW default is 30%, but different countries define
+forest using different minimum canopy densities in their national legislation and
+UNFCCC submissions (e.g. India uses 10% per FSI, Australia uses 20% per ABARES,
+Chile uses 25% per CONAF).
 
-The previous implementation encoded the country→threshold mapping as a large
-`TREE COVER THRESHOLD SELECTION` block inside the base system prompt. This block
-listed ~30 countries and their thresholds and instructed the LLM to infer the
-correct threshold from the query context and pass it as the `canopy_cover`
-argument to `pull_data`.
+The baseline agent always used 30%. This branch adds country-specific threshold
+selection so that queries about a known country automatically use the appropriate
+national forest definition.
 
-### Problems
+---
 
-1. **System prompt bloat.** The block was sent with every query, regardless of
-   whether tree cover analysis was involved. This increases token cost and
-   prompt complexity for all queries (raised by @yellowcap and @soumya).
+## Options Considered
 
-2. **LLM inference is unreliable.** Threshold selection based on country context
-   is a deterministic lookup; delegating it to LLM inference introduces
-   non-determinism and occasional errors.
+### Option A — System prompt instruction (rejected)
 
-3. **Maintenance coupling.** Adding a new country required editing the system
-   prompt, touching a high-traffic file with broad blast radius.
+Encode the country→threshold mapping as a section in the base system prompt and
+instruct the LLM to infer the correct threshold from the query context, passing it
+as the `canopy_cover` argument to `pull_data`.
 
-4. **Separation of concerns.** The base system prompt is meant to describe the
-   agent's workflow and tools, not to encode dataset-specific lookup tables.
+**Problems:**
+- **Token cost.** The block is sent with every query, regardless of whether tree
+  cover analysis is involved.
+- **System prompt bloat.** Dataset-specific lookup tables have no place in a prompt
+  that is meant to describe the agent's workflow. Gradual accumulation of similar
+  blocks will degrade quality and increase cost over time (raised by @soumya and
+  @yellowcap).
+- **Non-determinism.** Threshold selection is a pure lookup; delegating it to LLM
+  inference introduces occasional errors with no easy way to test or audit.
+- **Maintenance coupling.** Adding a country means editing the system prompt — a
+  high-traffic file with broad blast radius.
+
+### Option B — Deterministic code lookup (selected)
+
+Encode the country→threshold mapping in a dedicated Python module. Resolve the
+threshold deterministically at data fetch time inside `pull_data`, using the
+country AOI already stored in state from `pick_aoi`.
 
 ---
 
 ## Decision
 
-Move the country→threshold mapping out of the system prompt and into a dedicated
-Python module (`src/agent/tools/canopy_cover.py`). Apply the mapping
-deterministically at data fetch time inside `pull_data`, using the country AOI
-already stored in state.
-
-### Resolution priority
+Option B. The mapping lives in `src/agent/tools/canopy_cover.py` as a typed dict
+keyed on ISO 3166-1 alpha-3 country codes. `resolve_canopy_cover()` applies the
+following priority at call time:
 
 ```
 1. Explicit user override  →  user said "use 20% canopy cover"
-2. Country lookup          →  first gadm country-level AOI in state["aoi_selection"]
+2. Country lookup          →  ISO3 src_id from first gadm country-level AOI in state
 3. GFW default             →  30%
 ```
 
-Only country-level (`subtype="country"`, `source="gadm"`) AOIs are matched.
-Sub-national AOIs (states, districts) and non-gadm sources (wdpa, kba, landmark)
-fall through to the GFW default.
-
-### System prompt change
-
-The 27-line `TREE COVER THRESHOLD SELECTION` block was removed entirely. No
-replacement was needed — the `pull_data` tool docstring already instructs the LLM
-to only set `canopy_cover` when the user explicitly requests a threshold. A
-system prompt note on top would have been redundant.
+The base system prompt is unchanged — the `pull_data` tool docstring is sufficient
+to instruct the LLM to only pass `canopy_cover` when the user explicitly names a
+threshold.
 
 ### Citation and justification in responses
 
 The citation language ("10% — India's national forest definition per the
-[Forest Survey of India (FSI)](https://fsi.nic.in/)") has always lived in
-`presentation_instructions` inside `tree_cover_loss.yml`. This is unchanged.
-`presentation_instructions` is injected only by `generate_insights` when the
-Tree Cover Loss dataset is active — it is never in the base system prompt.
+[Forest Survey of India (FSI)](https://fsi.nic.in/)") lives in
+`presentation_instructions` inside `tree_cover_loss.yml`. This is injected by
+`generate_insights` only when the Tree Cover Loss dataset is active — never in the
+base system prompt. This is unchanged.
 
 ### Files changed
 
 | File | Change |
 |------|--------|
-| `src/agent/tools/canopy_cover.py` | **New.** Lookup table + `resolve_canopy_cover()` |
-| `src/agent/tools/pull_data.py` | Uses `resolve_canopy_cover()` instead of `canopy_cover or 30` |
-| `src/agent/graph.py` | Removed 27-line system prompt block |
+| `src/agent/tools/canopy_cover.py` | **New.** Typed lookup table + `resolve_canopy_cover()` |
+| `src/agent/tools/pull_data.py` | Calls `resolve_canopy_cover()` instead of `canopy_cover or 30` |
+| `src/agent/graph.py` | Removed 27-line `TREE COVER THRESHOLD SELECTION` block |
 | `tests/tools/test_canopy_cover_lookup.py` | **New.** Unit tests for lookup table and resolver |
 
 ---
@@ -87,24 +89,29 @@ Tree Cover Loss dataset is active — it is never in the base system prompt.
 
 ### Positive
 
-- **Cheaper and simpler.** ~25 lines removed from the base system prompt; every
-  query saves those tokens regardless of dataset.
-- **Deterministic.** Country→threshold mapping is a pure function; identical
-  inputs always produce identical outputs with no LLM inference step.
-- **Easier to extend.** Adding a new country means adding one dict entry to
-  `COUNTRY_THRESHOLDS` — no prompt editing required.
-- **Better separation of concerns.** System prompt describes workflow; dataset
-  YAML describes presentation; Python code handles data logic.
+- **Cheaper.** ~25 lines removed from the base system prompt; token savings on
+  every query regardless of dataset.
+- **Deterministic and testable.** Country→threshold mapping is a pure function
+  with a full unit test suite.
+- **Easier to extend.** Adding a country is one dict entry in `canopy_cover.py`;
+  no prompt editing required.
+- **Better separation of concerns.** System prompt describes workflow; dataset YAML
+  describes presentation; Python code handles data logic.
 
 ### Trade-offs
 
-- **Only country-level AOIs are auto-resolved.** Sub-national queries (e.g.,
-  "show deforestation in Maharashtra") default to 30% even though India's
-  national threshold is 10%. The user can still override explicitly. This is a
-  known limitation and can be improved by adding parent-country resolution later.
-- **Unknown countries default to 30%.** Any country not in `COUNTRY_THRESHOLDS`
-  silently uses the GFW default. The table covers the countries listed in the
-  original system prompt; gaps should be filled as new country support is added.
+- **Sub-national AOIs are not yet auto-resolved.** Needs to be confirmed with the
+  reserach team before proceeding. A query for "Maharashtra, India" will currently
+  default to 30% rather than India's 10%.
+  This is trivial to fix: GADM `src_id` values for sub-national units encode
+  the ISO3 prefix (e.g. `"IND.12_1"`), so extracting `src_id.split(".")[0]` would
+  cover all GADM admin levels without any DB lookup. Left as a follow-up.
+- **Non-gadm sources default to 30%.** Protected areas (wdpa), Key Biodiversity
+  Areas (kba), and indigenous lands (landmark) have no country code in their
+  `src_id`. A DB lookup would be required to resolve the parent country.
+- **Unknown countries default to 30%.** Countries not in `COUNTRY_THRESHOLDS`
+  silently use the GFW default. The table covers the countries from the original
+  system prompt; gaps should be filled incrementally.
 - **Explicit overrides still go through the LLM.** The `canopy_cover` parameter
-  on `pull_data` remains LLM-settable for cases where the user explicitly names
-  a threshold. The system prompt note keeps the LLM aware of this path.
+  on `pull_data` remains LLM-settable for cases where the user explicitly names a
+  threshold.

--- a/docs/adr-canopy-cover-threshold-resolution.md
+++ b/docs/adr-canopy-cover-threshold-resolution.md
@@ -66,20 +66,32 @@ The base system prompt is unchanged — the `pull_data` tool docstring is suffic
 to instruct the LLM to only pass `canopy_cover` when the user explicitly names a
 threshold.
 
-### Citation and justification in responses
+### Surfacing the citation in the agent response
 
-The citation language ("10% — India's national forest definition per the
-[Forest Survey of India (FSI)](https://fsi.nic.in/)") lives in
-`presentation_instructions` inside `tree_cover_loss.yml`. This is injected by
-`generate_insights` only when the Tree Cover Loss dataset is active — never in the
-base system prompt. This is unchanged.
+`resolve_canopy_cover()` returns both the threshold int and the full citation
+markdown string. For tree cover datasets (Tree cover loss, Tree cover loss by
+dominant driver, Tree cover), `pull_data` appends the citation to its tool
+message:
+
+```
+Canopy cover threshold: 10% — India's national forest definition per the [Forest Survey of India (FSI)](https://fsi.nic.in/)
+```
+
+The main agent LLM sees this in its context between tool calls and includes it in
+its conversational response. Forest greenhouse gas net flux is excluded — it
+always uses a fixed 30% and the threshold is not user-configurable.
+
+The citation text in `presentation_instructions` inside `tree_cover_loss.yml`
+provides additional guidance to the insight-generation step (injected by
+`generate_insights` only when Tree Cover Loss is active — never in the base system
+prompt). This is unchanged.
 
 ### Files changed
 
 | File | Change |
 |------|--------|
 | `src/agent/tools/canopy_cover.py` | **New.** Typed lookup table + `resolve_canopy_cover()` |
-| `src/agent/tools/pull_data.py` | Calls `resolve_canopy_cover()` instead of `canopy_cover or 30` |
+| `src/agent/tools/pull_data.py` | Calls `resolve_canopy_cover()`, appends threshold + citation to tool message for tree cover datasets |
 | `src/agent/graph.py` | Removed 27-line `TREE COVER THRESHOLD SELECTION` block |
 | `tests/tools/test_canopy_cover_lookup.py` | **New.** Unit tests for lookup table and resolver |
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -106,11 +106,18 @@ TREE COVER THRESHOLD SELECTION (canopy_cover parameter in pull_data):
 - If the user references a country's national forest definition, map to the appropriate threshold
 - If the dataset is Forest greenhouse gas net flux, do NOT set canopy_cover — it is always fixed at 30%
 - When stating the threshold in your response, ALWAYS justify it: name the national agency or framework it comes from
-  (e.g. "10% — India's national forest definition per the Forest Survey of India (FSI)",
-        "20% — Australia's national definition per ABARES",
-        "30% — Colombia's national definition per IDEAM / UNFCCC REDD+ submission",
-        "30% — GFW default (no country-specific definition applied)")
-- If the user does not specify a country or threshold, state "30% (GFW default)"
+  AND include a markdown hyperlink to the relevant definition or report. Examples:
+  - "10% — India's national forest definition per the [Forest Survey of India (FSI)](https://fsi.nic.in/)"
+  - "10% — USA national forest definition per the [USFS Forest Inventory and Analysis (FIA)](https://www.fia.fs.usda.gov/)"
+  - "10% — Canada's national forest definition per [Natural Resources Canada (NRCan)](https://natural-resources.canada.ca/our-natural-resources/forests/state-canadas-forests-report/how-does-canada-define-forest/17639)"
+  - "10% — [FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/) (≥10% canopy cover, ≥0.5 ha, ≥5 m height)"
+  - "20% — Australia's national forest definition per [ABARES](https://www.agriculture.gov.au/abares/forestsaustralia/forest-data-maps-and-tools/forest-definition)"
+  - "20% — UK national forest definition per [Forest Research](https://www.forestresearch.gov.uk/tools-and-resources/statistics/statistics-by-topic/woodland-statistics/)"
+  - "25% — Chile's national forest definition per [CONAF](https://www.conaf.cl/)"
+  - "30% — Colombia's national forest definition per [IDEAM](https://www.ideam.gov.co/) / UNFCCC REDD+ submission"
+  - "30% — Costa Rica's national forest definition per [FONAFIFO](https://www.fonafifo.go.cr/)"
+  - "30% — [GFW default](https://www.globalforestwatch.org/) (no country-specific definition applied)"
+- If the user does not specify a country or threshold, state "30% — [GFW default](https://www.globalforestwatch.org/)"
 
 GENERATE_INSIGHTS TOOL NOTES:
 - Provide a 1-2 sentence summary of the insights in the response.

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -91,34 +91,6 @@ PICK_DATASET TOOL NOTES:
     2. If the user requests a change in context for a  layer (like drivers, land cover change, data over time, etc.)
 - Warn the user if there is not an exact date match for the dataset, but move forward with the analysis.
 
-TREE COVER THRESHOLD SELECTION (canopy_cover parameter in pull_data):
-- Valid thresholds: 10, 15, 20, 25, 30, 50, 75 (percent canopy density)
-- Default to 30% when unsure or not specified by the user
-- Infer threshold from context using national forest definitions below. The LLM already knows these — trust its knowledge:
-  - 10%: USA (USFS FIA), Canada (NRCan), Brazil (FAO alignment), Mexico, Peru, Argentina, Ecuador, Germany, France, Sweden,
-          Finland, Italy, Norway, India (FSI), Vietnam, Philippines, South Africa, Kenya, Ethiopia, Russia — FAO/UNFCCC standard
-  - 20%: Australia (ABARES), China (national), United Kingdom (Forest Research), Spain
-  - 25%: Chile (CONAF)
-  - 30%: Colombia (IDEAM), Costa Rica (FONAFIFO), DRC, Republic of Congo, Japan, New Zealand — GFW default
-  - 50%: Dense closed-canopy forest analyses; high-density forest filter
-  - 75%: Very dense closed canopy only
-- If the user explicitly names a threshold (e.g. "using 10% canopy cover"), use that value exactly
-- If the user references a country's national forest definition, map to the appropriate threshold
-- If the dataset is Forest greenhouse gas net flux, do NOT set canopy_cover — it is always fixed at 30%
-- When stating the threshold in your response, ALWAYS justify it: name the national agency or framework it comes from
-  AND include a markdown hyperlink to the relevant definition or report. Examples:
-  - "10% — India's national forest definition per the [Forest Survey of India (FSI)](https://fsi.nic.in/)"
-  - "10% — USA national forest definition per the [USFS Forest Inventory and Analysis (FIA)](https://www.fia.fs.usda.gov/)"
-  - "10% — Canada's national forest definition per [Natural Resources Canada (NRCan)](https://natural-resources.canada.ca/our-natural-resources/forests/state-canadas-forests-report/how-does-canada-define-forest/17639)"
-  - "10% — [FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/) (≥10% canopy cover, ≥0.5 ha, ≥5 m height)"
-  - "20% — Australia's national forest definition per [ABARES](https://www.agriculture.gov.au/abares/forestsaustralia/forest-data-maps-and-tools/forest-definition)"
-  - "20% — UK national forest definition per [Forest Research](https://www.forestresearch.gov.uk/tools-and-resources/statistics/statistics-by-topic/woodland-statistics/)"
-  - "25% — Chile's national forest definition per [CONAF](https://www.conaf.cl/)"
-  - "30% — Colombia's national forest definition per [IDEAM](https://www.ideam.gov.co/) / UNFCCC REDD+ submission"
-  - "30% — Costa Rica's national forest definition per [FONAFIFO](https://www.fonafifo.go.cr/)"
-  - "30% — [GFW default](https://www.globalforestwatch.org/) (no country-specific definition applied)"
-- If the user does not specify a country or threshold, state "30% — [GFW default](https://www.globalforestwatch.org/)"
-
 GENERATE_INSIGHTS TOOL NOTES:
 - Provide a 1-2 sentence summary of the insights in the response.
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -91,6 +91,27 @@ PICK_DATASET TOOL NOTES:
     2. If the user requests a change in context for a  layer (like drivers, land cover change, data over time, etc.)
 - Warn the user if there is not an exact date match for the dataset, but move forward with the analysis.
 
+TREE COVER THRESHOLD SELECTION (canopy_cover parameter in pull_data):
+- Valid thresholds: 10, 15, 20, 25, 30, 50, 75 (percent canopy density)
+- Default to 30% when unsure or not specified by the user
+- Infer threshold from context using national forest definitions below. The LLM already knows these — trust its knowledge:
+  - 10%: USA (USFS FIA), Canada (NRCan), Brazil (FAO alignment), Mexico, Peru, Argentina, Ecuador, Germany, France, Sweden,
+          Finland, Italy, Norway, India (FSI), Vietnam, Philippines, South Africa, Kenya, Ethiopia, Russia — FAO/UNFCCC standard
+  - 20%: Australia (ABARES), China (national), United Kingdom (Forest Research), Spain
+  - 25%: Chile (CONAF)
+  - 30%: Colombia (IDEAM), Costa Rica (FONAFIFO), DRC, Republic of Congo, Japan, New Zealand — GFW default
+  - 50%: Dense closed-canopy forest analyses; high-density forest filter
+  - 75%: Very dense closed canopy only
+- If the user explicitly names a threshold (e.g. "using 10% canopy cover"), use that value exactly
+- If the user references a country's national forest definition, map to the appropriate threshold
+- If the dataset is Forest greenhouse gas net flux, do NOT set canopy_cover — it is always fixed at 30%
+- When stating the threshold in your response, ALWAYS justify it: name the national agency or framework it comes from
+  (e.g. "10% — India's national forest definition per the Forest Survey of India (FSI)",
+        "20% — Australia's national definition per ABARES",
+        "30% — Colombia's national definition per IDEAM / UNFCCC REDD+ submission",
+        "30% — GFW default (no country-specific definition applied)")
+- If the user does not specify a country or threshold, state "30% (GFW default)"
+
 GENERATE_INSIGHTS TOOL NOTES:
 - Provide a 1-2 sentence summary of the insights in the response.
 

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -37,6 +37,7 @@ class AgentState(TypedDict):
     # pull-data tool
     start_date: str
     end_date: str
+    canopy_cover: int
     statistics: Annotated[list[Statistics], operator.add]
 
     # generate-insights tool

--- a/src/agent/tools/canopy_cover.py
+++ b/src/agent/tools/canopy_cover.py
@@ -1,0 +1,259 @@
+"""
+Country-level canopy cover threshold lookup.
+
+Maps ISO 3166-1 alpha-3 country codes to the national forest definition
+threshold used by that country (or the FAO/UNFCCC standard where the country
+has adopted it without publishing a distinct definition).
+
+Threshold resolution priority (see resolve_canopy_cover):
+  1. Explicit user override — user said "use 20% canopy cover"
+  2. Country-specific lookup — first gadm country-level AOI in state
+  3. GFW default (30%)
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class CountryThresholdEntry(TypedDict):
+    threshold: int
+    citation: str
+
+
+DEFAULT_THRESHOLD = 30
+DEFAULT_CITATION = (
+    "[GFW default](https://www.globalforestwatch.org/); "
+    "no country-specific definition applied"
+)
+
+# ISO 3166-1 alpha-3 → {"threshold": int, "citation": markdown_str}
+COUNTRY_THRESHOLDS: dict[str, CountryThresholdEntry] = {
+    # ── 10%: FAO/UNFCCC standard, broadly adopted ──────────────────────────
+    "USA": {
+        "threshold": 10,
+        "citation": (
+            "USA national forest definition per the "
+            "[USFS Forest Inventory and Analysis (FIA)](https://www.fia.fs.usda.gov/)"
+        ),
+    },
+    "CAN": {
+        "threshold": 10,
+        "citation": (
+            "Canada's national forest definition per "
+            "[Natural Resources Canada (NRCan)](https://natural-resources.canada.ca/"
+            "our-natural-resources/forests/state-canadas-forests-report/"
+            "how-does-canada-define-forest/17639)"
+        ),
+    },
+    "BRA": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/) "
+            "(≥10% canopy cover, ≥0.5 ha, ≥5 m height)"
+        ),
+    },
+    "MEX": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "PER": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "ARG": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "ECU": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "DEU": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "FRA": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "SWE": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "FIN": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "ITA": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "NOR": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "IND": {
+        "threshold": 10,
+        "citation": (
+            "India's national forest definition per the "
+            "[Forest Survey of India (FSI)](https://fsi.nic.in/)"
+        ),
+    },
+    "VNM": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "PHL": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "ZAF": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "KEN": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "ETH": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    "RUS": {
+        "threshold": 10,
+        "citation": (
+            "[FAO/UNFCCC standard forest definition](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    # ── 20% ────────────────────────────────────────────────────────────────
+    "AUS": {
+        "threshold": 20,
+        "citation": (
+            "Australia's national forest definition per "
+            "[ABARES](https://www.agriculture.gov.au/abares/forestsaustralia/"
+            "forest-data-maps-and-tools/forest-definition)"
+        ),
+    },
+    "CHN": {
+        "threshold": 20,
+        "citation": "China's national forest definition (≥20% canopy cover)",
+    },
+    "GBR": {
+        "threshold": 20,
+        "citation": (
+            "UK national forest definition per "
+            "[Forest Research](https://www.forestresearch.gov.uk/tools-and-resources/"
+            "statistics/statistics-by-topic/woodland-statistics/)"
+        ),
+    },
+    "ESP": {
+        "threshold": 20,
+        "citation": (
+            "Spain's national forest definition per "
+            "[FAO Global Forest Resources Assessment](https://www.fao.org/forestry/fra/en/)"
+        ),
+    },
+    # ── 25% ────────────────────────────────────────────────────────────────
+    "CHL": {
+        "threshold": 25,
+        "citation": (
+            "Chile's national forest definition per [CONAF](https://www.conaf.cl/)"
+        ),
+    },
+    # ── 30%: country-specific definitions that match GFW default ───────────
+    "COL": {
+        "threshold": 30,
+        "citation": (
+            "Colombia's national forest definition per "
+            "[IDEAM](https://www.ideam.gov.co/) / UNFCCC REDD+ submission"
+        ),
+    },
+    "CRI": {
+        "threshold": 30,
+        "citation": (
+            "Costa Rica's national forest definition per "
+            "[FONAFIFO](https://www.fonafifo.go.cr/)"
+        ),
+    },
+    "COD": {
+        "threshold": 30,
+        "citation": "DRC forest definition per UNFCCC REDD+ submission",
+    },
+    "COG": {
+        "threshold": 30,
+        "citation": DEFAULT_CITATION,
+    },
+    "JPN": {
+        "threshold": 30,
+        "citation": DEFAULT_CITATION,
+    },
+    "NZL": {
+        "threshold": 30,
+        "citation": DEFAULT_CITATION,
+    },
+}
+
+
+def resolve_canopy_cover(
+    aois: list[dict],
+    explicit: int | None = None,
+) -> tuple[int, str]:
+    """Resolve the canopy cover threshold and citation for a query.
+
+    Priority:
+      1. Explicit user override — if the user directly named a threshold, use it.
+      2. Country-level lookup — ISO3 src_id from the first gadm country AOI in
+         ``aois``. Sub-national or non-gadm AOIs are not matched (defaults to 30%).
+      3. GFW default (30%).
+
+    Args:
+        aois: List of AOI dicts from ``state["aoi_selection"]["aois"]``.
+        explicit: User-specified threshold (the ``canopy_cover`` parameter on
+            the ``pull_data`` tool), or ``None`` when not provided.
+
+    Returns:
+        ``(threshold, citation_markdown)`` — threshold as an int, citation as a
+        markdown string suitable for inclusion in the agent response.
+    """
+    if explicit is not None:
+        return explicit, "user-specified threshold"
+
+    for aoi in aois:
+        if aoi.get("source") == "gadm" and aoi.get("subtype") == "country":
+            iso3 = aoi.get("src_id", "")
+            entry = COUNTRY_THRESHOLDS.get(iso3)
+            if entry:
+                return entry["threshold"], entry["citation"]
+
+    return DEFAULT_THRESHOLD, DEFAULT_CITATION

--- a/src/agent/tools/data_handlers/analytics_handler.py
+++ b/src/agent/tools/data_handlers/analytics_handler.py
@@ -192,6 +192,7 @@ class AnalyticsHandler(DataSourceHandler):
         aois: list[dict],
         start_date: str,
         end_date: str,
+        canopy_cover: int = 30,
     ) -> Dict:
         """Build the API payload based on dataset type"""
         # Base payload structure common to all endpoints
@@ -276,7 +277,7 @@ class AnalyticsHandler(DataSourceHandler):
                 **base_payload,
                 "start_year": start_date[:4],
                 "end_year": end_date[:4],
-                "canopy_cover": 30,
+                "canopy_cover": canopy_cover,
                 "forest_filter": None,
                 "intersections": (
                     [dataset["context_layer"]]
@@ -297,6 +298,7 @@ class AnalyticsHandler(DataSourceHandler):
                 "forest_filter": None,
             }
         elif dataset.get("dataset_id") == FOREST_CARBON_FLUX_ID:
+            # Forest Carbon Flux threshold is fixed at 30% and cannot be changed
             payload = {
                 **base_payload,
                 "canopy_cover": 30,
@@ -304,7 +306,7 @@ class AnalyticsHandler(DataSourceHandler):
         elif dataset.get("dataset_id") == TREE_COVER_ID:
             payload = {
                 **base_payload,
-                "canopy_cover": 30,
+                "canopy_cover": canopy_cover,
                 "forest_filter": None,
             }
         elif dataset.get("dataset_id") == SLUC_EMISSION_FACTORS_ID:
@@ -434,6 +436,7 @@ class AnalyticsHandler(DataSourceHandler):
         end_date: str,
         change_over_time_query: bool,
         aois: list[dict],
+        canopy_cover: int = 30,
     ) -> DataPullResult:
         # SLUC emission factors are only available for GADM levels 0, 1, and 2
         if (
@@ -481,7 +484,7 @@ class AnalyticsHandler(DataSourceHandler):
 
             # Build the payload based on dataset type
             payload = await self._build_payload(
-                dataset, aois, start_date, end_date
+                dataset, aois, start_date, end_date, canopy_cover
             )
 
             # Debug logging for payload

--- a/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
+++ b/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
@@ -37,8 +37,7 @@ selection_hints: 'Shows net greenhouse gas flux from forests — balance between
   '
 code_instructions: 'CHART TYPES: - Net flux → split/diverging bar chart (emissions positive y-axis, removals negative) DATA
   RULES: - Values are TOTALS over model period 2001-2024 — present them as totals, NOT annual values - Do NOT divide by 24
-  in code — keep the raw period totals - Do NOT pre-calculate or present annual averages - 30% canopy density threshold (fixed,
-  cannot be changed) - Units: MgCO2e (tonnes of CO2 equivalent) DO/DON''T: - DO NOT show trends over time or annual values
+  in code — keep the raw period totals - Do NOT pre-calculate or present annual averages - THRESHOLD: ALWAYS print "Canopy cover threshold: 30% (fixed — cannot be changed for this dataset)" at the start of the analysis output AND in the chart title - Units: MgCO2e (tonnes of CO2 equivalent) DO/DON''T: - DO NOT show trends over time or annual values
   — this is a single-period aggregate - DO NOT attempt timeseries charts - Use "net sink" for net-negative flux (removals
   > emissions) - Use "net source" for net-positive flux (emissions > removals)
 

--- a/src/agent/tools/datasets/tree_cover.yml
+++ b/src/agent/tools/datasets/tree_cover.yml
@@ -46,10 +46,13 @@ code_instructions: "CHART TYPES: - Tree cover area by canopy-density bin → bar
   \  (c) This recommendation is REQUIRED, not optional\n"
 presentation_instructions: 'This is a year 2000 baseline snapshot — clarify the date to users. Use "tree cover" not "forest"
   unless primary forest or IFL layer is active. Tree cover includes plantations, not just natural forest. Always state the
-  canopy density threshold used AND justify it with the relevant national or international definition and its authoritative
-  source (e.g. "10% — India''s national forest definition per the Forest Survey of India (FSI)",
-  "20% — Australia''s national definition per ABARES",
-  "30% — GFW default; no country-specific definition applied").
+  canopy density threshold used AND justify it with the relevant national or international definition, its authoritative
+  source, AND a markdown hyperlink to the official definition or report (e.g.
+  "10% — India''s national forest definition per the [Forest Survey of India (FSI)](https://fsi.nic.in/)",
+  "10% — [FAO/UNFCCC standard definition](https://www.fao.org/forestry/fra/en/)",
+  "20% — Australia''s national definition per [ABARES](https://www.agriculture.gov.au/abares/forestsaustralia/forest-data-maps-and-tools/forest-definition)",
+  "25% — Chile''s national definition per [CONAF](https://www.conaf.cl/)",
+  "30% — [GFW default](https://www.globalforestwatch.org/); no country-specific definition applied").
   For change analysis, direct to Tree Cover Loss or Tree Cover Gain datasets.
 
   '

--- a/src/agent/tools/datasets/tree_cover.yml
+++ b/src/agent/tools/datasets/tree_cover.yml
@@ -26,7 +26,7 @@ prompt_instructions: 'Shows tree cover area (area_ha) per pixel for year 2000 wi
   to describe results. Otherwise, only use the term ''tree cover''. Binned % tree cover extent can be reported in bar chart
   or pie chart. When calculating area in bins, exclude tree cover area = 0 (and specify that the exclusion has happened).
   Use the tree cover loss and gain data for data on change in tree area. Cannot be used to asses pixel-level percent changes
-  (gains and losses).
+  (gains and losses). Use the appropriate canopy cover threshold for the context (default 30%); always state the threshold used.
 
   '
 selection_hints: 'Single-year snapshot of tree cover canopy density for year 2000 only. Vegetation >5m height including natural
@@ -37,15 +37,20 @@ selection_hints: 'Single-year snapshot of tree cover canopy density for year 200
   '
 code_instructions: "CHART TYPES: - Tree cover area by canopy-density bin → bar chart or pie chart - Values MUST be area in\
   \ hectares (ha), NOT percentages or proportions DATA RULES: - Year 2000 data only — single snapshot - Exclude rows where\
-  \ area_ha = 0 (and note that exclusion has happened) - All areas in hectares (ha) — do NOT convert to percentages DO/DON'T:\
-  \ - Do NOT use the term \"forest\" unless primary_forest or intact_forest variable is active —\n  use \"tree cover\" instead\n\
-  - This is a SINGLE YEAR (2000) snapshot — do NOT attempt timeseries - Cannot assess pixel-level percent changes (gains/losses)\
-  \ TEMPORAL CONSTRAINT: - If user asks about change, trends, or temporal patterns: you MUST include ALL of:\n  (a) State\
-  \ that this dataset cannot show change — it is a single year 2000 snapshot\n  (b) Recommend Tree Cover Loss and Tree Cover\
-  \ Gain datasets by name\n  (c) This recommendation is REQUIRED, not optional\n"
+  \ area_ha = 0 (and note that exclusion has happened) - All areas in hectares (ha) — do NOT convert to percentages - Use\
+  \ THRESHOLD: extract the canopy cover threshold from the query (e.g. 10%, 30%); if not specified, use 30%. ALWAYS print 'Canopy cover threshold: X% (source)' at the start of the analysis output AND include it in the chart title. If no source was specified, write 30% (GFW default). DO/DON'T: - Do NOT use the term \"forest\"\
+  \ unless primary_forest or intact_forest variable is active —\n  use \"tree cover\" instead\n- This is a SINGLE YEAR (2000)\
+  \ snapshot — do NOT attempt timeseries - Cannot assess pixel-level percent changes (gains/losses) TEMPORAL CONSTRAINT: -\
+  \ If user asks about change, trends, or temporal patterns: you MUST include ALL of:\n  (a) State that this dataset cannot\
+  \ show change — it is a single year 2000 snapshot\n  (b) Recommend Tree Cover Loss and Tree Cover Gain datasets by name\n\
+  \  (c) This recommendation is REQUIRED, not optional\n"
 presentation_instructions: 'This is a year 2000 baseline snapshot — clarify the date to users. Use "tree cover" not "forest"
-  unless primary forest or IFL layer is active. Tree cover includes plantations, not just natural forest. For change analysis,
-  direct to Tree Cover Loss or Tree Cover Gain datasets.
+  unless primary forest or IFL layer is active. Tree cover includes plantations, not just natural forest. Always state the
+  canopy density threshold used AND justify it with the relevant national or international definition and its authoritative
+  source (e.g. "10% — India''s national forest definition per the Forest Survey of India (FSI)",
+  "20% — Australia''s national definition per ABARES",
+  "30% — GFW default; no country-specific definition applied").
+  For change analysis, direct to Tree Cover Loss or Tree Cover Gain datasets.
 
   '
 description: 'Tree Cover (Hansen/UMD/GLAD) provides global percent tree canopy cover at 30-meter resolution for the years

--- a/src/agent/tools/datasets/tree_cover_loss.yml
+++ b/src/agent/tools/datasets/tree_cover_loss.yml
@@ -51,11 +51,14 @@ code_instructions: 'CHART TYPES: - Yearly loss → bar chart (x=year, y=area_ha)
   '
 presentation_instructions: 'Use "tree cover loss" not "deforestation" — tree cover includes plantations, not just natural
   forest. This measures canopy loss only; it doesn''t track regrowth or permanence. Always state the canopy density threshold
-  used AND justify it with the relevant national or international definition and its authoritative source (e.g.
-  "10% — India''s national forest definition per the Forest Survey of India (FSI)",
-  "20% — Australia''s national definition per ABARES",
-  "30% — Colombia''s REDD+ submission to the UNFCCC (IDEAM)",
-  "30% — GFW default; no country-specific definition applied").
+  used AND justify it with the relevant national or international definition, its authoritative source, AND a markdown
+  hyperlink to the official definition or report (e.g.
+  "10% — India''s national forest definition per the [Forest Survey of India (FSI)](https://fsi.nic.in/)",
+  "10% — [FAO/UNFCCC standard definition](https://www.fao.org/forestry/fra/en/)",
+  "20% — Australia''s national definition per [ABARES](https://www.agriculture.gov.au/abares/forestsaustralia/forest-data-maps-and-tools/forest-definition)",
+  "25% — Chile''s national definition per [CONAF](https://www.conaf.cl/)",
+  "30% — Colombia''s national definition per [IDEAM](https://www.ideam.gov.co/) / UNFCCC REDD+ submission",
+  "30% — [GFW default](https://www.globalforestwatch.org/); no country-specific definition applied").
   If showing emissions, clarify units are MgCO2e (tonnes of CO2 equivalent). If trend spans 2001-2024, note the
   methodology change after 2010.
 

--- a/src/agent/tools/datasets/tree_cover_loss.yml
+++ b/src/agent/tools/datasets/tree_cover_loss.yml
@@ -28,7 +28,7 @@ prompt_instructions: 'Reports gross annual loss of tree cover ≥ 5 m height (20
   methodology so comparisons between, and trends across the periods 2001-2010 and 2011-2024 should be performed with caution.
   DO NOT use the term "deforestation", use "tree cover loss" instead since "Tree cover" includes plantations as well as natural
   forest meaning loss is not automatically deforestation or carbon loss. The product measures canopy loss only; it doesn''t
-  track regrowth or permanence. Use 30% threshold. If a user asks for net gain/loss, refuse and explain that the methodologies
+  track regrowth or permanence. Use the appropriate canopy cover threshold for the context (default 30%); always state the threshold used. If a user asks for net gain/loss, refuse and explain that the methodologies
   for the two datasets differ and thus they cannot be combined directly to calculate net change. DO NOT show emissions and
   loss in the same chart, use separate charts.
 
@@ -42,7 +42,7 @@ selection_hints: 'Best dataset for annual tree cover loss questions (2001-2024) 
   '
 code_instructions: 'CHART TYPES: - Yearly loss → bar chart (x=year, y=area_ha) - Cumulative loss → stacked-area chart - Emissions
   → MUST be a SEPARATE chart from loss area (NEVER combine on same chart) DATA RULES: - Always include GHG emissions (MgCO2e)
-  alongside loss area, but in a SEPARATE chart - Drop rows where area_ha = 0 - Use 30% canopy density threshold - If primary_forest
+  alongside loss area, but in a SEPARATE chart - Drop rows where area_ha = 0 - THRESHOLD: extract the canopy cover threshold from the query (e.g. "10%", "30%"); if not specified, use 30%. ALWAYS print "Canopy cover threshold: X% (<source>)" at the start of the analysis output AND include it in the chart title. If no source was specified, write "30% (GFW default)". - If primary_forest
   or intact_forest variable is active, filter accordingly DO/DON''T: - DO NOT use the term "deforestation" — always use "tree
   cover loss" - If user asks for intra-year or seasonal breakdown, REFUSE — data is annual only - If user asks for net gain/loss,
   REFUSE — methodologies differ between loss and gain datasets - Warn about 2001-2010 vs 2011-2024 methodology difference
@@ -51,7 +51,12 @@ code_instructions: 'CHART TYPES: - Yearly loss → bar chart (x=year, y=area_ha)
   '
 presentation_instructions: 'Use "tree cover loss" not "deforestation" — tree cover includes plantations, not just natural
   forest. This measures canopy loss only; it doesn''t track regrowth or permanence. Always state the canopy density threshold
-  used (30%). If showing emissions, clarify units are MgCO2e (tonnes of CO2 equivalent). If trend spans 2001-2024, note the
+  used AND justify it with the relevant national or international definition and its authoritative source (e.g.
+  "10% — India''s national forest definition per the Forest Survey of India (FSI)",
+  "20% — Australia''s national definition per ABARES",
+  "30% — Colombia''s REDD+ submission to the UNFCCC (IDEAM)",
+  "30% — GFW default; no country-specific definition applied").
+  If showing emissions, clarify units are MgCO2e (tonnes of CO2 equivalent). If trend spans 2001-2024, note the
   methodology change after 2010.
 
   '

--- a/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
+++ b/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
@@ -52,7 +52,10 @@ selection_hints: 'Use when user asks WHY tree cover was lost — attributes loss
   other natural disturbances.
 
   '
-code_instructions: "CHART TYPES: - Driver breakdown → pie chart or table ONLY - DO NOT attempt a timeseries — this is a single-period\
+code_instructions: "THRESHOLD (MANDATORY FIRST STEP): Extract the canopy cover threshold from the query (e.g. 10%, 30%);\
+  \ if not specified, use 30%. You MUST print 'Canopy cover threshold: X% (source)' as the FIRST LINE of the analysis output\
+  \ AND include it in the chart title or caption. If no source was specified, write 30% (GFW default). This step is required\
+  \ — do not skip it.\nCHART TYPES: - Driver breakdown → pie chart or table ONLY - DO NOT attempt a timeseries — this is a single-period\
   \ aggregate (2001-2024) DATA RULES: - Exclude the \"Unknown\" driver class from analysis - Show area_ha or emissions (MgCO2e)\
   \ per driver class for the full period 2001-2024 - 7 driver classes:\n  1. Permanent agriculture — long-term, permanent\
   \ tree cover loss for agriculture\n  2. Hard commodities — loss due to mining or energy infrastructure\n  3. Shifting cultivation\

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -125,6 +125,7 @@ def build_analysis_prompt(
     dataset_guidelines: str = "",
     code_instructions: str | None = None,
     context_layer: str | None = None,
+    canopy_cover: int = 30,
 ) -> str:
     """
     Build the analysis prompt for the code executor.
@@ -153,9 +154,13 @@ def build_analysis_prompt(
         header = "### DATASET-SPECIFIC RULES (follow these strictly):\n"
         if context_layer:
             header += f"Active context layer: {context_layer}\n"
+        threshold_override = (
+            f"THRESHOLD USED FOR DATA FETCH: {canopy_cover}% — "
+            f"use this exact value in your output. Do not infer from the query.\n"
+        )
         dataset_rules_section = f"""
 {header}
-{code_instructions}
+{threshold_override}{code_instructions}
 
 ---
 """
@@ -346,6 +351,7 @@ async def generate_insights(
         dataset_guidelines=dataset_guidelines,
         code_instructions=code_instructions,
         context_layer=dataset.get("context_layer"),
+        canopy_cover=state.get("canopy_cover", 30),
     )
     logger.debug(f"Analysis prompt:\n{analysis_prompt}")
 

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -193,6 +193,8 @@ async def pull_data(
         tool_call_id=tool_call_id,
     )
 
+    resolved_canopy_cover = canopy_cover if canopy_cover is not None else 30
+
     return Command(
         update={
             "statistics": [
@@ -210,6 +212,7 @@ async def pull_data(
             # TODO: This is deprecated, remove it in the future
             "start_date": effective_start,
             "end_date": effective_end,
+            "canopy_cover": resolved_canopy_cover,
             "messages": [tool_message],
         },
     )

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Annotated, Dict
+from typing import Annotated, Dict, Optional
 
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
@@ -31,6 +31,7 @@ class DataPullOrchestrator:
         end_date: str,
         change_over_time_query: bool,
         aois: list[dict],
+        canopy_cover: int = 30,
     ) -> DataPullResult:
         """Pull data using the appropriate handler"""
 
@@ -44,6 +45,7 @@ class DataPullOrchestrator:
                     dataset=dataset,
                     start_date=start_date,
                     end_date=end_date,
+                    canopy_cover=canopy_cover,
                 )
 
         return DataPullResult(
@@ -95,6 +97,7 @@ async def pull_data(
     start_date: str,
     end_date: str,
     change_over_time_query: bool,
+    canopy_cover: Optional[int] = None,
     tool_call_id: Annotated[str, InjectedToolCallId] = None,
     state: Annotated[Dict, InjectedState] = None,
 ) -> Command:
@@ -110,6 +113,9 @@ async def pull_data(
         start_date: Start date in YYYY-MM-DD format
         end_date: End date in YYYY-MM-DD format
         change_over_time_query: Whether the query is about change over time. If it is about composition or current status, return False. If it is about dynamics or change, return True.
+        canopy_cover: Tree cover canopy density threshold as a percentage (e.g. 10, 15, 20, 25, 30, 50, 75).
+            Infer from user context or country forest definitions. Defaults to 30 when not specified.
+            Note: Forest greenhouse gas net flux dataset ignores this and always uses 30%.
     """
     dataset = state["dataset"]
     aoi_names = [a["name"] for a in state["aoi_selection"]["aois"]]
@@ -143,6 +149,7 @@ async def pull_data(
         end_date=effective_end,
         change_over_time_query=change_over_time_query,
         aois=state["aoi_selection"]["aois"],
+        canopy_cover=canopy_cover if canopy_cover is not None else 30,
     )
 
     # Create tool message

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -122,7 +122,7 @@ async def pull_data(
     dataset = state["dataset"]
     aois = state["aoi_selection"]["aois"]
     aoi_names = [a["name"] for a in aois]
-    resolved_canopy_cover, _ = resolve_canopy_cover(aois, explicit=canopy_cover)
+    resolved_canopy_cover, canopy_cover_citation = resolve_canopy_cover(aois, explicit=canopy_cover)
     logger.info(
         f"PULL-DATA-TOOL: AOI: {aoi_names}, Dataset: {dataset.get('dataset_name', '')}, "
         f"Start Date: {start_date}, End Date: {end_date}, canopy_cover: {resolved_canopy_cover}%"
@@ -191,6 +191,16 @@ async def pull_data(
         tool_messages.append(
             f"Date range was adjusted to the dataset's available range: {effective_start} to {effective_end} "
             f"(requested: {start_date} to {end_date})."
+        )
+
+    _canopy_cover_datasets = {
+        "Tree cover loss",
+        "Tree cover loss by dominant driver",
+        "Tree cover",
+    }
+    if dataset.get("dataset_name") in _canopy_cover_datasets:
+        tool_messages.append(
+            f"Canopy cover threshold: {resolved_canopy_cover}% — {canopy_cover_citation}"
         )
 
     tool_message = ToolMessage(

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -7,6 +7,7 @@ from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
+from src.agent.tools.canopy_cover import resolve_canopy_cover
 from src.agent.tools.data_handlers.analytics_handler import AnalyticsHandler
 from src.agent.tools.data_handlers.base import DataPullResult
 from src.agent.tools.datasets_config import DATASETS
@@ -114,13 +115,17 @@ async def pull_data(
         end_date: End date in YYYY-MM-DD format
         change_over_time_query: Whether the query is about change over time. If it is about composition or current status, return False. If it is about dynamics or change, return True.
         canopy_cover: Tree cover canopy density threshold as a percentage (e.g. 10, 15, 20, 25, 30, 50, 75).
-            Infer from user context or country forest definitions. Defaults to 30 when not specified.
-            Note: Forest greenhouse gas net flux dataset ignores this and always uses 30%.
+            Only set this if the user explicitly requests a specific threshold (e.g. "use 20% canopy cover").
+            When omitted, the threshold is resolved automatically from the country's national forest
+            definition. Note: Forest greenhouse gas net flux always uses 30% regardless of this value.
     """
     dataset = state["dataset"]
-    aoi_names = [a["name"] for a in state["aoi_selection"]["aois"]]
+    aois = state["aoi_selection"]["aois"]
+    aoi_names = [a["name"] for a in aois]
+    resolved_canopy_cover, _ = resolve_canopy_cover(aois, explicit=canopy_cover)
     logger.info(
-        f"PULL-DATA-TOOL: AOI: {aoi_names}, Dataset: {dataset.get('dataset_name', '')}, Start Date: {start_date}, End Date: {end_date}"
+        f"PULL-DATA-TOOL: AOI: {aoi_names}, Dataset: {dataset.get('dataset_name', '')}, "
+        f"Start Date: {start_date}, End Date: {end_date}, canopy_cover: {resolved_canopy_cover}%"
     )
 
     effective_start, effective_end, range_clamped = await revise_date_range(
@@ -148,8 +153,8 @@ async def pull_data(
         start_date=effective_start,
         end_date=effective_end,
         change_over_time_query=change_over_time_query,
-        aois=state["aoi_selection"]["aois"],
-        canopy_cover=canopy_cover if canopy_cover is not None else 30,
+        aois=aois,
+        canopy_cover=resolved_canopy_cover,
     )
 
     # Create tool message
@@ -192,8 +197,6 @@ async def pull_data(
         content="|".join(tool_messages) if tool_messages else "No data pulled",
         tool_call_id=tool_call_id,
     )
-
-    resolved_canopy_cover = canopy_cover if canopy_cover is not None else 30
 
     return Command(
         update={

--- a/tests/evals/judge.py
+++ b/tests/evals/judge.py
@@ -6,6 +6,7 @@ Every judgment logs: query, rubric, tool_output summary, judge prompt,
 judge raw response, verdict, and comment.
 """
 
+import base64
 import json
 import logging
 import uuid
@@ -49,12 +50,13 @@ JUDGE_PROMPT = """You are evaluating whether an AI-generated data visualization 
 ### Insight Text
 {insight_text}
 
-### Generated Code (summary)
-{generated_code}
+### Analysis Text Output (printed during code execution)
+{text_output}
 
 ## Instructions
 Evaluate whether the actual output satisfies EACH requirement in the rubric.
 For each requirement, state whether it is MET or NOT MET with a brief reason.
+Note: "printed output" in the rubric refers to the Analysis Text Output section above.
 
 Then give an overall verdict: PASS if ALL requirements are met, FAIL if ANY is not met.
 
@@ -90,7 +92,7 @@ async def judge_output(query: str, rubric: str, tool_output: dict) -> Verdict:
         chart_type=tool_output.get("chart_type", "(unknown)"),
         chart_data_preview=chart_data_preview,
         insight_text=tool_output.get("insight", "(no insight)"),
-        generated_code=tool_output.get("code", "(no code)")[:2000],
+        text_output=tool_output.get("text_output", "(no text output)")[:3000],
     )
 
     # Build a summary of what the tool produced (for logging, not sent to judge)
@@ -218,14 +220,28 @@ async def run_generate_insights(query: str, state: dict) -> dict:
         result["chart_data"] = chart.get("data", [])
         result["insight"] = chart.get("insight", "")
 
-    # Extract code from codeact_parts
+    # Extract code and text_output from codeact_parts (content is base64-encoded)
     codeact_parts = update.get("codeact_parts", [])
     code_parts = []
+    text_output_parts = []
     for part in codeact_parts:
-        if isinstance(part, dict) and part.get("type") == "code_block":
-            code_parts.append(part.get("content", ""))
-        elif hasattr(part, "type") and str(part.type) == "code_block":
-            code_parts.append(getattr(part, "content", ""))
+        if isinstance(part, dict):
+            part_type = part.get("type", "")
+            raw_content = part.get("content", "")
+        elif hasattr(part, "type"):
+            part_type = str(part.type)
+            raw_content = getattr(part, "content", "")
+        else:
+            continue
+        try:
+            content = base64.b64decode(raw_content).decode("utf-8")
+        except Exception:
+            content = raw_content
+        if part_type == "code_block":
+            code_parts.append(content)
+        elif part_type == "text_output":
+            text_output_parts.append(content)
     result["code"] = "\n".join(code_parts)
+    result["text_output"] = "\n".join(text_output_parts)
 
     return result

--- a/tests/evals/test_threshold_citations.py
+++ b/tests/evals/test_threshold_citations.py
@@ -1,0 +1,309 @@
+"""
+Eval tests: country-specific threshold selection with citation justification.
+
+These tests verify that generate_insights correctly:
+  1. Uses the threshold implied by the country context in the query
+  2. States that threshold in the output
+  3. Cites the authoritative national source for the definition
+
+Data is deterministic (pre-baked). Only LLM calls are live.
+
+Country reference (from national UNFCCC/FAO submissions):
+  10%: India (FSI), USA (USFS FIA), Canada (NRCan), Kenya, Ethiopia, South Africa
+  20%: Australia (ABARES), UK (Forest Research), China, Spain
+  25%: Chile (CONAF)
+  30%: Colombia (IDEAM), DRC (UNFCCC REDD+), Japan, New Zealand, GFW default
+"""
+
+import pytest
+
+from src.agent.state import Statistics
+from src.agent.tools.datasets_config import DATASETS as _ALL_DATASETS
+from tests.evals.fixture_data import TCL_STATE, TREE_COVER_STATE
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_DS_BY_ID = {ds["dataset_id"]: ds for ds in _ALL_DATASETS}
+
+
+def _dataset_fields(dataset_id: int, context_layer=None) -> dict:
+    ds = _DS_BY_ID[dataset_id]
+    result = {
+        "dataset_id": ds["dataset_id"],
+        "dataset_name": ds["dataset_name"],
+        "context_layer": context_layer,
+        "tile_url": ds.get("tile_url", ""),
+        "analytics_api_endpoint": ds.get("analytics_api_endpoint", ""),
+        "description": ds.get("description", ""),
+        "prompt_instructions": ds.get("prompt_instructions", ""),
+        "methodology": ds.get("methodology", ""),
+        "cautions": ds.get("cautions", ""),
+        "function_usage_notes": ds.get("function_usage_notes", ""),
+        "citation": ds.get("citation", ""),
+    }
+    for field in ("selection_hints", "code_instructions", "presentation_instructions"):
+        val = ds.get(field)
+        if val:
+            result[field] = val
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Shared data shape — reused across country fixtures (only aoi/source differs)
+# ---------------------------------------------------------------------------
+
+def _tcl_state(aoi_name: str, aoi_id: str, source_suffix: str) -> dict:
+    return {
+        "dataset": _dataset_fields(4),
+        "statistics": [
+            Statistics(
+                dataset_name="Tree cover loss",
+                source_url=f"http://example.com/analytics/tcl-{source_suffix}",
+                start_date="2015-01-01",
+                end_date="2022-12-31",
+                aoi_names=[aoi_name],
+                data={
+                    "year": [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022],
+                    "area_ha": [
+                        120000, 135000, 118000, 142000,
+                        155000, 148000, 161000, 143000,
+                    ],
+                    "emissions_MgCO2e": [
+                        53000, 60000, 52000, 63000,
+                        69000, 65000, 71000, 63000,
+                    ],
+                    "aoi_id": [aoi_id] * 8,
+                    "aoi_type": ["admin"] * 8,
+                },
+            )
+        ],
+    }
+
+
+_INDIA_TCL_STATE = _tcl_state("India", "IND", "india")
+_AUSTRALIA_TCL_STATE = _tcl_state("Australia", "AUS", "australia")
+_COLOMBIA_TCL_STATE = _tcl_state("Colombia", "COL", "colombia")
+_DRC_TCL_STATE = _tcl_state("Democratic Republic of the Congo", "COD", "drc")
+_CHILE_TCL_STATE = _tcl_state("Chile", "CHL", "chile")
+_USA_TCL_STATE = _tcl_state("United States", "USA", "usa")
+_KENYA_TCL_STATE = _tcl_state("Kenya", "KEN", "kenya")
+_JAPAN_TCL_STATE = _tcl_state("Japan", "JPN", "japan")
+
+
+# ---------------------------------------------------------------------------
+# 10% threshold countries
+# ---------------------------------------------------------------------------
+
+
+async def test_india_uses_10pct_threshold_with_fsi_citation(run_insights, judge):
+    """India: 10% threshold, cited to Forest Survey of India (FSI)."""
+    query = (
+        "Show tree cover loss in India from 2015 to 2022. "
+        "Use India's national forest definition (10% canopy cover threshold, "
+        "per the Forest Survey of India)."
+    )
+    result = await run_insights(query, _INDIA_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 10% canopy density threshold.
+        - It must NOT state 30% as the threshold for this analysis.
+        - Acceptable forms: "10%", "10 percent canopy cover", "10% canopy threshold".
+        - Ideally the output references the Forest Survey of India (FSI) or India's national
+          definition, but a plain "10%" mention is sufficient — citations may appear in the
+          agent's conversational response rather than the chart insight text.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_usa_uses_10pct_threshold_with_usfs_citation(run_insights, judge):
+    """USA: 10% threshold, cited to USFS Forest Inventory and Analysis (FIA)."""
+    query = (
+        "Show tree cover loss in the United States from 2015 to 2022. "
+        "Apply the US national forest definition (10% canopy cover, "
+        "per USFS Forest Inventory and Analysis)."
+    )
+    result = await run_insights(query, _USA_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 10% canopy density threshold.
+        - It must NOT state 30% as the threshold for this analysis.
+        - Ideally the output references USFS, FIA, or the US national definition, but a
+          plain "10%" mention is sufficient.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_kenya_uses_10pct_threshold_with_fao_citation(run_insights, judge):
+    """Kenya: 10% threshold aligned with FAO/UNFCCC standard."""
+    query = (
+        "Show tree cover loss in Kenya from 2015 to 2022. "
+        "Using 10% canopy cover threshold (Kenya's national definition, "
+        "aligned with FAO Global Forest Resources Assessment guidelines)."
+    )
+    result = await run_insights(query, _KENYA_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 10% canopy density threshold.
+        - It must NOT state 30% as the threshold for this analysis.
+        - Ideally the output references FAO, UNFCCC REDD+, or Kenya's national definition,
+          but a plain "10%" mention is sufficient.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+# ---------------------------------------------------------------------------
+# 20% threshold countries
+# ---------------------------------------------------------------------------
+
+
+async def test_australia_uses_20pct_threshold_with_abares_citation(run_insights, judge):
+    """Australia: 20% threshold, cited to ABARES."""
+    query = (
+        "Show tree cover loss in Australia from 2015 to 2022. "
+        "Use Australia's national forest definition (20% canopy cover, ≥2m height, "
+        "per ABARES Forests Australia)."
+    )
+    result = await run_insights(query, _AUSTRALIA_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 20% canopy density threshold.
+        - It must NOT state 30% as the threshold.
+        - Ideally the output references ABARES or Forests Australia, but a plain "20%"
+          mention is sufficient.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+# ---------------------------------------------------------------------------
+# 25% threshold countries
+# ---------------------------------------------------------------------------
+
+
+async def test_chile_uses_25pct_threshold_with_conaf_citation(run_insights, judge):
+    """Chile: 25% threshold, cited to CONAF."""
+    query = (
+        "Show tree cover loss in Chile from 2015 to 2022. "
+        "Use Chile's national forest definition (25% canopy cover, "
+        "per CONAF — Corporación Nacional Forestal)."
+    )
+    result = await run_insights(query, _CHILE_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 25% canopy density threshold.
+        - It must NOT state 30% as the threshold for this analysis.
+        - Ideally the output references CONAF or Chile's national definition, but a plain
+          "25%" mention is sufficient.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+# ---------------------------------------------------------------------------
+# 30% threshold countries (non-default reasons)
+# ---------------------------------------------------------------------------
+
+
+async def test_colombia_uses_30pct_threshold_with_ideam_citation(run_insights, judge):
+    """Colombia: 30% threshold, cited to IDEAM / UNFCCC REDD+."""
+    query = (
+        "Show tree cover loss in Colombia from 2015 to 2022. "
+        "Use Colombia's national forest definition (30% canopy cover, ≥1 ha, ≥5m height, "
+        "per IDEAM and Colombia's UNFCCC REDD+ submission)."
+    )
+    result = await run_insights(query, _COLOMBIA_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 30% canopy density threshold.
+        - Ideally the output references IDEAM or Colombia's national definition, but a
+          plain "30%" mention is sufficient.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_drc_uses_30pct_threshold_with_redd_citation(run_insights, judge):
+    """DRC: 30% threshold, cited to UNFCCC REDD+ submission."""
+    query = (
+        "Show tree cover loss in the Democratic Republic of the Congo from 2015 to 2022. "
+        "Use DRC's forest definition (30% canopy cover threshold established for REDD+ "
+        "monitoring per the UNFCCC REDD+ Hub)."
+    )
+    result = await run_insights(query, _DRC_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 30% canopy density threshold.
+        - Ideally the output references DRC's REDD+ definition or the UNFCCC REDD+ Hub,
+          but a plain "30%" mention is acceptable — citations may appear in the agent's
+          conversational response rather than the chart insight text.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_japan_uses_30pct_threshold_with_kyoto_citation(run_insights, judge):
+    """Japan: 30% threshold, cited to UNFCCC / Kyoto Protocol reporting."""
+    query = (
+        "Show tree cover loss in Japan from 2015 to 2022. "
+        "Use Japan's forest definition (30% canopy cover per the Forestry Agency of Japan "
+        "and UNFCCC National Inventory reporting)."
+    )
+    result = await run_insights(query, _JAPAN_TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 30% canopy density threshold.
+        - Ideally the output references the Forestry Agency of Japan or UNFCCC National
+          Inventory reporting, but a plain "30%" mention is sufficient — citations may
+          appear in the agent's conversational response rather than the chart insight text.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+# ---------------------------------------------------------------------------
+# Default (no country-specific definition) — must state "GFW default"
+# ---------------------------------------------------------------------------
+
+
+async def test_default_threshold_cites_gfw_default(run_insights, judge):
+    """When no country-specific definition applies, insight must say 30% is the GFW default.
+
+    The agent selects 30% (GFW default) and passes that context to generate_insights
+    via the query — we include it here to mirror that realistic flow.
+    """
+    query = (
+        "Show tree cover loss in Pará, Brazil from 2015 to 2022. "
+        "Using the 30% canopy cover threshold (GFW default — no country-specific "
+        "definition applies here)."
+    )
+    result = await run_insights(query, TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 30% canopy density threshold.
+        - Ideally the output indicates this is the GFW default (e.g. "30% (GFW default)",
+          "standard GFW threshold of 30%"), but a plain "30%" or "30% canopy cover" mention
+          in the output text or chart title is sufficient.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment

--- a/tests/evals/test_threshold_presentation.py
+++ b/tests/evals/test_threshold_presentation.py
@@ -1,0 +1,270 @@
+"""
+Eval tests: canopy cover threshold presentation in generate_insights output.
+
+These tests verify that the LLM (via generate_insights) correctly follows the
+updated dataset instructions around threshold disclosure:
+
+  - TCL and Tree Cover insights must state the canopy threshold used
+  - Forest Carbon Flux must mention the fixed 30% threshold
+  - When the query carries explicit threshold context (e.g. country definition),
+    the insight must reflect that threshold
+
+Data side is deterministic (pre-baked fixtures). Only LLM calls are live.
+"""
+
+import copy
+
+import pytest
+
+from src.agent.state import Statistics
+from src.agent.tools.datasets_config import DATASETS as _ALL_DATASETS
+from tests.evals.fixture_data import GHG_FLUX_STATE, TCL_STATE, TREE_COVER_STATE
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_DS_BY_ID = {ds["dataset_id"]: ds for ds in _ALL_DATASETS}
+
+
+def _dataset_fields(dataset_id: int, context_layer=None) -> dict:
+    """Replicate the helper from fixture_data to build dataset state dicts."""
+    ds = _DS_BY_ID[dataset_id]
+    result = {
+        "dataset_id": ds["dataset_id"],
+        "dataset_name": ds["dataset_name"],
+        "context_layer": context_layer,
+        "tile_url": ds.get("tile_url", ""),
+        "analytics_api_endpoint": ds.get("analytics_api_endpoint", ""),
+        "description": ds.get("description", ""),
+        "prompt_instructions": ds.get("prompt_instructions", ""),
+        "methodology": ds.get("methodology", ""),
+        "cautions": ds.get("cautions", ""),
+        "function_usage_notes": ds.get("function_usage_notes", ""),
+        "citation": ds.get("citation", ""),
+    }
+    for field in ("selection_hints", "code_instructions", "presentation_instructions"):
+        val = ds.get(field)
+        if val:
+            result[field] = val
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fixture: TCL state for India (represents a 10% threshold query context)
+# The data itself is the same shape, but the query will carry the India context
+# so the model must mention 10% not 30%.
+# ---------------------------------------------------------------------------
+_TCL_INDIA_STATE = {
+    "dataset": _dataset_fields(4),
+    "statistics": [
+        Statistics(
+            dataset_name="Tree cover loss",
+            source_url="http://example.com/analytics/tcl-india-eval",
+            start_date="2018-01-01",
+            end_date="2023-12-31",
+            aoi_names=["India"],
+            data={
+                "year": [2018, 2019, 2020, 2021, 2022, 2023],
+                "area_ha": [165432, 183210, 172345, 158901, 189023, 176543],
+                "emissions_MgCO2e": [73456, 81345, 76543, 70456, 83901, 78345],
+                "aoi_id": ["IND"] * 6,
+                "aoi_type": ["admin"] * 6,
+            },
+        )
+    ],
+}
+
+# TCL by Driver state — Indonesia, driver breakdown
+_TCL_DRIVER_THRESHOLD_STATE = {
+    "dataset": _dataset_fields(8, context_layer="driver"),
+    "statistics": [
+        Statistics(
+            dataset_name="Tree cover loss by dominant driver",
+            source_url="http://example.com/analytics/tcl-driver-threshold-eval",
+            start_date="2001-01-01",
+            end_date="2024-12-31",
+            aoi_names=["Indonesia"],
+            data={
+                "driver": [
+                    "Permanent agriculture",
+                    "Shifting cultivation",
+                    "Logging",
+                    "Wildfire",
+                    "Hard commodities",
+                ],
+                "area_ha": [4523100, 3214500, 2876400, 1543200, 234500],
+                "emissions_MgCO2e": [2012340, 1423560, 1278900, 687450, 104230],
+                "aoi_id": ["IDN"] * 5,
+                "aoi_type": ["admin"] * 5,
+            },
+        )
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_tcl_default_insight_mentions_threshold(run_insights, judge):
+    """generate_insights must mention the 30% threshold for default TCL analysis."""
+    query = "How much tree cover was lost in Pará, Brazil between 2015 and 2022?"
+    result = await run_insights(query, TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight text or output must explicitly mention the canopy density threshold
+          (30% is the default and expected value here).
+        - The threshold mention may appear as "30%", "30 percent", or "30% canopy density".
+        - It is acceptable if it appears in the chart title, caption, or summary text.
+        - The output must NOT omit the threshold entirely.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_tcl_chart_caption_includes_threshold(run_insights, judge):
+    """TCL chart code should reference the canopy threshold in its title or caption.
+
+    The agent selects 30% (GFW default) and passes it in the query to generate_insights.
+    """
+    query = (
+        "Show annual tree cover loss in Pará, Brazil from 2015 to 2022. "
+        "Using 30% canopy cover threshold (GFW default)."
+    )
+    result = await run_insights(query, TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The generated Python code or chart output must include a reference to the
+          canopy density threshold, either in the chart title, subtitle, or a caption/annotation.
+        - Acceptable: title contains "30%", subtitle says "canopy threshold: 30%",
+          or a note in the printed output mentions the threshold.
+        - The insight text alone is sufficient if it explicitly names the threshold.
+        - The output must NOT be completely silent about the threshold.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_tcl_india_query_context_threshold(run_insights, judge):
+    """When the query explicitly states 10% threshold (India definition), the insight must reflect it.
+
+    In real usage the agent selects 10% based on India's national forest definition
+    and passes it to pull_data. Here we inject that context via the query so
+    generate_insights receives it and must acknowledge it.
+    """
+    query = (
+        "Show tree cover loss in India from 2018 to 2023. "
+        "This analysis uses a 10% canopy cover threshold, "
+        "consistent with India's national forest definition."
+    )
+    result = await run_insights(query, _TCL_INDIA_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the 10% canopy density threshold.
+        - It must NOT incorrectly state that 30% was used (30% is the global default
+          but 10% was explicitly provided in the query for this analysis).
+        - Acceptable forms: "10%", "10 percent canopy cover", "10% threshold".
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_ghg_flux_mentions_fixed_threshold(run_insights, judge):
+    """Forest Carbon Flux insight must state the 30% threshold is fixed."""
+    query = "What is the forest greenhouse gas net flux for Brazil?"
+    result = await run_insights(query, GHG_FLUX_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight must mention the 30% canopy density threshold.
+        - The insight should indicate the threshold is fixed and cannot be changed
+          (phrases like "fixed", "cannot be changed", or "fixed at 30%" are acceptable).
+        - The threshold disclosure may appear in the insight text, chart caption, or
+          the printed analysis output.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_tree_cover_insight_mentions_threshold(run_insights, judge):
+    """Tree Cover 2000 baseline insight must state the canopy threshold used.
+
+    DRC uses 30% (UNFCCC REDD+ definition). The agent passes this in the query.
+    """
+    query = (
+        "What was the tree cover extent in the Democratic Republic of Congo in 2000? "
+        "Using 30% canopy cover threshold (DRC national definition per UNFCCC REDD+ Hub)."
+    )
+    result = await run_insights(query, TREE_COVER_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the canopy density threshold (30% default).
+        - Acceptable: "30%", "30 percent", "30% canopy cover", "30% threshold".
+        - The threshold may appear in insight text, chart title, or printed output.
+        - The output must NOT omit the threshold entirely.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_tcl_by_driver_mentions_threshold(run_insights, judge):
+    """TCL by driver breakdown must state the canopy threshold used.
+
+    Indonesia uses 30% (GFW default). The agent passes this in the query.
+    """
+    query = (
+        "What are the main drivers of tree cover loss in Indonesia from 2001 to 2024? "
+        "This analysis uses the 30% canopy cover threshold (GFW default). "
+        "State the threshold in the output."
+    )
+    result = await run_insights(query, _TCL_DRIVER_THRESHOLD_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The insight or output must mention the canopy density threshold used.
+        - 30% is the expected default value.
+        - Acceptable forms: "30%", "30 percent canopy", "canopy threshold: 30%".
+        - The threshold may appear in the insight, chart title, or printed output.
+        - The output must NOT be completely silent about which threshold was applied.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment
+
+
+async def test_tcl_does_not_use_term_deforestation(run_insights, judge):
+    """
+    Sanity check: TCL insight must use "tree cover loss" as the primary term.
+
+    Included here to confirm that adding threshold instructions did not inadvertently
+    break the existing "use tree cover loss not deforestation" rule.
+
+    Note: mentioning "deforestation" to explain the distinction (e.g. "tree cover loss
+    does not always equate to permanent deforestation") is acceptable and encouraged.
+    """
+    query = "How much forest was lost in Pará, Brazil between 2015 and 2022?"
+    result = await run_insights(query, TCL_STATE)
+    verdict = await judge(
+        query,
+        """
+        - The primary term used to describe the phenomenon must be "tree cover loss",
+          not "deforestation".
+        - The output must NOT use "deforestation" as a synonym for or primary label of
+          the data (e.g. "X ha of deforestation occurred" is NOT acceptable).
+        - It IS acceptable — even good — to mention "deforestation" when explaining the
+          distinction from tree cover loss (e.g. "tree cover loss does not always equate
+          to permanent deforestation", "not all loss represents deforestation").
+        - Check that the insight frames the data as tree cover loss, not as deforestation.
+        """,
+        result,
+    )
+    assert verdict.passed, verdict.comment

--- a/tests/tools/test_canopy_cover_lookup.py
+++ b/tests/tools/test_canopy_cover_lookup.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for the canopy cover country lookup table and resolve_canopy_cover().
+
+All tests are synchronous and require no network, database, or LLM calls.
+"""
+
+import pytest
+
+from src.agent.tools.canopy_cover import (
+    COUNTRY_THRESHOLDS,
+    DEFAULT_CITATION,
+    DEFAULT_THRESHOLD,
+    resolve_canopy_cover,
+)
+
+# Override DB fixtures — these tests have no database dependency
+@pytest.fixture(scope="function", autouse=True)
+def test_db():
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_session():
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_pool():
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helper AOI factories
+# ---------------------------------------------------------------------------
+
+
+def _country_aoi(iso3: str, name: str = "Country") -> dict:
+    return {"source": "gadm", "subtype": "country", "src_id": iso3, "name": name}
+
+
+def _state_aoi(src_id: str = "123", name: str = "State") -> dict:
+    return {"source": "gadm", "subtype": "state", "src_id": src_id, "name": name}
+
+
+def _wdpa_aoi(src_id: str = "456", name: str = "Protected Area") -> dict:
+    return {"source": "wdpa", "subtype": "wdpa", "src_id": src_id, "name": name}
+
+
+# ---------------------------------------------------------------------------
+# resolve_canopy_cover: explicit override
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitOverride:
+    def test_explicit_beats_country_lookup(self):
+        """An explicit threshold overrides the country mapping."""
+        aois = [_country_aoi("IND")]
+        threshold, citation = resolve_canopy_cover(aois, explicit=25)
+        assert threshold == 25
+        assert citation == "user-specified threshold"
+
+    def test_explicit_beats_default(self):
+        """An explicit threshold overrides the GFW default even with unknown country."""
+        aois = [_country_aoi("ZZZ")]  # unknown ISO3
+        threshold, citation = resolve_canopy_cover(aois, explicit=15)
+        assert threshold == 15
+        assert citation == "user-specified threshold"
+
+    def test_explicit_zero_is_not_treated_as_falsy(self):
+        """explicit=0 is technically falsy in Python; ensure it's handled as int check."""
+        # 0 is not a valid GFW threshold, but the function should respect any non-None int.
+        aois = [_country_aoi("IND")]
+        threshold, citation = resolve_canopy_cover(aois, explicit=0)
+        assert threshold == 0
+        assert citation == "user-specified threshold"
+
+
+# ---------------------------------------------------------------------------
+# resolve_canopy_cover: country lookup
+# ---------------------------------------------------------------------------
+
+
+class TestCountryLookup:
+    """Known countries must resolve to their national forest definition threshold."""
+
+    @pytest.mark.parametrize(
+        "iso3, expected_threshold",
+        [
+            # 10%
+            ("IND", 10),
+            ("USA", 10),
+            ("CAN", 10),
+            ("BRA", 10),
+            ("MEX", 10),
+            ("PER", 10),
+            ("ARG", 10),
+            ("ECU", 10),
+            ("DEU", 10),
+            ("FRA", 10),
+            ("SWE", 10),
+            ("FIN", 10),
+            ("ITA", 10),
+            ("NOR", 10),
+            ("VNM", 10),
+            ("PHL", 10),
+            ("ZAF", 10),
+            ("KEN", 10),
+            ("ETH", 10),
+            ("RUS", 10),
+            # 20%
+            ("AUS", 20),
+            ("CHN", 20),
+            ("GBR", 20),
+            ("ESP", 20),
+            # 25%
+            ("CHL", 25),
+            # 30%
+            ("COL", 30),
+            ("CRI", 30),
+            ("COD", 30),
+            ("COG", 30),
+            ("JPN", 30),
+            ("NZL", 30),
+        ],
+    )
+    def test_known_country_threshold(self, iso3, expected_threshold):
+        aois = [_country_aoi(iso3)]
+        threshold, citation = resolve_canopy_cover(aois)
+        assert threshold == expected_threshold, (
+            f"{iso3}: expected {expected_threshold}%, got {threshold}%"
+        )
+        assert citation, f"{iso3}: citation must not be empty"
+
+    def test_india_citation_references_fsi(self):
+        """India's citation must point to the Forest Survey of India."""
+        _, citation = resolve_canopy_cover([_country_aoi("IND")])
+        assert "Forest Survey of India" in citation
+        assert "fsi.nic.in" in citation
+
+    def test_usa_citation_references_fia(self):
+        _, citation = resolve_canopy_cover([_country_aoi("USA")])
+        assert "FIA" in citation or "Forest Inventory" in citation
+
+    def test_australia_citation_references_abares(self):
+        _, citation = resolve_canopy_cover([_country_aoi("AUS")])
+        assert "ABARES" in citation
+
+    def test_chile_citation_references_conaf(self):
+        _, citation = resolve_canopy_cover([_country_aoi("CHL")])
+        assert "CONAF" in citation
+
+    def test_colombia_citation_references_ideam(self):
+        _, citation = resolve_canopy_cover([_country_aoi("COL")])
+        assert "IDEAM" in citation
+
+
+# ---------------------------------------------------------------------------
+# resolve_canopy_cover: fallback to GFW default
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultFallback:
+    def test_unknown_country_returns_default(self):
+        aois = [_country_aoi("ZZZ")]
+        threshold, citation = resolve_canopy_cover(aois)
+        assert threshold == DEFAULT_THRESHOLD
+        assert citation == DEFAULT_CITATION
+
+    def test_empty_aois_returns_default(self):
+        threshold, citation = resolve_canopy_cover([])
+        assert threshold == DEFAULT_THRESHOLD
+        assert citation == DEFAULT_CITATION
+
+    def test_sub_national_aoi_returns_default(self):
+        """State-level AOIs must not match the country lookup."""
+        aois = [_state_aoi("12345")]
+        threshold, citation = resolve_canopy_cover(aois)
+        assert threshold == DEFAULT_THRESHOLD
+
+    def test_wdpa_aoi_returns_default(self):
+        """Protected-area AOIs must not match the country lookup."""
+        aois = [_wdpa_aoi("67890")]
+        threshold, citation = resolve_canopy_cover(aois)
+        assert threshold == DEFAULT_THRESHOLD
+
+    def test_no_aoi_arg_returns_default(self):
+        threshold, citation = resolve_canopy_cover([], explicit=None)
+        assert threshold == DEFAULT_THRESHOLD
+        assert citation == DEFAULT_CITATION
+
+
+# ---------------------------------------------------------------------------
+# resolve_canopy_cover: multi-AOI lists (subregion queries)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiAOI:
+    def test_first_country_aoi_wins(self):
+        """When multiple country AOIs are present, the first one is used."""
+        aois = [_country_aoi("IND"), _country_aoi("AUS")]
+        threshold, _ = resolve_canopy_cover(aois)
+        assert threshold == 10  # India's threshold
+
+    def test_country_aoi_found_after_state_aois(self):
+        """Country AOI later in list is still found (state AOIs are skipped)."""
+        aois = [_state_aoi("1"), _state_aoi("2"), _country_aoi("AUS")]
+        threshold, _ = resolve_canopy_cover(aois)
+        assert threshold == 20  # Australia's threshold
+
+    def test_mixed_sources_finds_gadm_country(self):
+        aois = [_wdpa_aoi(), _country_aoi("CHL")]
+        threshold, _ = resolve_canopy_cover(aois)
+        assert threshold == 25
+
+
+# ---------------------------------------------------------------------------
+# COUNTRY_THRESHOLDS data integrity
+# ---------------------------------------------------------------------------
+
+
+class TestLookupTableIntegrity:
+    def test_all_thresholds_are_valid_gfw_values(self):
+        """Every threshold must be a value the GFW analytics API accepts."""
+        valid = {10, 15, 20, 25, 30, 50, 75}
+        for iso3, entry in COUNTRY_THRESHOLDS.items():
+            assert entry["threshold"] in valid, (
+                f"{iso3}: threshold {entry['threshold']} is not a valid GFW value"
+            )
+
+    def test_all_entries_have_citation(self):
+        for iso3, entry in COUNTRY_THRESHOLDS.items():
+            assert entry.get("citation"), f"{iso3}: citation must not be empty"
+
+    def test_all_iso3_codes_are_three_letters(self):
+        for iso3 in COUNTRY_THRESHOLDS:
+            assert len(iso3) == 3 and iso3.isupper(), (
+                f"'{iso3}' is not a valid ISO 3166-1 alpha-3 code"
+            )
+
+    def test_default_threshold_is_30(self):
+        assert DEFAULT_THRESHOLD == 30
+
+    def test_default_citation_references_gfw(self):
+        assert "globalforestwatch.org" in DEFAULT_CITATION

--- a/tests/tools/test_canopy_cover_threshold.py
+++ b/tests/tools/test_canopy_cover_threshold.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for canopy cover threshold support in analytics_handler and pull_data.
+
+These tests are purely deterministic — no LLM calls, no HTTP calls.
+They verify that:
+  1. _build_payload uses the passed canopy_cover for TCL, Tree Cover, and TCL by Driver
+  2. Forest Carbon Flux always uses 30% regardless of the canopy_cover argument
+  3. DataPullOrchestrator and the pull_data tool correctly thread canopy_cover through
+
+Database access is not needed and is overridden to no-ops.
+"""
+
+import inspect
+
+import pytest
+
+from src.agent.tools.data_handlers.analytics_handler import AnalyticsHandler
+from src.agent.tools.datasets_config import DATASETS
+from src.agent.tools.pull_data import DataPullOrchestrator, pull_data
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+# Override DB fixtures — these tests don't need the database
+@pytest.fixture(scope="function", autouse=True)
+def test_db():
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_session():
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_pool():
+    pass
+
+
+_DS_BY_NAME = {ds["dataset_name"]: ds for ds in DATASETS}
+
+# Minimal admin AOI that doesn't require DB or geometry lookups
+_BRAZIL_ADMIN_AOI = {
+    "subtype": "country",
+    "src_id": "BRA",
+    "name": "Brazil",
+}
+
+_HANDLER = AnalyticsHandler()
+
+
+def _dataset(name: str, context_layer=None) -> dict:
+    """Return a copy of a dataset dict with context_layer set."""
+    ds = dict(_DS_BY_NAME[name])
+    ds["context_layer"] = context_layer
+    return ds
+
+
+# ---------------------------------------------------------------------------
+# _build_payload: canopy_cover is forwarded for tree cover datasets
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPayloadCanopyCover:
+    """_build_payload must use the canopy_cover kwarg for variable-threshold datasets."""
+
+    async def test_tcl_default_is_30(self):
+        """Tree Cover Loss uses 30% when canopy_cover is not specified."""
+        payload = await _HANDLER._build_payload(
+            _dataset("Tree cover loss"),
+            [_BRAZIL_ADMIN_AOI],
+            "2020-01-01",
+            "2022-12-31",
+        )
+        assert payload["canopy_cover"] == 30
+
+    @pytest.mark.parametrize("threshold", [10, 15, 20, 25, 50, 75])
+    async def test_tcl_uses_specified_threshold(self, threshold):
+        """Tree Cover Loss uses the exact threshold passed in."""
+        payload = await _HANDLER._build_payload(
+            _dataset("Tree cover loss"),
+            [_BRAZIL_ADMIN_AOI],
+            "2020-01-01",
+            "2022-12-31",
+            canopy_cover=threshold,
+        )
+        assert payload["canopy_cover"] == threshold
+
+    @pytest.mark.parametrize("threshold", [10, 15, 25, 50])
+    async def test_tcl_by_driver_uses_specified_threshold(self, threshold):
+        """Tree Cover Loss by Dominant Driver uses the exact threshold passed in."""
+        payload = await _HANDLER._build_payload(
+            _dataset("Tree cover loss by dominant driver"),
+            [_BRAZIL_ADMIN_AOI],
+            "2020-01-01",
+            "2022-12-31",
+            canopy_cover=threshold,
+        )
+        assert payload["canopy_cover"] == threshold
+
+    @pytest.mark.parametrize("threshold", [10, 15, 25, 50])
+    async def test_tree_cover_uses_specified_threshold(self, threshold):
+        """Tree Cover (2000 baseline) uses the exact threshold passed in."""
+        payload = await _HANDLER._build_payload(
+            _dataset("Tree cover"),
+            [_BRAZIL_ADMIN_AOI],
+            "2000-01-01",
+            "2000-12-31",
+            canopy_cover=threshold,
+        )
+        assert payload["canopy_cover"] == threshold
+
+    @pytest.mark.parametrize("threshold", [10, 15, 20, 25, 50, 75])
+    async def test_forest_carbon_flux_always_30(self, threshold):
+        """Forest Carbon Flux always uses 30%, regardless of input threshold.
+
+        This dataset has a fixed threshold that cannot be changed per the API
+        and dataset documentation.
+        """
+        payload = await _HANDLER._build_payload(
+            _dataset("Forest greenhouse gas net flux"),
+            [_BRAZIL_ADMIN_AOI],
+            "2001-01-01",
+            "2024-12-31",
+            canopy_cover=threshold,
+        )
+        assert payload["canopy_cover"] == 30, (
+            f"Forest Carbon Flux must always use 30%, got {payload['canopy_cover']} "
+            f"when canopy_cover={threshold} was requested"
+        )
+
+    async def test_tcl_intersections_present_with_context_layer(self):
+        """When context_layer is set, intersections are included alongside canopy_cover."""
+        payload = await _HANDLER._build_payload(
+            _dataset("Tree cover loss by dominant driver", context_layer="driver"),
+            [_BRAZIL_ADMIN_AOI],
+            "2020-01-01",
+            "2022-12-31",
+            canopy_cover=10,
+        )
+        assert payload["canopy_cover"] == 10
+        assert payload["intersections"] == ["driver"]
+
+
+# ---------------------------------------------------------------------------
+# Signature checks: canopy_cover is present with correct defaults
+# ---------------------------------------------------------------------------
+
+
+class TestSignatures:
+    """Verify canopy_cover is plumbed through every layer of the call stack.
+
+    These are synchronous checks — no async needed.
+    """
+
+    # Override the module-level asyncio mark for this class
+    pytestmark = []
+
+    def test_build_payload_has_canopy_cover_param(self):
+        sig = inspect.signature(AnalyticsHandler._build_payload)
+        assert "canopy_cover" in sig.parameters
+        assert sig.parameters["canopy_cover"].default == 30
+
+    def test_analytics_handler_pull_data_has_canopy_cover_param(self):
+        sig = inspect.signature(AnalyticsHandler.pull_data)
+        assert "canopy_cover" in sig.parameters
+        assert sig.parameters["canopy_cover"].default == 30
+
+    def test_orchestrator_pull_data_has_canopy_cover_param(self):
+        sig = inspect.signature(DataPullOrchestrator.pull_data)
+        assert "canopy_cover" in sig.parameters
+        assert sig.parameters["canopy_cover"].default == 30
+
+    def test_pull_data_tool_has_canopy_cover_param(self):
+        """The LangChain tool exposes canopy_cover so the LLM can set it."""
+        # StructuredTool stores the underlying coroutine in .coroutine
+        underlying = pull_data.coroutine
+        sig = inspect.signature(underlying)
+        assert "canopy_cover" in sig.parameters
+        # Optional — defaults to None so the tool layer defaults to 30
+        assert sig.parameters["canopy_cover"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Default propagation: None → 30 at the tool boundary
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPropagation:
+    """None passed to the tool should be interpreted as the 30% default.
+
+    The pull_data tool function accepts canopy_cover=None (Optional[int]) and
+    must normalise it to 30 before forwarding to the orchestrator.
+    We verify this by checking the orchestrator receives the correct default
+    through a mocked handler.
+    """
+
+    async def test_orchestrator_default_canopy_cover_propagates_to_handler(self):
+        """Orchestrator passes canopy_cover=30 to handler by default."""
+        captured = {}
+
+        class _MockHandler:
+            def can_handle(self, _dataset):
+                return True
+
+            async def pull_data(self, **kwargs):
+                captured["canopy_cover"] = kwargs.get("canopy_cover")
+                from src.agent.tools.data_handlers.base import DataPullResult
+
+                return DataPullResult(
+                    success=True,
+                    data={"data": []},
+                    message="mock",
+                    data_points_count=0,
+                    analytics_api_url="http://example.com",
+                )
+
+        orchestrator = DataPullOrchestrator()
+        orchestrator.handlers = [_MockHandler()]
+
+        await orchestrator.pull_data(
+            query="test",
+            dataset={"dataset_id": 99, "dataset_name": "mock"},
+            start_date="2020-01-01",
+            end_date="2022-12-31",
+            change_over_time_query=False,
+            aois=[_BRAZIL_ADMIN_AOI],
+            # canopy_cover intentionally omitted — should default to 30
+        )
+        assert captured["canopy_cover"] == 30
+
+    async def test_orchestrator_custom_canopy_cover_propagates_to_handler(self):
+        """Orchestrator forwards an explicit canopy_cover value to the handler."""
+        captured = {}
+
+        class _MockHandler:
+            def can_handle(self, _dataset):
+                return True
+
+            async def pull_data(self, **kwargs):
+                captured["canopy_cover"] = kwargs.get("canopy_cover")
+                from src.agent.tools.data_handlers.base import DataPullResult
+
+                return DataPullResult(
+                    success=True,
+                    data={"data": []},
+                    message="mock",
+                    data_points_count=0,
+                    analytics_api_url="http://example.com",
+                )
+
+        orchestrator = DataPullOrchestrator()
+        orchestrator.handlers = [_MockHandler()]
+
+        await orchestrator.pull_data(
+            query="test",
+            dataset={"dataset_id": 99, "dataset_name": "mock"},
+            start_date="2020-01-01",
+            end_date="2022-12-31",
+            change_over_time_query=False,
+            aois=[_BRAZIL_ADMIN_AOI],
+            canopy_cover=10,
+        )
+        assert captured["canopy_cover"] == 10

--- a/tests/tools/test_canopy_cover_threshold.py
+++ b/tests/tools/test_canopy_cover_threshold.py
@@ -16,6 +16,7 @@ import pytest
 
 from src.agent.tools.data_handlers.analytics_handler import AnalyticsHandler
 from src.agent.tools.datasets_config import DATASETS
+from src.agent.tools.generate_insights import build_analysis_prompt
 from src.agent.tools.pull_data import DataPullOrchestrator, pull_data
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
@@ -261,3 +262,92 @@ class TestDefaultPropagation:
             canopy_cover=10,
         )
         assert captured["canopy_cover"] == 10
+
+
+# ---------------------------------------------------------------------------
+# build_analysis_prompt: canopy_cover override appears in the prompt
+# ---------------------------------------------------------------------------
+
+_TCL_CODE_INSTRUCTIONS = (
+    'THRESHOLD: extract the canopy cover threshold from the query (e.g. "10%", "30%"); '
+    'if not specified, use 30%. ALWAYS print "Canopy cover threshold: X% (<source>)" '
+    "at the start of the analysis output AND include it in the chart title. "
+    'If no source was specified, write "30% (GFW default)".'
+)
+
+
+@pytest.mark.no_cover
+class TestBuildAnalysisPromptCanopyOverride:
+    """build_analysis_prompt must inject the resolved threshold so Gemini
+    cannot fall back to its own inference from the query text."""
+
+    # Pure-function synchronous tests — opt out of the module-level asyncio mark.
+    pytestmark = [pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")]
+
+    def test_override_line_present_for_non_default_threshold(self):
+        """A non-default threshold produces an explicit override line."""
+        prompt = build_analysis_prompt(
+            query="Show tree cover loss in India from 2015 to 2022",
+            file_references="input_file_0.csv",
+            code_instructions=_TCL_CODE_INSTRUCTIONS,
+            canopy_cover=10,
+        )
+        assert "THRESHOLD USED FOR DATA FETCH: 10%" in prompt
+
+    def test_override_line_present_for_default_threshold(self):
+        """The override line is also injected for the 30% default so the
+        instruction is always explicit, not left to inference."""
+        prompt = build_analysis_prompt(
+            query="Show tree cover loss in Brazil from 2015 to 2022",
+            file_references="input_file_0.csv",
+            code_instructions=_TCL_CODE_INSTRUCTIONS,
+            canopy_cover=30,
+        )
+        assert "THRESHOLD USED FOR DATA FETCH: 30%" in prompt
+
+    def test_override_line_precedes_code_instructions(self):
+        """The override must appear before the raw code_instructions so it
+        takes precedence over the 'if not specified, use 30%' fallback."""
+        prompt = build_analysis_prompt(
+            query="Show tree cover loss in India",
+            file_references="input_file_0.csv",
+            code_instructions=_TCL_CODE_INSTRUCTIONS,
+            canopy_cover=10,
+        )
+        override_pos = prompt.index("THRESHOLD USED FOR DATA FETCH: 10%")
+        fallback_pos = prompt.index("if not specified, use 30%")
+        assert override_pos < fallback_pos
+
+    def test_no_override_when_no_code_instructions(self):
+        """When there are no code_instructions the dataset_rules_section is
+        skipped entirely — no spurious override line should appear."""
+        prompt = build_analysis_prompt(
+            query="Show tree cover loss in India",
+            file_references="input_file_0.csv",
+            code_instructions=None,
+            canopy_cover=10,
+        )
+        assert "THRESHOLD USED FOR DATA FETCH" not in prompt
+
+    def test_state_canopy_cover_stored_in_pull_data_command(self):
+        """pull_data resolves canopy_cover=None to 30 and stores it in state."""
+        # Verify the Command update dict contains canopy_cover at the tool level.
+        # We check the source rather than running the full async tool to keep
+        # this test fast and dependency-free.
+        import ast
+        import inspect
+
+        source = inspect.getsource(pull_data.coroutine)
+        tree = ast.parse(source)
+
+        # Find all string constants in the source — "canopy_cover" must appear
+        # as a dict key in the Command(update={...}) call.
+        string_literals = {
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        assert "canopy_cover" in string_literals, (
+            "pull_data must store 'canopy_cover' in the Command update dict "
+            "so generate_insights can read it from state"
+        )


### PR DESCRIPTION
## Summary
                                                                                                 
The agent previously used a hardcoded 30% GFW default canopy cover threshold for all tree cover  
analyses, regardless of country context. This PR makes threshold selection dynamic and proactive: the agent
infers the correct national forest definition from context, applies it to the data fetch, and    
cites the authoritative source with a link in all outputs.

## What changed                                                                                       
Users asking about tree cover in a specific country now get analysis using that country's official forest definition without having to specify the threshold themselves. These are states in the agent instructiosn (see citations below)/.
                                                                                                   
  > "Show tree cover loss in India from 2015 to 2022" → fetches and analyses at 10% (FSI national  
  definition), not 30%
> "Tree cover loss in Australia" → 20% (ABARES)                                                  
> "Forest loss in Chile" → 25% (CONAF)                                                           
> "Tree cover loss in Colombia" → 30% (IDEAM/UNFCCC REDD+)
                                                                                                   
- Added a canopy_cover parameter to the pull_data tool (LLM-visible), threaded through           
DataPullOrchestrator → AnalyticsHandler → _build_payload()                                       
- Added a TREE COVER THRESHOLD SELECTION block to the system prompt with a country-to-threshold  
lookup table covering ~40 countries/regions               
- Forest GHG net flux remains hardcoded at 30% (API constraint)                                                                                
 
## Citations                                                                                        
Every threshold statement in the response and chart output now includes a named agency and a     
markdown link to the official definition:
                                                                                               
> 10% — India's national forest definition per the Forest Survey of India (FSI)                  
> 30% — Colombia's national definition per IDEAM / UNFCCC REDD+ submission
> 30% — GFW default; no country-specific definition applied                                      
                                                                                                 
## Tests                                                                                            
- 33 unit tests in test_canopy_cover_threshold.py covering payload construction, default  propagation, and prompt override injection                                                       
- Evals in test_threshold_citations.py and test_threshold_presentation.py checking LLM output
quality for threshold selection and citation formatting     