### PR TITLE
Type/schema hardening for agent state, pick_aoi cleanup, and CI test reruns

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -75,4 +75,4 @@ jobs:
         run: |
           mkdir -p data
           uv run python src/ingest/embed_datasets.py
-          uv run pytest tests/tools tests/agent -v
+          uv run pytest tests/tools tests/agent -v --reruns 2 --reruns-delay 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "geopandas==1.0.1",
     "lancedb==0.24.1",
     "pytest-asyncio==1.1.0",
+    "pytest-rerunfailures==15.0",
     "locust==2.32.5",
 ]
 frontend = [

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -5,8 +5,6 @@ from langchain_core.messages import BaseMessage
 from langgraph.graph import add_messages
 from typing_extensions import TypedDict
 
-from src.agent.tools.code_executors.base import CodeActPart
-
 
 class AOISelection(TypedDict):
     name: str
@@ -29,6 +27,11 @@ class Statistics(TypedDict):
     context_layer: str | None
 
 
+class EncodedCodeActPart(TypedDict):
+    type: str
+    content: str
+
+
 class AgentState(TypedDict):
     messages: Annotated[Sequence[BaseMessage], add_messages]
     user_persona: str
@@ -47,6 +50,7 @@ class AgentState(TypedDict):
     statistics: Annotated[list[Statistics], operator.add]
 
     # generate-insights tool
-    insights: list
+    insight: str
+    follow_up_suggestions: list[str]
     charts_data: list
-    codeact_parts: list[CodeActPart]
+    codeact_parts: list[EncodedCodeActPart]

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -1,5 +1,5 @@
 import operator
-from typing import Annotated, Sequence
+from typing import Annotated, Any, Sequence
 
 from langchain_core.messages import BaseMessage
 from langgraph.graph import add_messages
@@ -13,6 +13,11 @@ class AOISelection(TypedDict):
     aois: list[dict]
 
 
+class StatisticsParameter(TypedDict):
+    name: str
+    values: list[Any]
+
+
 class Statistics(TypedDict):
     dataset_name: str
     start_date: str
@@ -20,7 +25,7 @@ class Statistics(TypedDict):
     source_url: str
     data: dict
     aoi_names: list[str]
-    parameters: list[dict] | None
+    parameters: list[StatisticsParameter] | None
     context_layer: str | None
 
 

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -37,8 +37,6 @@ class AgentState(TypedDict):
     user_persona: str
 
     # pick-aoi tool
-    aoi: dict
-    subtype: str
     aoi_selection: AOISelection
 
     # pick-dataset tool

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -430,11 +430,11 @@ async def generate_insights(
     available_datasets = _get_available_datasets()
     # Prefer presentation_instructions (tiered PoC) over prompt_instructions (legacy blob)
     dataset_guidelines = (
-        state.get("dataset").get("presentation_instructions")
-        or state.get("dataset").get("prompt_instructions")
+        dataset.get("presentation_instructions")
+        or dataset.get("prompt_instructions")
         or "No specific dataset guidelines provided."
     )
-    dataset_cautions = state.get("dataset").get(
+    dataset_cautions = dataset.get(
         "cautions", "No specific dataset cautions provided."
     )
 

--- a/src/agent/tools/pick_aoi/global_queries.py
+++ b/src/agent/tools/pick_aoi/global_queries.py
@@ -71,8 +71,6 @@ async def handle_global_request(
                 "name": GLOBAL_AOI_SELECTION_NAME,
                 "aois": final_aois,
             },
-            "aoi": final_aois[0],
-            "subtype": final_aois[0]["subtype"],
             "messages": [
                 ToolMessage(
                     "Selected all countries in the world",

--- a/src/agent/tools/pick_aoi/tool.py
+++ b/src/agent/tools/pick_aoi/tool.py
@@ -659,9 +659,6 @@ async def pick_aoi(
                 "name": selection_name,
                 "aois": [aoi.model_dump() for aoi in final_aois],
             },
-            # TODO: This is deprecated, remove it in the future
-            "aoi": final_aois[0].model_dump(),
-            "subtype": final_aois[0].subtype,
             "messages": [ToolMessage(tool_message, tool_call_id=tool_call_id)],
         },
     )

--- a/tests/fixtures/aoi_pick_aoi_v1.json
+++ b/tests/fixtures/aoi_pick_aoi_v1.json
@@ -708,6 +708,24 @@
           "similarity_score": 0.6499999761581421
         }
       ]
+    },
+    "Russia": {
+      "columns": [
+        "src_id",
+        "name",
+        "subtype",
+        "source",
+        "similarity_score"
+      ],
+      "records": [
+        {
+          "src_id": "RUS",
+          "name": "Russia",
+          "subtype": "country",
+          "source": "gadm",
+          "similarity_score": 1.0
+        }
+      ]
     }
   },
   "query_subregion_database": {
@@ -2450,6 +2468,598 @@
         "src_id"
       ],
       "records": []
