### PR TITLE
Add TCD threshold to map

### DIFF
--- a/src/agent/tools/data_handlers/analytics_handler.py
+++ b/src/agent/tools/data_handlers/analytics_handler.py
@@ -280,15 +280,9 @@ class AnalyticsHandler(DataSourceHandler):
             TREE_COVER_LOSS_BY_DRIVER_ID,
         ]:
             forest_filter = None
-            canopy_cover = 30
 
             if dataset.get("context_layer") == "primary_forest":
                 forest_filter = "primary_forest"
-
-            if dataset.get("parameters") is not None:
-                for param in dataset.get("parameters"):
-                    if param["name"] == "canopy_cover":
-                        canopy_cover = max(param["values"])
 
             intersections = []
             if dataset.get("dataset_id") == TREE_COVER_LOSS_BY_DRIVER_ID:
@@ -298,7 +292,6 @@ class AnalyticsHandler(DataSourceHandler):
                 **base_payload,
                 "start_year": start_date[:4],
                 "end_year": end_date[:4],
-                "canopy_cover": canopy_cover,
                 "forest_filter": forest_filter,
                 "intersections": intersections,
             }
@@ -322,7 +315,6 @@ class AnalyticsHandler(DataSourceHandler):
         elif dataset.get("dataset_id") == FOREST_CARBON_FLUX_ID:
             payload = {
                 **base_payload,
-                "canopy_cover": 30,
             }
         elif dataset.get("dataset_id") == TREE_COVER_ID:
             forest_filter = None
@@ -331,7 +323,6 @@ class AnalyticsHandler(DataSourceHandler):
 
             payload = {
                 **base_payload,
-                "canopy_cover": 30,
                 "forest_filter": forest_filter,
             }
         elif dataset.get("dataset_id") == SLUC_EMISSION_FACTORS_ID:
@@ -346,6 +337,20 @@ class AnalyticsHandler(DataSourceHandler):
             raise ValueError(
                 f"Unknown dataset ID: {dataset.get('dataset_id')}"
             )
+        
+        if dataset.get("dataset_id") in [
+            TREE_COVER_LOSS_ID,
+            TREE_COVER_ID,
+            TREE_COVER_LOSS_BY_DRIVER_ID,
+            FOREST_CARBON_FLUX_ID,
+        ]:
+            canopy_cover = 30
+            if dataset.get("parameters") is not None:
+                for param in dataset.get("parameters"):
+                    if param["name"] == "canopy_cover":
+                        canopy_cover = max(param["values"])
+            
+            payload["canopy_cover"] = canopy_cover
 
         return payload
 

--- a/src/agent/tools/data_handlers/analytics_handler.py
+++ b/src/agent/tools/data_handlers/analytics_handler.py
@@ -337,7 +337,7 @@ class AnalyticsHandler(DataSourceHandler):
             raise ValueError(
                 f"Unknown dataset ID: {dataset.get('dataset_id')}"
             )
