### PR TITLE
Return dates used for dataset selection

### DIFF
--- a/src/agent/tools/pick_dataset/schema.py
+++ b/src/agent/tools/pick_dataset/schema.py
@@ -30,6 +30,14 @@ class DatasetOption(BaseModel):
     parameters: Optional[list[DatasetParameter]] = Field(
         None, description="Dataset specific parameters."
     )
+    start_date: Optional[str] = Field(
+        None,
+        description="Start date of the dataset that best matches the user query.",
+    )
+    end_date: Optional[str] = Field(
+        None,
+        description="End date of the dataset that best matches the user query.",
+    )
     reason: str = Field(
         description="Short reason why the dataset is the best match."
     )

--- a/src/agent/tools/pick_dataset/schema.py
+++ b/src/agent/tools/pick_dataset/schema.py
@@ -32,11 +32,11 @@ class DatasetOption(BaseModel):
     )
     start_date: Optional[str] = Field(
         None,
-        description="Start date of the dataset that best matches the user query.",
+        description="User defined start date truncated to the dataset's available range.",
     )
     end_date: Optional[str] = Field(
         None,
-        description="End date of the dataset that best matches the user query.",
+        description="User defined end date truncated to the dataset's available range.",
     )
     reason: str = Field(
         description="Short reason why the dataset is the best match."

--- a/src/agent/tools/pick_dataset/tool.py
+++ b/src/agent/tools/pick_dataset/tool.py
@@ -184,6 +184,8 @@ async def select_best_dataset(
         dataset_name=selected_row.dataset_name,
         context_layer=selection_result.context_layer,
         parameters=selection_result.parameters,
+        start_date=effective_start_date,
+        end_date=effective_end_date,
         reason=selection_result.reason,
         tile_url=dataset_tile_url,
         analytics_api_endpoint=selected_row.analytics_api_endpoint,
@@ -386,7 +388,7 @@ def get_tile_services_for_dataset(
         )
 
     if selected_row.dataset_id == TREE_COVER_LOSS_ID:
-        if end_date.year in range(2001, 2025):
+        if end_date.year in range(2001, 2026):
             tile_url += (
                 f"&start_year={start_date.year}&end_year={end_date.year}"
             )
@@ -395,10 +397,8 @@ def get_tile_services_for_dataset(
     elif selection_result.dataset_id == DIST_ALERT_ID:
         tile_url += f"&start_date={start_date}&end_date={end_date}"
     elif selection_result.dataset_id in [LAND_COVER_CHANGE_ID, GRASSLANDS_ID]:
-        if end_date.year in range(2000, 2023):
-            tile_url = tile_url.format(year=end_date.year)
-        else:
-            tile_url = tile_url.format(year="2022")
+        # Annual raster item in URL; start/end are already clamped to dataset YAML
+        tile_url = tile_url.format(year=end_date.year)
 
     return tile_url, context_layers
 

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -426,8 +426,11 @@ async def test_queries_return_expected_dataset(
     assert lookup[dataset_id] == expected_dataset
 
     assert dataset.get("start_date") and dataset.get("end_date")
-    date.fromisoformat(dataset["start_date"])
-    date.fromisoformat(dataset["end_date"])
+    for key in ("start_date", "end_date"):
+        try:
+            date.fromisoformat(dataset[key])
+        except ValueError:
+            assert False, f"{key} is not valid ISO 8601: {dataset[key]!r}"
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -1,5 +1,6 @@
 import sys
 import uuid
+from datetime import date
 from typing import Literal, Optional
 from unittest.mock import AsyncMock, patch
 
@@ -420,8 +421,13 @@ async def test_queries_return_expected_dataset(
 
     command = await pick_dataset.ainvoke(tool_call)
 
-    dataset_id = command.update.get("dataset", {}).get("dataset_id")
+    dataset = command.update.get("dataset", {})
+    dataset_id = dataset.get("dataset_id")
     assert lookup[dataset_id] == expected_dataset
+
+    assert dataset.get("start_date") and dataset.get("end_date")
+    date.fromisoformat(dataset["start_date"])
+    date.fromisoformat(dataset["end_date"])
 
 
 @pytest.mark.parametrize(
@@ -509,13 +515,17 @@ async def test_query_with_parameter(
 
     command = await pick_dataset.ainvoke(tool_call)
 
-    dataset_id = command.update.get("dataset", {}).get("dataset_id")
+    dataset = command.update.get("dataset", {})
+    dataset_id = dataset.get("dataset_id")
     assert dataset_id == expected_dataset_id
 
+    assert dataset["start_date"] == "2022-01-01"
+    assert dataset["end_date"] == "2022-12-31"
+
     if expected_parameter_name is None:
-        assert command.update.get("dataset", {}).get("parameters") is None
+        assert dataset.get("parameters") is None
     else:
-        param = command.update.get("dataset", {}).get("parameters")[0]
+        param = dataset.get("parameters")[0]
         assert param["name"] == expected_parameter_name
         assert expected_parameter_value in param["values"]
 


### PR DESCRIPTION
This adds the effective date range to the pick dataset tool. This is in preparation for showing this information on the legend in  [PZB-720](https://gfw.atlassian.net/browse/PZB-720).

- Adds start and end date to `DatasetOption`
- Updates date range in tile url construction (specially TCL 2025)
- Adds tests to check if data is there

cc @kamicut 

[PZB-720]: https://gfw.atlassian.net/browse/PZB-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