+    },
+    "state|gadm|RUS": {
+      "columns": [
+        "name",
+        "subtype",
+        "gadm_id",
+        "source",
+        "src_id"
+      ],
+      "records": [
+        {
+          "name": "Adygeya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.1_1",
+          "source": "gadm",
+          "src_id": "RUS.1_1"
+        },
+        {
+          "name": "Altay, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.2_1",
+          "source": "gadm",
+          "src_id": "RUS.2_1"
+        },
+        {
+          "name": "Altayskiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.3_1",
+          "source": "gadm",
+          "src_id": "RUS.3_1"
+        },
+        {
+          "name": "Amurskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.4_1",
+          "source": "gadm",
+          "src_id": "RUS.4_1"
+        },
+        {
+          "name": "Arkhangel'skaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.5_1",
+          "source": "gadm",
+          "src_id": "RUS.5_1"
+        },
+        {
+          "name": "Astrakhanskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.6_1",
+          "source": "gadm",
+          "src_id": "RUS.6_1"
+        },
+        {
+          "name": "Bashkortostan, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.7_1",
+          "source": "gadm",
+          "src_id": "RUS.7_1"
+        },
+        {
+          "name": "Belgorodskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.8_1",
+          "source": "gadm",
+          "src_id": "RUS.8_1"
+        },
+        {
+          "name": "Bryanskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.9_1",
+          "source": "gadm",
+          "src_id": "RUS.9_1"
+        },
+        {
+          "name": "Buryatiya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.10_1",
+          "source": "gadm",
+          "src_id": "RUS.10_1"
+        },
+        {
+          "name": "Chelyabinskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.11_1",
+          "source": "gadm",
+          "src_id": "RUS.11_1"
+        },
+        {
+          "name": "Chechnya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.12_1",
+          "source": "gadm",
+          "src_id": "RUS.12_1"
+        },
+        {
+          "name": "Chukotskiy avtonomnyy okrug, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.13_1",
+          "source": "gadm",
+          "src_id": "RUS.13_1"
+        },
+        {
+          "name": "Chuvashskaya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.14_1",
+          "source": "gadm",
+          "src_id": "RUS.14_1"
+        },
+        {
+          "name": "Dagestan, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.15_1",
+          "source": "gadm",
+          "src_id": "RUS.15_1"
+        },
+        {
+          "name": "Ingushetiya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.16_1",
+          "source": "gadm",
+          "src_id": "RUS.16_1"
+        },
+        {
+          "name": "Irkutskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.17_1",
+          "source": "gadm",
+          "src_id": "RUS.17_1"
+        },
+        {
+          "name": "Ivanovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.18_1",
+          "source": "gadm",
+          "src_id": "RUS.18_1"
+        },
+        {
+          "name": "Yevreyskaya avtonomnaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.19_1",
+          "source": "gadm",
+          "src_id": "RUS.19_1"
+        },
+        {
+          "name": "Kabardino-Balkarskaya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.20_1",
+          "source": "gadm",
+          "src_id": "RUS.20_1"
+        },
+        {
+          "name": "Kaliningradskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.21_1",
+          "source": "gadm",
+          "src_id": "RUS.21_1"
+        },
+        {
+          "name": "Kalmykiya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.22_1",
+          "source": "gadm",
+          "src_id": "RUS.22_1"
+        },
+        {
+          "name": "Kaluzhskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.23_1",
+          "source": "gadm",
+          "src_id": "RUS.23_1"
+        },
+        {
+          "name": "Kamchatskiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.24_1",
+          "source": "gadm",
+          "src_id": "RUS.24_1"
+        },
+        {
+          "name": "Karachayevo-Cherkesskaya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.25_1",
+          "source": "gadm",
+          "src_id": "RUS.25_1"
+        },
+        {
+          "name": "Kareliya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.26_1",
+          "source": "gadm",
+          "src_id": "RUS.26_1"
+        },
+        {
+          "name": "Kemerovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.27_1",
+          "source": "gadm",
+          "src_id": "RUS.27_1"
+        },
+        {
+          "name": "Khabarovskiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.28_1",
+          "source": "gadm",
+          "src_id": "RUS.28_1"
+        },
+        {
+          "name": "Khakasiya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.29_1",
+          "source": "gadm",
+          "src_id": "RUS.29_1"
+        },
+        {
+          "name": "Khanty-Mansiyskiy avtonomnyy okrug-Yugra, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.30_1",
+          "source": "gadm",
+          "src_id": "RUS.30_1"
+        },
+        {
+          "name": "Kirovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.31_1",
+          "source": "gadm",
+          "src_id": "RUS.31_1"
+        },
+        {
+          "name": "Komi, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.32_1",
+          "source": "gadm",
+          "src_id": "RUS.32_1"
+        },
+        {
+          "name": "Kostromskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.33_1",
+          "source": "gadm",
+          "src_id": "RUS.33_1"
+        },
+        {
+          "name": "Krasnodarskiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.34_1",
+          "source": "gadm",
+          "src_id": "RUS.34_1"
+        },
+        {
+          "name": "Krasnoyarskiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.35_1",
+          "source": "gadm",
+          "src_id": "RUS.35_1"
+        },
+        {
+          "name": "Kurganskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.36_1",
+          "source": "gadm",
+          "src_id": "RUS.36_1"
+        },
+        {
+          "name": "Kurskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.37_1",
+          "source": "gadm",
+          "src_id": "RUS.37_1"
+        },
+        {
+          "name": "Leningradskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.38_1",
+          "source": "gadm",
+          "src_id": "RUS.38_1"
+        },
+        {
+          "name": "Lipetskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.39_1",
+          "source": "gadm",
+          "src_id": "RUS.39_1"
+        },
+        {
+          "name": "Magadanskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.40_1",
+          "source": "gadm",
+          "src_id": "RUS.40_1"
+        },
+        {
+          "name": "Mariy El, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.41_1",
+          "source": "gadm",
+          "src_id": "RUS.41_1"
+        },
+        {
+          "name": "Mordoviya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.42_1",
+          "source": "gadm",
+          "src_id": "RUS.42_1"
+        },
+        {
+          "name": "Moskovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.43_1",
+          "source": "gadm",
+          "src_id": "RUS.43_1"
+        },
+        {
+          "name": "Moskva, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.44_1",
+          "source": "gadm",
+          "src_id": "RUS.44_1"
+        },
+        {
+          "name": "Murmanskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.45_1",
+          "source": "gadm",
+          "src_id": "RUS.45_1"
+        },
+        {
+          "name": "Nenetskiy avtonomnyy okrug, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.46_1",
+          "source": "gadm",
+          "src_id": "RUS.46_1"
+        },
+        {
+          "name": "Nizhegorodskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.47_1",
+          "source": "gadm",
+          "src_id": "RUS.47_1"
+        },
+        {
+          "name": "North Ossetia - Alania, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.48_1",
+          "source": "gadm",
+          "src_id": "RUS.48_1"
+        },
+        {
+          "name": "Novgorodskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.49_1",
+          "source": "gadm",
+          "src_id": "RUS.49_1"
+        },
+        {
+          "name": "Novosibirskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.50_1",
+          "source": "gadm",
+          "src_id": "RUS.50_1"
+        },
+        {
+          "name": "Omskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.51_1",
+          "source": "gadm",
+          "src_id": "RUS.51_1"
+        },
+        {
+          "name": "Orenburgskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.52_1",
+          "source": "gadm",
+          "src_id": "RUS.52_1"
+        },
+        {
+          "name": "Orlovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.53_1",
+          "source": "gadm",
+          "src_id": "RUS.53_1"
+        },
+        {
+          "name": "Penzenskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.54_1",
+          "source": "gadm",
+          "src_id": "RUS.54_1"
+        },
+        {
+          "name": "Permskiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.55_1",
+          "source": "gadm",
+          "src_id": "RUS.55_1"
+        },
+        {
+          "name": "Primorskiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.56_1",
+          "source": "gadm",
+          "src_id": "RUS.56_1"
+        },
+        {
+          "name": "Pskovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.57_1",
+          "source": "gadm",
+          "src_id": "RUS.57_1"
+        },
+        {
+          "name": "Rostovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.58_1",
+          "source": "gadm",
+          "src_id": "RUS.58_1"
+        },
+        {
+          "name": "Ryazanskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.59_1",
+          "source": "gadm",
+          "src_id": "RUS.59_1"
+        },
+        {
+          "name": "Saint Petersburg, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.60_1",
+          "source": "gadm",
+          "src_id": "RUS.60_1"
+        },
+        {
+          "name": "Sakha, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.61_1",
+          "source": "gadm",
+          "src_id": "RUS.61_1"
+        },
+        {
+          "name": "Sakhalinskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.62_1",
+          "source": "gadm",
+          "src_id": "RUS.62_1"
+        },
+        {
+          "name": "Samarskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.63_1",
+          "source": "gadm",
+          "src_id": "RUS.63_1"
+        },
+        {
+          "name": "Saratovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.64_1",
+          "source": "gadm",
+          "src_id": "RUS.64_1"
+        },
+        {
+          "name": "Smolenskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.65_1",
+          "source": "gadm",
+          "src_id": "RUS.65_1"
+        },
+        {
+          "name": "Stavropol'skiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.66_1",
+          "source": "gadm",
+          "src_id": "RUS.66_1"
+        },
+        {
+          "name": "Sverdlovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.67_1",
+          "source": "gadm",
+          "src_id": "RUS.67_1"
+        },
+        {
+          "name": "Tambovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.68_1",
+          "source": "gadm",
+          "src_id": "RUS.68_1"
+        },
+        {
+          "name": "Tatarstan, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.69_1",
+          "source": "gadm",
+          "src_id": "RUS.69_1"
+        },
+        {
+          "name": "Tomskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.70_1",
+          "source": "gadm",
+          "src_id": "RUS.70_1"
+        },
+        {
+          "name": "Tul'skaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.71_1",
+          "source": "gadm",
+          "src_id": "RUS.71_1"
+        },
+        {
+          "name": "Tyva, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.72_1",
+          "source": "gadm",
+          "src_id": "RUS.72_1"
+        },
+        {
+          "name": "Tverskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.73_1",
+          "source": "gadm",
+          "src_id": "RUS.73_1"
+        },
+        {
+          "name": "Tyumenskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.74_1",
+          "source": "gadm",
+          "src_id": "RUS.74_1"
+        },
+        {
+          "name": "Udmurtskaya, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.75_1",
+          "source": "gadm",
+          "src_id": "RUS.75_1"
+        },
+        {
+          "name": "Ul'yanovskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.76_1",
+          "source": "gadm",
+          "src_id": "RUS.76_1"
+        },
+        {
+          "name": "Vladimirskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.77_1",
+          "source": "gadm",
+          "src_id": "RUS.77_1"
+        },
+        {
+          "name": "Volgogradskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.78_1",
+          "source": "gadm",
+          "src_id": "RUS.78_1"
+        },
+        {
+          "name": "Vologodskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.79_1",
+          "source": "gadm",
+          "src_id": "RUS.79_1"
+        },
+        {
+          "name": "Voronezhskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.80_1",
+          "source": "gadm",
+          "src_id": "RUS.80_1"
+        },
+        {
+          "name": "Yamalo-Nenetskiy avtonomnyy okrug, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.81_1",
+          "source": "gadm",
+          "src_id": "RUS.81_1"
+        },
+        {
+          "name": "Yaroslavskaya oblast', Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.82_1",
+          "source": "gadm",
+          "src_id": "RUS.82_1"
+        },
+        {
+          "name": "Zabaykal'skiy kray, Russia",
+          "subtype": "state-province",
+          "gadm_id": "RUS.83_1",
+          "source": "gadm",
+          "src_id": "RUS.83_1"
+        }
+      ]
     }
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -2873,6 +2873,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-rerunfailures" },
     { name = "ruff" },
 ]
 frontend = [
@@ -2943,6 +2944,7 @@ dev = [
     { name = "pre-commit", specifier = "==4.2.0" },
     { name = "pytest", specifier = "==8.4.1" },
     { name = "pytest-asyncio", specifier = "==1.1.0" },
+    { name = "pytest-rerunfailures", specifier = "==15.0" },
     { name = "ruff", specifier = "==0.12.4" },
 ]
 frontend = [
@@ -3386,6 +3388,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/47/ec4e12f45f4b9fac027a41ccaabb353ed4f23695aae860258ba11a84ed9b/pytest-rerunfailures-15.0.tar.gz", hash = "sha256:2d9ac7baf59f4c13ac730b47f6fa80e755d1ba0581da45ce30b72fb3542b4474", size = 21816, upload-time = "2024-11-20T07:23:51.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/37/54e5ffc7c0cebee7cf30a3ac5915faa7e7abf8bdfdf3228c277f7c192489/pytest_rerunfailures-15.0-py3-none-any.whl", hash = "sha256:dd150c4795c229ef44320adc9a0c0532c51b78bb7a6843a8c53556b9a611df1a", size = 13017, upload-time = "2024-11-20T07:23:50.077Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What changed
- Strengthened agent state typing in `src/agent/state.py`:
  - Added `StatisticsParameter` typed structure (`name`, `values`)
  - Changed `Statistics.parameters` from `list[dict] | None` to `list[StatisticsParameter] | None`
  - Replaced `insights: list` with explicit fields:
    - `insight: str`
    - `follow_up_suggestions: list[str]`
  - Replaced `codeact_parts: list[CodeActPart]` with serializable `EncodedCodeActPart` typed dict
  - Removed deprecated top-level state fields:
    - `aoi`
    - `subtype`

- Updated `generate_insights` state access in `src/agent/tools/generate_insights.py`:
  - Switched dataset guideline/caution lookup to use the local `dataset` object consistently (instead of repeated `state.get("dataset")` lookups), making access safer and clearer.

- Removed deprecated `pick_aoi` state writes:
  - `src/agent/tools/pick_aoi/tool.py`
  - `src/agent/tools/pick_aoi/global_queries.py`
  - No longer sets deprecated `update["aoi"]` / `update["subtype"]`; relies on `aoi_selection`.

- Expanded AOI fixtures for tests:
  - Added Russia entries to `tests/fixtures/aoi_pick_aoi_v1.json` for country lookup and subregion query coverage.

- Improved CI resilience for flaky model-dependent tests:
  - Added `pytest-rerunfailures==15.0` to dev deps in `pyproject.toml`
  - Updated `uv.lock`
  - Updated tools workflow command to:
    - `uv run pytest tests/tools tests/agent -v --reruns 2 --reruns-delay 5`

### Why
- Tightening state/schema types reduces ambiguity and catches integration mistakes earlier.
- Removing deprecated `aoi`/`subtype` eliminates duplicate state representations and prevents drift from `aoi_selection`.
- Russia fixture expansion supports newer AOI test scenarios.
- CI reruns mitigate transient Gemini/API failures while still failing truly unstable tests (3 consecutive failures required).

### Impact
- **Typing/contracts:** clearer, stricter state definitions for insights/statistics/codeact payloads.
- **Runtime behavior:** no intended functional change to AOI selection flow beyond removing deprecated fields.
- **Tests/CI:** broader AOI fixture coverage and lower flaky-failure rate in tools/agent workflow.
- **Dependencies:** one new dev dependency (`pytest-rerunfailures`).