### PR TITLE
Allow triggering tools tests with label

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -2,9 +2,16 @@ name: Tools Tests
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: tools-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-tools-tests')
     runs-on: ubuntu-latest
 
     services:
@@ -64,4 +71,6 @@ jobs:
           COOKIE_SIGNER_SECRET_KEY: fake-cookie-key
           NEXTJS_API_KEY: test-nextjs-api-key
         run: |
+          mkdir -p data
+          uv run python src/ingest/embed_datasets.py
           uv run pytest tests/tools -v

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ Then run the API tests using pytest:
 uv run pytest tests/api/
 ```
 
+### CI (GitHub Actions)
+
+**Lint** (`pre-commit`/`uv`) runs on every push. **Pytest** runs on every pull request with a Postgres service. **`tests/tools`** runs only when the PR has the `run-tools-tests` label or you start the “Tools Tests” workflow manually (it embeds datasets first).
+
 ## CLI User Management
 
 For user administration commands (making users admin, whitelisting emails), see [CLI Documentation](docs/CLI.md).


### PR DESCRIPTION
Allow triggering tools unit tests in CI through adding the `run-tools-tests` on PRs.