### PR TITLE
Fixing type errors, so mypy is clean

### DIFF
--- a/src/agent/tools/code_executors/gemini_executor.py
+++ b/src/agent/tools/code_executors/gemini_executor.py
@@ -3,7 +3,7 @@
 import asyncio
 import io
 from functools import partial
-from typing import Dict, List
+from typing import Dict, List, cast
 
 import pandas as pd
 from google import genai
@@ -120,7 +120,7 @@ class GeminiCodeExecutor:
                         f"retrying in {delay:.1f}s"
                     )
                     await asyncio.sleep(delay)
-        raise last_error
+        raise cast(Exception, last_error)
 
     def _parse_response(self, response) -> ExecutionResult:
         """Parse a generate_content response into ExecutionResult."""

--- a/src/agent/tools/data_handlers/analytics_handler.py
+++ b/src/agent/tools/data_handlers/analytics_handler.py
@@ -166,7 +166,7 @@ class AnalyticsHandler(DataSourceHandler):
             SLUC_EMISSION_FACTORS_ID,
         ]
 
-    def _get_aoi_type(self, aoi: Dict) -> str:
+    def _get_aoi_type(self, aoi: Dict) -> dict[str, str]:
         """Get the type of the AOI"""
 
         if aoi["subtype"] in ADMIN_SUBTYPES:
@@ -250,6 +250,7 @@ class AnalyticsHandler(DataSourceHandler):
 
         logger.debug(f"dataset: {dataset}")
 
+        payload: dict[str, Any]
         if dataset.get("dataset_id") == DIST_ALERT_ID:
             payload = {
                 **base_payload,
@@ -345,8 +346,9 @@ class AnalyticsHandler(DataSourceHandler):
             FOREST_CARBON_FLUX_ID,
         ]:
             canopy_cover = 30
-            if dataset.get("parameters") is not None:
-                for param in dataset.get("parameters"):
+            params = dataset.get("parameters")
+            if params is not None:
+                for param in params:
                     if param["name"] == "canopy_cover":
                         canopy_cover = max(param["values"])
 
@@ -407,7 +409,7 @@ class AnalyticsHandler(DataSourceHandler):
         self,
         result: Dict,
         aois: list[dict],
-    ) -> tuple[Any, int, str]:
+    ) -> tuple[Any, int, str, str]:
         """Process the response data based on dataset type."""
 
         if "data" not in result:
@@ -500,8 +502,8 @@ class AnalyticsHandler(DataSourceHandler):
                     + "/v0/land_change/land_cover_composition/analytics"
                 )
             else:
-                endpoint_url = self.BASE_URL + dataset.get(
-                    "analytics_api_endpoint"
+                endpoint_url = (
+                    self.BASE_URL + dataset["analytics_api_endpoint"]
                 )
 
             # Build the payload based on dataset type

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -1,5 +1,5 @@
 import re
-from typing import Annotated, Dict, List
+from typing import Annotated, Dict, List, Optional
 
 import pandas as pd
 import structlog
@@ -33,7 +33,7 @@ def _get_available_datasets() -> str:
 
 def prepare_dataframes(
     statistics: list[dict],
-) -> List[tuple[pd.DataFrame, str]]:
+) -> tuple[List[tuple[pd.DataFrame, str]], List]:
     """
     Prepare DataFrames from raw data for code executor.
     """
@@ -70,7 +70,7 @@ def prepare_dataframes(
 
 def replace_csv_paths_with_urls(
     code_block: str, source_urls: List[str]
-) -> List[str]:
+) -> str:
     """
     Replace CSV file paths in code blocks with URL-based data loading.
 
@@ -314,7 +314,7 @@ class MultiChartInsight(BaseModel):
 async def generate_insights(
     query: str,
     state: Annotated[Dict, InjectedState] | None = None,
-    tool_call_id: Annotated[str, InjectedToolCallId] = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
     """
     Analyzes raw data and generates a single chart insight with Recharts-compatible data.

