### PR TITLE
PZB-815: build aoi bbox when aoi is selected in the UI

### DIFF
--- a/src/agent/tools/pick_aoi/tool.py
+++ b/src/agent/tools/pick_aoi/tool.py
@@ -93,6 +93,26 @@ CUSTOM_BBOX_SQL = f"""
 """
 
 
+async def fetch_aoi_bbox(source: str, src_id: str) -> list[float]:
+    """Look up bbox for an AOI by source and src_id, using the same antimeridian-aware SQL as pick_aoi."""
+    if source not in SOURCE_ID_MAPPING:
+        return [-180.0, -90.0, 180.0, 90.0]
+
+    table = SOURCE_ID_MAPPING[source]["table"]
+    id_column = SOURCE_ID_MAPPING[source]["id_column"]
+    bbox_expr = CUSTOM_BBOX_SQL if source == "custom" else BBOX_SQL
+
+    query = text(
+        f"SELECT {bbox_expr} FROM {table} WHERE {id_column} = :src_id"
+    )
+    async with get_connection_from_pool() as conn:
+        result = await conn.execute(query, {"src_id": src_id})
+        row = result.fetchone()
+        if row and row[0]:
+            return row[0]
+    return [-180.0, -90.0, 180.0, 90.0]
+
+
 class AOIId(BaseModel):
     src_id: str = Field(description="`src_id` of the best matched location.")
 

--- a/src/api/services/chat.py
+++ b/src/api/services/chat.py
@@ -12,6 +12,7 @@ from langfuse.langchain import CallbackHandler
 
 from src.agent.graph import fetch_zeno
 from src.agent.llms import SMALL_MODEL
+from src.agent.tools.pick_aoi.tool import fetch_aoi_bbox
 from src.api.schemas import ThreadNameOutput
 from src.shared.logging_config import get_logger
 
@@ -140,8 +141,13 @@ async def stream_chat(
             match action_type:
                 case "aoi_selected":
                     content = f"User selected AOI in UI: {action_data['aoi_name']}\n\n"
+                    aoi = action_data["aoi"]
+                    if not aoi.get("bbox"):
+                        aoi["bbox"] = await fetch_aoi_bbox(
+                            aoi["source"], aoi["src_id"]
+                        )
                     state_updates["aoi_selection"] = {
-                        "aois": [action_data["aoi"]],
+                        "aois": [aoi],
                         "name": action_data["aoi_name"],
                     }
                 case "dataset_selected":

--- a/tests/unit/agent/tools/pick_aoi/test_tool.py
+++ b/tests/unit/agent/tools/pick_aoi/test_tool.py
@@ -1,4 +1,12 @@
-from src.agent.tools.pick_aoi.tool import _antimeridian_bbox_sql
+from importlib import import_module
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agent.tools.pick_aoi.tool import (
+    _antimeridian_bbox_sql,
+    fetch_aoi_bbox,
+)
 
 
 def test_sql_contains_crossing_condition():
@@ -27,3 +35,68 @@ def test_sql_uses_west_xmin_and_east_xmax():
     sql = _antimeridian_bbox_sql("geometry")
     assert "ST_XMin(ST_Envelope(ST_ClipByBox2D" in sql
     assert "ST_XMax(ST_Envelope(ST_ClipByBox2D" in sql
+
+
+@pytest.mark.asyncio
+async def test_fetch_aoi_bbox_unknown_source_returns_default():
+    result = await fetch_aoi_bbox("unknown_source", "some_id")
+    assert result == [-180.0, -90.0, 180.0, 90.0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_aoi_bbox_uses_custom_bbox_sql_for_custom_source(
+    monkeypatch,
+):
+    captured = {}
+    tool_module = import_module("src.agent.tools.pick_aoi.tool")
+
+    class _FakeConn:
+        async def execute(self, query, params=None):
+            captured["sql"] = str(query)
+            result = MagicMock()
+            result.fetchone.return_value = ([1.0, 2.0, 3.0, 4.0],)
+            return result
+
+    class _FakeConnContext:
+        async def __aenter__(self):
+            return _FakeConn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    def fake_pool():
+        return _FakeConnContext()
+
+    monkeypatch.setattr(tool_module, "get_connection_from_pool", fake_pool)
+
+    await fetch_aoi_bbox("custom", "some-uuid")
+
+    assert "jsonb_array_elements_text" in captured["sql"]
+    assert "custom_areas" in captured["sql"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_aoi_bbox_no_row_returns_default(monkeypatch):
+    tool_module = import_module("src.agent.tools.pick_aoi.tool")
+
+    class _FakeConn:
+        async def execute(self, query, params=None):
+            result = MagicMock()
+            result.fetchone.return_value = None
+            return result
+
+    class _FakeConnContext:
+        async def __aenter__(self):
+            return _FakeConn()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    def fake_pool():
+        return _FakeConnContext()
+
+    monkeypatch.setattr(tool_module, "get_connection_from_pool", fake_pool)
+
+    result = await fetch_aoi_bbox("gadm", "NONEXISTENT")
+
+    assert result == [-180.0, -90.0, 180.0, 90.0]


### PR DESCRIPTION
When users select AOI manually on the UI, the bbox is missing from the AOI object in the state which breaks `pick_dataset` tool when getting contextual layers that overlap with the AOI.  This resolves that by injecting the bbox into the AOI object from the `ui_context`.

trace with the issue:

<img width="418" height="771" alt="Screenshot 2026-05-05 at 3 49 21 PM" src="https://github.com/user-attachments/assets/7a522b01-b0d1-4664-8ff9-97331af5a8a1" />


trace with the fix:

<img width="415" height="723" alt="Screenshot 2026-05-05 at 3 50 07 PM" src="https://github.com/user-attachments/assets/74e55d08-a70f-4eaf-bc73-d0db79e73aba" />




