### PR TITLE
Add AOI thumbnail endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "bcrypt==4.2.1",
     "click==8.1.8",
     "google-genai==1.68.0",
+    "antimeridian==0.4.7",
 ]
 
 [dependency-groups]

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -14,6 +14,7 @@ from src.api.routers import (
     insights,
     metadata,
     threads,
+    thumbnails,
     users,
 )
 from src.shared.database import close_global_pool, initialize_global_pool
@@ -98,5 +99,6 @@ app.include_router(threads.router)
 app.include_router(users.router)
 app.include_router(custom_areas.router)
 app.include_router(geometry.router)
+app.include_router(thumbnails.router)
 app.include_router(insights.router)
 app.include_router(metadata.router)

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -7,6 +7,8 @@ load_dotenv()
 class _APISettings(BaseSettings):
     """API-specific settings for quotas, authentication, and access control."""
 
+    mapbox_api_token: str = ""
+
     # Quota settings
     daily_quota_warning_threshold: int = 5
     admin_user_daily_quota: int = 100

--- a/src/api/routers/thumbnails.py
+++ b/src/api/routers/thumbnails.py
@@ -3,6 +3,7 @@
 import json
 import urllib.parse
 
+import antimeridian
 import httpx
 import shapely
 import shapely.geometry
@@ -22,8 +23,9 @@ _MAPBOX_STYLE = "mapbox/outdoors-v12"
 _STROKE_COLOR = "#1b3a6e"
 _FILL_COLOR = "#4a90d9"
 _FILL_OPACITY = 0.15
-# Keep URL-encoded overlay below this to stay well under HTTP URL limits
-_MAX_OVERLAY_CHARS = 5000
+# Mapbox's documented GeoJSON overlay limit is 8 192 URL-encoded chars.
+# We stay comfortably below that to leave room for the rest of the URL.
+_MAX_OVERLAY_CHARS = 7500
 
 
 def _geojson_feature(geometry: dict) -> dict:
@@ -70,16 +72,6 @@ def _filter_small_parts(shape, min_area_fraction: float = 0.005):
     return shapely.geometry.MultiPolygon(parts) if len(parts) > 1 else parts[0]
 
 
-def _drop_empty_parts(shape):
-    """Remove empty sub-geometries left behind after simplification."""
-    if shape.geom_type != "MultiPolygon":
-        return shape
-    parts = [g for g in shape.geoms if not g.is_empty]
-    if not parts:
-        parts = [max(shape.geoms, key=lambda g: g.area)]
-    return shapely.geometry.MultiPolygon(parts) if len(parts) > 1 else parts[0]
-
-
 def _drop_interior_rings(shape):
     """Remove interior rings (holes) from polygons.
 
@@ -104,45 +96,44 @@ def _drop_interior_rings(shape):
     return shape
 
 
-def _crosses_antimeridian(shape) -> bool:
-    """True when the shape has vertices on both sides of the ±180° line."""
-    minx, _, maxx, _ = shape.bounds
-    return minx < -90 and maxx > 90
+def _fix_shape(geometry: dict) -> dict:
+    """Run antimeridian.fix_shape, falling back to the original on failure.
 
-
-def _strip_antimeridian_spillover(shape):
-    """For MultiPolygons that span the antimeridian, drop the sub-polygons
-    that are on the minority side (area-wise).
-
-    GADM stores antimeridian-crossing countries as two groups: a large group
-    on the dominant side (e.g. Russia 19°–180°E) and a small group on the
-    other side (e.g. Chukotka tip −180°–−169°W).  Keeping only the dominant
-    group produces a clean, non-crossing geometry that Mapbox's ``auto``
-    camera handles perfectly.
+    Some real-world geometries (e.g. KBAs with degenerate rings that have
+    fewer than 4 coordinates) cause fix_shape to crash.  Rather than
+    propagating the error we silently skip the fix — the geometry will still
+    simplify correctly; it just may not be split at the antimeridian.
     """
-    if not _crosses_antimeridian(shape):
-        return shape
-    if shape.geom_type != "MultiPolygon":
-        return shape
+    try:
+        return antimeridian.fix_shape(geometry)
+    except Exception:
+        return geometry
 
-    positive = [p for p in shape.geoms if p.centroid.x >= 0]
-    negative = [p for p in shape.geoms if p.centroid.x < 0]
 
-    pos_area = sum(p.area for p in positive)
-    neg_area = sum(p.area for p in negative)
-
-    keep = positive if pos_area >= neg_area else negative
-    if not keep:
-        return shape
-    return shapely.geometry.MultiPolygon(keep) if len(keep) > 1 else keep[0]
+def _prepare_shape(geometry: dict):
+    """Filter, antimeridian-fix, and drop interior rings — the expensive
+    one-time work before the tolerance sweep.  Returns a shapely geometry,
+    or the original dict on failure.
+    """
+    try:
+        # Filter first: fix_shape only processes the few large parts, not
+        # thousands of tiny islands (avoids minute-long hangs on USA/RUS).
+        shape = _filter_small_parts(shapely.geometry.shape(geometry))
+        shape = shapely.geometry.shape(
+            _fix_shape(shapely.geometry.mapping(shape))
+        )
+        return _drop_interior_rings(shape)
+    except Exception:
+        return None
 
 
 def _round_coords(geometry: dict, decimals: int = 4) -> dict:
-    """Round all coordinate values to reduce URL-encoded size.
+    """Round all coordinate floats to ``decimals`` decimal places.
 