-        
+
         if dataset.get("dataset_id") in [
             TREE_COVER_LOSS_ID,
             TREE_COVER_ID,
@@ -349,7 +349,7 @@ class AnalyticsHandler(DataSourceHandler):
                 for param in dataset.get("parameters"):
                     if param["name"] == "canopy_cover":
                         canopy_cover = max(param["values"])
-            
+
             payload["canopy_cover"] = canopy_cover
 
         return payload

--- a/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
+++ b/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
@@ -1,10 +1,6 @@
 dataset_id: 6
 dataset_name: Forest greenhouse gas net flux
 context_layers: null
-parameters: null
-context_layers:
-- value: primary_forest
-  description: Shows loss within humid tropical primary forest in global pan-tropical regions
 parameters:
 - name: canopy_cover
   description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.

--- a/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
+++ b/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
@@ -24,9 +24,8 @@ keywords:
 analytics_api_endpoint: /v0/land_change/carbon_flux/analytics
 prompt_instructions: 'DO NOT show trends over time or annual values. Caution users that this data shows net flux, gross emissions
   and removals as total values over the model period of 2001-2024, not an annual values. Show net flux as a split bar chart,
-  with emissions in the positive y-axis and removals in the negative. The data is calculcated with a  30% canopy density threshold,
-  requests for a different threshold are not yet possible. Use the term "net sink" for net-negative flux values (removals/sequestration)
-  and "net source" for net-positive (emissions)
+  with emissions in the positive y-axis and removals in the negative. The data is valid only 30% or higher canopy cover densities.
+  Use the term "net sink" for net-negative flux values (removals/sequestration) and "net source" for net-positive (emissions)
 
   '
 selection_hints: 'Shows net greenhouse gas flux from forests — balance between emissions and removals. Total over model period

--- a/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
+++ b/src/agent/tools/datasets/forest_greenhouse_gas_net_flux.yml
@@ -2,13 +2,15 @@ dataset_id: 6
 dataset_name: Forest greenhouse gas net flux
 context_layers: null
 parameters: null
-variables:
+context_layers:
 - value: primary_forest
   description: Shows loss within humid tropical primary forest in global pan-tropical regions
-- value: intact_forest_landscape
-  description: Shows gain within large, unfragmented areas of natural forest ecosystems that were free from significant human
-    disturbance as of 2000.
-tile_url: https://tiles.globalforestwatch.org/gfw_forest_carbon_net_flux/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30
+parameters:
+- name: canopy_cover
+  description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.
+  values: [30, 50, 75]
+  tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
+tile_url: https://tiles.globalforestwatch.org/gfw_forest_carbon_net_flux/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold={threshold}
 license: CC by 4.0
 geographic_coverage: Global
 resolution: 30 x 30 meters

--- a/src/agent/tools/datasets/tree_cover.yml
+++ b/src/agent/tools/datasets/tree_cover.yml
@@ -8,7 +8,7 @@ context_layers:
 parameters:
 - name: canopy_cover
   description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.
-  values: [10, 15, 20, 25, 30, 35, 50, 75]
+  values: [10, 15, 20, 25, 30, 50, 75]
 tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
 license: CC by 4.0
 geographic_coverage: Global land (excluding Antarctica and Arctic islands)

--- a/src/agent/tools/datasets/tree_cover.yml
+++ b/src/agent/tools/datasets/tree_cover.yml
@@ -1,12 +1,15 @@
 dataset_id: 7
 dataset_name: Tree cover
-parameters: null
 context_layers:
 - value: primary_forest
   description: Shows loss within humid tropical primary forest in global pan-tropical regions
   extent:  [-180.0, -30, 180.0, 30]
   tile_url: https://tiles.globalforestwatch.org/umd_regional_primary_forest_2001/v201901/uint16/{z}/{x}/{y}.png
-tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_30/{z}/{x}/{y}.png
+parameters:
+- name: canopy_cover
+  description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.
+  values: [10, 15, 20, 25, 30, 35, 50, 75]
+tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
 license: CC by 4.0
 geographic_coverage: Global land (excluding Antarctica and Arctic islands)
 resolution: 30 x 30 meters

--- a/src/agent/tools/datasets/tree_cover_loss.yml
+++ b/src/agent/tools/datasets/tree_cover_loss.yml
@@ -9,6 +9,7 @@ parameters:
 - name: canopy_cover
   description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.
   values: [10, 15, 20, 25, 30, 35, 50, 75]
+  tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
 tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30&render_type=true_color
 license: CC by 4.0
 geographic_coverage: Global land area (excluding Antarctica and other Arctic islands)

--- a/src/agent/tools/datasets/tree_cover_loss.yml
+++ b/src/agent/tools/datasets/tree_cover_loss.yml
@@ -8,9 +8,9 @@ context_layers:
 parameters:
 - name: canopy_cover
   description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.
-  values: [10, 15, 20, 25, 30, 35, 50, 75]
+  values: [10, 15, 20, 25, 30, 50, 75]
   tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
-tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30&render_type=true_color
+tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_loss/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold={threshold}&render_type=true_color
 license: CC by 4.0
 geographic_coverage: Global land area (excluding Antarctica and other Arctic islands)
 resolution: 30 x 30 meters

--- a/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
+++ b/src/agent/tools/datasets/tree_cover_loss_by_dominant_driver.yml
@@ -1,9 +1,13 @@
 dataset_id: 8
 dataset_name: Tree cover loss by dominant driver
 context_layers: null
-parameters: null
+parameters:
+- name: canopy_cover
+  description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.
+  values: [10, 15, 20, 25, 30, 50, 75]
+  tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
 variables: null
-tile_url: https://tiles.globalforestwatch.org/wri_google_tree_cover_loss_drivers/v1.12/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30&render_type=true_color
+tile_url: https://tiles.globalforestwatch.org/wri_google_tree_cover_loss_drivers/v1.12/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold={threshold}&render_type=true_color
 license: CC by 4.0
 geographic_coverage: Global
 resolution: 0.01 x 0.01 degree (approximately 1 km at the equator)

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -128,6 +128,46 @@ class DatasetOption(BaseModel):
 
         return self
 
+    @model_validator(mode="after")
+    def validate_parameters_for_dataset(self) -> "DatasetOption":
+        """Ensure parameters and their chosen values are valid for the chosen dataset_id."""
+        dataset_id = self.dataset_id
+        if dataset_id is None or self.parameters is None:
+            self.parameters = None
+            return self
+
+        selected_dataset = [
+            ds for ds in DATASETS if ds["dataset_id"] == dataset_id
+        ][0]
+        dataset_parameters = selected_dataset.get("parameters") or []
+        allowed_parameters = {
+            param["name"]: param for param in dataset_parameters
+        }
+
+        validated_parameters = []
+        for parameter in self.parameters:
+            allowed_parameter = allowed_parameters.get(parameter.name)
+            if allowed_parameter is None:
+                continue
+
+            allowed_values = allowed_parameter.get("values") or []
+            valid_values = [
+                value for value in parameter.values if value in allowed_values
+            ]
+            if not valid_values:
+                continue
+
+            validated_parameters.append(
+                DatasetParameter(
+                    name=parameter.name,
+                    description=parameter.description,
+                    values=valid_values,
+                )
+            )
+
+        self.parameters = validated_parameters or None
+        return self
+
 
 class DatasetSelectionResult(DatasetOption):
     tile_url: str = Field(

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -180,7 +180,11 @@ class DatasetSelectionResult(DatasetOption):
 
 
 async def select_best_dataset(
-    query: str, candidate_datasets: pd.DataFrame, aoi_selection=None
+    query: str,
+    candidate_datasets: pd.DataFrame,
+    start_date: str,
+    end_date: str,
+    aoi_selection=None,
 ) -> DatasetSelectionResult:
     DATASET_SELECTION_PROMPT = ChatPromptTemplate.from_messages(
         [
@@ -264,55 +268,9 @@ async def select_best_dataset(
         candidate_datasets.dataset_id == selection_result.dataset_id
     ].iloc[0]
 
-    context_layers = []
-    if (
-        selection_result.context_layer
-        and selected_row.context_layers is not None
-    ):
-        selected_context_layer = next(
-            (
-                x
-                for x in selected_row.context_layers
-                if x["value"] == selection_result.context_layer
-            ),
-            None,
-        )
-        context_layer = ContextLayer(
-            name=selected_context_layer.get("value"),
-            tile_url=selected_context_layer.get("tile_url"),
-        )
-        context_layers.append(context_layer)
-
-    if selected_row.dataset_id in [TREE_COVER_LOSS_ID, TREE_COVER_ID, TREE_COVER_LOSS_BY_DRIVER_ID, FOREST_CARBON_FLUX_ID]:
-        canopy_cover = 30
-        if selection_result.parameters is not None:
-            for param in selection_result.parameters:
-                if param.name == "canopy_cover":
-                    canopy_cover = max(param.values)
-
-        if selected_row.dataset_id != TREE_COVER_ID:
-            canopy_cover_tile_url = next(
-                (
-                    param["tile_url"]
-                    for param in selected_row.parameters
-                    if param["name"] == "canopy_cover"
-                ),
-                None,
-            )
-
-            thresholded_tile_url = canopy_cover_tile_url.replace(
-                "{threshold}", str(canopy_cover)
-            )
-
-            context_layer = ContextLayer(
-                name="canopy_cover",
-                tile_url=thresholded_tile_url,
-            )
-            context_layers.append(context_layer)
-        
-        selected_row.tile_url = selected_row.tile_url.replace(
-            "{threshold}", str(canopy_cover)
-        )
+    dataset_tile_url, context_layers = get_tile_services_for_dataset(
+        selection_result, selected_row, start_date, end_date
+    )
 
     return DatasetSelectionResult(
         dataset_id=selected_row.dataset_id,
@@ -320,7 +278,7 @@ async def select_best_dataset(
         context_layer=selection_result.context_layer,
         parameters=selection_result.parameters,
         reason=selection_result.reason,
-        tile_url=selected_row.tile_url,
+        tile_url=dataset_tile_url,
         analytics_api_endpoint=selected_row.analytics_api_endpoint,
         description=selected_row.description,
         prompt_instructions=selected_row.prompt_instructions,
@@ -363,7 +321,7 @@ async def pick_dataset(
     candidate_datasets = await rag_candidate_datasets(query, k=3)
     # Step 2: LLM to select best dataset and potential context layer
     selection_result = await select_best_dataset(
-        query, candidate_datasets, aoi_selection
+        query, candidate_datasets, start_date, end_date, aoi_selection
     )
 
     tool_message = f"""# About the selection
@@ -391,35 +349,6 @@ async def pick_dataset(
     """
 
     logger.debug(f"Pick dataset tool message: {tool_message}")
-
-    start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
-    end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
-
-    if not selection_result.tile_url.startswith("http"):
-        selection_result.tile_url = (
-            SharedSettings.eoapi_base_url + selection_result.tile_url
-        )
-
-    if selection_result.dataset_id == DIST_ALERT_ID:
-        selection_result.tile_url += (
-            f"&start_date={start_date}&end_date={end_date}"
-        )
-    elif selection_result.dataset_id in [LAND_COVER_CHANGE_ID, GRASSLANDS_ID]:
-        if end_date.year in range(2000, 2023):
-            selection_result.tile_url = selection_result.tile_url.format(
-                year=end_date.year
-            )
-        else:
-            selection_result.tile_url = selection_result.tile_url.format(
-                year="2022"
-            )
-    elif selection_result.dataset_id == TREE_COVER_LOSS_ID:
-        if end_date.year in range(2001, 2025):
-            selection_result.tile_url += (
-                f"&start_year={start_date.year}&end_year={end_date.year}"
-            )
-        else:
-            selection_result.tile_url += "&start_year=2001&end_year=2024"
 
     return Command(
         update={
@@ -482,3 +411,86 @@ def get_filtered_contextual_layers(
     )
 
     return filtered_layers, removed_df
+
+
+def get_tile_services_for_dataset(
+    selection_result, selected_row, start_date, end_date
+):
+    context_layers = []
+    tile_url = selected_row.tile_url
+    start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
+    end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
+
+    if not selected_row.tile_url.startswith("http"):
+        tile_url = SharedSettings.eoapi_base_url + tile_url
+
+    if (
+        selection_result.context_layer
+        and selected_row.context_layers is not None
+    ):
+        selected_context_layer = next(
+            (
+                x
+                for x in selected_row.context_layers
+                if x["value"] == selection_result.context_layer
+            ),
+            None,
+        )
+        context_layer = ContextLayer(
+            name=selected_context_layer.get("value"),
+            tile_url=selected_context_layer.get("tile_url"),
+        )
+        context_layers.append(context_layer)
+
+    if selected_row.dataset_id in [
+        TREE_COVER_LOSS_ID,
+        TREE_COVER_ID,
+        TREE_COVER_LOSS_BY_DRIVER_ID,
+        FOREST_CARBON_FLUX_ID,
+    ]:
+        canopy_cover = 30
+        if selection_result.parameters is not None:
+            for param in selection_result.parameters:
+                if param.name == "canopy_cover":
+                    canopy_cover = max(param.values)
+
+        if selected_row.dataset_id != TREE_COVER_ID:
+            canopy_cover_tile_url = next(
+                (
+                    param["tile_url"]
+                    for param in selected_row.parameters
+                    if param["name"] == "canopy_cover"
+                ),
+                None,
+            )
+
+            thresholded_tile_url = canopy_cover_tile_url.replace(
+                "{threshold}", str(canopy_cover)
+            )
+
+            context_layer = ContextLayer(
+                name="canopy_cover",
+                tile_url=thresholded_tile_url,
+            )
+            context_layers.append(context_layer)
+
+        tile_url = selected_row.tile_url.replace(
+            "{threshold}", str(canopy_cover)
+        )
+
+        if selected_row.dataset_id == TREE_COVER_LOSS_ID:
+            if end_date.year in range(2001, 2025):
+                tile_url += (
+                    f"&start_year={start_date.year}&end_year={end_date.year}"
+                )
+            else:
+                tile_url += "&start_year=2001&end_year=2024"
+    elif selection_result.dataset_id == DIST_ALERT_ID:
+        tile_url += f"&start_date={start_date}&end_date={end_date}"
+    elif selection_result.dataset_id in [LAND_COVER_CHANGE_ID, GRASSLANDS_ID]:
+        if end_date.year in range(2000, 2023):
+            tile_url = tile_url.format(year=end_date.year)
+        else:
+            tile_url = tile_url.format(year="2022")
+
+    return tile_url, context_layers

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -281,6 +281,32 @@ async def select_best_dataset(
         )
         context_layers.append(context_layer)
 
+    if selected_row.dataset_id in [TREE_COVER_LOSS_ID]:
+        canopy_cover = 30
+        if selection_result.parameters is not None:
+            for param in selection_result.parameters:
+                if param.name == "canopy_cover":
+                    canopy_cover = max(param.values)
+
+        canopy_cover_tile_url = next(
+            (
+                param["tile_url"]
+                for param in selected_row.parameters
+                if param["name"] == "canopy_cover"
+            ),
+            None,
+        )
+
+        thresholded_tile_url = canopy_cover_tile_url.replace(
+            "{threshold}", str(canopy_cover)
+        )
+
+        context_layer = ContextLayer(
+            name="canopy_cover",
+            tile_url=thresholded_tile_url,
+        )
+        context_layers.append(context_layer)
+
     return DatasetSelectionResult(
         dataset_id=selected_row.dataset_id,
         dataset_name=selected_row.dataset_name,

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -17,6 +17,7 @@ from shapely import box
 from src.agent.llms import SMALL_MODEL
 from src.agent.tools.data_handlers.analytics_handler import (
     DIST_ALERT_ID,
+    FOREST_CARBON_FLUX_ID,
     GRASSLANDS_ID,
     LAND_COVER_CHANGE_ID,
     TREE_COVER_ID,
@@ -282,14 +283,14 @@ async def select_best_dataset(
         )
         context_layers.append(context_layer)
 
-    if selected_row.dataset_id in [TREE_COVER_LOSS_ID, TREE_COVER_ID]:
+    if selected_row.dataset_id in [TREE_COVER_LOSS_ID, TREE_COVER_ID, TREE_COVER_LOSS_BY_DRIVER_ID, FOREST_CARBON_FLUX_ID]:
         canopy_cover = 30
         if selection_result.parameters is not None:
             for param in selection_result.parameters:
                 if param.name == "canopy_cover":
                     canopy_cover = max(param.values)
 
-        if selected_row.dataset_id in [TREE_COVER_LOSS_ID]:
+        if selected_row.dataset_id != TREE_COVER_ID:
             canopy_cover_tile_url = next(
                 (
                     param["tile_url"]
@@ -308,10 +309,10 @@ async def select_best_dataset(
                 tile_url=thresholded_tile_url,
             )
             context_layers.append(context_layer)
-        else:
-            selected_row.tile_url = selected_row.tile_url.replace(
-                "{threshold}", str(canopy_cover)
-            )
+        
+        selected_row.tile_url = selected_row.tile_url.replace(
+            "{threshold}", str(canopy_cover)
+        )
 
     return DatasetSelectionResult(
         dataset_id=selected_row.dataset_id,

--- a/src/agent/tools/pick_dataset.py
+++ b/src/agent/tools/pick_dataset.py
@@ -19,6 +19,7 @@ from src.agent.tools.data_handlers.analytics_handler import (
     DIST_ALERT_ID,
     GRASSLANDS_ID,
     LAND_COVER_CHANGE_ID,
+    TREE_COVER_ID,
     TREE_COVER_LOSS_BY_DRIVER_ID,
     TREE_COVER_LOSS_ID,
 )
@@ -281,31 +282,36 @@ async def select_best_dataset(
         )
         context_layers.append(context_layer)
 
-    if selected_row.dataset_id in [TREE_COVER_LOSS_ID]:
+    if selected_row.dataset_id in [TREE_COVER_LOSS_ID, TREE_COVER_ID]:
         canopy_cover = 30
         if selection_result.parameters is not None:
             for param in selection_result.parameters:
                 if param.name == "canopy_cover":
                     canopy_cover = max(param.values)
 
-        canopy_cover_tile_url = next(
-            (
-                param["tile_url"]
-                for param in selected_row.parameters
-                if param["name"] == "canopy_cover"
-            ),
-            None,
-        )
+        if selected_row.dataset_id in [TREE_COVER_LOSS_ID]:
+            canopy_cover_tile_url = next(
+                (
+                    param["tile_url"]
+                    for param in selected_row.parameters
+                    if param["name"] == "canopy_cover"
+                ),
+                None,
+            )
 
-        thresholded_tile_url = canopy_cover_tile_url.replace(
-            "{threshold}", str(canopy_cover)
-        )
+            thresholded_tile_url = canopy_cover_tile_url.replace(
+                "{threshold}", str(canopy_cover)
+            )
 
-        context_layer = ContextLayer(
-            name="canopy_cover",
-            tile_url=thresholded_tile_url,
-        )
-        context_layers.append(context_layer)
+            context_layer = ContextLayer(
+                name="canopy_cover",
+                tile_url=thresholded_tile_url,
+            )
+            context_layers.append(context_layer)
+        else:
+            selected_row.tile_url = selected_row.tile_url.replace(
+                "{threshold}", str(canopy_cover)
+            )
 
     return DatasetSelectionResult(
         dataset_id=selected_row.dataset_id,

--- a/tests/tools/test_analytics_handler.py
+++ b/tests/tools/test_analytics_handler.py
@@ -1,0 +1,97 @@
+import pytest
+
+from src.agent.tools.data_handlers.analytics_handler import (
+    TREE_COVER_LOSS_ID,
+    AnalyticsHandler,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db():
+    """Override the global test_db fixture to avoid database connections."""
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_session():
+    """Override the global test_db_session fixture to avoid database connections."""
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_pool():
+    """Override the global test_db_pool fixture to avoid database pool operations."""
+    pass
+
+
+async def test_build_payload_uses_canopy_cover_parameter():
+    handler = AnalyticsHandler()
+    dataset = {
+        "dataset_id": TREE_COVER_LOSS_ID,
+        "dataset_name": "Tree cover loss",
+        "context_layer": None,
+        "parameters": [{"name": "canopy_cover", "values": [50]}],
+    }
+    aois = [
+        {
+            "name": "Brazil",
+            "subtype": "country",
+            "src_id": "BRA",
+        }
+    ]
+
+    payload = await handler._build_payload(
+        dataset=dataset,
+        aois=aois,
+        start_date="2020-01-01",
+        end_date="2024-12-31",
+    )
+
+    assert payload == {
+        "aoi": {
+            "type": "admin",
+            "ids": ["BRA"],
+        },
+        "start_year": "2020",
+        "end_year": "2024",
+        "canopy_cover": 50,
+        "forest_filter": None,
+        "intersections": [],
+    }
+
+
+async def test_build_payload_uses_no_canopy_cover_parameter():
+    handler = AnalyticsHandler()
+    dataset = {
+        "dataset_id": TREE_COVER_LOSS_ID,
+        "dataset_name": "Tree cover loss",
+        "context_layer": None,
+    }
+    aois = [
+        {
+            "name": "Brazil",
+            "subtype": "country",
+            "src_id": "BRA",
+        }
+    ]
+
+    payload = await handler._build_payload(
+        dataset=dataset,
+        aois=aois,
+        start_date="2020-01-01",
+        end_date="2024-12-31",
+    )
+
+    assert payload == {
+        "aoi": {
+            "type": "admin",
+            "ids": ["BRA"],
+        },
+        "start_year": "2020",
+        "end_year": "2024",
+        "canopy_cover": 30,
+        "forest_filter": None,
+        "intersections": [],
+    }

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -560,6 +560,31 @@ async def test_tile_url_contains_date(dataset, state):
     assert response.status_code == 200
 
 
+async def test_tree_cover_tile_url_with_canopy_density(state):
+    tool_call_id = str(uuid.uuid4())
+
+    tool_call = {
+        "type": "tool_call",
+        "name": "pick_dataset",
+        "id": tool_call_id,
+        "args": {
+            "query": "Tree cover where where canopy density is greater than 15%",
+            "start_date": "2000-01-01",
+            "end_date": "2000-12-31",
+            "state": state,
+            "tool_call_id": tool_call_id,
+        },
+    }
+
+    command = await pick_dataset.ainvoke(tool_call)
+
+    tile_url = command.update.get("dataset", {}).get("tile_url")
+    assert "tcd_15" in tile_url
+    tile_url_format = tile_url.format(z=3, x=5, y=3)
+    response = requests.get(tile_url_format)
+    assert response.status_code == 200
+
+
 def _make_fake_selection(
     dataset_id: int,
     context_layer: str | None,

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -666,7 +666,6 @@ async def test_hallucinated_context_layer_is_discarded(
     )
 
 
-
 @pytest.mark.parametrize(
     "dataset_id,hallucinated_parameter",
     [
@@ -681,7 +680,9 @@ async def test_hallucinated_parameter_is_discarded(
     """Verify that invalid parameter values from LLM are set to None."""
     import pandas as pd
 
-    fake_selection = _make_fake_selection(dataset_id, None, parameters=hallucinated_parameter)
+    fake_selection = _make_fake_selection(
+        dataset_id, None, parameters=hallucinated_parameter
+    )
     candidate_df = pd.DataFrame(
         [d for d in DATASETS if d["dataset_id"] == dataset_id]
     )
@@ -719,7 +720,6 @@ async def test_hallucinated_parameter_is_discarded(
         f"Expected hallucinated paramter '{hallucinated_parameter}' to be discarded, "
         f"but got '{result_params}'"
     )
-
 
 
 async def test_valid_context_layer_is_preserved():

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -1,6 +1,6 @@
 import sys
 import uuid
-from typing import Literal
+from typing import Literal, Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -11,6 +11,7 @@ from src.agent.llms import SMALL_MODEL
 from src.agent.state import AgentState, AOISelection
 from src.agent.tools.datasets_config import DATASETS
 from src.agent.tools.pick_dataset import (
+    DatasetParameter,
     DatasetSelectionResult,
     pick_dataset,
 )
@@ -588,6 +589,7 @@ async def test_tree_cover_tile_url_with_canopy_density(state):
 def _make_fake_selection(
     dataset_id: int,
     context_layer: str | None,
+    parameters: Optional[list[DatasetParameter]] = None,
 ) -> DatasetSelectionResult:
     """Build a DatasetSelectionResult for the given dataset with a fake context_layer."""
     ds = next(d for d in DATASETS if d["dataset_id"] == dataset_id)
@@ -605,6 +607,7 @@ def _make_fake_selection(
         function_usage_notes=ds.get("function_usage_notes", ""),
         citation=ds.get("citation", ""),
         content_date=ds.get("content_date", ""),
+        parameters=parameters,
     )
 
 
@@ -661,6 +664,62 @@ async def test_hallucinated_context_layer_is_discarded(
         f"Expected hallucinated layer '{hallucinated_layer}' to be discarded, "
         f"but got '{result_layer}'"
     )
+
+
+
+@pytest.mark.parametrize(
+    "dataset_id,hallucinated_parameter",
+    [
+        (4, [{"name": "canopy_cover", "values": [-1], "description": ""}]),
+        (7, [{"name": "made_up", "values": [30], "description": ""}]),
+    ],
+)
+async def test_hallucinated_parameter_is_discarded(
+    dataset_id,
+    hallucinated_parameter,
+):
+    """Verify that invalid parameter values from LLM are set to None."""
+    import pandas as pd
+
+    fake_selection = _make_fake_selection(dataset_id, None, parameters=hallucinated_parameter)
+    candidate_df = pd.DataFrame(
+        [d for d in DATASETS if d["dataset_id"] == dataset_id]
+    )
+    tool_call_id = str(uuid.uuid4())
+
+    with (
+        patch(
+            "src.agent.tools.pick_dataset.rag_candidate_datasets",
+            new_callable=AsyncMock,
+            return_value=candidate_df,
+        ),
+        patch(
+            "src.agent.tools.pick_dataset.select_best_dataset",
+            new_callable=AsyncMock,
+            return_value=fake_selection,
+        ),
+    ):
+        tool_call = {
+            "type": "tool_call",
+            "name": "pick_dataset",
+            "id": tool_call_id,
+            "args": {
+                "query": "test query",
+                "start_date": "2022-01-01",
+                "end_date": "2022-12-31",
+                "state": dict(),
+                "tool_call_id": tool_call_id,
+            },
+        }
+
+        command = await pick_dataset.ainvoke(tool_call)
+
+    result_params = command.update.get("dataset", {}).get("parameters")
+    assert not result_params, (
+        f"Expected hallucinated paramter '{hallucinated_parameter}' to be discarded, "
+        f"but got '{result_params}'"
+    )
+
 
 
 async def test_valid_context_layer_is_preserved():


### PR DESCRIPTION
Right now, TCD threshold is always set to 30 for layers with a parameter option, and isn't included as contextual layer. This PR:

- Add TCD as contextual layer for datasets where it's used as a filter
- Sets the appropriate TCD parameter in the tile URL for all appropriate datasets/contextual layers
- Added TCD parameter to tree cover, TCL by driver and carbon flux, since these all should be filtered by TCD to match TCL from the user
- Pull outs all dataset-specific logic for building tile services into one function to make future refactoring easier. @gtempus our discussion made me think at least putting all this logic in one separate place is a good first step before a bigger refactor, lmk if you agree.

