### PR TITLE
Deal with case where user's start_date/end_date not included.

### DIFF
--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -90,7 +90,9 @@ async def pull_data(
         dataset["dataset_id"],
         dataset.get("context_layer"),
     )
-    if end_date < effective_start or start_date > effective_end:
+    if (end_date is not None and end_date < effective_start) or (
+        start_date is not None and start_date > effective_end
+    ):
         return Command(
             update={
                 "messages": [


### PR DESCRIPTION
Deal with simple error that results in an exception during an eval case that I noticed (but the eval recovers and continues).

Seems like this error and exception can happen whenever the user does not specify start date or end date.
