### PR TITLE
add merge migration for alembic multiple heads

### DIFF
--- a/db/alembic/versions/73c0c72faa9e_merge_insights_and_drop_whitelisted_.py
+++ b/db/alembic/versions/73c0c72faa9e_merge_insights_and_drop_whitelisted_.py
@@ -1,0 +1,28 @@
+"""merge insights and drop_whitelisted_users heads
+
+Revision ID: 73c0c72faa9e
+Revises: 75841e9932e5, f2a9c8d1e7b4
+Create Date: 2026-05-12 14:12:15.326825
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '73c0c72faa9e'
+down_revision: Union[str, None] = ('75841e9932e5', 'f2a9c8d1e7b4')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/db/alembic/versions/73c0c72faa9e_merge_insights_and_drop_whitelisted_.py
+++ b/db/alembic/versions/73c0c72faa9e_merge_insights_and_drop_whitelisted_.py
@@ -5,15 +5,12 @@ Revises: 75841e9932e5, f2a9c8d1e7b4
 Create Date: 2026-05-12 14:12:15.326825
 
 """
+
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
-
 # revision identifiers, used by Alembic.
-revision: str = '73c0c72faa9e'
-down_revision: Union[str, None] = ('75841e9932e5', 'f2a9c8d1e7b4')
+revision: str = "73c0c72faa9e"
+down_revision: Union[str, None] = ("75841e9932e5", "f2a9c8d1e7b4")
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
The latest alembic migrations needed a merge migration else was getting a `multiple heads` error:

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
FAILED: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
```

@yellowcap can you give a quick 👀 ?