### PR TITLE
PZB-895 - Persist pull-data statistics and link insights to source data

### DIFF
--- a/db/alembic/versions/9f8e7d6c5b4a_add_statistics_table.py
+++ b/db/alembic/versions/9f8e7d6c5b4a_add_statistics_table.py
@@ -1,0 +1,75 @@
+"""add_statistics_table
+
+Revision ID: 9f8e7d6c5b4a
+Revises: 75841e9932e5
+Create Date: 2026-04-27 10:49:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "9f8e7d6c5b4a"
+down_revision: Union[str, None] = "75841e9932e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "statistics",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("thread_id", sa.String(), nullable=True),
+        sa.Column("dataset_name", sa.String(), nullable=False),
+        sa.Column("start_date", sa.String(), nullable=False),
+        sa.Column("end_date", sa.String(), nullable=False),
+        sa.Column("source_url", sa.String(), nullable=True),
+        sa.Column(
+            "data",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "aoi_names",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+        sa.Column(
+            "parameters",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("context_layer", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_statistics_thread_id", "statistics", ["thread_id"])
+    op.create_index("idx_statistics_user_id", "statistics", ["user_id"])
+    op.add_column(
+        "insights",
+        sa.Column(
+            "statistics_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("insights", "statistics_ids")
+    op.drop_index("idx_statistics_user_id", table_name="statistics")
+    op.drop_index("idx_statistics_thread_id", table_name="statistics")
+    op.drop_table("statistics")

--- a/db/alembic/versions/9f8e7d6c5b4a_add_statistics_table.py
+++ b/db/alembic/versions/9f8e7d6c5b4a_add_statistics_table.py
@@ -1,7 +1,7 @@
 """add_statistics_table
 
 Revision ID: 9f8e7d6c5b4a
-Revises: 75841e9932e5
+Revises: 73c0c72faa9e
 Create Date: 2026-04-27 10:49:00.000000
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "9f8e7d6c5b4a"
-down_revision: Union[str, None] = "75841e9932e5"
+down_revision: Union[str, None] = "73c0c72faa9e"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -34,11 +34,6 @@ def upgrade() -> None:
         sa.Column("start_date", sa.String(), nullable=False),
         sa.Column("end_date", sa.String(), nullable=False),
         sa.Column("source_url", sa.String(), nullable=True),
