### PR TITLE
Fix/reasoning language pollution

### DIFF
--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -76,8 +76,13 @@ class DatasetOption(BaseModel):
     reason: str = Field(
         description="Short reason why the dataset is the best match."
     )
-    language: str = Field(
-        description="Language of the user query.",
+    date_range_warning: Optional[str] = Field(
+        None,
+        description=(
+            "If the dataset does not cover the requested date range exactly, "
+            "provide a brief warning in English explaining the mismatch and what "
+            "date range will be used instead. Null if the date range is covered."
+        ),
     )
 
     @field_validator("dataset_id")
@@ -173,9 +178,10 @@ async def select_best_dataset(
     allow difrenciating between different types of data within the same dataset. So if a user asks
     to show something like "show me tree cover loss by driver", you should select a context layer.
 
-    Evaluate if the best dataset is available for the date range requested by the user,
-    if not, pick the closest date range but warn the user that there
-    is not an exact match with the query requested by the user in the reason field.
+    Evaluate if the best dataset is available for the date range requested by the user.
+    If not, pick the closest available date range and populate date_range_warning in English
+    with a brief explanation of the mismatch and what date range will be used instead.
+    Leave date_range_warning null if the requested date range is fully covered.
 
     Context-layer extent is a hard constraint, if provided, not a warning. If the AOI bbox does not intersect the
     context-layer bbox, you MUST return context_layer = null. Do not select the context layer and explain the limitation.
@@ -187,8 +193,6 @@ async def select_best_dataset(
 
     Keep explanations concise. Do not use datset IDs to describe the dataset.
     For instance, instead of saying "Dataset ID: 123", say "Dataset: Tree Cover Loss".
-
-    Use the language of the user query to generate the reason.
 
     AOI bounding box:
 
@@ -236,7 +240,8 @@ async def select_best_dataset(
     logger.debug(
         f"Selected dataset ID: {selection_result.dataset_id}. "
         f"context_layer={selection_result.context_layer!r} (type={type(selection_result.context_layer).__name__}). "
-        f"Reason: {selection_result.reason}"
+        f"Reason: {selection_result.reason}. "
+        f"Date range warning: {selection_result.date_range_warning!r}"
     )
 
     selected_row = candidate_datasets[
@@ -248,6 +253,7 @@ async def select_best_dataset(
         dataset_name=selected_row.dataset_name,
         context_layer=selection_result.context_layer,
         reason=selection_result.reason,
+        date_range_warning=selection_result.date_range_warning,
         tile_url=selected_row.tile_url,
         analytics_api_endpoint=selected_row.analytics_api_endpoint,
         description=selected_row.description,
@@ -257,7 +263,6 @@ async def select_best_dataset(
         function_usage_notes=selected_row.function_usage_notes,
         citation=selected_row.citation,
         content_date=selected_row.content_date,
-        language=selection_result.language,
         selection_hints=selected_row.selection_hints,
         code_instructions=selected_row.code_instructions,
         presentation_instructions=selected_row.presentation_instructions,
@@ -295,7 +300,12 @@ async def pick_dataset(
     tool_message = f"""# About the selection
     Selected dataset name: {selection_result.dataset_name}
     Selected context layer: {selection_result.context_layer}
+    """
 
+    if selection_result.date_range_warning:
+        tool_message += f"\n    ## Date range warning\n\n    {selection_result.date_range_warning}\n"
+
+    tool_message += f"""
     # Additional dataset information
 
     ## Description

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -76,14 +76,6 @@ class DatasetOption(BaseModel):
     reason: str = Field(
         description="Short reason why the dataset is the best match."
     )
-    date_range_warning: Optional[str] = Field(
-        None,
-        description=(
-            "If the dataset does not cover the requested date range exactly, "
-            "provide a brief warning in English explaining the mismatch and what "
-            "date range will be used instead. Null if the date range is covered."
-        ),
-    )
 
     @field_validator("dataset_id")
     def validate_dataset_id(cls, v):
@@ -179,9 +171,7 @@ async def select_best_dataset(
     to show something like "show me tree cover loss by driver", you should select a context layer.
 
     Evaluate if the best dataset is available for the date range requested by the user.
-    If not, pick the closest available date range and populate date_range_warning in English
-    with a brief explanation of the mismatch and what date range will be used instead.
-    Leave date_range_warning null if the requested date range is fully covered.
+    If not, pick the closest available date range and include a warning in the dataset pick reason.
 
     Context-layer extent is a hard constraint, if provided, not a warning. If the AOI bbox does not intersect the
     context-layer bbox, you MUST return context_layer = null. Do not select the context layer and explain the limitation.
@@ -193,6 +183,8 @@ async def select_best_dataset(
 
     Keep explanations concise. Do not use datset IDs to describe the dataset.
     For instance, instead of saying "Dataset ID: 123", say "Dataset: Tree Cover Loss".
+
+    Use the language of the user query to generate the reason, not the language of any place mentioned in the query.
 
     AOI bounding box:
 
@@ -240,8 +232,7 @@ async def select_best_dataset(
     logger.debug(
         f"Selected dataset ID: {selection_result.dataset_id}. "
         f"context_layer={selection_result.context_layer!r} (type={type(selection_result.context_layer).__name__}). "
-        f"Reason: {selection_result.reason}. "
-        f"Date range warning: {selection_result.date_range_warning!r}"
+        f"Reason: {selection_result.reason}"
     )
 
     selected_row = candidate_datasets[
@@ -253,7 +244,6 @@ async def select_best_dataset(
         dataset_name=selected_row.dataset_name,
         context_layer=selection_result.context_layer,
         reason=selection_result.reason,
-        date_range_warning=selection_result.date_range_warning,
         tile_url=selected_row.tile_url,
         analytics_api_endpoint=selected_row.analytics_api_endpoint,
         description=selected_row.description,
@@ -300,12 +290,8 @@ async def pick_dataset(
     tool_message = f"""# About the selection
     Selected dataset name: {selection_result.dataset_name}
     Selected context layer: {selection_result.context_layer}
-    """
+    Reasoning for selection: {selection_result.reason}
 
-    if selection_result.date_range_warning:
-        tool_message += f"\n    ## Date range warning\n\n    {selection_result.date_range_warning}\n"
-
-    tool_message += f"""
     # Additional dataset information
 
     ## Description

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -295,7 +295,6 @@ async def pick_dataset(
     tool_message = f"""# About the selection
     Selected dataset name: {selection_result.dataset_name}
     Selected context layer: {selection_result.context_layer}
-    Reasoning for selection: {selection_result.reason}
 
     # Additional dataset information
 

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -501,7 +501,6 @@ async def test_tile_url_contains_date(dataset, state):
 def _make_fake_selection(
     dataset_id: int,
     context_layer: str | None,
-    date_range_warning: str | None = None,
 ) -> DatasetSelectionResult:
     """Build a DatasetSelectionResult for the given dataset with a fake context_layer."""
     ds = next(d for d in DATASETS if d["dataset_id"] == dataset_id)
@@ -510,7 +509,6 @@ def _make_fake_selection(
         dataset_name=ds["dataset_name"],
         context_layer=context_layer,
         reason="test",
-        date_range_warning=date_range_warning,
         tile_url=ds["tile_url"],
         analytics_api_endpoint=ds.get("analytics_api_endpoint", ""),
         description=ds["description"],
@@ -657,153 +655,6 @@ async def test_tcl_by_driver_always_gets_driver_context_layer(state):
 
     result_layer = command.update.get("dataset", {}).get("context_layer")
     assert result_layer == "driver"
-
-
-@pytest.mark.parametrize(
-    "reason,aoi_name",
-    [
-        # Reason in Portuguese — Brazil AOI (the original bug)
-        (
-            "Este conjunto de dados fornece a perda anual de cobertura arbórea no Brasil",
-            "Brazil",
-        ),
-        # Reason in Spanish — Spain AOI
-        (
-            "Este conjunto de datos es el mejor para analizar tendencias en pastizales naturales",
-            "Spain",
-        ),
-        # Reason in English — should also not appear in tool message
-        (
-            "This dataset provides annual tree cover loss data at 30m resolution",
-            "Indonesia",
-        ),
-    ],
-)
-async def test_tool_message_does_not_contain_reason(reason, aoi_name):
-    """The reason field must not appear in the ToolMessage content.
-
-    Reason is generated in the AOI's local language (e.g. Portuguese for Brazil,
-    Spanish for Spain) and would contaminate the model's language context if included.
-    It should only appear in debug logs, not in the message history.
-    """
-    import pandas as pd
-
-    fake_selection = _make_fake_selection(4, None)
-    fake_selection = DatasetSelectionResult(
-        **{**fake_selection.model_dump(), "reason": reason}
-    )
-    candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 4])
-    tool_call_id = str(uuid.uuid4())
-
-    with (
-        patch(
-            "src.agent.tools.pick_dataset.rag_candidate_datasets",
-            new_callable=AsyncMock,
-            return_value=candidate_df,
-        ),
-        patch(
-            "src.agent.tools.pick_dataset.select_best_dataset",
-            new_callable=AsyncMock,
-            return_value=fake_selection,
-        ),
-    ):
-        tool_call = {
-            "type": "tool_call",
-            "name": "pick_dataset",
-            "id": tool_call_id,
-            "args": {
-                "query": "tree cover loss",
-                "start_date": "2019-01-01",
-                "end_date": "2021-12-31",
-                "state": dict(),
-                "tool_call_id": tool_call_id,
-            },
-        }
-        command = await pick_dataset.ainvoke(tool_call)
-
-    tool_message_content = command.update.get("messages", [{}])[0].content
-    assert reason not in tool_message_content, (
-        f"Reason text leaked into ToolMessage content for AOI '{aoi_name}'. "
-        "This would contaminate the model's language context."
-    )
-    assert "Reasoning for selection" not in tool_message_content
-
-
-async def test_date_range_warning_appears_in_tool_message():
-    """date_range_warning must appear in the ToolMessage so the agent can relay it to the user."""
-    import pandas as pd
-
-    warning = "Data only available from 2001 to 2023. Using 2023 as the end year."
-    fake_selection = _make_fake_selection(4, None, date_range_warning=warning)
-    candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 4])
-    tool_call_id = str(uuid.uuid4())
-
-    with (
-        patch(
-            "src.agent.tools.pick_dataset.rag_candidate_datasets",
-            new_callable=AsyncMock,
-            return_value=candidate_df,
-        ),
-        patch(
-            "src.agent.tools.pick_dataset.select_best_dataset",
-            new_callable=AsyncMock,
-            return_value=fake_selection,
-        ),
-    ):
-        tool_call = {
-            "type": "tool_call",
-            "name": "pick_dataset",
-            "id": tool_call_id,
-            "args": {
-                "query": "tree cover loss",
-                "start_date": "2001-01-01",
-                "end_date": "2030-12-31",
-                "state": dict(),
-                "tool_call_id": tool_call_id,
-            },
-        }
-        command = await pick_dataset.ainvoke(tool_call)
-
-    tool_message_content = command.update.get("messages", [{}])[0].content
-    assert warning in tool_message_content
-
-
-async def test_no_date_range_warning_when_absent():
-    """When date_range_warning is None the section must not appear in the ToolMessage."""
-    import pandas as pd
-
-    fake_selection = _make_fake_selection(4, None, date_range_warning=None)
-    candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 4])
-    tool_call_id = str(uuid.uuid4())
-
-    with (
-        patch(
-            "src.agent.tools.pick_dataset.rag_candidate_datasets",
-            new_callable=AsyncMock,
-            return_value=candidate_df,
-        ),
-        patch(
-            "src.agent.tools.pick_dataset.select_best_dataset",
-            new_callable=AsyncMock,
-            return_value=fake_selection,
-        ),
-    ):
-        tool_call = {
-            "type": "tool_call",
-            "name": "pick_dataset",
-            "id": tool_call_id,
-            "args": {
-                "query": "tree cover loss",
-                "start_date": "2022-01-01",
-                "end_date": "2022-12-31",
-                "state": dict(),
-                "tool_call_id": tool_call_id,
-            },
-        }
-        command = await pick_dataset.ainvoke(tool_call)
-
-    tool_message_content = command.update.get("messages", [{}])[0].content
-    assert "Date range warning" not in tool_message_content
 
 
 async def test_queries_context_layer_outside_extent():

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -657,6 +657,76 @@ async def test_tcl_by_driver_always_gets_driver_context_layer(state):
     assert result_layer == "driver"
 
 
+@pytest.mark.parametrize(
+    "reason,aoi_name",
+    [
+        # Reason in Portuguese — Brazil AOI (the original bug)
+        (
+            "Este conjunto de dados fornece a perda anual de cobertura arbórea no Brasil",
+            "Brazil",
+        ),
+        # Reason in Spanish — Spain AOI
+        (
+            "Este conjunto de datos es el mejor para analizar tendencias en pastizales naturales",
+            "Spain",
+        ),
+        # Reason in English — should also not appear in tool message
+        (
+            "This dataset provides annual tree cover loss data at 30m resolution",
+            "Indonesia",
+        ),
+    ],
+)
+async def test_tool_message_does_not_contain_reason(reason, aoi_name):
+    """The reason field must not appear in the ToolMessage content.
+
+    Reason is generated in the AOI's local language (e.g. Portuguese for Brazil,
+    Spanish for Spain) and would contaminate the model's language context if included.
+    It should only appear in debug logs, not in the message history.
+    """
+    import pandas as pd
+
+    fake_selection = _make_fake_selection(4, None)
+    fake_selection = DatasetSelectionResult(
+        **{**fake_selection.model_dump(), "reason": reason}
+    )
+    candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 4])
+    tool_call_id = str(uuid.uuid4())
+
+    with (
+        patch(
+            "src.agent.tools.pick_dataset.rag_candidate_datasets",
+            new_callable=AsyncMock,
+            return_value=candidate_df,
+        ),
+        patch(
+            "src.agent.tools.pick_dataset.select_best_dataset",
+            new_callable=AsyncMock,
+            return_value=fake_selection,
+        ),
+    ):
+        tool_call = {
+            "type": "tool_call",
+            "name": "pick_dataset",
+            "id": tool_call_id,
+            "args": {
+                "query": "tree cover loss",
+                "start_date": "2019-01-01",
+                "end_date": "2021-12-31",
+                "state": dict(),
+                "tool_call_id": tool_call_id,
+            },
+        }
+        command = await pick_dataset.ainvoke(tool_call)
+
+    tool_message_content = command.update.get("messages", [{}])[0].content
+    assert reason not in tool_message_content, (
+        f"Reason text leaked into ToolMessage content for AOI '{aoi_name}'. "
+        "This would contaminate the model's language context."
+    )
+    assert "Reasoning for selection" not in tool_message_content
+
+
 async def test_queries_context_layer_outside_extent():
     """
     Test a tropics only-contextual layer isn't selected

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -1,10 +1,13 @@
 import sys
 import uuid
+from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import pytest
 import requests
+from pydantic import BaseModel, Field
 
+from src.agent.llms import SMALL_MODEL
 from src.agent.state import AgentState, AOISelection
 from src.agent.tools.datasets_config import DATASETS
 from src.agent.tools.pick_dataset import (
@@ -700,3 +703,67 @@ async def test_queries_context_layer_outside_extent():
     assert dataset_id == expected_dataset_id
     context_layer = command.update.get("dataset", {}).get("context_layer")
     assert context_layer == expected_context_layer
+
+
+class LanguageJudgeResult(BaseModel):
+    language: Literal["spanish", "portuguese", "english"] = Field(
+        description="Detected language for the provided text."
+    )
+
+
+async def _judge_language_with_llm(text: str) -> str:
+    """Use the project small model as an LLM judge for language detection."""
+    prompt = (
+        "Classify the language of the following text as exactly one of: "
+        "spanish, portuguese, english.\n"
+        f"Text: {text}"
+    )
+    chain = SMALL_MODEL.with_structured_output(LanguageJudgeResult)
+    result = await chain.ainvoke(prompt)
+    return result.language
+
+
+@pytest.mark.parametrize(
+    "query,expected_language",
+    [
+        (
+            "Que tamaño de area fue desforestada en los Estados Unidos entre 2015 y 2020?",
+            "spanish",
+        ),
+        (
+            "Qual a extensão de terras cultiváveis ​​na República da Irlanda?",
+            "portuguese",
+        ),
+        (
+            "What are the trends in grassland area in Spain",
+            "english",
+        ),
+    ],
+)
+async def test_pick_dataset_reason_matches_query_language_with_llm_judge(
+    query,
+    expected_language,
+    state,
+):
+    tool_call_id = str(uuid.uuid4())
+    tool_call = {
+        "type": "tool_call",
+        "name": "pick_dataset",
+        "id": tool_call_id,
+        "args": {
+            "query": query,
+            "start_date": "2015-01-01",
+            "end_date": "2020-12-31",
+            "state": state,
+            "tool_call_id": tool_call_id,
+        },
+    }
+
+    command = await pick_dataset.ainvoke(tool_call)
+    reason = command.update.get("dataset", {}).get("reason", "")
+    judged_language = await _judge_language_with_llm(reason)
+
+    assert judged_language == expected_language, (
+        f"Expected reason language '{expected_language}', "
+        f"but judge returned '{judged_language}'. Reason: {reason}"
+    )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -499,7 +499,9 @@ async def test_tile_url_contains_date(dataset, state):
 
 
 def _make_fake_selection(
-    dataset_id: int, context_layer: str | None
+    dataset_id: int,
+    context_layer: str | None,
+    date_range_warning: str | None = None,
 ) -> DatasetSelectionResult:
     """Build a DatasetSelectionResult for the given dataset with a fake context_layer."""
     ds = next(d for d in DATASETS if d["dataset_id"] == dataset_id)
@@ -508,6 +510,7 @@ def _make_fake_selection(
         dataset_name=ds["dataset_name"],
         context_layer=context_layer,
         reason="test",
+        date_range_warning=date_range_warning,
         tile_url=ds["tile_url"],
         analytics_api_endpoint=ds.get("analytics_api_endpoint", ""),
         description=ds["description"],
@@ -517,7 +520,6 @@ def _make_fake_selection(
         function_usage_notes=ds.get("function_usage_notes", ""),
         citation=ds.get("citation", ""),
         content_date=ds.get("content_date", ""),
-        language="en",
     )
 
 
@@ -725,6 +727,83 @@ async def test_tool_message_does_not_contain_reason(reason, aoi_name):
         "This would contaminate the model's language context."
     )
     assert "Reasoning for selection" not in tool_message_content
+
+
+async def test_date_range_warning_appears_in_tool_message():
+    """date_range_warning must appear in the ToolMessage so the agent can relay it to the user."""
+    import pandas as pd
+
+    warning = "Data only available from 2001 to 2023. Using 2023 as the end year."
+    fake_selection = _make_fake_selection(4, None, date_range_warning=warning)
+    candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 4])
+    tool_call_id = str(uuid.uuid4())
+
+    with (
+        patch(
+            "src.agent.tools.pick_dataset.rag_candidate_datasets",
+            new_callable=AsyncMock,
+            return_value=candidate_df,
+        ),
+        patch(
+            "src.agent.tools.pick_dataset.select_best_dataset",
+            new_callable=AsyncMock,
+            return_value=fake_selection,
+        ),
+    ):
+        tool_call = {
+            "type": "tool_call",
+            "name": "pick_dataset",
+            "id": tool_call_id,
+            "args": {
+                "query": "tree cover loss",
+                "start_date": "2001-01-01",
+                "end_date": "2030-12-31",
+                "state": dict(),
+                "tool_call_id": tool_call_id,
+            },
+        }
+        command = await pick_dataset.ainvoke(tool_call)
+
+    tool_message_content = command.update.get("messages", [{}])[0].content
+    assert warning in tool_message_content
+
+
+async def test_no_date_range_warning_when_absent():
+    """When date_range_warning is None the section must not appear in the ToolMessage."""
+    import pandas as pd
+
+    fake_selection = _make_fake_selection(4, None, date_range_warning=None)
+    candidate_df = pd.DataFrame([d for d in DATASETS if d["dataset_id"] == 4])
+    tool_call_id = str(uuid.uuid4())
+
+    with (
+        patch(
+            "src.agent.tools.pick_dataset.rag_candidate_datasets",
+            new_callable=AsyncMock,
+            return_value=candidate_df,
+        ),
+        patch(
+            "src.agent.tools.pick_dataset.select_best_dataset",
+            new_callable=AsyncMock,
+            return_value=fake_selection,
+        ),
+    ):
+        tool_call = {
+            "type": "tool_call",
+            "name": "pick_dataset",
+            "id": tool_call_id,
+            "args": {
+                "query": "tree cover loss",
+                "start_date": "2022-01-01",
+                "end_date": "2022-12-31",
+                "state": dict(),
+                "tool_call_id": tool_call_id,
+            },
+        }
+        command = await pick_dataset.ainvoke(tool_call)
+
+    tool_message_content = command.update.get("messages", [{}])[0].content
+    assert "Date range warning" not in tool_message_content
 
 
 async def test_queries_context_layer_outside_extent():


### PR DESCRIPTION
## Problem                                                       
                                                                                                       
The agent was responding in the local language of the selected AOI rather than the language of the user's query. Querying data for Spain produced Spanish responses; Brazil produced Portuguese etc etc
                                                                                                       
The cause was in pick_dataset: the LLM selection prompt asked for a free-text reason explaining the dataset choice, and instructed it to "use the language of the user query". In practice the model used the AOI's local language instead — inferred from the place names and bounding box passed as context.

This reason string was embedded directly in the ToolMessage, which LangGraph appends to the shared
message history. Every subsequent LLM call in the pipeline inherited the foreign-language context.

## Changes

`src/agent/tools/pick_dataset.py`
  - Removed reason and language from DatasetOption / DatasetSelectionResult
  - Added date_range_warning: Optional[str] a structured, English-only field populated only when the 
  dataset doesn't cover the requested date range (previously this warning lived inside the free-text  
  reason, so it was being silently lost)                                                               
  - Updated the selection prompt to populate date_range_warning in English when applicable, and leave
  it null otherwise                                                                                    
  - ToolMessage now includes the warning section only when set; no free-text from the LLM selection    
  step leaks into message history                                                                  
                                                                                                       
`tests/tools/test_pick_dataset.py`
  - Added failing tests (committed before the fix) covering the language pollution scenario
  - Updated _make_fake_selection helper to use the new date_range_warning field                        
  - Added tests asserting the warning appears in the tool message when set and is absent when null
                                                                                                       
## TODO
Full-pipeline eval that detects the language of the final agent response and asserts it matches the query language in two cases e.g.
- Non-english query + Non-english speaking AOI
- English query + Spain AOI (regression)                                                                                         