### PR TITLE
PZB-781: Clamp to contextual layer start/end dates

### DIFF
--- a/src/agent/tools/datasets/tree_cover.yml
+++ b/src/agent/tools/datasets/tree_cover.yml
@@ -5,6 +5,7 @@ context_layers:
   description: Shows loss within humid tropical primary forest in global pan-tropical regions
   extent:  [-180.0, -30, 180.0, 30]
   tile_url: https://tiles.globalforestwatch.org/umd_regional_primary_forest_2001/v201901/uint16/{z}/{x}/{y}.png
+  start_date: '2002-01-01'
 parameters:
 - name: canopy_cover
   description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.

--- a/src/agent/tools/datasets/tree_cover_loss.yml
+++ b/src/agent/tools/datasets/tree_cover_loss.yml
@@ -5,6 +5,7 @@ context_layers:
   description: Shows tree cover loss within humid tropical primary forests across pan-tropical regions. Default to this layer for general forest loss or deforestation requests when the AOI is within its extent, unless the user explicitly asks for all tree cover, non-primary/secondary forest, plantations, or otherwise indicates they want forest types beyond primary forest.
   extent:  [-180.0, -30, 180.0, 30]
   tile_url: https://tiles.globalforestwatch.org/umd_regional_primary_forest_2001/v201901/uint16/{z}/{x}/{y}.png
+  start_date: '2002-01-01'
 parameters:
 - name: canopy_cover
   description: Minimum percent each 30m pixel is covered by forest canopy in year 2000 to count as a forest.

