### PR TITLE
Decouple Alembic migrations from API models

### DIFF
--- a/db/alembic/env.py
+++ b/db/alembic/env.py
@@ -4,8 +4,6 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import create_engine
 
-from src.api.data_models import Base
-
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
@@ -15,16 +13,7 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = Base.metadata
-
-MANAGED_TABLES = set(target_metadata.tables.keys())
-
-
-def include_name(name, type_, parent_names):
-    """Only include tables managed by our ORM in autogenerate diffs."""
-    if type_ == "table":
-        return name in MANAGED_TABLES
-    return True
+target_metadata = None
 
 
 def run_migrations_offline() -> None:
@@ -49,7 +38,6 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
-        include_name=include_name,
     )
 
     with context.begin_transaction():
@@ -75,7 +63,6 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
-            include_name=include_name,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
## Summary
- Remove Alembic's runtime import of `src.api.data_models.Base`
- Run migrations with `target_metadata = None`, avoiding application model imports during deployment
- Keep Alembic focused on executing explicit migration scripts
## Autogenerate
- Alembic autogenerate is no longer supported from this runtime `env.py`
- Future schema changes should be added as explicit migration scripts
- This tradeoff keeps deployment migrations independent from API model imports
