### PR TITLE
PZB-783 Caution user that TCL driver data is only avail for full time period

### DIFF
--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -145,14 +145,20 @@ async def pull_data(
     raw_data["dataset_name"] = dataset["dataset_name"]
     raw_data["source_url"] = result.analytics_api_url
 
-    if range_clamped:
-        tool_messages.append(
-            f"Date range was adjusted to the dataset's available range: {effective_start} to {effective_end} "
-            f"(requested: {start_date} to {end_date})."
-        )
+    if tool_messages:
+        content = "|".join(tool_messages)
+        if range_clamped:
+            # Ensure that the agent mentions this warning in its final output.
+            content = (
+                f"TOOL_RESULT: {content}\n\n"
+                f"IMPORTANT INSTRUCTION FOR LLM: The user's specified date range ({start_date} to {end_date}) was adjusted to the dataset's available range: {effective_start} to {effective_end}."
+                "Please include a warning in the final response to the user describing the change to the date range"
+            )
+    else:
+        content = "No data pulled"
 
     tool_message = ToolMessage(
-        content="|".join(tool_messages) if tool_messages else "No data pulled",
+        content=content,
         tool_call_id=tool_call_id,
     )
 

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -145,20 +145,14 @@ async def pull_data(
     raw_data["dataset_name"] = dataset["dataset_name"]
     raw_data["source_url"] = result.analytics_api_url
 
-    if tool_messages:
-        content = "|".join(tool_messages)
-        if range_clamped:
-            # Ensure that the agent mentions this warning in its final output.
-            content = (
-                f"TOOL_RESULT: {content}\n\n"
-                f"IMPORTANT INSTRUCTION FOR LLM: The user's specified date range ({start_date} to {end_date}) was adjusted to the dataset's available range: {effective_start} to {effective_end}."
-                "Please include a warning in the final response to the user describing the change to the date range"
-            )
-    else:
-        content = "No data pulled"
+    if range_clamped:
+        tool_messages.append(
+            f"Date range was adjusted to the dataset's available range: {effective_start} to {effective_end} "
+            f"(requested: {start_date} to {end_date}). Warn the user about this adjustment."
+        )
 
     tool_message = ToolMessage(
-        content=content,
+        content="|".join(tool_messages) if tool_messages else "No data pulled",
         tool_call_id=tool_call_id,
     )
 


### PR DESCRIPTION
There was already a ToolMessage warning created in pull_data.py when the available date range for the dataset is different from the requested date range. However, the agent was not usually including the warning from the tool message in the final output. I gave the tool message more explicit instructions that ensures that the agent does display the warning. It handles the case in PZB-783, and should give warnings more reliably in other cases where range_clamped (returned by revise_date_range()) is true.