-        sa.Column(
-            "data",
-            postgresql.JSONB(astext_type=sa.Text()),
-            nullable=False,
-        ),
         sa.Column(
             "aoi_names",
             postgresql.JSONB(astext_type=sa.Text()),

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -3,7 +3,7 @@ from typing import Annotated, Any, Sequence
 
 from langchain_core.messages import BaseMessage
 from langgraph.graph import add_messages
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 
 class AOISelection(TypedDict):
@@ -17,6 +17,7 @@ class StatisticsParameter(TypedDict):
 
 
 class Statistics(TypedDict):
+    id: NotRequired[str]
     dataset_name: str
     start_date: str
     end_date: str

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -22,7 +22,9 @@ class Statistics(TypedDict):
     start_date: str
     end_date: str
     source_url: str
-    data: dict
+    # DEPRECATED: use fetch_statistics_from_url(source_url) instead.
+    # Kept for frontend backward compatibility.
+    data: NotRequired[dict]
     aoi_names: list[str]
     parameters: list[StatisticsParameter] | None
     context_layer: str | None

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -68,6 +68,14 @@ def prepare_dataframes(
     return dataframes, source_urls
 
 
+def _extract_statistics_ids(statistics: list[dict]) -> list[str]:
+    return [
+        stat["id"]
+        for stat in statistics
+        if isinstance(stat, dict) and stat.get("id")
+    ]
+
+
 def replace_csv_paths_with_urls(
     code_block: str, source_urls: List[str]
 ) -> List[str]:
@@ -558,6 +566,7 @@ Cautions: {dataset_cautions}
 
     # 9. PERSIST INSIGHT(S) TO DB
     ctx = structlog.contextvars.get_contextvars()
+    statistics_ids = _extract_statistics_ids(statistics)
     insight_ids: list[str] = []
     async with get_session_from_pool() as session:
         insight_row = InsightOrm(
@@ -565,6 +574,7 @@ Cautions: {dataset_cautions}
             thread_id=ctx.get("thread_id", ""),
             insight_text=chart_insight_response.primary_insight,
             follow_up_suggestions=chart_insight_response.follow_up_suggestions,
+            statistics_ids=statistics_ids,
             codeact_types=[p["type"] for p in encoded_parts],
             codeact_contents=[p["content"] for p in encoded_parts],
         )

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 from typing import Annotated, Dict, List, Optional
 
@@ -16,6 +17,8 @@ from src.agent.tools.code_executors.base import (
     MultiChartInsight,
     PartType,
 )
+from src.agent.tools.datasets_config import DATASETS
+from src.agent.tools.pull_data import fetch_statistics_from_url
 from src.api.data_models import InsightChartOrm, InsightOrm
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
@@ -23,20 +26,35 @@ from src.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def prepare_dataframes(
+def _get_available_datasets() -> str:
+    """Get a concise list of available datasets from the datasets configuration."""
+    dataset_names = []
+    for dataset in DATASETS:
+        dataset_names.append(dataset["dataset_name"])
+
+    return ", ".join(dataset_names)
+
+
+async def prepare_dataframes(
     statistics: list[dict],
 ) -> tuple[List[tuple[pd.DataFrame, str]], List]:
     """
     Prepare DataFrames from raw data for code executor.
+
+    Fetches all source URLs concurrently, then builds DataFrames in order.
     """
+    raw_results = await asyncio.gather(
+        *[fetch_statistics_from_url(s["source_url"]) for s in statistics]
+    )
+
     dataframes = []
     source_urls = []
 
-    for data in statistics:
-        if not data:
+    for data, raw_data in zip(statistics, raw_results):
+        if not raw_data:
             continue
 
-        df = pd.DataFrame(data["data"])
+        df = pd.DataFrame(raw_data)
         if len(df) > 1:
             constants = df.nunique() == 1
             logger.debug(
@@ -322,8 +340,8 @@ async def generate_insights(
 
     statistics = state["statistics"]
 
-    # 1. PREPARE DATAFRAMES: Convert raw_data to DataFrames
-    dataframes, source_urls = prepare_dataframes(statistics)
+    # 1. PREPARE DATAFRAMES: Fetch data from source URLs and build DataFrames
+    dataframes, source_urls = await prepare_dataframes(statistics)
     logger.info(f"Prepared {len(dataframes)} dataframes for analysis")
 
     # 2. EXTRACT DATASET GUIDELINES: Get dataset-specific instructions early

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -60,6 +60,14 @@ def prepare_dataframes(
     return dataframes, source_urls
 
 
+def _extract_statistics_ids(statistics: list[dict]) -> list[str]:
+    return [
+        stat["id"]
+        for stat in statistics
+        if isinstance(stat, dict) and stat.get("id")
+    ]
+
+
 def replace_csv_paths_with_urls(
     code_block: str, source_urls: List[str]
 ) -> str:
@@ -441,6 +449,7 @@ async def generate_insights(
 
     # 9. PERSIST INSIGHT(S) TO DB
     ctx = structlog.contextvars.get_contextvars()
+    statistics_ids = _extract_statistics_ids(statistics)
     insight_ids: list[str] = []
     async with get_session_from_pool() as session:
         insight_row = InsightOrm(
@@ -448,6 +457,7 @@ async def generate_insights(
             thread_id=ctx.get("thread_id", ""),
             insight_text=result.insight.primary_insight,
             follow_up_suggestions=result.insight.follow_up_suggestions,
+            statistics_ids=statistics_ids,
             codeact_types=[p["type"] for p in encoded_parts],
             codeact_contents=[p["content"] for p in encoded_parts],
         )

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Dict, Optional
 
+import structlog
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
@@ -9,6 +10,8 @@ from langgraph.types import Command
 from src.agent.tools.data_handlers.analytics_handler import AnalyticsHandler
 from src.agent.tools.data_handlers.base import DataPullResult
 from src.agent.tools.util import revise_date_range
+from src.api.data_models import StatisticsOrm
+from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -156,22 +159,39 @@ async def pull_data(
         tool_call_id=tool_call_id,
     )
 
+    statistics = {
+        "dataset_name": dataset["dataset_name"],
+        "start_date": effective_start,
+        "end_date": effective_end,
+        "source_url": result.analytics_api_url,
+        "data": raw_data,
+        "aoi_names": [aoi["name"] for aoi in state["aoi_selection"]["aois"]],
+        "parameters": dataset.get("parameters"),
+        "context_layer": dataset.get("context_layer"),
+    }
+
+    ctx = structlog.contextvars.get_contextvars()
+    async with get_session_from_pool() as session:
+        statistics_row = StatisticsOrm(
+            user_id=ctx.get("user_id"),
+            thread_id=ctx.get("thread_id"),
+            dataset_name=statistics["dataset_name"],
+            start_date=statistics["start_date"],
+            end_date=statistics["end_date"],
+            source_url=statistics["source_url"],
+            data=statistics["data"],
+            aoi_names=statistics["aoi_names"],
+            parameters=statistics["parameters"],
+            context_layer=statistics["context_layer"],
+        )
+        session.add(statistics_row)
+        await session.flush()
+        statistics["id"] = str(statistics_row.id)
+        await session.commit()
+
     return Command(
         update={
-            "statistics": [
-                {
-                    "dataset_name": dataset["dataset_name"],
-                    "start_date": effective_start,
-                    "end_date": effective_end,
-                    "source_url": result.analytics_api_url,
-                    "data": raw_data,
-                    "aoi_names": [
-                        aoi["name"] for aoi in state["aoi_selection"]["aois"]
-                    ],
-                    "parameters": dataset.get("parameters"),
-                    "context_layer": dataset.get("context_layer"),
-                }
-            ],
+            "statistics": [statistics],
             "start_date": effective_start,
             "end_date": effective_end,
             "messages": [tool_message],

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -1,5 +1,6 @@
 from typing import Annotated, Dict, Optional
 
+import httpx
 import structlog
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
@@ -15,6 +16,19 @@ from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+async def fetch_statistics_from_url(source_url: str) -> dict:
+    """Fetch raw result data from an analytics source URL.
+
+    The analytics API returns JSON with shape
+    ``{"data": {"result": {...}}}``.  Returns the inner ``result`` dict
+    so callers never need to deal with the response envelope.
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(source_url)
+        response.raise_for_status()
+        return response.json()["data"]["result"]
 
 
 class DataPullOrchestrator:
@@ -122,16 +136,7 @@ async def pull_data(
     tool_messages.append(result.message)
     logger.debug(f"Pull data tool message: {result.message}")
 
-    # Determine raw data format for backward compatibility
-    if (
-        result.success
-        and isinstance(result.data, dict)
-        and "data" in result.data
-    ):
-        raw_data = result.data["data"]
-    elif result.success:
-        raw_data = result.data
-    else:
+    if not result.success:
         return Command(
             update={
                 "messages": [
@@ -145,8 +150,13 @@ async def pull_data(
             },
         )
 
-    raw_data["dataset_name"] = dataset["dataset_name"]
-    raw_data["source_url"] = result.analytics_api_url
+    # Reconstruct raw_data for backward compatibility with frontend consumers
+    # that still read statistics["data"].
+    # DEPRECATED: use source_url and fetch via fetch_statistics_from_url(source_url)
+    if isinstance(result.data, dict) and "data" in result.data:
+        raw_data = result.data["data"]
+    else:
+        raw_data = result.data
 
     if range_clamped:
         tool_messages.append(
@@ -164,6 +174,9 @@ async def pull_data(
         "start_date": effective_start,
         "end_date": effective_end,
         "source_url": result.analytics_api_url,
+        # DEPRECATED: kept for frontend backward compatibility.
+        # Fetch fresh data via fetch_statistics_from_url(source_url)
+        # instead of reading from this field.
         "data": raw_data,
         "aoi_names": [aoi["name"] for aoi in state["aoi_selection"]["aois"]],
         "parameters": dataset.get("parameters"),
@@ -179,7 +192,6 @@ async def pull_data(
             start_date=statistics["start_date"],
             end_date=statistics["end_date"],
             source_url=statistics["source_url"],
-            data=statistics["data"],
             aoi_names=statistics["aoi_names"],
             parameters=statistics["parameters"],
             context_layer=statistics["context_layer"],

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -182,6 +182,27 @@ class MachineUserKeyOrm(Base):
     user = relationship("UserOrm", back_populates="machine_user_keys")
 
 
+class StatisticsOrm(Base):
+    __tablename__ = "statistics"
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id = Column(String, ForeignKey("users.id"), nullable=True)
+    thread_id = Column(String, nullable=True)
+    dataset_name = Column(String, nullable=False)
+    start_date = Column(String, nullable=False)
+    end_date = Column(String, nullable=False)
+    source_url = Column(String, nullable=True)
+    data = Column(JSONB, nullable=False)
+    aoi_names = Column(JSONB, nullable=False, server_default="[]")
+    parameters = Column(JSONB, nullable=True)
+    context_layer = Column(String, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+
+
 class InsightOrm(Base):
     __tablename__ = "insights"
 
@@ -194,6 +215,7 @@ class InsightOrm(Base):
     thread_id = Column(String, nullable=False)
     insight_text = Column(String, nullable=False)
     follow_up_suggestions = Column(JSONB, nullable=False, server_default="[]")
+    statistics_ids = Column(JSONB, nullable=False, server_default="[]")
     codeact_types = Column(ARRAY(String), nullable=False, server_default="{}")
     codeact_contents = Column(
         ARRAY(String), nullable=False, server_default="{}"

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -180,6 +180,27 @@ class MachineUserKeyOrm(Base):
     user = relationship("UserOrm", back_populates="machine_user_keys")
 
 
+class StatisticsOrm(Base):
+    __tablename__ = "statistics"
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id = Column(String, ForeignKey("users.id"), nullable=True)
+    thread_id = Column(String, nullable=True)
+    dataset_name = Column(String, nullable=False)
+    start_date = Column(String, nullable=False)
+    end_date = Column(String, nullable=False)
+    source_url = Column(String, nullable=True)
+    data = Column(JSONB, nullable=False)
+    aoi_names = Column(JSONB, nullable=False, server_default="[]")
+    parameters = Column(JSONB, nullable=True)
+    context_layer = Column(String, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+
+
 class InsightOrm(Base):
     __tablename__ = "insights"
 
@@ -192,6 +213,7 @@ class InsightOrm(Base):
     thread_id = Column(String, nullable=False)
     insight_text = Column(String, nullable=False)
     follow_up_suggestions = Column(JSONB, nullable=False, server_default="[]")
+    statistics_ids = Column(JSONB, nullable=False, server_default="[]")
     codeact_types = Column(ARRAY(String), nullable=False, server_default="{}")
     codeact_contents = Column(
         ARRAY(String), nullable=False, server_default="{}"

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -196,7 +196,6 @@ class StatisticsOrm(Base):
     start_date = Column(String, nullable=False)
     end_date = Column(String, nullable=False)
     source_url = Column(String, nullable=True)
-    data = Column(JSONB, nullable=False)
     aoi_names = Column(JSONB, nullable=False, server_default="[]")
     parameters = Column(JSONB, nullable=True)
     context_layer = Column(String, nullable=True)

--- a/src/api/routers/insights.py
+++ b/src/api/routers/insights.py
@@ -31,6 +31,7 @@ def _row_to_response(row: InsightOrm) -> InsightResponse:
         thread_id=row.thread_id,
         insight_text=row.insight_text,
         follow_up_suggestions=row.follow_up_suggestions or [],
+        statistics_ids=row.statistics_ids or [],
         charts=[
             InsightChartResponse(
                 id=chart.id,

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -403,6 +403,7 @@ class InsightResponse(BaseModel):
     thread_id: str
     insight_text: str
     follow_up_suggestions: List[str]
+    statistics_ids: List[str] = []
     charts: List[InsightChartResponse]
     codeact_parts: List[CodeActPartResponse]
     is_public: bool

--- a/tests/agent/test_graph.py
+++ b/tests/agent/test_graph.py
@@ -70,6 +70,31 @@ def mock_insight_db():
         yield mock_session
 
 
+@pytest.fixture(autouse=True)
+def mock_pull_data_db():
+    """Mock pull_data DB writes to avoid requiring a real global pool."""
+    mock_session = AsyncMock()
+
+    def capture_add(row):
+        mock_session._last_added_row = row
+
+    async def fake_flush():
+        row = getattr(mock_session, "_last_added_row", None)
+        if row is not None and not getattr(row, "id", None):
+            row.id = uuid.uuid4()
+
+    mock_session.add = capture_add
+    mock_session.flush = fake_flush
+    mock_session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def fake_pool():
+        yield mock_session
+
+    with patch("src.agent.tools.pull_data.get_session_from_pool", fake_pool):
+        yield mock_session
+
+
 @pytest.fixture(scope="function", autouse=True)
 def mock_query_aoi_database():
     """Mock query_aoi_database to return MOCK_AOI_QUERY_RESULTS_PARA_BRAZIL."""

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -391,6 +391,7 @@ async def test_insight_response_shape(client, auth_override):
         "charts",
         "codeact_parts",
         "is_public",
+        "statistics_ids",
         "created_at",
     }
     assert set(item.keys()) == expected_keys

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -8,19 +8,29 @@ structural properties of the output (chart type, data filtering, terminology).
 These tests hit the Gemini API — they are integration tests by nature.
 """
 
+import importlib
 import re
 import sys
 import uuid
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from src.agent.state import Statistics
-from src.agent.tools.generate_insights import generate_insights
+from src.agent.tools.generate_insights import (
+    ChartInsight,
+    MultiChartInsight,
+    _extract_statistics_ids,
+    generate_insights,
+)
 from src.api.data_models import InsightOrm
 
+generate_insights_module = importlib.import_module(
+    "src.agent.tools.generate_insights"
+)
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 _last_insight_row: InsightOrm | None = None
@@ -128,6 +138,84 @@ def insight_text(update: dict) -> str:
     if msgs:
         return msgs[0].content
     return ""
+
+
+async def test_extract_statistics_ids_tracks_new_state_ids():
+    assert _extract_statistics_ids(
+        [
+            {"id": "stat-1", "data": {}},
+            {"id": "stat-2", "data": {}},
+        ]
+    ) == ["stat-1", "stat-2"]
+
+
+async def test_extract_statistics_ids_keeps_older_states_compatible():
+    assert _extract_statistics_ids([{"data": {}}, {}, None]) == []
+
+
+async def test_generate_insights_persists_statistics_provenance(monkeypatch):
+    class FakeExecutionResult:
+        error = None
+        chart_data = [{"name": "Brazil", "value": 1}]
+        parts = [
+            SimpleNamespace(
+                type=generate_insights_module.PartType.TEXT_OUTPUT,
+                content="Brazil has one unit.",
+            )
+        ]
+
+        def get_encoded_parts(self):
+            return [{"type": "text_output", "content": "Brazil has one unit."}]
+
+    class FakeExecutor:
+        def build_file_references(self, dataframes):
+            return "input_file_0.csv"
+
+        async def prepare_dataframes(self, dataframes):
+            return []
+
+        async def execute(self, analysis_prompt, file_refs):
+            return FakeExecutionResult()
+
+    class FakeStructuredOutput:
+        async def ainvoke(self, prompt):
+            return MultiChartInsight(
+                charts=[
+                    ChartInsight(
+                        title="Brazil Value",
+                        chart_type="bar",
+                        x_axis="name",
+                        y_axis="value",
+                    )
+                ],
+                primary_insight="Brazil has one unit.",
+                follow_up_suggestions=["Compare another area."],
+            )
+
+    class FakeGemini:
+        def with_structured_output(self, model):
+            return FakeStructuredOutput()
+
+    monkeypatch.setattr(
+        generate_insights_module, "GeminiCodeExecutor", FakeExecutor
+    )
+    monkeypatch.setattr(generate_insights_module, "GEMINI_FLASH", FakeGemini())
+
+    await invoke_generate_insights(
+        "Show Brazil value",
+        GHG_FLUX_DATASET,
+        [{**GHG_FLUX_STATS[0], "id": "stat-123"}],
+    )
+    assert _last_insight_row is not None
+    assert _last_insight_row.statistics_ids == ["stat-123"]
+
+    await invoke_generate_insights(
+        "Show Brazil value",
+        GHG_FLUX_DATASET,
+        [GHG_FLUX_STATS[0]],
+    )
+    assert _last_insight_row is not None
+    assert _last_insight_row.statistics_ids == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -98,6 +98,268 @@ def mock_insight_db():
 
 
 # ---------------------------------------------------------------------------
+# URL → data mapping used by mock_fetch_data fixture
+# ---------------------------------------------------------------------------
+_URL_TO_DATA: dict[str, dict] = {
+    "http://example.com/analytics/ghg-flux": {
+        "variable": [
+            "Gross emissions",
+            "Gross removals",
+            "Net flux",
+        ],
+        "value": [12350000000, -8770000000, 3580000000],
+        "unit": ["MgCO2e", "MgCO2e", "MgCO2e"],
+    },
+    "http://example.com/analytics/grasslands": {
+        "year": list(range(2000, 2023)),
+        "area_ha": [
+            28456000,
+            28300000,
+            28150000,
+            28000000,
+            27850000,
+            27700000,
+            27550000,
+            27400000,
+            27250000,
+            27100000,
+            26950000,
+            26800000,
+            26650000,
+            26500000,
+            26350000,
+            26200000,
+            26050000,
+            25900000,
+            25750000,
+            25600000,
+            25450000,
+            25280000,
+            25124000,
+        ],
+    },
+    "http://example.com/analytics/grasslands-with-zeros": {
+        "year": list(range(2000, 2023)),
+        "area_ha": [
+            28456000,
+            28300000,
+            28150000,
+            28000000,
+            0,
+            27700000,
+            27550000,
+            27400000,
+            27250000,
+            27100000,
+            26950000,
+            26800000,
+            26650000,
+            26500000,
+            26350000,
+            26200000,
+            26050000,
+            25900000,
+            25750000,
+            25600000,
+            25450000,
+            25280000,
+            25124000,
+        ],
+    },
+    "http://example.com/analytics/tree-cover": {
+        "canopy_density": [
+            "0%",
+            "1-10%",
+            "11-20%",
+            "21-30%",
+            "31-40%",
+            "41-50%",
+            "51-60%",
+            "61-70%",
+            "71-80%",
+            "81-90%",
+            "91-100%",
+        ],
+        "area_ha": [
+            0,
+            12350000,
+            5670000,
+            4320000,
+            3890000,
+            4560000,
+            5230000,
+            6780000,
+            8900000,
+            10540000,
+            19982107,
+        ],
+    },
+    "http://example.com/analytics/tree-cover-gain": {
+        "period": ["2000-2020", "2005-2020", "2010-2020", "2015-2020"],
+        "area_ha": [4567890, 3456789, 2345678, 1234567],
+    },
+    "http://example.com/analytics/land-cover": {
+        "start_class": [
+            "Tree cover",
+            "Tree cover",
+            "Short vegetation",
+            "Short vegetation",
+            "Short vegetation",
+            "Cropland",
+            "Cropland",
+        ],
+        "end_class": [
+            "Cropland",
+            "Short vegetation",
+            "Cropland",
+            "Built-up",
+            "Tree cover",
+            "Built-up",
+            "Tree cover",
+        ],
+        "area_ha": [1234567, 345678, 890123, 56789, 123456, 145568, 78901],
+    },
+    "http://example.com/analytics/land-cover-composition": {
+        "land_cover_class": [
+            "Tree cover",
+            "Cropland",
+            "Short vegetation",
+            "Cultivated grassland",
+            "Built-up",
+            "Wetlands",
+            "Water",
+        ],
+        "area_ha": [
+            45000000,
+            22000000,
+            15000000,
+            8000000,
+            2000000,
+            1500000,
+            500000,
+        ],
+    },
+    "http://example.com/analytics/natural-lands": {
+        "land_class": [
+            "Natural forest",
+            "Natural grassland/shrubland",
+            "Natural wetland",
+            "Mangrove",
+            "Natural wetland forest",
+            "Natural peat forest",
+            "Cropland",
+            "Cultivated grassland",
+            "Plantation forest",
+            "Built-up",
+        ],
+        "class_id": [2, 3, 4, 5, 8, 9, 13, 14, 17, 18],
+        "area_ha": [
+            34567890,
+            5678901,
+            2345678,
+            890123,
+            456789,
+            234567,
+            8901234,
+            4567890,
+            1234567,
+            890123,
+        ],
+        "is_natural": [
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+        ],
+    },
+    "http://example.com/analytics/sluc-ef": {
+        "crop": ["Soybean", "Soybean", "Soybean"],
+        "gas_type": ["CO2", "CH4", "N2O"],
+        "emissions_tco2e": [4567890, 123456, 45678],
+        "emission_factor_tco2e_per_tonne": [0.45, 0.012, 0.005],
+    },
+    "http://example.com/analytics/sluc-ef-multi-crop": {
+        "crop": [
+            "Soybean",
+            "Soybean",
+            "Soybean",
+            "Cattle",
+            "Cattle",
+            "Cattle",
+            "Cocoa",
+            "Cocoa",
+            "Cocoa",
+            "Oil Palm",
+            "Oil Palm",
+            "Oil Palm",
+            "Coffee",
+            "Coffee",
+            "Coffee",
+        ],
+        "gas_type": ["CO2", "CH4", "N2O"] * 5,
+        "emissions_tco2e": [
+            4567890,
+            123456,
+            45678,
+            8901234,
+            234567,
+            89012,
+            1234567,
+            56789,
+            23456,
+            567890,
+            12345,
+            4567,
+            345678,
+            9012,
+            3456,
+        ],
+        "emission_factor_tco2e_per_tonne": [
+            0.45,
+            0.012,
+            0.005,
+            1.23,
+            0.033,
+            0.012,
+            2.34,
+            0.056,
+            0.023,
+            0.67,
+            0.015,
+            0.006,
+            0.12,
+            0.003,
+            0.001,
+        ],
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_fetch_data():
+    """Patch fetch_statistics_from_url to return test data by source_url."""
+
+    async def _fetch(source_url: str) -> dict:
+        if source_url not in _URL_TO_DATA:
+            raise ValueError(
+                f"No mock data registered for source_url: {source_url!r}"
+            )
+        return _URL_TO_DATA[source_url]
+
+    with patch(
+        "src.agent.tools.generate_insights.fetch_statistics_from_url",
+        side_effect=_fetch,
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 async def invoke_generate_insights(
@@ -143,14 +405,14 @@ def insight_text(update: dict) -> str:
 async def test_extract_statistics_ids_tracks_new_state_ids():
     assert _extract_statistics_ids(
         [
-            {"id": "stat-1", "data": {}},
-            {"id": "stat-2", "data": {}},
+            {"id": "stat-1"},
+            {"id": "stat-2"},
         ]
     ) == ["stat-1", "stat-2"]
 
 
 async def test_extract_statistics_ids_keeps_older_states_compatible():
-    assert _extract_statistics_ids([{"data": {}}, {}, None]) == []
+    assert _extract_statistics_ids([{}, {}, None]) == []
 
 
 async def test_generate_insights_persists_statistics_provenance(monkeypatch):
@@ -267,15 +529,6 @@ GHG_FLUX_STATS: list[dict] = [
         aoi_names=["Brazil"],
         parameters=None,
         context_layer=None,
-        data={
-            "variable": [
-                "Gross emissions",
-                "Gross removals",
-                "Net flux",
-            ],
-            "value": [12350000000, -8770000000, 3580000000],
-            "unit": ["MgCO2e", "MgCO2e", "MgCO2e"],
-        },
     )
 ]
 
@@ -320,34 +573,6 @@ GRASSLAND_STATS: list[dict] = [
         aoi_names=["Kenya"],
         parameters=None,
         context_layer=None,
-        data={
-            "year": list(range(2000, 2023)),
-            "area_ha": [
-                28456000,
-                28300000,
-                28150000,
-                28000000,
-                27850000,
-                27700000,
-                27550000,
-                27400000,
-                27250000,
-                27100000,
-                26950000,
-                26800000,
-                26650000,
-                26500000,
-                26350000,
-                26200000,
-                26050000,
-                25900000,
-                25750000,
-                25600000,
-                25450000,
-                25280000,
-                25124000,
-            ],
-        },
     )
 ]
 
@@ -355,40 +580,12 @@ GRASSLAND_STATS: list[dict] = [
 GRASSLAND_STATS_WITH_ZEROS: list[dict] = [
     Statistics(
         dataset_name="Global natural/semi-natural grassland extent",
-        source_url="http://example.com/analytics/grasslands",
+        source_url="http://example.com/analytics/grasslands-with-zeros",
         start_date="2000-01-01",
         end_date="2022-12-31",
         aoi_names=["Kenya"],
         parameters=None,
         context_layer=None,
-        data={
-            "year": list(range(2000, 2023)),
-            "area_ha": [
-                28456000,
-                28300000,
-                28150000,
-                28000000,
-                0,  # zero row that should be excluded
-                27700000,
-                27550000,
-                27400000,
-                27250000,
-                27100000,
-                26950000,
-                26800000,
-                26650000,
-                26500000,
-                26350000,
-                26200000,
-                26050000,
-                25900000,
-                25750000,
-                25600000,
-                25450000,
-                25280000,
-                25124000,
-            ],
-        },
     )
 ]
 
@@ -438,34 +635,6 @@ TREE_COVER_STATS: list[dict] = [
         aoi_names=["Democratic Republic of Congo"],
         parameters=None,
         context_layer=None,
-        data={
-            "canopy_density": [
-                "0%",
-                "1-10%",
-                "11-20%",
-                "21-30%",
-                "31-40%",
-                "41-50%",
-                "51-60%",
-                "61-70%",
-                "71-80%",
-                "81-90%",
-                "91-100%",
-            ],
-            "area_ha": [
-                0,  # 0% bin — should be excluded
-                12350000,
-                5670000,
-                4320000,
-                3890000,
-                4560000,
-                5230000,
-                6780000,
-                8900000,
-                10540000,
-                19982107,
-            ],
-        },
     )
 ]
 
@@ -519,15 +688,6 @@ TREE_COVER_GAIN_STATS: list[dict] = [
         aoi_names=["Indonesia"],
         parameters=None,
         context_layer=None,
-        data={
-            "period": [
-                "2000-2020",
-                "2005-2020",
-                "2010-2020",
-                "2015-2020",
-            ],
-            "area_ha": [4567890, 3456789, 2345678, 1234567],
-        },
     )
 ]
 
@@ -575,67 +735,18 @@ LAND_COVER_TRANSITION_STATS: list[dict] = [
         aoi_names=["Brazil"],
         parameters=None,
         context_layer=None,
-        data={
-            "start_class": [
-                "Tree cover",
-                "Tree cover",
-                "Short vegetation",
-                "Short vegetation",
-                "Short vegetation",
-                "Cropland",
-                "Cropland",
-            ],
-            "end_class": [
-                "Cropland",
-                "Short vegetation",
-                "Cropland",
-                "Built-up",
-                "Tree cover",
-                "Built-up",
-                "Tree cover",
-            ],
-            "area_ha": [
-                1234567,
-                345678,
-                890123,
-                56789,
-                123456,
-                145568,
-                78901,
-            ],
-        },
     )
 ]
 
 LAND_COVER_COMPOSITION_STATS: list[dict] = [
     Statistics(
         dataset_name="Global land cover",
-        source_url="http://example.com/analytics/land-cover",
+        source_url="http://example.com/analytics/land-cover-composition",
         start_date="2024-01-01",
         end_date="2024-12-31",
         aoi_names=["Brazil"],
         parameters=None,
         context_layer=None,
-        data={
-            "land_cover_class": [
-                "Tree cover",
-                "Cropland",
-                "Short vegetation",
-                "Cultivated grassland",
-                "Built-up",
-                "Wetlands",
-                "Water",
-            ],
-            "area_ha": [
-                45000000,
-                22000000,
-                15000000,
-                8000000,
-                2000000,
-                1500000,
-                500000,
-            ],
-        },
     )
 ]
 
@@ -681,45 +792,6 @@ NATURAL_LANDS_STATS: list[dict] = [
         aoi_names=["Colombia"],
         parameters=None,
         context_layer=None,
-        data={
-            "land_class": [
-                "Natural forest",
-                "Natural grassland/shrubland",
-                "Natural wetland",
-                "Mangrove",
-                "Natural wetland forest",
-                "Natural peat forest",
-                "Cropland",
-                "Cultivated grassland",
-                "Plantation forest",
-                "Built-up",
-            ],
-            "class_id": [2, 3, 4, 5, 8, 9, 13, 14, 17, 18],
-            "area_ha": [
-                34567890,
-                5678901,
-                2345678,
-                890123,
-                456789,
-                234567,
-                8901234,
-                4567890,
-                1234567,
-                890123,
-            ],
-            "is_natural": [
-                True,
-                True,
-                True,
-                True,
-                True,
-                True,
-                False,
-                False,
-                False,
-                False,
-            ],
-        },
     )
 ]
 
@@ -767,78 +839,18 @@ SLUC_EF_GAS_STATS: list[dict] = [
         aoi_names=["Brazil"],
         parameters=None,
         context_layer=None,
-        data={
-            "crop": ["Soybean", "Soybean", "Soybean"],
-            "gas_type": ["CO2", "CH4", "N2O"],
-            "emissions_tco2e": [4567890, 123456, 45678],
-            "emission_factor_tco2e_per_tonne": [0.45, 0.012, 0.005],
-        },
     )
 ]
 
 SLUC_EF_MULTI_CROP_STATS: list[dict] = [
     Statistics(
         dataset_name="Deforestation (sLUC) Emission Factors by Agricultural Crop",
-        source_url="http://example.com/analytics/sluc-ef",
+        source_url="http://example.com/analytics/sluc-ef-multi-crop",
         start_date="2024-01-01",
         end_date="2024-12-31",
         aoi_names=["Brazil"],
         parameters=None,
         context_layer=None,
-        data={
-            "crop": [
-                "Soybean",
-                "Soybean",
-                "Soybean",
-                "Cattle",
-                "Cattle",
-                "Cattle",
-                "Cocoa",
-                "Cocoa",
-                "Cocoa",
-                "Oil Palm",
-                "Oil Palm",
-                "Oil Palm",
-                "Coffee",
-                "Coffee",
-                "Coffee",
-            ],
-            "gas_type": ["CO2", "CH4", "N2O"] * 5,
-            "emissions_tco2e": [
-                4567890,
-                123456,
-                45678,
-                8901234,
-                234567,
-                89012,
-                1234567,
-                56789,
-                23456,
-                567890,
-                12345,
-                4567,
-                345678,
-                9012,
-                3456,
-            ],
-            "emission_factor_tco2e_per_tonne": [
-                0.45,
-                0.012,
-                0.005,
-                1.23,
-                0.033,
-                0.012,
-                2.34,
-                0.056,
-                0.023,
-                0.67,
-                0.015,
-                0.006,
-                0.12,
-                0.003,
-                0.001,
-            ],
-        },
     )
 ]
 

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -1,18 +1,24 @@
+import importlib
 import uuid
 from datetime import datetime, timedelta
 
 import pytest
 import structlog
+from sqlalchemy import select
 
+from src.agent.tools.data_handlers.base import DataPullResult
 from src.agent.tools.datasets_config import DATASETS
 from src.agent.tools.pull_data import pull_data, revise_date_range
 from src.api.app import app
 from src.api.auth.dependencies import fetch_user_from_rw_api
+from src.api.data_models import StatisticsOrm
 from src.api.schemas import UserModel
+from tests.conftest import async_session_maker
 
 # Use session-scoped event loop to match conftest.py fixtures and avoid
 # "Event loop is closed" errors when running with other test modules
 pytestmark = pytest.mark.asyncio(loop_scope="session")
+pull_data_module = importlib.import_module("src.agent.tools.pull_data")
 
 # All dataset and intersection combinations from OpenAPI spec
 # https://analytics.globalnaturewatch.org/openapi.json
@@ -207,6 +213,86 @@ async def test_pull_data_queries(aoi_data, dataset):
         assert len(statistics) == 1
         assert statistics[0]["source_url"].startswith("http")
         assert statistics[0]["aoi_names"] == [aoi_data["name"]]
+
+
+async def test_pull_data_persists_statistics(monkeypatch):
+    class FakeDataPullOrchestrator:
+        async def pull_data(
+            self,
+            query,
+            dataset,
+            start_date,
+            end_date,
+            change_over_time_query,
+            aois,
+        ):
+            return DataPullResult(
+                success=True,
+                data={"data": {"value": [1], "aoi_id": ["BRA"]}},
+                message="Pulled data.",
+                data_points_count=1,
+                analytics_api_url="http://example.com/analytics/statistics",
+            )
+
+    async def fake_revise_date_range(start_date, end_date, dataset_id):
+        return start_date, end_date, False
+
+    monkeypatch.setattr(
+        pull_data_module, "data_pull_orchestrator", FakeDataPullOrchestrator()
+    )
+    monkeypatch.setattr(
+        pull_data_module, "revise_date_range", fake_revise_date_range
+    )
+
+    tool_call = {
+        "type": "tool_call",
+        "name": "pull_data",
+        "id": "test-persist-statistics",
+        "args": {
+            "query": "find tree cover loss in Brazil",
+            "start_date": "2020-01-01",
+            "end_date": "2020-12-31",
+            "change_over_time_query": False,
+            "tool_call_id": "test-persist-statistics",
+            "state": {
+                "aoi_selection": {
+                    "name": "Brazil",
+                    "aois": [TEST_AOIS[0]],
+                },
+                "dataset": {
+                    "dataset_id": 4,
+                    "dataset_name": "Tree cover loss",
+                    "reason": "",
+                    "tile_url": "",
+                    "context_layer": None,
+                    "parameters": [{"name": "canopy_cover", "values": [75]}],
+                },
+            },
+        },
+    }
+
+    command = await pull_data.ainvoke(tool_call)
+    statistics = command.update.get("statistics", [])
+    assert len(statistics) == 1
+    assert statistics[0]["id"]
+    assert statistics[0]["data"]["value"] == [1]
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(StatisticsOrm).where(
+                StatisticsOrm.id == uuid.UUID(statistics[0]["id"])
+            )
+        )
+        statistics_row = result.scalar_one()
+
+    assert statistics_row.dataset_name == "Tree cover loss"
+    assert statistics_row.start_date == "2020-01-01"
+    assert statistics_row.end_date == "2020-12-31"
+    assert statistics_row.data == statistics[0]["data"]
+    assert statistics_row.aoi_names == ["Brazil"]
+    assert statistics_row.parameters == [
+        {"name": "canopy_cover", "values": [75]}
+    ]
 
 
 async def test_tree_cover_loss_date_range_clamped_to_2025():

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -1,5 +1,6 @@
 import importlib
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 
 import pytest
@@ -19,6 +20,19 @@ from tests.conftest import async_session_maker
 # "Event loop is closed" errors when running with other test modules
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 pull_data_module = importlib.import_module("src.agent.tools.pull_data")
+
+
+@pytest.fixture(autouse=True)
+def mock_pull_data_db_session(monkeypatch):
+    @asynccontextmanager
+    async def fake_pool_session():
+        async with async_session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(
+        pull_data_module, "get_session_from_pool", fake_pool_session
+    )
+
 
 # All dataset and intersection combinations from OpenAPI spec
 # https://analytics.globalnaturewatch.org/openapi.json

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -288,7 +288,6 @@ async def test_pull_data_persists_statistics(monkeypatch):
     assert statistics_row.dataset_name == "Tree cover loss"
     assert statistics_row.start_date == "2020-01-01"
     assert statistics_row.end_date == "2020-12-31"
-    assert statistics_row.data == statistics[0]["data"]
     assert statistics_row.aoi_names == ["Brazil"]
     assert statistics_row.parameters == [
         {"name": "canopy_cover", "values": [75]}


### PR DESCRIPTION
## Summary

- Add a dedicated `statistics` database table for outputs produced by `pull_data`, including dataset metadata, date range, AOIs, parameters, context layer, source URL, and the raw statistics payload.
- Keep the existing inline `state["statistics"]` payload for backwards compatibility, while adding the persisted statistics row ID to each new statistics object returned by `pull_data`.
- Add `statistics_ids` to persisted insights so each generated insight can track which statistics objects were used as source data.
- Preserve backwards compatibility for older thread states and tests where statistics objects do not yet include IDs.
- Expose `statistics_ids` in insight API responses so clients can inspect provenance from fetched insights.
- Add an Alembic migration for the new `statistics` table, indexes on `user_id` and `thread_id`, and the new `insights.statistics_ids` provenance column.
- Add focused test coverage for statistics persistence, insight provenance tracking, and older state compatibility.

## Implementation Details

- Introduces `StatisticsOrm` in the SQLAlchemy data models with UUID primary keys and JSONB columns for raw data, AOI names, and optional parameters.
- Updates `pull_data` to persist successful analytics results through the shared DB session pool using the current structlog context for `user_id` and `thread_id`.
- Updates `generate_insights` to extract statistics IDs from agent state and write them to `InsightOrm.statistics_ids`.
- Adds a helper for extracting statistics IDs so provenance behavior is easy to test independently from live LLM execution.
- Leaves existing state consumers unchanged by keeping `data`, `dataset_name`, `start_date`, `end_date`, `source_url`, `aoi_names`, `parameters`, and `context_layer` in the state update.

## Test Plan
- `uv run ruff check src/api/data_models.py src/api/schemas.py src/api/routers/insights.py src/agent/state.py src/agent/tools/pull_data.py src/agent/tools/generate_insights.py tests/tools/test_pull_data.py tests/tools/test_generate_insights_tiered.py db/alembic/versions/9f8e7d6c5b4a_add_statistics_table.py`
- `uv run pytest tests/tools/test_generate_insights_tiered.py -k 'statistics_provenance or extract_statistics_ids'`
- `uv run pytest tests/tools/test_pull_data.py -k 'persists_statistics'`


Refs https://github.com/wri/project-zeno/pull/628