### PR TITLE
PZB-830: Prompting fixes for primary forest

### DIFF
--- a/src/agent/tools/datasets/tree_cover_loss.yml
+++ b/src/agent/tools/datasets/tree_cover_loss.yml
@@ -30,15 +30,16 @@ prompt_instructions: 'Reports gross annual loss of tree cover ≥ 5 m height (20
   GHG emissions associated with that loss, in MgCO2e (tonnes of CO2 equivalent). If users ask for intra-year or seasonal tree
   cover loss OR emissions, refuse and remind that the data is annual only. The 2011-2025 data was produced using an updated
   methodology so comparisons between, and trends across the periods 2001-2010 and 2011-2025 should be performed with caution.
-  DO NOT use the term "deforestation", use "tree cover loss" instead since "Tree cover" includes plantations as well as natural
-  forest meaning loss is not automatically deforestation or carbon loss. The product measures canopy loss only; it doesn''t
+  If neither primary nor intact forest is applied as a context layer, DO NOT use the term "deforestation"; use "tree cover
+  loss" instead since "tree cover" includes plantations as well as natural forest, meaning loss is not automatically
+  deforestation. The product measures canopy loss only; it doesn''t
   track regrowth or permanence. Use 30% threshold. If a user asks for net gain/loss, refuse and explain that the methodologies
   for the two datasets differ and thus they cannot be combined directly to calculate net change. DO NOT show emissions and
   loss in the same chart, use separate charts.
 
   '
 selection_hints: 'Best dataset for annual tree cover loss questions (2001-2025) at 30m resolution. Covers all vegetation >5m
-  height including plantations — NOT limited to natural forest. Annual resolution only; cannot answer intra-year or seasonal
+  height including plantations unless primary or intact forest is applied as a context layer. Annual resolution only; cannot answer intra-year or seasonal
   questions. For driver attribution (WHY loss happened), use "Tree cover loss by dominant driver" instead. For net change,
   loss and gain datasets use different methodologies and cannot be combined. Includes GHG emissions (MgCO2e) associated with
   loss. Methodology changed between 2010 and 2011; cross-period trend comparisons need caution.
@@ -47,16 +48,18 @@ selection_hints: 'Best dataset for annual tree cover loss questions (2001-2025) 
 code_instructions: 'CHART TYPES: - Yearly loss → bar chart (x=year, y=area_ha) - Cumulative loss → stacked-area chart - Emissions
   → MUST be a SEPARATE chart from loss area (NEVER combine on same chart) DATA RULES: - Always include GHG emissions (MgCO2e)
   alongside loss area, but in a SEPARATE chart - Drop rows where area_ha = 0 - Use 30% canopy density threshold - If primary_forest
-  or intact_forest variable is active, filter accordingly DO/DON''T: - DO NOT use the term "deforestation" — always use "tree
-  cover loss" - If user asks for intra-year or seasonal breakdown, REFUSE — data is annual only - If user asks for net gain/loss,
+  or intact_forest variable is active, filter accordingly DO/DON''T: - If neither primary_forest nor intact_forest is active,
+  DO NOT use the term "deforestation"; use "tree cover loss" - If user asks for intra-year or seasonal breakdown, REFUSE
+  — data is annual only - If user asks for net gain/loss,
   REFUSE — methodologies differ between loss and gain datasets - Warn about 2001-2010 vs 2011-2025 methodology difference
   when showing trends across both periods
 
   '
-presentation_instructions: 'Use "tree cover loss" not "deforestation" — tree cover includes plantations, not just natural
-  forest. This measures canopy loss only; it doesn''t track regrowth or permanence. Always state the canopy density threshold
+presentation_instructions: 'Use "tree cover loss" rather than "deforestation" only when neither primary nor intact forest
+  is applied as a context layer. This measures canopy loss only; it doesn''t track regrowth or permanence. Always state the canopy density threshold
   used (30%). If showing emissions, clarify units are MgCO2e (tonnes of CO2 equivalent). If trend spans 2001-2025, note the
-  methodology change after 2010. CHART TITLES: each chart title must reflect only the metric(s) actually plotted in
+  methodology change after 2010. If a context layer is applied, prefer referencing the data concisely like "primary forest loss" or "intact forest loss"
+  instead of "primary forest tree cover loss". CHART TITLES: each chart title must reflect only the metric(s) actually plotted in
   that chart — do not mention emissions in a title if the chart only shows area, and do not mention area if the chart
   only shows emissions.
 

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -263,7 +263,9 @@ class ChartInsight(BaseModel):
     Represents a chart-based insight with Recharts-compatible data.
     """
 
-    title: str = Field(description="Clear, descriptive title for the chart")
+    title: str = Field(
+        description="Clear, descriptive, concise title for the chart, including dataset and contextual layers."
+    )
     chart_type: str = Field(
         description="Chart type: 'line', 'bar', 'stacked-bar', 'grouped-bar', 'pie', 'area', 'scatter', or 'table'"
     )


### PR DESCRIPTION
PZB-830 cover a few minor but related issues:

- There's many rules in the TCL YAML about "deforestation" that don't apply the same when primary forest is a context layer, since that filters to just natural forests and removes plantations. 
- The agent inconsistently mentions the context layer in the title for the chart.
- The agent also has a tendency to use verbose names like "primary forest tree cover loss", when researchers expressed it'd be more readable as "primary forest loss".