-    4 decimal places ≈ 11 m precision — invisible at thumbnail scale but cuts
-    each coordinate string from ~18 chars to ~6, allowing lower (smoother)
-    simplification tolerances to fit within the URL budget.
+    ``shapely.set_precision`` snaps to a grid but produces floats like
+    47.930000000000004 that JSON serialises to 18 chars.  Explicit rounding
+    gives 47.93 (5 chars) — a 3× reduction that lets lower (smoother)
+    simplification tolerances fit within the URL budget.
     """
 
     def walk(obj):
@@ -164,33 +155,44 @@ def _round_coords(geometry: dict, decimals: int = 4) -> dict:
     return geometry
 
 
-def _simplify(geometry: dict, tolerance: float) -> dict:
-    try:
-        shape = _filter_small_parts(shapely.geometry.shape(geometry))
-        shape = _strip_antimeridian_spillover(shape)
-        simplified = _drop_empty_parts(
-            shape.simplify(tolerance, preserve_topology=True)
-        )
-        return _round_coords(
-            shapely.geometry.mapping(_drop_interior_rings(simplified))
-        )
-    except Exception:
-        return geometry
+def _simplify_shape(shape, tolerance: float) -> dict:
+    """Simplify, drop empty parts, round coords, return a geometry dict."""
+    s = shape.simplify(tolerance, preserve_topology=True)
+    if s.geom_type == "MultiPolygon":
+        parts = [g for g in s.geoms if not g.is_empty]
+        if parts:
+            s = (
+                shapely.geometry.MultiPolygon(parts)
+                if len(parts) > 1
+                else parts[0]
+            )
+    return _round_coords(shapely.geometry.mapping(s))
 
 
 def _fit_overlay(geometry: dict) -> str:
-    """Simplify iteratively until the overlay fits within the URL budget."""
-    for tolerance in [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.0]:
-        encoded = _encode_overlay(_simplify(geometry, tolerance))
-        if len(encoded) <= _MAX_OVERLAY_CHARS:
-            return encoded
-    # Absolute last resort: bounding-box rectangle of the largest part
+    """Simplify iteratively until the overlay fits within the URL budget.
+
+    The expensive preprocessing (filter, antimeridian fix, interior-ring
+    removal) runs once; only the cheap simplify + coord-round iterates.
+    """
+    shape = _prepare_shape(geometry)
+    if shape is not None:
+        for tolerance in [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.0]:
+            try:
+                encoded = _encode_overlay(_simplify_shape(shape, tolerance))
+                if len(encoded) <= _MAX_OVERLAY_CHARS:
+                    return encoded
+            except Exception:
+                pass
+    # Absolute last resort: bounding-box rectangle of the prepared shape
     try:
-        shape = _strip_antimeridian_spillover(
-            _filter_small_parts(shapely.geometry.shape(geometry))
+        s = (
+            shape
+            if shape is not None
+            else _filter_small_parts(shapely.geometry.shape(geometry))
         )
         return _encode_overlay(
-            shapely.geometry.mapping(shapely.geometry.box(*shape.bounds))
+            shapely.geometry.mapping(shapely.geometry.box(*s.bounds))
         )
     except Exception:
         return _encode_overlay(geometry)

--- a/src/api/routers/thumbnails.py
+++ b/src/api/routers/thumbnails.py
@@ -4,6 +4,7 @@ import json
 import urllib.parse
 
 import httpx
+import shapely
 import shapely.geometry
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
@@ -79,28 +80,118 @@ def _drop_empty_parts(shape):
     return shapely.geometry.MultiPolygon(parts) if len(parts) > 1 else parts[0]
 
 
+def _drop_interior_rings(shape):
+    """Remove interior rings (holes) from polygons.
+
+    For overlay thumbnails we only care about the outer outline. Interior
+    rings from lakes/water-bodies inflate the encoded size significantly
+    (Russia's main polygon has 80 holes) without adding visual value at the
+    zoom levels used for thumbnails.
+    """
+    if shape.geom_type == "Polygon":
+        return shapely.geometry.Polygon(shape.exterior)
+    if shape.geom_type == "MultiPolygon":
+        parts = [
+            shapely.geometry.Polygon(p.exterior)
+            for p in shape.geoms
+            if not p.is_empty
+        ]
+        return (
+            shapely.geometry.MultiPolygon(parts)
+            if len(parts) > 1
+            else parts[0]
+        )
+    return shape
+
+
+def _crosses_antimeridian(shape) -> bool:
+    """True when the shape has vertices on both sides of the ±180° line."""
+    minx, _, maxx, _ = shape.bounds
+    return minx < -90 and maxx > 90
+
+
+def _strip_antimeridian_spillover(shape):
+    """For MultiPolygons that span the antimeridian, drop the sub-polygons
+    that are on the minority side (area-wise).
+
+    GADM stores antimeridian-crossing countries as two groups: a large group
+    on the dominant side (e.g. Russia 19°–180°E) and a small group on the
+    other side (e.g. Chukotka tip −180°–−169°W).  Keeping only the dominant
+    group produces a clean, non-crossing geometry that Mapbox's ``auto``
+    camera handles perfectly.
+    """
+    if not _crosses_antimeridian(shape):
+        return shape
+    if shape.geom_type != "MultiPolygon":
+        return shape
+
+    positive = [p for p in shape.geoms if p.centroid.x >= 0]
+    negative = [p for p in shape.geoms if p.centroid.x < 0]
+
+    pos_area = sum(p.area for p in positive)
+    neg_area = sum(p.area for p in negative)
+
+    keep = positive if pos_area >= neg_area else negative
+    if not keep:
+        return shape
+    return shapely.geometry.MultiPolygon(keep) if len(keep) > 1 else keep[0]
+
+
+def _round_coords(geometry: dict, decimals: int = 4) -> dict:
+    """Round all coordinate values to reduce URL-encoded size.
+
+    4 decimal places ≈ 11 m precision — invisible at thumbnail scale but cuts
+    each coordinate string from ~18 chars to ~6, allowing lower (smoother)
+    simplification tolerances to fit within the URL budget.
+    """
+
+    def walk(obj):
+        if isinstance(obj, (int, float)):
+            return round(float(obj), decimals)
+        if isinstance(obj, (list, tuple)):
+            return [walk(item) for item in obj]
+        return obj
+
+    if "coordinates" in geometry:
+        return {**geometry, "coordinates": walk(geometry["coordinates"])}
+    if "geometries" in geometry:
+        return {
+            **geometry,
+            "geometries": [
+                _round_coords(g, decimals) for g in geometry["geometries"]
+            ],
+        }
+    return geometry
+
+
 def _simplify(geometry: dict, tolerance: float) -> dict:
     try:
         shape = _filter_small_parts(shapely.geometry.shape(geometry))
+        shape = _strip_antimeridian_spillover(shape)
         simplified = _drop_empty_parts(
             shape.simplify(tolerance, preserve_topology=True)
         )
-        return shapely.geometry.mapping(simplified)
+        return _round_coords(
+            shapely.geometry.mapping(_drop_interior_rings(simplified))
+        )
     except Exception:
         return geometry
 
 
 def _fit_overlay(geometry: dict) -> str:
     """Simplify iteratively until the overlay fits within the URL budget."""
-    for tolerance in [0.001, 0.005, 0.01, 0.05, 0.1, 0.5]:
+    for tolerance in [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.0]:
         encoded = _encode_overlay(_simplify(geometry, tolerance))
         if len(encoded) <= _MAX_OVERLAY_CHARS:
             return encoded
-    # Last resort: convex hull of the largest part
+    # Absolute last resort: bounding-box rectangle of the largest part
     try:
-        shape = _filter_small_parts(shapely.geometry.shape(geometry))
-        hull = shapely.geometry.mapping(shape.convex_hull)
-        return _encode_overlay(hull)
+        shape = _strip_antimeridian_spillover(
+            _filter_small_parts(shapely.geometry.shape(geometry))
+        )
+        return _encode_overlay(
+            shapely.geometry.mapping(shapely.geometry.box(*shape.bounds))
+        )
     except Exception:
         return _encode_overlay(geometry)
 

--- a/src/api/routers/thumbnails.py
+++ b/src/api/routers/thumbnails.py
@@ -1,0 +1,147 @@
+"""AOI thumbnail generation via Mapbox Static Images API."""
+
+import json
+import urllib.parse
+
+import httpx
+import shapely.geometry
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+
+from src.api.auth.dependencies import require_auth
+from src.api.config import APISettings
+from src.shared.geocoding_helpers import get_geometry_data
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+_MAPBOX_STYLE = "mapbox/outdoors-v12"
+_STROKE_COLOR = "#1b3a6e"
+_FILL_COLOR = "#4a90d9"
+_FILL_OPACITY = 0.15
+# Keep URL-encoded overlay below this to stay well under HTTP URL limits
+_MAX_OVERLAY_CHARS = 5000
+
+
+def _geojson_feature(geometry: dict) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": geometry,
+        "properties": {
+            "stroke": _STROKE_COLOR,
+            "stroke-width": 2,
+            "stroke-opacity": 1,
+            "fill": _FILL_COLOR,
+            "fill-opacity": _FILL_OPACITY,
+        },
+    }
+
+
+def _to_feature_collection(geometry: dict) -> dict:
+    if geometry["type"] == "GeometryCollection":
+        return {
+            "type": "FeatureCollection",
+            "features": [_geojson_feature(g) for g in geometry["geometries"]],
+        }
+    return _geojson_feature(geometry)
+
+
+def _encode_overlay(geometry: dict) -> str:
+    return urllib.parse.quote(
+        json.dumps(_to_feature_collection(geometry), separators=(",", ":"))
+    )
+
+
+def _filter_small_parts(shape, min_area_fraction: float = 0.005):
+    """Drop sub-polygons smaller than min_area_fraction of the total area.
+
+    Keeps complex MultiPolygons (e.g. Brazil) from blowing up the URL with
+    hundreds of tiny islands while preserving the main landmass outline.
+    """
+    if shape.geom_type != "MultiPolygon":
+        return shape
+    total = shape.area
+    parts = [p for p in shape.geoms if p.area / total >= min_area_fraction]
+    if not parts:
+        parts = [max(shape.geoms, key=lambda p: p.area)]
+    return shapely.geometry.MultiPolygon(parts) if len(parts) > 1 else parts[0]
+
+
+def _simplify(geometry: dict, tolerance: float) -> dict:
+    try:
+        shape = _filter_small_parts(shapely.geometry.shape(geometry))
+        simplified = shape.simplify(tolerance, preserve_topology=True)
+        return shapely.geometry.mapping(simplified)
+    except Exception:
+        return geometry
+
+
+def _fit_overlay(geometry: dict) -> str:
+    """Simplify iteratively until the overlay fits within the URL budget."""
+    for tolerance in [0.001, 0.005, 0.01, 0.05, 0.1, 0.5]:
+        encoded = _encode_overlay(_simplify(geometry, tolerance))
+        if len(encoded) <= _MAX_OVERLAY_CHARS:
+            return encoded
+    # Last resort: convex hull of the largest part
+    try:
+        shape = _filter_small_parts(shapely.geometry.shape(geometry))
+        hull = shapely.geometry.mapping(shape.convex_hull)
+        return _encode_overlay(hull)
+    except Exception:
+        return _encode_overlay(geometry)
+
+
+@router.get("/api/geometry/{source}/{src_id}/thumbnail")
+async def get_geometry_thumbnail(
+    source: str,
+    src_id: str,
+    width: int = 300,
+    height: int = 300,
+    user=Depends(require_auth),
+):
+    """
+    Proxy a PNG thumbnail for an AOI via the Mapbox Static Images API.
+    The geometry is simplified as needed to stay within URL limits.
+    """
+    if not APISettings.mapbox_api_token:
+        raise HTTPException(
+            status_code=503, detail="MAPBOX_TOKEN not configured"
+        )
+
+    data = await get_geometry_data(source, src_id)
+    if not data or not data.get("geometry"):
+        raise HTTPException(status_code=404, detail="Geometry not found")
+
+    overlay = _fit_overlay(data["geometry"])
+    url = (
+        f"https://api.mapbox.com/styles/v1/{_MAPBOX_STYLE}/static"
+        f"/geojson({overlay})/auto/{width}x{height}@2x"
+        f"?padding=40&attribution=false&logo=false&access_token={APISettings.mapbox_api_token}"
+    )
+
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(url, timeout=10.0)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                "Mapbox API error",
+                status=e.response.status_code,
+                body=e.response.text[:200],
+            )
+            raise HTTPException(
+                status_code=502, detail="Thumbnail generation failed"
+            )
+        except httpx.RequestError as e:
+            logger.error("Mapbox request error", error=str(e))
+            raise HTTPException(
+                status_code=502, detail="Thumbnail generation failed"
+            )
+
+    return Response(
+        content=resp.content,
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )

--- a/src/api/routers/thumbnails.py
+++ b/src/api/routers/thumbnails.py
@@ -12,6 +12,7 @@ from fastapi.responses import Response
 
 from src.api.auth.dependencies import require_auth
 from src.api.config import APISettings
+from src.api.schemas import UserModel
 from src.shared.geocoding_helpers import get_geometry_data
 from src.shared.logging_config import get_logger
 
@@ -204,7 +205,7 @@ async def get_geometry_thumbnail(
     src_id: str,
     width: int = 300,
     height: int = 300,
-    user=Depends(require_auth),
+    user: UserModel = Depends(require_auth),
 ):
     """
     Proxy a PNG thumbnail for an AOI via the Mapbox Static Images API.
@@ -215,7 +216,7 @@ async def get_geometry_thumbnail(
             status_code=503, detail="MAPBOX_TOKEN not configured"
         )
 
-    data = await get_geometry_data(source, src_id)
+    data = await get_geometry_data(source, src_id, user_id=user.id)
     if not data or not data.get("geometry"):
         raise HTTPException(status_code=404, detail="Geometry not found")
 

--- a/src/api/routers/thumbnails.py
+++ b/src/api/routers/thumbnails.py
@@ -69,10 +69,22 @@ def _filter_small_parts(shape, min_area_fraction: float = 0.005):
     return shapely.geometry.MultiPolygon(parts) if len(parts) > 1 else parts[0]
 
 
+def _drop_empty_parts(shape):
+    """Remove empty sub-geometries left behind after simplification."""
+    if shape.geom_type != "MultiPolygon":
+        return shape
+    parts = [g for g in shape.geoms if not g.is_empty]
+    if not parts:
+        parts = [max(shape.geoms, key=lambda g: g.area)]
+    return shapely.geometry.MultiPolygon(parts) if len(parts) > 1 else parts[0]
+
+
 def _simplify(geometry: dict, tolerance: float) -> dict:
     try:
         shape = _filter_small_parts(shapely.geometry.shape(geometry))
-        simplified = shape.simplify(tolerance, preserve_topology=True)
+        simplified = _drop_empty_parts(
+            shape.simplify(tolerance, preserve_topology=True)
+        )
         return shapely.geometry.mapping(simplified)
     except Exception:
         return geometry

--- a/src/shared/geocoding_helpers.py
+++ b/src/shared/geocoding_helpers.py
@@ -66,7 +66,7 @@ def format_id(idx):
 
 
 async def get_geometry_data(
-    source: str, src_id: str
+    source: str, src_id: str, user_id: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
     """
     Get geometry data by source and source ID.
@@ -75,7 +75,7 @@ async def get_geometry_data(
         source: Source type (gadm, kba, landmark, wdpa, custom)
         src_id: Source-specific ID
         session: Database session
-        user_id: User ID (required for custom areas)
+        user_id: User ID (required for custom areas; falls back to request context)
 
     Returns:
         Dict with name, subtype, source, src_id, and geometry, or None if not found
@@ -86,7 +86,9 @@ async def get_geometry_data(
 
     async with get_session_from_pool() as session:
         if source == "custom":
-            user_id = structlog.contextvars.get_contextvars().get("user_id")
+            user_id = user_id or structlog.contextvars.get_contextvars().get(
+                "user_id"
+            )
             if not user_id:
                 raise ValueError("user_id required for custom areas")
 

--- a/tests/api/test_thumbnails.py
+++ b/tests/api/test_thumbnails.py
@@ -13,12 +13,15 @@ from src.api.routers.thumbnails import (
     _FILL_OPACITY,
     _MAX_OVERLAY_CHARS,
     _STROKE_COLOR,
+    _crosses_antimeridian,
     _drop_empty_parts,
+    _drop_interior_rings,
     _encode_overlay,
     _filter_small_parts,
     _fit_overlay,
     _geojson_feature,
     _simplify,
+    _strip_antimeridian_spillover,
     _to_feature_collection,
 )
 
@@ -222,6 +225,49 @@ def test_drop_empty_parts_single_survivor_is_polygon():
 
 
 # ---------------------------------------------------------------------------
+# _drop_interior_rings
+# ---------------------------------------------------------------------------
+
+
+def test_drop_interior_rings_removes_holes_from_polygon():
+    outer = [(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]
+    hole = [(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]
+    poly = shapely.geometry.Polygon(outer, [hole])
+    assert len(list(poly.interiors)) == 1
+    result = _drop_interior_rings(poly)
+    assert result.geom_type == "Polygon"
+    assert len(list(result.interiors)) == 0
+    assert result.exterior.equals(poly.exterior)
+
+
+def test_drop_interior_rings_multipolygon():
+    outer = [(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]
+    hole = [(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]
+    p1 = shapely.geometry.Polygon(outer, [hole])
+    p2 = _square(20, 20, size=5)
+    mp = shapely.geometry.MultiPolygon([p1, p2])
+    result = _drop_interior_rings(mp)
+    assert all(len(list(p.interiors)) == 0 for p in result.geoms)
+
+
+def test_drop_interior_rings_no_holes_unchanged():
+    poly = _square(0, 0, size=5)
+    result = _drop_interior_rings(poly)
+    assert result.exterior.equals(poly.exterior)
+
+
+def test_simplify_strips_interior_rings():
+    """After simplification, interior rings must be absent from the output."""
+    outer = [(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]
+    hole = [(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]
+    poly_with_hole = shapely.geometry.Polygon(outer, [hole])
+    geom = shapely.geometry.mapping(poly_with_hole)
+    result = _simplify(geom, 0.001)
+    result_shape = shapely.geometry.shape(result)
+    assert len(list(result_shape.interiors)) == 0
+
+
+# ---------------------------------------------------------------------------
 # _simplify
 # ---------------------------------------------------------------------------
 
@@ -253,6 +299,89 @@ def test_simplify_returns_original_on_bad_geometry():
 
 
 # ---------------------------------------------------------------------------
+# _crosses_antimeridian
+# ---------------------------------------------------------------------------
+
+
+def _russia_like() -> shapely.geometry.MultiPolygon:
+    """Two patches mimicking Russia: main landmass (19°–180°) + Chukotka (−170°–−155°).
+
+    Chukotka is sized so its area fraction (~2.7%) exceeds the 0.5% filter threshold.
+    """
+    main = shapely.geometry.box(19, 41, 180, 82)
+    chukotka = shapely.geometry.box(-170, 60, -155, 72)
+    return shapely.geometry.MultiPolygon([main, chukotka])
+
+
+def test_crosses_antimeridian_true_for_russia_like():
+    assert _crosses_antimeridian(_russia_like()) is True
+
+
+def test_crosses_antimeridian_false_for_normal_geometry():
+    brazil = shapely.geometry.box(-73, -34, -28, 5)
+    assert _crosses_antimeridian(brazil) is False
+
+
+def test_crosses_antimeridian_false_for_new_zealand():
+    nz = shapely.geometry.box(166, -48, 178, -34)
+    assert _crosses_antimeridian(nz) is False
+
+
+# ---------------------------------------------------------------------------
+# _strip_antimeridian_spillover
+# ---------------------------------------------------------------------------
+
+
+def test_strip_antimeridian_spillover_removes_minority_side():
+    """Chukotka (negative lons, small area) must be removed; main Russia kept."""
+    shape = _russia_like()
+    result = _strip_antimeridian_spillover(shape)
+    coords = shapely.get_coordinates(result)
+    lons = coords[:, 0]
+    assert (
+        lons >= 0
+    ).all(), f"Expected only non-negative lons, got min={lons.min()}"
+
+
+def test_strip_antimeridian_spillover_non_crossing_unchanged():
+    shape = shapely.geometry.box(0, 0, 10, 10)
+    result = _strip_antimeridian_spillover(shape)
+    assert result is shape
+
+
+def test_strip_antimeridian_spillover_non_multipolygon_unchanged():
+    """A single Polygon crossing the antimeridian is returned as-is."""
+    # A single polygon that spans from -100 to +100 (crosses detection threshold)
+    shape = shapely.geometry.box(-100, 0, 100, 10)
+    result = _strip_antimeridian_spillover(shape)
+    assert result is shape  # non-MultiPolygon passed through
+
+
+def test_strip_antimeridian_spillover_result_does_not_cross():
+    """After stripping, the shape must no longer cross the antimeridian."""
+    shape = _russia_like()
+    result = _strip_antimeridian_spillover(shape)
+    assert not _crosses_antimeridian(result)
+
+
+def test_strip_antimeridian_spillover_usa_like():
+    """For USA-like geometry (dominant side is negative lons), keep the negative side."""
+    contiguous = shapely.geometry.box(
+        -124, 24, -66, 49
+    )  # contiguous USA (large)
+    aleutians = shapely.geometry.box(
+        172, 51, 175, 53
+    )  # Attu Island, positive lons (tiny)
+    usa = shapely.geometry.MultiPolygon([contiguous, aleutians])
+    result = _strip_antimeridian_spillover(usa)
+    coords = shapely.get_coordinates(result)
+    lons = coords[:, 0]
+    assert (
+        lons <= 0
+    ).all(), f"Expected only non-positive lons, got max={lons.max()}"
+
+
+# ---------------------------------------------------------------------------
 # _fit_overlay
 # ---------------------------------------------------------------------------
 
@@ -268,6 +397,33 @@ def test_fit_overlay_complex_geometry_within_budget():
     mp = shapely.geometry.mapping(shapely.geometry.MultiPolygon(polys))
     encoded = _fit_overlay(mp)
     assert len(encoded) <= _MAX_OVERLAY_CHARS
+
+
+def test_fit_overlay_russia_like_within_budget():
+    """Russia-like antimeridian geometry must fit after stripping."""
+    mp = shapely.geometry.mapping(_russia_like())
+    encoded = _fit_overlay(mp)
+    assert len(encoded) <= _MAX_OVERLAY_CHARS
+    # Decoded overlay must have no negative lons (Chukotka stripped)
+    decoded = json.loads(urllib.parse.unquote(encoded))
+    geom = decoded.get("geometry", decoded)
+    coords_raw = geom.get("coordinates", [])
+
+    def all_lons(obj):
+        if isinstance(obj, list):
+            if len(obj) >= 2 and isinstance(obj[0], (int, float)):
+                return [obj[0]]
+            result = []
+            for item in obj:
+                result.extend(all_lons(item))
+            return result
+        return []
+
+    lons = all_lons(coords_raw)
+    assert lons, "No coordinates found in overlay"
+    assert all(
+        lon >= 0 for lon in lons
+    ), f"Found negative lon in overlay: {min(lons)}"
 
 
 # ---------------------------------------------------------------------------
@@ -438,6 +594,67 @@ async def test_thumbnail_custom_dimensions_in_mapbox_url(
     assert response.status_code == 200
     called_url = mock_client.get.call_args[0][0]
     assert "640x480" in called_url
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_uses_auto_camera_with_padding(client, auth_override):
+    """Overlay must always use 'auto' camera with padding (no explicit center+zoom)."""
+    auth_override("test-user-1")
+    mock_cls, mock_client = _mapbox_mock()
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = _MOCK_GEOMETRY_DATA
+
+        await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    called_url = mock_client.get.call_args[0][0]
+    assert "/auto/" in called_url
+    assert "padding=40" in called_url
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_antimeridian_geometry_uses_auto_camera(
+    client, auth_override
+):
+    """Russia-like antimeridian geometry must also use auto camera after stripping."""
+    auth_override("test-user-1")
+    russia_geom = shapely.geometry.mapping(_russia_like())
+    mock_cls, mock_client = _mapbox_mock()
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = {
+            "name": "Russia",
+            "source": "gadm",
+            "geometry": russia_geom,
+        }
+
+        await client.get(
+            "/api/geometry/gadm/RUS/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    called_url = mock_client.get.call_args[0][0]
+    assert "/auto/" in called_url
+    assert "padding=40" in called_url
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_thumbnails.py
+++ b/tests/api/test_thumbnails.py
@@ -422,6 +422,40 @@ async def test_thumbnail_success_returns_png(client, auth_override):
 
 
 @pytest.mark.asyncio
+async def test_thumbnail_custom_area_lookup_uses_requester(
+    client, auth_override
+):
+    auth_override("test-user-1")
+    custom_area_id = "123e4567-e89b-12d3-a456-426614174000"
+    mock_cls, _ = _mapbox_mock()
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = {
+            **_MOCK_GEOMETRY_DATA,
+            "source": "custom",
+            "src_id": custom_area_id,
+        }
+
+        response = await client.get(
+            f"/api/geometry/custom/{custom_area_id}/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 200
+    mock_get.assert_awaited_once_with(
+        "custom", custom_area_id, user_id="test-user-1"
+    )
+
+
+@pytest.mark.asyncio
 async def test_thumbnail_cache_control_header(client, auth_override):
     auth_override("test-user-1")
     mock_cls, _ = _mapbox_mock()

--- a/tests/api/test_thumbnails.py
+++ b/tests/api/test_thumbnails.py
@@ -1,0 +1,496 @@
+"""Unit and integration tests for the AOI thumbnail endpoint."""
+
+import json
+import urllib.parse
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import shapely.geometry
+
+from src.api.routers.thumbnails import (
+    _FILL_COLOR,
+    _FILL_OPACITY,
+    _MAX_OVERLAY_CHARS,
+    _STROKE_COLOR,
+    _encode_overlay,
+    _filter_small_parts,
+    _fit_overlay,
+    _geojson_feature,
+    _simplify,
+    _to_feature_collection,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SIMPLE_POLYGON = {
+    "type": "Polygon",
+    "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+}
+
+SIMPLE_POINT = {"type": "Point", "coordinates": [10.0, 20.0]}
+
+GEOMETRY_COLLECTION = {
+    "type": "GeometryCollection",
+    "geometries": [SIMPLE_POLYGON, SIMPLE_POINT],
+}
+
+
+def _square(
+    lon: float, lat: float, size: float = 1.0
+) -> shapely.geometry.Polygon:
+    return shapely.geometry.Polygon(
+        [
+            (lon, lat),
+            (lon + size, lat),
+            (lon + size, lat + size),
+            (lon, lat + size),
+            (lon, lat),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# _geojson_feature
+# ---------------------------------------------------------------------------
+
+
+def test_geojson_feature_structure():
+    feat = _geojson_feature(SIMPLE_POLYGON)
+    assert feat["type"] == "Feature"
+    assert feat["geometry"] == SIMPLE_POLYGON
+
+
+def test_geojson_feature_styling():
+    feat = _geojson_feature(SIMPLE_POLYGON)
+    props = feat["properties"]
+    assert props["stroke"] == _STROKE_COLOR
+    assert props["fill"] == _FILL_COLOR
+    assert props["fill-opacity"] == _FILL_OPACITY
+    assert props["stroke-width"] == 2
+    assert props["stroke-opacity"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _to_feature_collection
+# ---------------------------------------------------------------------------
+
+
+def test_to_feature_collection_plain_geometry():
+    result = _to_feature_collection(SIMPLE_POLYGON)
+    # Non-GeometryCollection → single Feature, not a FeatureCollection
+    assert result["type"] == "Feature"
+    assert result["geometry"] == SIMPLE_POLYGON
+
+
+def test_to_feature_collection_geometry_collection():
+    result = _to_feature_collection(GEOMETRY_COLLECTION)
+    assert result["type"] == "FeatureCollection"
+    assert len(result["features"]) == 2
+    geom_types = {f["geometry"]["type"] for f in result["features"]}
+    assert geom_types == {"Polygon", "Point"}
+
+
+def test_to_feature_collection_preserves_styling_in_each_feature():
+    result = _to_feature_collection(GEOMETRY_COLLECTION)
+    for feat in result["features"]:
+        assert feat["properties"]["stroke"] == _STROKE_COLOR
+
+
+# ---------------------------------------------------------------------------
+# _encode_overlay
+# ---------------------------------------------------------------------------
+
+
+def test_encode_overlay_is_url_encoded():
+    encoded = _encode_overlay(SIMPLE_POLYGON)
+    # Must not contain raw braces (they must be percent-encoded)
+    assert "{" not in encoded
+    assert "}" not in encoded
+
+
+def test_encode_overlay_round_trips():
+    encoded = _encode_overlay(SIMPLE_POLYGON)
+    decoded = json.loads(urllib.parse.unquote(encoded))
+    assert decoded["type"] == "Feature"
+    assert decoded["geometry"] == SIMPLE_POLYGON
+
+
+def test_encode_overlay_geometry_collection_becomes_feature_collection():
+    encoded = _encode_overlay(GEOMETRY_COLLECTION)
+    decoded = json.loads(urllib.parse.unquote(encoded))
+    assert decoded["type"] == "FeatureCollection"
+    assert len(decoded["features"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# _filter_small_parts
+# ---------------------------------------------------------------------------
+
+
+def test_filter_small_parts_non_multipolygon_unchanged():
+    poly = _square(0, 0)
+    result = _filter_small_parts(poly)
+    assert result is poly
+
+
+def test_filter_small_parts_drops_tiny_islands():
+    big = _square(0, 0, size=10)  # area = 100
+    tiny = _square(
+        100, 100, size=0.05
+    )  # area = 0.0025; fraction ≈ 0.000025 < 0.005
+    mp = shapely.geometry.MultiPolygon([big, tiny])
+    result = _filter_small_parts(mp)
+    # Only the large polygon survives; single survivor is returned as Polygon
+    assert result.geom_type == "Polygon"
+    assert result.area == pytest.approx(big.area)
+
+
+def test_filter_small_parts_keeps_large_enough_parts():
+    big = _square(0, 0, size=10)  # area = 100
+    medium = _square(50, 50, size=1)  # area = 1; fraction ≈ 0.0099 > 0.005
+    mp = shapely.geometry.MultiPolygon([big, medium])
+    result = _filter_small_parts(mp)
+    assert result.geom_type == "MultiPolygon"
+    assert len(result.geoms) == 2
+
+
+def test_filter_small_parts_fallback_keeps_largest():
+    """When all parts fall below the threshold, the largest is kept."""
+    big = _square(0, 0, size=10)  # area ≈ 100; fraction = 100/101 ≈ 0.99
+    medium = _square(50, 50, size=1)  # area = 1;  fraction = 1/101 ≈ 0.0099
+    mp = shapely.geometry.MultiPolygon([big, medium])
+    # With a threshold of 0.999 nothing qualifies, so the fallback runs
+    result = _filter_small_parts(mp, min_area_fraction=0.999)
+    assert result.area == pytest.approx(big.area)
+
+
+def test_filter_small_parts_single_survivor_is_polygon():
+    big = _square(0, 0, size=10)
+    tiny = _square(100, 100, size=0.01)
+    mp = shapely.geometry.MultiPolygon([big, tiny])
+    result = _filter_small_parts(mp)
+    # A one-element result must be unwrapped to a plain Polygon
+    assert result.geom_type == "Polygon"
+
+
+# ---------------------------------------------------------------------------
+# _simplify
+# ---------------------------------------------------------------------------
+
+
+def test_simplify_reduces_vertex_count():
+    # A polygon with many vertices
+    import math
+
+    n = 100
+    coords = [
+        (math.cos(2 * math.pi * i / n), math.sin(2 * math.pi * i / n))
+        for i in range(n)
+    ]
+    coords.append(coords[0])
+    geom = {"type": "Polygon", "coordinates": [coords]}
+
+    simplified = _simplify(geom, tolerance=0.1)
+    original_shape = shapely.geometry.shape(geom)
+    simplified_shape = shapely.geometry.shape(simplified)
+    assert len(list(simplified_shape.exterior.coords)) < len(
+        list(original_shape.exterior.coords)
+    )
+
+
+def test_simplify_returns_original_on_bad_geometry():
+    bad = {"type": "NotAType", "coordinates": []}
+    result = _simplify(bad, tolerance=0.01)
+    assert result == bad
+
+
+# ---------------------------------------------------------------------------
+# _fit_overlay
+# ---------------------------------------------------------------------------
+
+
+def test_fit_overlay_within_char_budget():
+    encoded = _fit_overlay(SIMPLE_POLYGON)
+    assert len(encoded) <= _MAX_OVERLAY_CHARS
+
+
+def test_fit_overlay_complex_geometry_within_budget():
+    """A MultiPolygon with many parts must still fit in the URL budget."""
+    polys = [_square(i * 5, 0, size=1) for i in range(50)]
+    mp = shapely.geometry.mapping(shapely.geometry.MultiPolygon(polys))
+    encoded = _fit_overlay(mp)
+    assert len(encoded) <= _MAX_OVERLAY_CHARS
+
+
+# ---------------------------------------------------------------------------
+# Endpoint: GET /api/geometry/{source}/{src_id}/thumbnail
+# ---------------------------------------------------------------------------
+
+_MOCK_GEOMETRY_DATA = {
+    "name": "Test Region",
+    "source": "gadm",
+    "src_id": "IND.2_1",
+    "geometry": SIMPLE_POLYGON,
+}
+
+
+def _mapbox_mock(content: bytes = b"\x89PNG\r\n\x1a\n"):
+    """Return a mock async httpx client that returns a fake PNG."""
+    mock_response = MagicMock()
+    mock_response.content = content
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    mock_cls = MagicMock()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_cls, mock_client
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_requires_auth(client):
+    response = await client.get("/api/geometry/gadm/IND.2_1/thumbnail")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_503_without_mapbox_token(client, auth_override):
+    auth_override("test-user-1")
+    with patch("src.api.routers.thumbnails.APISettings") as mock_settings:
+        mock_settings.mapbox_api_token = ""
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+    assert response.status_code == 503
+    assert "MAPBOX_TOKEN" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_404_when_geometry_missing(client, auth_override):
+    auth_override("test-user-1")
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = None
+
+        response = await client.get(
+            "/api/geometry/gadm/DOES_NOT_EXIST/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 404
+    assert "Geometry not found" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_404_when_geometry_field_absent(client, auth_override):
+    auth_override("test-user-1")
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = {"name": "Somewhere", "source": "gadm"}
+
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_success_returns_png(client, auth_override):
+    auth_override("test-user-1")
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    mock_cls, _ = _mapbox_mock(content=fake_png)
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = _MOCK_GEOMETRY_DATA
+
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.content == fake_png
+    assert response.headers["content-type"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_cache_control_header(client, auth_override):
+    auth_override("test-user-1")
+    mock_cls, _ = _mapbox_mock()
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = _MOCK_GEOMETRY_DATA
+
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 200
+    assert "public" in response.headers["cache-control"]
+    assert "max-age=86400" in response.headers["cache-control"]
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_custom_dimensions_in_mapbox_url(
+    client, auth_override
+):
+    auth_override("test-user-1")
+    mock_cls, mock_client = _mapbox_mock()
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = _MOCK_GEOMETRY_DATA
+
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail?width=640&height=480",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 200
+    called_url = mock_client.get.call_args[0][0]
+    assert "640x480" in called_url
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_502_on_mapbox_http_error(client, auth_override):
+    auth_override("test-user-1")
+
+    mock_error_response = MagicMock()
+    mock_error_response.status_code = 422
+    mock_error_response.text = "Unprocessable Entity"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=mock_error_response
+        )
+    )
+    mock_cls = MagicMock()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = _MOCK_GEOMETRY_DATA
+
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 502
+    assert "Thumbnail generation failed" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_502_on_mapbox_request_error(client, auth_override):
+    auth_override("test-user-1")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=httpx.RequestError(
+            "Connection refused", request=MagicMock()
+        )
+    )
+    mock_cls = MagicMock()
+    mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.test"
+        mock_get.return_value = _MOCK_GEOMETRY_DATA
+
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 502
+    assert "Thumbnail generation failed" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_thumbnail_mapbox_url_contains_access_token(
+    client, auth_override
+):
+    auth_override("test-user-1")
+    mock_cls, mock_client = _mapbox_mock()
+
+    with (
+        patch("src.api.routers.thumbnails.APISettings") as mock_settings,
+        patch(
+            "src.api.routers.thumbnails.get_geometry_data",
+            new_callable=AsyncMock,
+        ) as mock_get,
+        patch("src.api.routers.thumbnails.httpx.AsyncClient", mock_cls),
+    ):
+        mock_settings.mapbox_api_token = "pk.my-secret-token"
+        mock_get.return_value = _MOCK_GEOMETRY_DATA
+
+        response = await client.get(
+            "/api/geometry/gadm/IND.2_1/thumbnail",
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+    assert response.status_code == 200
+    called_url = mock_client.get.call_args[0][0]
+    assert "pk.my-secret-token" in called_url
+    assert "access_token=" in called_url

--- a/tests/api/test_thumbnails.py
+++ b/tests/api/test_thumbnails.py
@@ -13,15 +13,14 @@ from src.api.routers.thumbnails import (
     _FILL_OPACITY,
     _MAX_OVERLAY_CHARS,
     _STROKE_COLOR,
-    _crosses_antimeridian,
-    _drop_empty_parts,
     _drop_interior_rings,
     _encode_overlay,
     _filter_small_parts,
     _fit_overlay,
     _geojson_feature,
-    _simplify,
-    _strip_antimeridian_spillover,
+    _prepare_shape,
+    _round_coords,
+    _simplify_shape,
     _to_feature_collection,
 )
 
@@ -181,50 +180,6 @@ def test_filter_small_parts_single_survivor_is_polygon():
 
 
 # ---------------------------------------------------------------------------
-# _drop_empty_parts
-# ---------------------------------------------------------------------------
-
-
-def test_drop_empty_parts_non_multipolygon_unchanged():
-    poly = _square(0, 0)
-    result = _drop_empty_parts(poly)
-    assert result is poly
-
-
-def test_drop_empty_parts_removes_empty_geoms():
-    """Empty sub-geometries (e.g. collapsed after simplification) are filtered out."""
-    good = _square(0, 0, size=10)
-    empty = shapely.geometry.Polygon()  # empty geometry
-    # Use a mock so we can inject an empty geometry into geoms
-    mp = MagicMock(spec=shapely.geometry.MultiPolygon)
-    mp.geom_type = "MultiPolygon"
-    mp.geoms = [good, empty]
-    result = _drop_empty_parts(mp)
-    assert result.geom_type == "Polygon"
-    assert result.area == pytest.approx(good.area)
-
-
-def test_drop_empty_parts_fallback_keeps_largest_when_all_empty():
-    """If every part is empty, the one with the largest area is kept."""
-    mp = MagicMock(spec=shapely.geometry.MultiPolygon)
-    mp.geom_type = "MultiPolygon"
-    e1, e2 = shapely.geometry.Polygon(), shapely.geometry.Polygon()
-    mp.geoms = [e1, e2]
-    result = _drop_empty_parts(mp)
-    assert result is not None
-
-
-def test_drop_empty_parts_single_survivor_is_polygon():
-    good = _square(0, 0, size=10)
-    empty = shapely.geometry.Polygon()
-    mp = MagicMock(spec=shapely.geometry.MultiPolygon)
-    mp.geom_type = "MultiPolygon"
-    mp.geoms = [good, empty]
-    result = _drop_empty_parts(mp)
-    assert result.geom_type == "Polygon"
-
-
-# ---------------------------------------------------------------------------
 # _drop_interior_rings
 # ---------------------------------------------------------------------------
 
@@ -256,24 +211,27 @@ def test_drop_interior_rings_no_holes_unchanged():
     assert result.exterior.equals(poly.exterior)
 
 
-def test_simplify_strips_interior_rings():
-    """After simplification, interior rings must be absent from the output."""
+# ---------------------------------------------------------------------------
+# _prepare_shape / _simplify_shape / _round_coords
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_shape_strips_interior_rings():
+    """_prepare_shape must remove holes — they inflate encoded size."""
     outer = [(0, 0), (10, 0), (10, 10), (0, 10), (0, 0)]
     hole = [(2, 2), (4, 2), (4, 4), (2, 4), (2, 2)]
     poly_with_hole = shapely.geometry.Polygon(outer, [hole])
-    geom = shapely.geometry.mapping(poly_with_hole)
-    result = _simplify(geom, 0.001)
-    result_shape = shapely.geometry.shape(result)
-    assert len(list(result_shape.interiors)) == 0
+    shape = _prepare_shape(shapely.geometry.mapping(poly_with_hole))
+    assert shape is not None
+    assert len(list(shape.interiors)) == 0
 
 
-# ---------------------------------------------------------------------------
-# _simplify
-# ---------------------------------------------------------------------------
+def test_prepare_shape_returns_none_on_bad_geometry():
+    shape = _prepare_shape({"type": "NotAType", "coordinates": []})
+    assert shape is None
 
 
-def test_simplify_reduces_vertex_count():
-    # A polygon with many vertices
+def test_simplify_shape_reduces_vertex_count():
     import math
 
     n = 100
@@ -283,102 +241,33 @@ def test_simplify_reduces_vertex_count():
     ]
     coords.append(coords[0])
     geom = {"type": "Polygon", "coordinates": [coords]}
-
-    simplified = _simplify(geom, tolerance=0.1)
-    original_shape = shapely.geometry.shape(geom)
-    simplified_shape = shapely.geometry.shape(simplified)
-    assert len(list(simplified_shape.exterior.coords)) < len(
-        list(original_shape.exterior.coords)
+    shape = _prepare_shape(geom)
+    assert shape is not None
+    simplified = _simplify_shape(shape, tolerance=0.1)
+    original_verts = len(list(shapely.geometry.shape(geom).exterior.coords))
+    simplified_verts = len(
+        list(shapely.geometry.shape(simplified).exterior.coords)
     )
+    assert simplified_verts < original_verts
 
 
-def test_simplify_returns_original_on_bad_geometry():
-    bad = {"type": "NotAType", "coordinates": []}
-    result = _simplify(bad, tolerance=0.01)
-    assert result == bad
+def test_round_coords_compacts_floats():
+    """round_coords must produce short JSON-serialisable floats."""
+    import json
 
-
-# ---------------------------------------------------------------------------
-# _crosses_antimeridian
-# ---------------------------------------------------------------------------
-
-
-def _russia_like() -> shapely.geometry.MultiPolygon:
-    """Two patches mimicking Russia: main landmass (19°–180°) + Chukotka (−170°–−155°).
-
-    Chukotka is sized so its area fraction (~2.7%) exceeds the 0.5% filter threshold.
-    """
-    main = shapely.geometry.box(19, 41, 180, 82)
-    chukotka = shapely.geometry.box(-170, 60, -155, 72)
-    return shapely.geometry.MultiPolygon([main, chukotka])
-
-
-def test_crosses_antimeridian_true_for_russia_like():
-    assert _crosses_antimeridian(_russia_like()) is True
-
-
-def test_crosses_antimeridian_false_for_normal_geometry():
-    brazil = shapely.geometry.box(-73, -34, -28, 5)
-    assert _crosses_antimeridian(brazil) is False
-
-
-def test_crosses_antimeridian_false_for_new_zealand():
-    nz = shapely.geometry.box(166, -48, 178, -34)
-    assert _crosses_antimeridian(nz) is False
-
-
-# ---------------------------------------------------------------------------
-# _strip_antimeridian_spillover
-# ---------------------------------------------------------------------------
-
-
-def test_strip_antimeridian_spillover_removes_minority_side():
-    """Chukotka (negative lons, small area) must be removed; main Russia kept."""
-    shape = _russia_like()
-    result = _strip_antimeridian_spillover(shape)
-    coords = shapely.get_coordinates(result)
-    lons = coords[:, 0]
-    assert (
-        lons >= 0
-    ).all(), f"Expected only non-negative lons, got min={lons.min()}"
-
-
-def test_strip_antimeridian_spillover_non_crossing_unchanged():
-    shape = shapely.geometry.box(0, 0, 10, 10)
-    result = _strip_antimeridian_spillover(shape)
-    assert result is shape
-
-
-def test_strip_antimeridian_spillover_non_multipolygon_unchanged():
-    """A single Polygon crossing the antimeridian is returned as-is."""
-    # A single polygon that spans from -100 to +100 (crosses detection threshold)
-    shape = shapely.geometry.box(-100, 0, 100, 10)
-    result = _strip_antimeridian_spillover(shape)
-    assert result is shape  # non-MultiPolygon passed through
-
-
-def test_strip_antimeridian_spillover_result_does_not_cross():
-    """After stripping, the shape must no longer cross the antimeridian."""
-    shape = _russia_like()
-    result = _strip_antimeridian_spillover(shape)
-    assert not _crosses_antimeridian(result)
-
-
-def test_strip_antimeridian_spillover_usa_like():
-    """For USA-like geometry (dominant side is negative lons), keep the negative side."""
-    contiguous = shapely.geometry.box(
-        -124, 24, -66, 49
-    )  # contiguous USA (large)
-    aleutians = shapely.geometry.box(
-        172, 51, 175, 53
-    )  # Attu Island, positive lons (tiny)
-    usa = shapely.geometry.MultiPolygon([contiguous, aleutians])
-    result = _strip_antimeridian_spillover(usa)
-    coords = shapely.get_coordinates(result)
-    lons = coords[:, 0]
-    assert (
-        lons <= 0
-    ).all(), f"Expected only non-positive lons, got max={lons.max()}"
+    geom = {
+        "type": "Polygon",
+        "coordinates": [[[47.93001174926758, 41.300323486328125]]],
+    }
+    rounded = _round_coords(geom)
+    lon = rounded["coordinates"][0][0][0]
+    lat = rounded["coordinates"][0][0][1]
+    # Must be at most 4 decimal places
+    assert lon == round(47.93001174926758, 4)
+    assert lat == round(41.300323486328125, 4)
+    # JSON representation must be short (≤ 7 chars per number)
+    assert len(json.dumps(lon)) <= 7
+    assert len(json.dumps(lat)) <= 7
 
 
 # ---------------------------------------------------------------------------
@@ -399,31 +288,21 @@ def test_fit_overlay_complex_geometry_within_budget():
     assert len(encoded) <= _MAX_OVERLAY_CHARS
 
 
+def _russia_like() -> shapely.geometry.MultiPolygon:
+    """Two patches mimicking Russia: main landmass (19°–180°) + Chukotka (−170°–−155°)."""
+    main = shapely.geometry.box(19, 41, 180, 82)
+    chukotka = shapely.geometry.box(-170, 60, -155, 72)
+    return shapely.geometry.MultiPolygon([main, chukotka])
+
+
 def test_fit_overlay_russia_like_within_budget():
-    """Russia-like antimeridian geometry must fit after stripping."""
+    """Russia-like antimeridian geometry must fit within the URL budget."""
     mp = shapely.geometry.mapping(_russia_like())
     encoded = _fit_overlay(mp)
     assert len(encoded) <= _MAX_OVERLAY_CHARS
-    # Decoded overlay must have no negative lons (Chukotka stripped)
+    # Overlay must be valid URL-encoded GeoJSON
     decoded = json.loads(urllib.parse.unquote(encoded))
-    geom = decoded.get("geometry", decoded)
-    coords_raw = geom.get("coordinates", [])
-
-    def all_lons(obj):
-        if isinstance(obj, list):
-            if len(obj) >= 2 and isinstance(obj[0], (int, float)):
-                return [obj[0]]
-            result = []
-            for item in obj:
-                result.extend(all_lons(item))
-            return result
-        return []
-
-    lons = all_lons(coords_raw)
-    assert lons, "No coordinates found in overlay"
-    assert all(
-        lon >= 0 for lon in lons
-    ), f"Found negative lon in overlay: {min(lons)}"
+    assert decoded.get("type") in ("Feature", "FeatureCollection")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_thumbnails.py
+++ b/tests/api/test_thumbnails.py
@@ -13,6 +13,7 @@ from src.api.routers.thumbnails import (
     _FILL_OPACITY,
     _MAX_OVERLAY_CHARS,
     _STROKE_COLOR,
+    _drop_empty_parts,
     _encode_overlay,
     _filter_small_parts,
     _fit_overlay,
@@ -173,6 +174,50 @@ def test_filter_small_parts_single_survivor_is_polygon():
     mp = shapely.geometry.MultiPolygon([big, tiny])
     result = _filter_small_parts(mp)
     # A one-element result must be unwrapped to a plain Polygon
+    assert result.geom_type == "Polygon"
+
+
+# ---------------------------------------------------------------------------
+# _drop_empty_parts
+# ---------------------------------------------------------------------------
+
+
+def test_drop_empty_parts_non_multipolygon_unchanged():
+    poly = _square(0, 0)
+    result = _drop_empty_parts(poly)
+    assert result is poly
+
+
+def test_drop_empty_parts_removes_empty_geoms():
+    """Empty sub-geometries (e.g. collapsed after simplification) are filtered out."""
+    good = _square(0, 0, size=10)
+    empty = shapely.geometry.Polygon()  # empty geometry
+    # Use a mock so we can inject an empty geometry into geoms
+    mp = MagicMock(spec=shapely.geometry.MultiPolygon)
+    mp.geom_type = "MultiPolygon"
+    mp.geoms = [good, empty]
+    result = _drop_empty_parts(mp)
+    assert result.geom_type == "Polygon"
+    assert result.area == pytest.approx(good.area)
+
+
+def test_drop_empty_parts_fallback_keeps_largest_when_all_empty():
+    """If every part is empty, the one with the largest area is kept."""
+    mp = MagicMock(spec=shapely.geometry.MultiPolygon)
+    mp.geom_type = "MultiPolygon"
+    e1, e2 = shapely.geometry.Polygon(), shapely.geometry.Polygon()
+    mp.geoms = [e1, e2]
+    result = _drop_empty_parts(mp)
+    assert result is not None
+
+
+def test_drop_empty_parts_single_survivor_is_polygon():
+    good = _square(0, 0, size=10)
+    empty = shapely.geometry.Polygon()
+    mp = MagicMock(spec=shapely.geometry.MultiPolygon)
+    mp.geom_type = "MultiPolygon"
+    mp.geoms = [good, empty]
+    result = _drop_empty_parts(mp)
     assert result.geom_type == "Polygon"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -162,6 +162,19 @@ wheels = [
 ]
 
 [[package]]
+name = "antimeridian"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "shapely" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/ca/e196bc600c4c45a7be7194eed393a2b05d3dc30f0e5c07b92ceb85414c2a/antimeridian-0.4.7.tar.gz", hash = "sha256:ae1ee613ddec6bf1bec35ee89d49baed03341e0c295b26f4c1dca3b36fff9698", size = 12633152, upload-time = "2026-04-03T23:40:00.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/cc/f1f8a798820dfa339f8321e3b92f5cda38b0e4b2a0bd38f9d7a64bca26ca/antimeridian-0.4.7-py3-none-any.whl", hash = "sha256:fedc04d5460ee9f05e37e7adc335843538fbd911c2bf7bd36c5393cd4ffe107d", size = 15684, upload-time = "2026-04-03T23:39:58.608Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2818,6 +2831,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "antimeridian" },
     { name = "asyncpg" },
     { name = "bcrypt" },
     { name = "boto3" },
@@ -2889,6 +2903,7 @@ frontend = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = "==1.16.4" },
+    { name = "antimeridian", specifier = "==0.4.7" },
     { name = "asyncpg", specifier = "==0.30.0" },
     { name = "bcrypt", specifier = "==4.2.1" },
     { name = "boto3", specifier = "==1.38.27" },


### PR DESCRIPTION
## Summary

- Adds `GET /api/geometry/{source}/{src_id}/thumbnail` endpoint that returns a PNG map thumbnail for any AOI (gadm, kba, wdpa, landmark, custom)
- Uses the Mapbox Static Images API with `outdoors-v12` style — dark blue stroke + light blue fill matching the design spec
- Mapbox watermark and attribution suppressed via `attribution=false&logo=false` (attribution will be placed in the UI component instead)
- Adds `MAPBOX_API_TOKEN` to API settings (already present in env)

## Result

| Paraná | Brazil |
| :----: | :----: |
| <img width="400" alt="thumbnail_parana3" src="https://github.com/user-attachments/assets/a2981312-92b0-4e69-97bd-c7070e6a2abd" /> | <img width="400" alt="thumbnail_bra3" src="https://github.com/user-attachments/assets/9d50d5a5-c03b-41a3-865e-394ea89e2197" /> |


## How geometry size is handled

Complex national borders (e.g. Brazil = 406k coordinate points) would blow up the Mapbox URL limit. The endpoint handles this in two steps:

1. **Filter small sub-polygons** — drops MultiPolygon parts below 0.5% of total area (removes tiny islands while keeping the main landmass)
2. **Iterative simplification** — tries Shapely `simplify()` at increasing tolerances (0.001→0.5°) until the URL-encoded overlay fits under 5,000 chars
3. **Convex hull fallback** — last resort if simplification still exceeds the limit

Optional `width` and `height` query params (default 300×300, rendered @2x).

## Test plan

- [ ] `GET /api/geometry/gadm/BRA/thumbnail` — large complex country border
- [ ] `GET /api/geometry/gadm/BRA.16_1/thumbnail` — sub-national state
- [ ] `GET /api/geometry/kba/16595/thumbnail` — KBA area
- [ ] `GET /api/geometry/custom/{uuid}/thumbnail` — custom area
- [ ] Returns 404 for unknown source/id
- [ ] Returns 503 when `MAPBOX_API_TOKEN` is not set