### PR TITLE
PZB-781: Default dataset dates

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -37,7 +37,7 @@ def get_prompt(user: Optional[dict] = None) -> str:
 
 CRITICAL INSTRUCTIONS:
 - You MUST call tools sequentially, never in parallel. No parallel tool calling allowed, always call tools one at a time.
-- You ALWAYS need AOI + dataset + date range to perform analysis. If ANY are missing, ask the user to specify.
+- You ALWAYS need AOI + dataset + date range to perform analysis. If AOI or dataset are missing, ask the user to specify. If user doesn't specify date range, pick dataset will provide defaults.
 - Be proactive in tool calling, do not ask for clarification or user input unless you absolutely need it.
   For instance, if dates, places, or datasets dont match exactly, warn the user but move forward with the analysis.,
 - Provide intermediate messages between tool calls to the user to keep them updated on the progress of the analysis.

--- a/src/agent/tools/pick_dataset/tool.py
+++ b/src/agent/tools/pick_dataset/tool.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Annotated, Dict, Optional, Union
 
@@ -13,6 +13,7 @@ from langchain_google_genai import GoogleGenerativeAIEmbeddings
 from langgraph.types import Command
 from shapely import box
 
+from src.agent.tools.util import revise_date_range
 from src.agent.llms import SMALL_MODEL
 from src.agent.tools.data_handlers.analytics_handler import (
     DIST_ALERT_ID,
@@ -78,8 +79,8 @@ async def rag_candidate_datasets(query: str, k=3):
 async def select_best_dataset(
     query: str,
     candidate_datasets: pd.DataFrame,
-    start_date: str,
-    end_date: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     aoi_selection=None,
 ) -> DatasetSelectionResult:
     DATASET_SELECTION_PROMPT = ChatPromptTemplate.from_messages(
@@ -165,8 +166,9 @@ async def select_best_dataset(
         candidate_datasets.dataset_id == selection_result.dataset_id
     ].iloc[0]
 
+    effective_start_date, effective_end_date, _ = await revise_date_range(start_date, end_date, selected_row.dataset_id)
     dataset_tile_url, context_layers = get_tile_services_for_dataset(
-        selection_result, selected_row, start_date, end_date
+        selection_result, selected_row, effective_start_date, effective_end_date
     )
 
     return DatasetSelectionResult(
@@ -375,13 +377,13 @@ def get_tile_services_for_dataset(
             "{threshold}", str(canopy_cover)
         )
 
-        if selected_row.dataset_id == TREE_COVER_LOSS_ID:
-            if end_date.year in range(2001, 2025):
-                tile_url += (
-                    f"&start_year={start_date.year}&end_year={end_date.year}"
-                )
-            else:
-                tile_url += "&start_year=2001&end_year=2024"
+    if selected_row.dataset_id == TREE_COVER_LOSS_ID:
+        if end_date.year in range(2001, 2025):
+            tile_url += (
+                f"&start_year={start_date.year}&end_year={end_date.year}"
+            )
+        else:
+            tile_url += "&start_year=2001&end_year=2025"
     elif selection_result.dataset_id == DIST_ALERT_ID:
         tile_url += f"&start_date={start_date}&end_date={end_date}"
     elif selection_result.dataset_id in [LAND_COVER_CHANGE_ID, GRASSLANDS_ID]:
@@ -391,3 +393,24 @@ def get_tile_services_for_dataset(
             tile_url = tile_url.format(year="2022")
 
     return tile_url, context_layers
+
+
+def get_dates_for_dataset(
+    selection_result, selected_row, start_date, end_date
+) -> tuple[str, str]:
+    """Resolve missing dates from the selected dataset's own coverage."""
+    dataset_start_date = selected_row.get("start_date")
+    dataset_end_date = selected_row.get("end_date") or str(date.today())
+
+    resolved_start_date = start_date or dataset_start_date
+    resolved_end_date = end_date or dataset_end_date
+
+    logger.debug(
+        "Resolved dates for dataset %s (%s): start=%s end=%s",
+        selection_result.dataset_id,
+        selected_row.get("dataset_name"),
+        resolved_start_date,
+        resolved_end_date,
+    )
+
+    return resolved_start_date, resolved_end_date

--- a/src/agent/tools/pick_dataset/tool.py
+++ b/src/agent/tools/pick_dataset/tool.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Dict, Union
+from typing import Annotated, Dict, Optional, Union
 
 import pandas as pd
 from langchain.tools import InjectedState
@@ -194,8 +194,8 @@ async def select_best_dataset(
 @tool("pick_dataset")
 async def pick_dataset(
     query: str,
-    start_date: str,
-    end_date: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     state: Annotated[Dict, InjectedState] = None,
     tool_call_id: Annotated[str, InjectedToolCallId] = None,
 ) -> Command:

--- a/src/agent/tools/pick_dataset/tool.py
+++ b/src/agent/tools/pick_dataset/tool.py
@@ -13,7 +13,6 @@ from langchain_google_genai import GoogleGenerativeAIEmbeddings
 from langgraph.types import Command
 from shapely import box
 
-from src.agent.tools.util import revise_date_range
 from src.agent.llms import SMALL_MODEL
 from src.agent.tools.data_handlers.analytics_handler import (
     DIST_ALERT_ID,
@@ -33,6 +32,7 @@ from src.agent.tools.pick_dataset.schema import (
     DatasetOption,
     DatasetSelectionResult,
 )
+from src.agent.tools.util import revise_date_range
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
 
@@ -166,9 +166,14 @@ async def select_best_dataset(
         candidate_datasets.dataset_id == selection_result.dataset_id
     ].iloc[0]
 
-    effective_start_date, effective_end_date, _ = await revise_date_range(start_date, end_date, selected_row.dataset_id)
+    effective_start_date, effective_end_date, _ = await revise_date_range(
+        start_date, end_date, selected_row.dataset_id
+    )
     dataset_tile_url, context_layers = get_tile_services_for_dataset(
-        selection_result, selected_row, effective_start_date, effective_end_date
+        selection_result,
+        selected_row,
+        effective_start_date,
+        effective_end_date,
     )
 
     return DatasetSelectionResult(

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -1,4 +1,3 @@
-from datetime import date
 from typing import Annotated, Dict, Optional
 
 from langchain_core.messages import ToolMessage
@@ -7,10 +6,9 @@ from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
-from src.agent.tools.util import revise_date_range
 from src.agent.tools.data_handlers.analytics_handler import AnalyticsHandler
 from src.agent.tools.data_handlers.base import DataPullResult
-from src.agent.tools.datasets_config import DATASETS
+from src.agent.tools.util import revise_date_range
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Annotated, Dict
+from typing import Annotated, Dict, Optional
 
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
@@ -7,6 +7,7 @@ from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
+from src.agent.tools.util import revise_date_range
 from src.agent.tools.data_handlers.analytics_handler import AnalyticsHandler
 from src.agent.tools.data_handlers.base import DataPullResult
 from src.agent.tools.datasets_config import DATASETS
@@ -57,44 +58,12 @@ class DataPullOrchestrator:
 data_pull_orchestrator = DataPullOrchestrator()
 
 
-async def revise_date_range(
-    start_date: str, end_date: str, dataset_id: int
-) -> tuple[str, str, bool]:
-    """
-    Revise the input date range to the dataset's available range
-    """
-    ds_original = next(
-        (ds for ds in DATASETS if ds["dataset_id"] == dataset_id),
-        None,
-    )
-    if not ds_original:
-        raise ValueError(f"Dataset not found: {dataset_id}")
-
-    ds_start_original = ds_original.get("start_date")
-    ds_end_original = ds_original.get("end_date")
-    if ds_end_original is None:
-        ds_end_original = str(
-            date.today()
-        )  # e.g. DIST-ALERT: ongoing, no fixed end
-
-    if ds_original.get("content_date_fixed"):
-        effective_start = ds_start_original
-        effective_end = ds_end_original
-    else:
-        effective_start = max(start_date, ds_start_original)
-        effective_end = min(end_date, ds_end_original)
-
-    range_clamped = effective_start != start_date or effective_end != end_date
-
-    return effective_start, effective_end, range_clamped
-
-
 @tool("pull_data")
 async def pull_data(
     query: str,
-    start_date: str,
-    end_date: str,
     change_over_time_query: bool,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
     tool_call_id: Annotated[str, InjectedToolCallId] = None,
     state: Annotated[Dict, InjectedState] = None,
 ) -> Command:

--- a/src/agent/tools/util.py
+++ b/src/agent/tools/util.py
@@ -28,7 +28,7 @@ async def revise_date_range(
         start_date = ds_start_original
     if end_date is None:
         end_date = ds_end_original
-    
+
     if ds_original.get("content_date_fixed"):
         effective_start = ds_start_original
         effective_end = ds_end_original

--- a/src/agent/tools/util.py
+++ b/src/agent/tools/util.py
@@ -1,0 +1,41 @@
+from datetime import date
+from typing import Optional
+
+from src.agent.tools.datasets_config import DATASETS
+
+
+async def revise_date_range(
+    start_date: Optional[str], end_date: Optional[str], dataset_id: int
+) -> tuple[str, str, bool]:
+    """
+    Revise the input date range to the dataset's available range
+    """
+    ds_original = next(
+        (ds for ds in DATASETS if ds["dataset_id"] == dataset_id),
+        None,
+    )
+    if not ds_original:
+        raise ValueError(f"Dataset not found: {dataset_id}")
+
+    ds_start_original = ds_original.get("start_date")
+    ds_end_original = ds_original.get("end_date")
+    if ds_end_original is None:
+        ds_end_original = str(
+            date.today()
+        )  # e.g. DIST-ALERT: ongoing, no fixed end
+
+    if start_date is None:
+        start_date = ds_start_original
+    if end_date is None:
+        end_date = ds_end_original
+    
+    if ds_original.get("content_date_fixed"):
+        effective_start = ds_start_original
+        effective_end = ds_end_original
+    else:
+        effective_start = max(start_date, ds_start_original)
+        effective_end = min(end_date, ds_end_original)
+
+    range_clamped = effective_start != start_date or effective_end != end_date
+
+    return effective_start, effective_end, range_clamped

--- a/tests/agent/test_graph.py
+++ b/tests/agent/test_graph.py
@@ -333,3 +333,11 @@ async def test_agent_for_disturbance_alerts_for_brazil(structlog_context):
     assert len(steps) > 0
     tool_steps = [dat["tools"] for dat in steps if "tools" in dat]
     assert has_insights(tool_steps), "No insights found"
+
+
+async def test_agent_for_deforestation_for_brazil(structlog_context):
+    query = "Show me deforestation in Para and Parana in Brazil"
+    steps = await run_agent(query)
+    assert len(steps) > 0
+    tool_steps = [dat["tools"] for dat in steps if "tools" in dat]
+    assert has_insights(tool_steps), "No insights found"

--- a/tests/agent/test_graph.py
+++ b/tests/agent/test_graph.py
@@ -255,6 +255,16 @@ def reset_google_clients():
     pd_module.retriever_cache = None
 
 
+def collect_tool_calls(steps):
+    calls = []
+    for step in steps:
+        for value in step.values():
+            for msg in value.get("messages", []):
+                if hasattr(msg, "tool_calls") and msg.tool_calls:
+                    calls.extend(msg.tool_calls)
+    return calls
+
+
 def has_insights(tool_steps: list[dict]) -> bool:
     for tool_step in tool_steps:
         if len(tool_step.get("charts_data", [])) > 0:
@@ -335,9 +345,23 @@ async def test_agent_for_disturbance_alerts_for_brazil(structlog_context):
     assert has_insights(tool_steps), "No insights found"
 
 
-async def test_agent_for_deforestation_for_brazil(structlog_context):
-    query = "Show me deforestation in Para and Parana in Brazil"
+async def test_agent_for_tcl_no_dates_for_brazil(structlog_context):
+    """
+    Test to confirm the agent will call the pick_dataset and pull_data tools with null
+    dates if not specified by the user, and instead use default ones from the config.
+    """
+    query = "Show me tree cover loss in Para and Parana in Brazil"
     steps = await run_agent(query)
     assert len(steps) > 0
     tool_steps = [dat["tools"] for dat in steps if "tools" in dat]
     assert has_insights(tool_steps), "No insights found"
+
+    tool_calls = collect_tool_calls(steps)
+    generate_insights_calls = [
+        c for c in tool_calls if c["name"] == "generate_insights"
+    ]
+
+    assert any(
+        "2001 to 2024" in call["args"].get("query", "")
+        for call in generate_insights_calls
+    )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -566,6 +566,28 @@ async def test_tile_url_contains_date(dataset, state):
     assert response.status_code == 200
 
 
+async def test_tile_url_contains_default_dates(state):
+    tool_call_id = str(uuid.uuid4())
+
+    tool_call = {
+        "type": "tool_call",
+        "name": "pick_dataset",
+        "id": tool_call_id,
+        "args": {
+            "query": "Find me tree cover loss data",
+            "start_date": None,
+            "end_date": None,
+            "state": state,
+            "tool_call_id": tool_call_id,
+        },
+    }
+
+    command = await pick_dataset.ainvoke(tool_call)
+
+    tile_url = command.update.get("dataset", {}).get("tile_url")
+    assert "start_year=2001" in tile_url
+
+
 async def test_tree_cover_tile_url_with_canopy_density(state):
     tool_call_id = str(uuid.uuid4())
 

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -463,7 +463,7 @@ class TestReviseDateRange:
 
     async def test_dataset_without_dates_uses_default(self):
         """Dataset 4 (TCL) has defaults to use if not provided."""
-  
+
         (
             effective_start,
             effective_end,

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -460,3 +460,15 @@ class TestReviseDateRange:
         assert effective_start == "2024-01-01"
         assert effective_end == str(date.today())
         assert range_clamped is True
+
+    async def test_dataset_without_dates_uses_default(self):
+        """Dataset 4 (TCL) has defaults to use if not provided."""
+  
+        (
+            effective_start,
+            effective_end,
+            range_clamped,
+        ) = await revise_date_range(None, None, 4)
+        assert effective_start == "2001-01-01"
+        assert effective_end == "2024-12-31"
+        assert range_clamped is False


### PR DESCRIPTION
Right now, the agent must choose start and end dates to call pick dataset and pull data. This leads to some "prompt pressure" to choose a date even if the user didn't specify, and so it'll sporadically choose between asking the user for clarification or selecting random dates.

This PR makes the dates now optional, and it'll re-use the existing function for checking against the dataset's full date range to choose a default if not specified. 