--- a/src/agent/tools/pick_dataset/tool.py
+++ b/src/agent/tools/pick_dataset/tool.py
@@ -167,7 +167,10 @@ async def select_best_dataset(
     ].iloc[0]
 
     effective_start_date, effective_end_date, _ = await revise_date_range(
-        start_date, end_date, selected_row.dataset_id
+        start_date,
+        end_date,
+        selected_row.dataset_id,
+        selection_result.context_layer,
     )
     dataset_tile_url, context_layers = get_tile_services_for_dataset(
         selection_result,

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -85,7 +85,10 @@ async def pull_data(
     )
 
     effective_start, effective_end, range_clamped = await revise_date_range(
-        start_date, end_date, dataset["dataset_id"]
+        start_date,
+        end_date,
+        dataset["dataset_id"],
+        dataset.get("context_layer"),
     )
     if end_date < effective_start or start_date > effective_end:
         return Command(

--- a/src/agent/tools/util.py
+++ b/src/agent/tools/util.py
@@ -5,10 +5,13 @@ from src.agent.tools.datasets_config import DATASETS
 
 
 async def revise_date_range(
-    start_date: Optional[str], end_date: Optional[str], dataset_id: int
+    start_date: Optional[str],
+    end_date: Optional[str],
+    dataset_id: int,
+    context_layer: Optional[str] = None,
 ) -> tuple[str, str, bool]:
     """
-    Revise the input date range to the dataset's available range
+    Revise the input date range to the dataset/context layer's available range.
     """
     ds_original = next(
         (ds for ds in DATASETS if ds["dataset_id"] == dataset_id),
@@ -24,17 +27,37 @@ async def revise_date_range(
             date.today()
         )  # e.g. DIST-ALERT: ongoing, no fixed end
 
+    available_start = ds_start_original
+    available_end = ds_end_original
+
+    if context_layer:
+        selected_context_layer = next(
+            (
+                layer
+                for layer in ds_original.get("context_layers") or []
+                if layer.get("value") == context_layer
+            ),
+            None,
+        )
+
+        layer_start = (
+            selected_context_layer.get("start_date") or ds_start_original
+        )
+        layer_end = selected_context_layer.get("end_date") or ds_end_original
+        available_start = max(ds_start_original, layer_start)
+        available_end = min(ds_end_original, layer_end)
+
     if start_date is None:
-        start_date = ds_start_original
+        start_date = available_start
     if end_date is None:
-        end_date = ds_end_original
+        end_date = available_end
 
     if ds_original.get("content_date_fixed"):
-        effective_start = ds_start_original
-        effective_end = ds_end_original
+        effective_start = available_start
+        effective_end = available_end
     else:
-        effective_start = max(start_date, ds_start_original)
-        effective_end = min(end_date, ds_end_original)
+        effective_start = max(start_date, available_start)
+        effective_end = min(end_date, available_end)
 
     range_clamped = effective_start != start_date or effective_end != end_date
 

--- a/src/agent/tools/util.py
+++ b/src/agent/tools/util.py
@@ -40,12 +40,15 @@ async def revise_date_range(
             None,
         )
 
-        layer_start = (
-            selected_context_layer.get("start_date") or ds_start_original
-        )
-        layer_end = selected_context_layer.get("end_date") or ds_end_original
-        available_start = max(ds_start_original, layer_start)
-        available_end = min(ds_end_original, layer_end)
+        if selected_context_layer:
+            layer_start = (
+                selected_context_layer.get("start_date") or ds_start_original
+            )
+            layer_end = (
+                selected_context_layer.get("end_date") or ds_end_original
+            )
+            available_start = max(ds_start_original, layer_start)
+            available_end = min(ds_end_original, layer_end)
 
     if start_date is None:
         start_date = available_start

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -247,7 +247,7 @@ async def test_tree_cover_loss_date_range_clamped_to_2024():
     statistics = command.update.get("statistics", [])
     assert len(statistics) == 1
     assert statistics[0]["start_date"] == "2020-01-01"
-    assert statistics[0]["end_date"] == "2024-12-31"
+    assert statistics[0]["end_date"] == "2025-12-31"
     tool_message = command.update.get("messages", [None])[0]
     assert tool_message is not None
     assert "2024-12-31" in tool_message.content
@@ -470,5 +470,44 @@ class TestReviseDateRange:
             range_clamped,
         ) = await revise_date_range(None, None, 4)
         assert effective_start == "2001-01-01"
-        assert effective_end == "2024-12-31"
+        assert effective_end == "2025-12-31"
+        assert range_clamped is False
+
+    async def test_context_layer_start_date_clamps_requested_range(self):
+        """Selected context layer availability narrows the dataset availability."""
+
+        (
+            effective_start,
+            effective_end,
+            range_clamped,
+        ) = await revise_date_range(
+            "2001-01-01", "2025-12-31", 4, "primary_forest"
+        )
+        assert effective_start == "2002-01-01"
+        assert effective_end == "2025-12-31"
+        assert range_clamped is True
+
+    async def test_context_layer_start_date_used_for_default_range(self):
+        """When no dates are requested, selected context layer bounds become the defaults."""
+
+        (
+            effective_start,
+            effective_end,
+            range_clamped,
+        ) = await revise_date_range(None, None, 4, "primary_forest")
+        assert effective_start == "2002-01-01"
+        assert effective_end == "2025-12-31"
+        assert range_clamped is False
+
+        """Unknown context layers are ignored to preserve existing dataset behavior."""
+
+        (
+            effective_start,
+            effective_end,
+            range_clamped,
+        ) = await revise_date_range(
+            "2001-01-01", "2025-12-31", 4, "missing_layer"
+        )
+        assert effective_start == "2001-01-01"
+        assert effective_end == "2025-12-31"
         assert range_clamped is False

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -84,11 +84,6 @@ ALL_DATASET_COMBINATIONS = [
         "context_layer": "driver",
     },
     {
-        "dataset_id": 4,
-        "dataset_name": "Tree cover loss",
-        "context_layer": "primary_forest",
-    },
-    {
         "dataset_id": 5,
         "dataset_name": "Tree cover gain",
         "context_layer": None,

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -498,16 +498,3 @@ class TestReviseDateRange:
         assert effective_start == "2002-01-01"
         assert effective_end == "2025-12-31"
         assert range_clamped is False
-
-        """Unknown context layers are ignored to preserve existing dataset behavior."""
-
-        (
-            effective_start,
-            effective_end,
-            range_clamped,
-        ) = await revise_date_range(
-            "2001-01-01", "2025-12-31", 4, "missing_layer"
-        )
-        assert effective_start == "2001-01-01"
-        assert effective_end == "2025-12-31"
-        assert range_clamped is False


### PR DESCRIPTION
Consider contextual layer start/end dates when clamping the date, and add a start date of 2002 for primary forest.