--- a/src/agent/tools/pick_aoi/tool.py
+++ b/src/agent/tools/pick_aoi/tool.py
@@ -291,7 +291,7 @@ async def query_aoi_database(
 
 
 async def query_subregion_database(
-    subregion_name: str, source: str, src_id: int
+    subregion_name: str, source: str, src_id: str
 ):
     """Query the right table in PostGIS database for subregions based on the selected AOI.
 
@@ -488,8 +488,10 @@ async def check_multiple_matches(
                 ]
             )
 
+    return None
 
-async def check_aoi_selection(aois: list[AOIIndex]) -> str:
+
+async def check_aoi_selection(aois: list[AOIIndex]) -> Optional[str]:
     if not aois:
         return (
             "No matching AOIs were found for your request. "
@@ -515,10 +517,12 @@ async def check_aoi_selection(aois: list[AOIIndex]) -> str:
             f"For optimal performance, please limit results to under {SUBREGION_LIMIT} subregions for KBA, WDPA, and Indigenous Lands, or under {SUBREGION_LIMIT_ADMIN} for other area types."
         )
 
+    return None
+
 
 async def check_duplicate_aois(
     selected_aois: list[AOIIndex], all_results: list[pd.DataFrame]
-) -> str:
+) -> Optional[str]:
     for selected_aoi, result in zip(selected_aois, all_results):
         if selected_aoi.source == "gadm":
             short_name = selected_aoi.name.split(",")[0]
@@ -527,6 +531,8 @@ async def check_duplicate_aois(
             )
             if candidate_names:
                 return f"I found multiple locations named '{short_name}' in different countries. Please tell me which one you meant:\n\n{candidate_names}\n\nWhich location are you looking for?"
+
+    return None
 
 
 @tool("pick_aoi")
@@ -546,7 +552,7 @@ async def pick_aoi(
             "landmark",
         ]
     ] = None,
-    tool_call_id: Annotated[str, InjectedToolCallId] = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
     """Selects the most appropriate area of interest (AOI) based on a place name and user's question. Optionally, it can also filter the results by a subregion.
 

--- a/src/agent/tools/pick_dataset/tool.py
+++ b/src/agent/tools/pick_dataset/tool.py
@@ -204,10 +204,10 @@ async def select_best_dataset(
 @tool("pick_dataset")
 async def pick_dataset(
     query: str,
+    state: Annotated[Dict, InjectedState],
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    state: Annotated[Dict, InjectedState] = None,
-    tool_call_id: Annotated[str, InjectedToolCallId] = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
     """
     Given a user query, runs RAG to retrieve relevant datasets, selects the best matching dataset within the specified time range with reasoning,

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -60,10 +60,10 @@ data_pull_orchestrator = DataPullOrchestrator()
 async def pull_data(
     query: str,
     change_over_time_query: bool,
+    state: Annotated[Dict, InjectedState],
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-    tool_call_id: Annotated[str, InjectedToolCallId] = None,
-    state: Annotated[Dict, InjectedState] = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
     """
     Pull data for the previously selected AOIs and dataset in a given time range.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,5 +1,6 @@
 import uuid
 from contextlib import asynccontextmanager
+from typing import Optional
 
 import structlog
 from fastapi import FastAPI, Request, Response, status
@@ -61,10 +62,10 @@ async def logging_middleware(request: Request, call_next) -> Response:
         request_id=req_id,
     )
     response_code = None
-    response = None
+    response: Optional[Response] = None
 
     try:
-        response: Response = await call_next(request)
+        response = await call_next(request)
         response_code = response.status_code
     except Exception as e:
         logger.exception(

--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -6,7 +6,7 @@ from typing import Optional
 import cachetools
 import httpx
 from fastapi import Depends, HTTPException, Request, status
-from fastapi.security import HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,12 +30,14 @@ ANONYMOUS_USER_PREFIX = "noauth"
 security = HTTPBearer(auto_error=False)
 
 # LRU cache for user info, keyed by token
-_user_info_cache = cachetools.TTLCache(maxsize=1024, ttl=60 * 60 * 24)  # 1 day
+_user_info_cache: cachetools.TTLCache = cachetools.TTLCache(
+    maxsize=1024, ttl=60 * 60 * 24
+)  # 1 day
 
 
 async def fetch_user_from_rw_api(
     request: Request,
-    authorization: Optional[str] = Depends(security),
+    authorization: Optional[HTTPAuthorizationCredentials] = Depends(security),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> UserModel:
     if not authorization:

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import uuid
 from datetime import date, datetime
+from typing import Any
 
 from sqlalchemy import (
     ARRAY,
@@ -20,7 +21,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
 from sqlalchemy.orm import declarative_base, relationship
 
-Base = declarative_base()
+# Add Any declaration so mypy knows Base is a class.
+Base: Any = declarative_base()
 
 
 class UserType(str, enum.Enum):

--- a/src/api/services/chat.py
+++ b/src/api/services/chat.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from fastapi import HTTPException
 from langchain_core.load import dumps
@@ -136,7 +136,7 @@ async def stream_chat(
 
     messages = []
     ui_action_message = []
-    state_updates = {}
+    state_updates: Dict[str, Any] = {}
 
     if ui_context:
         for action_type, action_data in ui_context.items():

--- a/src/ingest/ingest_gadm.py
+++ b/src/ingest/ingest_gadm.py
@@ -43,18 +43,18 @@ LAYER_CHUNK_SIZES = {
 
 def download(url: str, dest: str) -> str:
     """Stream-download *url* into *dest* (skips if already present)."""
-    dest = Path(dest)
-    if dest.exists():
+    destpath = Path(dest)
+    if destpath.exists():
         print(f"✓ Using cached file → {dest}")
         return dest
-    dest.parent.mkdir(parents=True, exist_ok=True)
+    destpath.parent.mkdir(parents=True, exist_ok=True)
     print(f"Downloading {url} to {dest}...")
     with requests.get(url, stream=True) as r:
         r.raise_for_status()
         with open(dest, "wb") as f:
             for chunk in r.iter_content(1 << 20):
                 f.write(chunk)
-    print(f"✓ Downloaded {dest.stat().st_size / 1e6:.1f} MB")
+    print(f"✓ Downloaded {destpath.stat().st_size / 1e6:.1f} MB")
     return dest
 
 

--- a/src/shared/geocoding_helpers.py
+++ b/src/shared/geocoding_helpers.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from uuid import UUID
 
 import structlog
@@ -152,14 +152,16 @@ async def get_geometry_data(
             WHERE "{id_column}" = :src_id
         """
 
+        nsrc_id: Union[int, str] = src_id
         if source == "kba":
-            # these sources IDs stored as numeric values
+            # These sources IDs stored as numeric values. Convert nsrc_id to integer
+            # if we can, else leave as string.
             try:
-                src_id = int(src_id)
+                nsrc_id = int(nsrc_id)
             except ValueError:
                 pass
 
-        q = await session.execute(text(sql_query), {"src_id": src_id})
+        q = await session.execute(text(sql_query), {"src_id": nsrc_id})
         result = q.first()
 
         if not result:
@@ -179,6 +181,6 @@ async def get_geometry_data(
             "name": result.name,
             "subtype": result.subtype,
             "source": source,
-            "src_id": src_id,
+            "src_id": nsrc_id,
             "geometry": geometry,
         }


### PR DESCRIPTION
Eliminated all the mypy errors when running this command:

cd src; mypy --exclude shared/config.py .

[In my mypy/config, I turn off warning about missing imports, especially library stubs, and about checking untyped functions.]

Among other things:
 - Correct the return types of _get_aoi_type(), _process_response_data(), replace_csv_paths_with_urls, check_duplicate_aois(), and prepare_dataframes().
 - Mark tool_call_id as Optional in generated_insights(), pick_aoi(), pick_dataset(), and pull_data(), but make sure (and make clear) that state is NOT Optional.
 - Fixed arg type of query_subregion_database()
 - Add type for _user_info_cache
 - Fix the type of 'authorization' param of fetch_user_from_rw_api()
 - Create different variable destpath with type Path in download()

All the tests/{api, cli, unit, tools, agent} still pass, except for 3 that were already broken.

