### PR TITLE
Vector tile endpoints for aoi selection

### DIFF
--- a/inspect_gfw_pbf_tiles.py
+++ b/inspect_gfw_pbf_tiles.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Download and inspect sample GFW vector PBF tiles.
+
+Uses **static** vector tiles only: ``/{dataset}/{version}/default/{z}/{x}/{y}.pbf``
+(see https://tiles.globalforestwatch.org/openapi.json — StaticVectorTileCacheDatasets).
+No ``/dynamic/`` endpoints.
+
+This script:
+- fetches a sample tile per dataset (scans x/y until one succeeds, unless a seed is set)
+- decodes vector tile layers/features
+- prints a schema-on-tile summary of layer properties
+
+Requires:
+    uv add mapbox-vector-tile
+or:
+    pip install mapbox-vector-tile
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import sys
+import urllib.error
+import urllib.request
+import zlib
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+try:
+    import mapbox_vector_tile
+except ImportError:
+    print(
+        "Missing dependency: mapbox-vector-tile\n"
+        "Install with: uv add mapbox-vector-tile",
+        file=sys.stderr,
+    )
+    raise
+
+
+BASE_URL = "https://tiles.globalforestwatch.org"
+ZOOM_LEVEL = 2
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    name: str
+    version: str = "latest"
+    implementation: str = "default"
+    # Override global zoom when a dataset only has geometry at higher z on static CDN.
+    zoom: Optional[int] = None
+    # Optional (x, y) tried before full scan (avoids huge scans at high z).
+    sample_xy: Optional[Tuple[int, int]] = None
+
+
+TARGET_DATASETS: List[DatasetSpec] = [
+    DatasetSpec("birdlife_key_biodiversity_areas", "v20240903"),
+    # Combined GADM uses v4.1.85 on static; level splits use v4.1.
+    DatasetSpec("gadm_administrative_boundaries", "v4.1.85"),
+    DatasetSpec("gadm_administrative_boundaries_adm0", "v4.1"),
+    DatasetSpec(
+        "gadm_administrative_boundaries_adm0_adm1",
+        "v4.1",
+        zoom=3,
+    ),
+    DatasetSpec(
+        "gadm_administrative_boundaries_adm0_adm1_adm2",
+        "v4.1",
+        zoom=6,
+        sample_xy=(0, 16),
+    ),
+    DatasetSpec("landmark_indigenous_and_community_lands", "latest"),
+    DatasetSpec("wdpa_protected_areas", "latest"),
+]
+
+
+def tile_url(spec: DatasetSpec, z: int, x: int, y: int) -> str:
+    return f"{BASE_URL}/{spec.name}/{spec.version}/{spec.implementation}/{z}/{x}/{y}.pbf"
+
+
+def fetch_tile(url: str, timeout_sec: int = 20) -> bytes:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "project-zeno-next/inspect-gfw-pbf",
+            "Accept": "application/x-protobuf,application/octet-stream,*/*",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout_sec) as response:
+        payload = response.read()
+        content_encoding = (
+            response.headers.get("Content-Encoding") or ""
+        ).lower()
+
+    # GFW tiles are sometimes returned as compressed payloads even for .pbf URLs.
+    # Decode to raw protobuf bytes before passing into mapbox_vector_tile.decode.
+    if content_encoding == "gzip":
+        return gzip.decompress(payload)
+    if content_encoding == "deflate":
+        return zlib.decompress(payload)
+
+    # Fallback for cases where content-encoding header is absent/misconfigured.
+    if payload.startswith(b"\x1f\x8b"):
+        return gzip.decompress(payload)
+    return payload
+
+
+def guess_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "str"
+    if isinstance(value, list):
+        return "list"
+    if isinstance(value, dict):
+        return "dict"
+    return type(value).__name__
+
+
+def print_dataset_header(spec: DatasetSpec) -> None:
+    print("\n" + "=" * 100)
+    print(f"DATASET: {spec.name}")
+    print(f"VERSION: {spec.version}")
+    print(f"IMPLEMENTATION: {spec.implementation}")
+    print("=" * 100)
+
+
+def inspect_decoded_tile(decoded: Dict[str, Any]) -> None:
+    if not decoded:
+        print("No layers decoded from tile.")
+        return
+
+    for layer_name, layer_data in decoded.items():
+        features: List[Dict[str, Any]] = layer_data.get("features", [])
+        extent: Any = layer_data.get("extent")
+        version: Any = layer_data.get("version")
+
+        print(f"\nLayer: {layer_name}")
+        print(f"  Feature count: {len(features)}")
+        if extent is not None:
+            print(f"  Extent: {extent}")
+        if version is not None:
+            print(f"  Vector tile version: {version}")
+
+        if not features:
+            print("  (No features)")
+            continue
+
+        geom_types: Dict[str, int] = defaultdict(int)
+        prop_types: Dict[str, set] = defaultdict(set)
+        sample_values: Dict[str, Any] = {}
+
+        for feature in features:
+            geom_type = feature.get("geometry", {}).get("type", "Unknown")
+            geom_types[geom_type] += 1
+
+            props = feature.get("properties", {})
+            for key, value in props.items():
+                prop_types[key].add(guess_type(value))
+                if key not in sample_values:
+                    sample_values[key] = value
+
+        print("  Geometry types:")
+        for geom_type, count in sorted(geom_types.items(), key=lambda x: x[0]):
+            print(f"    - {geom_type}: {count}")
+
+        print(f"  Property keys ({len(prop_types)}):")
+        for key in sorted(prop_types):
+            types = ", ".join(sorted(prop_types[key]))
+            sample = sample_values.get(key)
+            sample_repr = repr(sample)
+            if len(sample_repr) > 120:
+                sample_repr = sample_repr[:117] + "..."
+            print(f"    - {key}: [{types}] | sample={sample_repr}")
+
+
+def find_first_available_tile(
+    spec: DatasetSpec, default_z: int
+) -> Tuple[str, bytes]:
+    z = spec.zoom if spec.zoom is not None else default_z
+
+    def try_xy(x: int, y: int) -> Tuple[str, bytes] | None:
+        url = tile_url(spec, z, x, y)
+        try:
+            data = fetch_tile(url)
+            if data:
+                return url, data
+        except urllib.error.HTTPError:
+            pass
+        except urllib.error.URLError:
+            pass
+        return None
+
+    if spec.sample_xy is not None:
+        sx, sy = spec.sample_xy
+        hit = try_xy(sx, sy)
+        if hit:
+            return hit
+
+    for x in range(0, 2**z):
+        for y in range(0, 2**z):
+            hit = try_xy(x, y)
+            if hit:
+                return hit
+
+    raise RuntimeError(
+        f"Could not download any z={z} tile for dataset {spec.name}"
+    )
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect sample GFW static vector tiles (default implementation) "
+            "for selected datasets."
+        )
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print decoded tile JSON for each selected sample tile.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    print(
+        "Inspecting GFW static vector tile samples "
+        f"(default zoom z={ZOOM_LEVEL} unless overridden per dataset)..."
+    )
+    for spec in TARGET_DATASETS:
+        print_dataset_header(spec)
+        eff_z = spec.zoom if spec.zoom is not None else ZOOM_LEVEL
+        print(f"Tile zoom for scan: z={eff_z}")
+        try:
+            url, raw = find_first_available_tile(spec, ZOOM_LEVEL)
+            print(f"Sample tile URL: {url}")
+            print(f"Raw size (bytes): {len(raw)}")
+            decoded = mapbox_vector_tile.decode(raw)
+            inspect_decoded_tile(decoded)
+
+            if args.json:
+                print("\nDecoded JSON:")
+                print(json.dumps(decoded, indent=2, default=str)[:20000])
+        except Exception as exc:  # noqa: BLE001
+            print(f"Failed to inspect {spec.name}: {exc}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -1,9 +1,9 @@
 import operator
-from typing import Annotated, Sequence
+from typing import Annotated, Any, Sequence
 
 from langchain_core.messages import BaseMessage
 from langgraph.graph import add_messages
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 from src.agent.tools.code_executors.base import CodeActPart
 
@@ -30,6 +30,8 @@ class AgentState(TypedDict):
     aoi: dict
     subtype: str
     aoi_selection: AOISelection
+    # bbox_wgs84 + optional GFW static MVT filter for Mapbox/GL JS (see aoi_vector_highlight)
+    vector_layer_highlight: NotRequired[dict[str, Any]]
 
     # pick-dataset tool
     dataset: dict

--- a/src/agent/tools/aoi_vector_highlight.py
+++ b/src/agent/tools/aoi_vector_highlight.py
@@ -1,0 +1,387 @@
+"""GFW static vector tile filter + WGS84 bbox hints for pick_aoi UI state.
+
+Static tile URL pattern (no /dynamic/):
+``https://tiles.globalforestwatch.org/{dataset}/{version}/default/{z}/{x}/{y}.pbf``
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+import structlog
+from sqlalchemy import bindparam, text
+
+from src.shared.database import get_connection_from_pool
+from src.shared.geocoding_helpers import (
+    GADM_LEVELS,
+    SOURCE_ID_MAPPING,
+)
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+GFW_TILE_URL_PATTERN = (
+    "https://tiles.globalforestwatch.org/"
+    "{dataset}/{version}/default/{z}/{x}/{y}.pbf"
+)
+
+# GADM: split static caches use v4.1; combined uses v4.1.85 (see inspect_gfw_pbf_tiles).
+_GADM_SPLIT_VERSION = "v4.1"
+_GADM_COMBINED_VERSION = "v4.1.85"
+
+# subtype -> (dataset_name, version, suggested_detail_zoom, sample_xy for docs)
+GADM_GFW_STATIC: dict[str, tuple[str, str, int, tuple[int, int] | None]] = {
+    "country": (
+        "gadm_administrative_boundaries_adm0",
+        _GADM_SPLIT_VERSION,
+        2,
+        None,
+    ),
+    "state-province": (
+        "gadm_administrative_boundaries_adm0_adm1",
+        _GADM_SPLIT_VERSION,
+        3,
+        None,
+    ),
+    "district-county": (
+        "gadm_administrative_boundaries_adm0_adm1_adm2",
+        _GADM_SPLIT_VERSION,
+        6,
+        (0, 16),
+    ),
+    "municipality": (
+        "gadm_administrative_boundaries",
+        _GADM_COMBINED_VERSION,
+        8,
+        None,
+    ),
+    "locality": (
+        "gadm_administrative_boundaries",
+        _GADM_COMBINED_VERSION,
+        9,
+        None,
+    ),
+    "neighbourhood": (
+        "gadm_administrative_boundaries",
+        _GADM_COMBINED_VERSION,
+        10,
+        None,
+    ),
+    "global": (
+        "gadm_administrative_boundaries",
+        _GADM_COMBINED_VERSION,
+        2,
+        None,
+    ),
+}
+
+_NON_GADM_SPECS: dict[str, dict[str, Any]] = {
+    "kba": {
+        "dataset": "birdlife_key_biodiversity_areas",
+        "version": "v20240903",
+        "source_layer": "birdlife_key_biodiversity_areas",
+        "filter_property": "sitrecid",
+        "numeric_ids": True,
+        "zoom": 2,
+    },
+    "landmark": {
+        "dataset": "landmark_indigenous_and_community_lands",
+        "version": "latest",
+        "source_layer": "landmark_indigenous_and_community_lands",
+        # MVT uses gfw_fid; DB primary key is landmark_id — same value in GFW pipelines.
+        "filter_property": "gfw_fid",
+        "numeric_ids": True,
+        "zoom": 2,
+    },
+    "wdpa": {
+        "dataset": "wdpa_protected_areas",
+        "version": "latest",
+        "source_layer": "wdpa_protected_areas",
+        "filter_property": "wdpa_pid",
+        "numeric_ids": False,
+        "zoom": 2,
+    },
+}
+
+
+def _gadm_mvt_prop_for_subtype(subtype: str) -> str | None:
+    if subtype not in GADM_LEVELS and subtype != "global":
+        return None
+    if subtype == "global":
+        return "gid_0"
+    return GADM_LEVELS[subtype]["col_name"].lower()
+
+
+def mapbox_membership_filter(
+    property_name: str, values: List[Any]
+) -> list[Any]:
+    """Mapbox GL expression: feature is highlighted iff property is in values."""
+    if not values:
+        return ["==", ["get", property_name], "__no_match__"]
+    if len(values) == 1:
+        return ["==", ["get", property_name], values[0]]
+    return ["in", ["get", property_name], ["literal", values]]
+
+
+def _coerce_filter_values(
+    raw_ids: List[str], *, as_numbers: bool
+) -> List[Any]:
+    if not as_numbers:
+        return [str(x) for x in raw_ids]
+    out: List[Any] = []
+    for x in raw_ids:
+        try:
+            out.append(int(x))
+        except (TypeError, ValueError):
+            try:
+                out.append(float(x))
+            except (TypeError, ValueError):
+                out.append(str(x))
+    return out
+
+
+def _unique_preserve(ids: List[str]) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    for i in ids:
+        if i in seen:
+            continue
+        seen.add(i)
+        out.append(i)
+    return out
+
+
+def _gfw_static_config_for_gadm(
+    subtype: str, gadm_ids: List[str]
+) -> dict[str, Any] | None:
+    spec = GADM_GFW_STATIC.get(subtype) or GADM_GFW_STATIC["global"]
+    dataset, version, zoom, sample_xy = spec
+    prop = _gadm_mvt_prop_for_subtype(subtype)
+    if prop is None:
+        return None
+    values = _coerce_filter_values(
+        _unique_preserve(gadm_ids), as_numbers=False
+    )
+    filt = mapbox_membership_filter(prop, values)
+    cfg: dict[str, Any] = {
+        "tile_url_pattern": GFW_TILE_URL_PATTERN,
+        "dataset": dataset,
+        "version": version,
+        "implementation": "default",
+        "source_layer": dataset,
+        "filter": filt,
+        "filter_property": prop,
+        "suggested_detail_zoom": zoom,
+    }
+    if sample_xy is not None:
+        cfg["sample_tile_xy"] = list(sample_xy)
+    return cfg
+
+
+def _gfw_static_config_non_gadm(
+    source: str, src_ids: List[str]
+) -> dict[str, Any]:
+    meta = _NON_GADM_SPECS[source]
+    raw_ids = _unique_preserve(src_ids)
+    values = _coerce_filter_values(raw_ids, as_numbers=meta["numeric_ids"])
+    prop = meta["filter_property"]
+    filt = mapbox_membership_filter(prop, values)
+    return {
+        "tile_url_pattern": GFW_TILE_URL_PATTERN,
+        "dataset": meta["dataset"],
+        "version": meta["version"],
+        "implementation": "default",
+        "source_layer": meta["source_layer"],
+        "filter": filt,
+        "filter_property": prop,
+        "suggested_detail_zoom": meta["zoom"],
+    }
+
+
+def _flatten_positions(coords: Any) -> List[tuple[float, float]]:
+    if coords is None:
+        return []
+    if isinstance(coords, (list, tuple)) and len(coords) >= 2:
+        if isinstance(coords[0], (int, float)) and isinstance(
+            coords[1], (int, float)
+        ):
+            return [(float(coords[0]), float(coords[1]))]
+    if isinstance(coords, (list, tuple)):
+        out: List[tuple[float, float]] = []
+        for c in coords:
+            out.extend(_flatten_positions(c))
+        return out
+    return []
+
+
+def bbox_from_geojson_dict(geom: dict[str, Any]) -> List[tuple[float, float]]:
+    gtype = geom.get("type")
+    if gtype == "GeometryCollection":
+        nested = geom.get("geometries") or []
+        pts: List[tuple[float, float]] = []
+        for g in nested:
+            if isinstance(g, dict):
+                pts.extend(bbox_from_geojson_dict(g))
+        return pts
+    return _flatten_positions(geom.get("coordinates"))
+
+
+def bbox_wgs84_from_geojson_geometries(
+    geometries: List[Any],
+) -> dict[str, float] | None:
+    lngs: List[float] = []
+    lats: List[float] = []
+    for item in geometries:
+        if isinstance(item, str):
+            try:
+                body = json.loads(item)
+            except json.JSONDecodeError:
+                continue
+        elif isinstance(item, dict):
+            body = item
+        else:
+            continue
+        for lng, lat in bbox_from_geojson_dict(body):
+            lngs.append(lng)
+            lats.append(lat)
+    if not lngs:
+        return None
+    return {
+        "west": min(lngs),
+        "south": min(lats),
+        "east": max(lngs),
+        "north": max(lats),
+    }
+
+
+async def _fetch_bbox_postgis(
+    table: str, id_column: str, ids: List[str]
+) -> dict[str, float] | None:
+    if not ids:
+        return None
+
+    stmt = text(
+        f"""
+        SELECT
+            MIN(ST_XMin(geometry::geometry)) AS west,
+            MIN(ST_YMin(geometry::geometry)) AS south,
+            MAX(ST_XMax(geometry::geometry)) AS east,
+            MAX(ST_YMax(geometry::geometry)) AS north
+        FROM {table}
+        WHERE "{id_column}" IN :ids
+        """
+    ).bindparams(bindparam("ids", expanding=True))
+
+    async with get_connection_from_pool() as conn:
+
+        def _read(sync_conn):
+            result = sync_conn.execute(stmt, {"ids": list(ids)})
+            return result.mappings().first()
+
+        row = await conn.run_sync(_read)
+    if not row or row["west"] is None:
+        return None
+    return {
+        "west": float(row["west"]),
+        "south": float(row["south"]),
+        "east": float(row["east"]),
+        "north": float(row["north"]),
+    }
+
+
+async def _fetch_bbox_custom(
+    ids: List[str], user_id: str
+) -> dict[str, float] | None:
+    stmt = text(
+        """
+        SELECT geometries
+        FROM custom_areas
+        WHERE id IN :ids AND user_id = :user_id
+        """
+    ).bindparams(bindparam("ids", expanding=True))
+
+    async with get_connection_from_pool() as conn:
+
+        def _read(sync_conn):
+            result = sync_conn.execute(
+                stmt, {"ids": list(ids), "user_id": user_id}
+            )
+            return [r[0] for r in result.fetchall()]
+
+        rows = await conn.run_sync(_read)
+    all_geoms: List[Any] = []
+    for raw in rows:
+        if raw is None:
+            continue
+        if isinstance(raw, list):
+            all_geoms.extend(raw)
+        else:
+            all_geoms.append(raw)
+    return bbox_wgs84_from_geojson_geometries(all_geoms)
+
+
+async def fetch_selection_bbox(aois: list[dict]) -> dict[str, float] | None:
+    if not aois:
+        return None
+    source = aois[0]["source"]
+    if source not in SOURCE_ID_MAPPING:
+        return None
+    ids = _unique_preserve([str(a["src_id"]) for a in aois])
+    mapping = SOURCE_ID_MAPPING[source]
+    table = mapping["table"]
+    id_col = mapping["id_column"]
+    if source == "custom":
+        user_id = structlog.contextvars.get_contextvars().get("user_id")
+        if not user_id:
+            logger.warning("user_id missing for custom area bbox")
+            return None
+        return await _fetch_bbox_custom(ids, str(user_id))
+    return await _fetch_bbox_postgis(table, id_col, ids)
+
+
+def build_gfw_static_layer(aois: list[dict]) -> dict[str, Any] | None:
+    if not aois:
+        return None
+    source = aois[0]["source"]
+    if source == "custom":
+        return None
+    if source == "gadm":
+        subtype = aois[0].get("subtype") or "global"
+        gadm_ids = [str(a["src_id"]) for a in aois]
+        return _gfw_static_config_for_gadm(subtype, gadm_ids)
+    if source in _NON_GADM_SPECS:
+        return _gfw_static_config_non_gadm(
+            source, [str(a["src_id"]) for a in aois]
+        )
+    return None
+
+
+async def build_vector_layer_highlight(
+    aois: list[dict],
+) -> dict[str, Any]:
+    """Payload for LangGraph state / frontend: bbox + optional GFW static layer filter."""
+    if not aois:
+        return {
+            "source": "",
+            "bbox_wgs84": None,
+            "gfw_static_layer": None,
+        }
+    source = str(aois[0]["source"])
+    bbox: dict[str, float] | None = None
+    try:
+        bbox = await fetch_selection_bbox(aois)
+    except Exception:
+        logger.exception("bbox_query_failed", source=source)
+
+    gfw: dict[str, Any] | None = None
+    try:
+        gfw = build_gfw_static_layer(aois)
+    except Exception:
+        logger.exception("gfw_filter_build_failed", source=source)
+
+    return {
+        "source": source,
+        "bbox_wgs84": bbox,
+        "gfw_static_layer": gfw,
+    }

--- a/src/agent/tools/pick_aoi.py
+++ b/src/agent/tools/pick_aoi.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import text
 
 from src.agent.llms import SMALL_MODEL
+from src.agent.tools.aoi_vector_highlight import build_vector_layer_highlight
 from src.agent.tools.selection_name_util import build_selection_name
 from src.shared.database import get_connection_from_pool
 from src.shared.geocoding_helpers import (
@@ -551,12 +552,15 @@ async def pick_aoi(
         match_names, subregion, len(final_aois)
     )
 
+    vector_layer_highlight = await build_vector_layer_highlight(final_aois)
+
     return Command(
         update={
             "aoi_selection": {
                 "name": selection_name,
                 "aois": final_aois,
             },
+            "vector_layer_highlight": vector_layer_highlight,
             # TODO: This is deprecated, remove it in the future
             "aoi": final_aois[0],
             "subtype": final_aois[0]["subtype"],

--- a/tests/evals/judge.py
+++ b/tests/evals/judge.py
@@ -150,9 +150,9 @@ def _log_verdict(query: str, rubric: str, verdict: Verdict):
     """Log the full judgment chain for debugging."""
     status = "PASS ✅" if verdict.passed else "FAIL ❌"
     logger.info(
-        f"\n{'='*70}\n"
+        f"\n{'=' * 70}\n"
         f"EVAL JUDGMENT: {status}\n"
-        f"{'='*70}\n"
+        f"{'=' * 70}\n"
         f"Query: {query}\n"
         f"Rubric: {rubric.strip()}\n"
         f"Tool output: chart_type={verdict.tool_output_summary.get('chart_type')}, "
@@ -166,7 +166,7 @@ def _log_verdict(query: str, rubric: str, verdict: Verdict):
             f"  {'✓' if r.get('met') else '✗'} {r.get('requirement', '?')}: {r.get('reason', '')}"
             for r in verdict.requirements
         )
-        + f"\n{'='*70}"
+        + f"\n{'=' * 70}"
     )
 
 

--- a/tests/tools/test_aoi_vector_highlight.py
+++ b/tests/tools/test_aoi_vector_highlight.py
@@ -1,0 +1,78 @@
+"""Unit tests for GFW vector highlight helpers (no DB)."""
+
+from src.agent.tools.aoi_vector_highlight import (
+    bbox_wgs84_from_geojson_geometries,
+    build_gfw_static_layer,
+    mapbox_membership_filter,
+)
+
+
+def test_mapbox_membership_filter_single_and_multi():
+    assert mapbox_membership_filter("gid_0", ["USA"]) == [
+        "==",
+        ["get", "gid_0"],
+        "USA",
+    ]
+    assert mapbox_membership_filter("sitrecid", [1, 2]) == [
+        "in",
+        ["get", "sitrecid"],
+        ["literal", [1, 2]],
+    ]
+
+
+def test_bbox_from_geojson_polygon_string():
+    geoms = [
+        '{"type":"Polygon","coordinates":[[[0,1],[2,1],[2,3],[0,3],[0,1]]]}'
+    ]
+    b = bbox_wgs84_from_geojson_geometries(geoms)
+    assert b == {"west": 0.0, "south": 1.0, "east": 2.0, "north": 3.0}
+
+
+def test_build_gfw_static_gadm_country():
+    cfg = build_gfw_static_layer(
+        [
+            {
+                "source": "gadm",
+                "subtype": "country",
+                "src_id": "IDN",
+                "name": "Indonesia",
+            }
+        ]
+    )
+    assert cfg is not None
+    assert cfg["dataset"] == "gadm_administrative_boundaries_adm0"
+    assert cfg["version"] == "v4.1"
+    assert cfg["filter_property"] == "gid_0"
+    assert cfg["filter"] == ["==", ["get", "gid_0"], "IDN"]
+
+
+def test_build_gfw_static_kba():
+    cfg = build_gfw_static_layer(
+        [
+            {
+                "source": "kba",
+                "subtype": "key-biodiversity-area",
+                "src_id": "123",
+                "name": "X",
+            }
+        ]
+    )
+    assert cfg is not None
+    assert cfg["dataset"] == "birdlife_key_biodiversity_areas"
+    assert cfg["filter"] == ["==", ["get", "sitrecid"], 123]
+
+
+def test_build_gfw_custom_none():
+    assert (
+        build_gfw_static_layer(
+            [
+                {
+                    "source": "custom",
+                    "subtype": "custom-area",
+                    "src_id": "00000000-0000-0000-0000-000000000001",
+                    "name": "A",
+                }
+            ]
+        )
+        is None
+    )


### PR DESCRIPTION
Opening only for visibility

This draft PR adds vector tile endpoints and filters for rendering on the frontend after AOI seletction.

For many AOIs our current frontend solution does not work, it downloads geojsons one by one for each aoi selected.

The approach here uses the GFW static tiles api and generates filters that reduce the layer to the selected aois


We should consider adding vector tiles endpoints for custom areas, so that the frontend can always rely on vector tiles and we don't duplicate the layer mechanism in geojson + vectortiles.