### PR TITLE
Remove pull data from state but keep backwards compatability

### DIFF
--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -24,6 +24,9 @@ class Statistics(TypedDict):
     source_url: NotRequired[str]
     # Empty for ID-backed statistics; use fetch_statistics_from_url(source_url).
     data: NotRequired[dict]
+    # Mapping from aoi_id value to human-readable name, built at pull time and
+    # re-applied after URL fetch so chart labels stay readable.
+    aoi_id_to_name: NotRequired[dict]
     aoi_names: list[str]
     parameters: list[StatisticsParameter] | None
     context_layer: str | None

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -21,9 +21,8 @@ class Statistics(TypedDict):
     dataset_name: str
     start_date: str
     end_date: str
-    source_url: str
-    # DEPRECATED: use fetch_statistics_from_url(source_url) instead.
-    # Kept for frontend backward compatibility.
+    source_url: NotRequired[str]
+    # Empty for ID-backed statistics; use fetch_statistics_from_url(source_url).
     data: NotRequired[dict]
     aoi_names: list[str]
     parameters: list[StatisticsParameter] | None

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -268,7 +268,8 @@ Now prepare the data for visualization in Recharts.js:
       2. **Field names**: Use clear, lowercase names like 'date', 'value', 'category', 'year', 'count'
       3. **Numeric values**: Always numbers, never strings (e.g., 100 not "100")
       4. **Date ordering**: Chronological order for time series, not alphabetical
-      5. **Data format by chart type**:
+      5. **Grouping fields**: Group only by categorical, readable label columns such as names, dates, periods, classes, or metric labels. Do not group by numeric measure/value columns like 'value', 'count', 'area', 'sum', or continuous numeric readings unless the user explicitly asks for a distribution or histogram; aggregate those numeric columns instead.
+      6. **Data format by chart type**:
          - **Single-series line/bar**: [{{"date": "2020-01", "value": 100}}]
            → One metric column, use y_axis="value"
 

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -17,7 +17,6 @@ from src.agent.tools.code_executors.base import (
     MultiChartInsight,
     PartType,
 )
-from src.agent.tools.datasets_config import DATASETS
 from src.agent.tools.pull_data import fetch_statistics_from_url
 from src.api.data_models import InsightChartOrm, InsightOrm
 from src.shared.database import get_session_from_pool
@@ -26,13 +25,26 @@ from src.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def _get_available_datasets() -> str:
-    """Get a concise list of available datasets from the datasets configuration."""
-    dataset_names = []
-    for dataset in DATASETS:
-        dataset_names.append(dataset["dataset_name"])
+async def _extract_inline_statistics_data(data: dict) -> dict | None:
+    inline_data = data.get("data")
+    if not inline_data:
+        return None
+    if isinstance(inline_data, dict) and set(inline_data.keys()) == {"data"}:
+        return inline_data["data"]
+    return inline_data
 
-    return ", ".join(dataset_names)
+
+async def _load_statistics_data(data: dict) -> dict | None:
+    # If data is inline already, return it
+    legacy_data = await _extract_inline_statistics_data(data)
+    if legacy_data:
+        return legacy_data
+    # Otherwise, fetch from source URL
+    source_url = data.get("source_url")
+    if source_url:
+        return await fetch_statistics_from_url(source_url)
+
+    return None
 
 
 async def prepare_dataframes(
@@ -41,10 +53,11 @@ async def prepare_dataframes(
     """
     Prepare DataFrames from raw data for code executor.
 
-    Fetches all source URLs concurrently, then builds DataFrames in order.
+    Fetches ID-backed data by source URL, while keeping older inline-data
+    thread state working.
     """
     raw_results = await asyncio.gather(
-        *[fetch_statistics_from_url(s["source_url"]) for s in statistics]
+        *[_load_statistics_data(s) for s in statistics]
     )
 
     dataframes = []
@@ -71,7 +84,7 @@ async def prepare_dataframes(
         param_suffix = f" [{', '.join(param_parts)}]" if param_parts else ""
         display_name = f"{', '.join(data['aoi_names'])} — {data['dataset_name']} ({data['start_date']} to {data['end_date']}){param_suffix}"
         dataframes.append((df, display_name))
-        source_urls.append(data["source_url"])
+        source_urls.append(data.get("source_url", ""))
 
         logger.info(f"Prepared: {display_name}")
 
@@ -113,7 +126,7 @@ def replace_csv_paths_with_urls(
 
     def replace_match(match):
         file_index = int(match.group(1))
-        if file_index < len(source_urls):
+        if file_index < len(source_urls) and source_urls[file_index]:
             url = source_urls[file_index]
             # Replace the entire pd.read_csv(...) call with URL-based loading
             return f'pd.DataFrame(pd.read_json("{url}")["data"]["result"])'
@@ -133,7 +146,7 @@ def replace_csv_paths_with_urls(
 
     def replace_standalone(match):
         file_index = int(match.group(1))
-        if file_index < len(source_urls):
+        if file_index < len(source_urls) and source_urls[file_index]:
             url = source_urls[file_index]
             # Replace with URL string
             return f'"{url}"'

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -39,10 +39,14 @@ async def _load_statistics_data(data: dict) -> dict | None:
     legacy_data = await _extract_inline_statistics_data(data)
     if legacy_data:
         return legacy_data
-    # Otherwise, fetch from source URL
+    # Otherwise, fetch from source URL and re-apply the aoi_id→name mapping so
+    # chart labels stay readable (the raw API result doesn't include names).
     source_url = data.get("source_url")
     if source_url:
-        return await fetch_statistics_from_url(source_url)
+        raw = await fetch_statistics_from_url(source_url)
+        if raw and (mapping := data.get("aoi_id_to_name")):
+            raw["name"] = [mapping.get(i, i) for i in raw.get("aoi_id", [])]
+        return raw
 
     return None
 

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -448,11 +448,10 @@ async def generate_insights(
     for idx, chart in enumerate(result.insight.charts, 1):
         tool_message += f"Chart {idx}: {chart.title}\n"
 
-    MAX_CHART_DATA_ROWS_FOR_TOOL_MESSAGE = 50
-    if len(chart_data_df) < MAX_CHART_DATA_ROWS_FOR_TOOL_MESSAGE:
-        tool_message += (
-            f"\nChart data CSV:\n{chart_data_df.to_csv(index=False)}"
-        )
+    MAX_CHART_DATA_CHARS_FOR_TOOL_MESSAGE = 4000
+    csv_str = chart_data_df.to_csv(index=False, float_format="%.2f")
+    if len(csv_str) < MAX_CHART_DATA_CHARS_FOR_TOOL_MESSAGE:
+        tool_message += f"\nChart data CSV:\n{csv_str}"
 
     tool_message += "\nFollow-up suggestions:"
     for i, suggestion in enumerate(result.insight.follow_up_suggestions, 1):

--- a/src/agent/tools/generate_insights.py
+++ b/src/agent/tools/generate_insights.py
@@ -449,7 +449,12 @@ async def generate_insights(
         tool_message += f"Chart {idx}: {chart.title}\n"
 
     MAX_CHART_DATA_CHARS_FOR_TOOL_MESSAGE = 4000
-    csv_str = chart_data_df.to_csv(index=False, float_format="%.2f")
+    formatted_df = chart_data_df.apply(
+        lambda col: col.map(lambda x: f"{x:.4f}".rstrip("0").rstrip("."))
+        if pd.api.types.is_float_dtype(col)
+        else col
+    )
+    csv_str = formatted_df.to_csv(index=False)
     if len(csv_str) < MAX_CHART_DATA_CHARS_FOR_TOOL_MESSAGE:
         tool_message += f"\nChart data CSV:\n{csv_str}"
 

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -152,14 +152,6 @@ async def pull_data(
             },
         )
 
-    # Reconstruct raw_data for backward compatibility with frontend consumers
-    # that still read statistics["data"].
-    # DEPRECATED: use source_url and fetch via fetch_statistics_from_url(source_url)
-    if isinstance(result.data, dict) and "data" in result.data:
-        raw_data = result.data["data"]
-    else:
-        raw_data = result.data
-
     if range_clamped:
         tool_messages.append(
             f"Date range was adjusted to the dataset's available range: {effective_start} to {effective_end} "
@@ -176,10 +168,8 @@ async def pull_data(
         "start_date": effective_start,
         "end_date": effective_end,
         "source_url": result.analytics_api_url,
-        # DEPRECATED: kept for frontend backward compatibility.
-        # Fetch fresh data via fetch_statistics_from_url(source_url)
-        # instead of reading from this field.
-        "data": raw_data,
+        # ID-backed statistics keep state light; fetch data from source_url when needed.
+        "data": {},
         "aoi_names": [aoi["name"] for aoi in state["aoi_selection"]["aois"]],
         "parameters": dataset.get("parameters"),
         "context_layer": dataset.get("context_layer"),

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -163,6 +163,9 @@ async def pull_data(
         tool_call_id=tool_call_id,
     )
 
+    raw = result.data if isinstance(result.data, dict) else {}
+    aoi_id_to_name = dict(zip(raw.get("aoi_id", []), raw.get("name", [])))
+
     statistics = {
         "dataset_name": dataset["dataset_name"],
         "start_date": effective_start,
@@ -170,6 +173,7 @@ async def pull_data(
         "source_url": result.analytics_api_url,
         # ID-backed statistics keep state light; fetch data from source_url when needed.
         "data": {},
+        "aoi_id_to_name": aoi_id_to_name,
         "aoi_names": [aoi["name"] for aoi in state["aoi_selection"]["aois"]],
         "parameters": dataset.get("parameters"),
         "context_layer": dataset.get("context_layer"),

--- a/tests/tools/test_generate_insights.py
+++ b/tests/tools/test_generate_insights.py
@@ -225,6 +225,66 @@ async def test_generate_insights_comparison():
     assert isinstance(command.update.get("follow_up_suggestions"), list)
 
 
+async def test_generate_insights_legacy_inline_data():
+    """Backwards-compat: Statistics with inline data dict still works without URL fetch."""
+    mock_state = {
+        "dataset": {
+            "dataset_id": 1,
+            "context_layer": None,
+            "date_request_match": True,
+            "reason": "Deforestation alerts dataset.",
+            "tile_url": "https://tiles.example.com/deforestation/latest/dynamic/{z}/{x}/{y}.png",
+            "dataset_name": "Deforestation Alerts",
+            "analytics_api_endpoint": "/v0/deforestation/alerts/analytics",
+            "description": "Deforestation alerts tracking forest loss events.",
+            "prompt_instructions": "Analyze deforestation alert trends over time",
+            "methodology": "Satellite-based detection of forest loss events.",
+            "cautions": "Alert data may have temporal lag.",
+            "function_usage_notes": "Identifies deforestation events\n",
+            "citation": "Global Forest Watch Deforestation Alerts.",
+        },
+        "statistics": [
+            Statistics(
+                dataset_name="Deforestation Alerts",
+                source_url="http://example.com/analytics/should-not-be-fetched",
+                start_date="2020-01-01",
+                end_date="2023-12-31",
+                aoi_names=["Amazon Region"],
+                data={
+                    "alert_date": [
+                        "2020-01-01",
+                        "2021-01-01",
+                        "2022-01-01",
+                        "2023-01-01",
+                    ],
+                    "value": [1200, 1450, 1100, 980],
+                    "aoi_id": ["BRA.15"] * 4,
+                    "aoi_type": ["admin"] * 4,
+                },
+            )
+        ],
+    }
+
+    tool_call_id = str(uuid.uuid4())
+    # No patch on fetch_statistics_from_url — inline data must be used without a network call
+    result = await generate_insights.ainvoke(
+        {
+            "type": "tool_call",
+            "name": "generate_insights",
+            "id": tool_call_id,
+            "args": {
+                "query": "What are the trends in deforestation alerts over time?",
+                "state": mock_state,
+            },
+        }
+    )
+
+    assert "insight_id" in result.update
+    assert result.update["insight_id"]
+    assert "charts_data" in result.update
+    assert len(result.update["charts_data"]) > 0
+
+
 async def test_simple_line_chart():
     """Test simple line chart generation for time series data."""
     line_data = {

--- a/tests/tools/test_generate_insights.py
+++ b/tests/tools/test_generate_insights.py
@@ -12,6 +12,8 @@ from src.agent.tools.generate_insights import generate_insights
 # "Event loop is closed" errors when running with other test modules
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
+_FETCH_PATCH = "src.agent.tools.generate_insights.fetch_statistics_from_url"
+
 
 @pytest.fixture(scope="function", autouse=True)
 def test_db():
@@ -67,6 +69,94 @@ def mock_insight_db():
 
 
 async def test_generate_insights_comparison():
+    usa_data = {
+        "country": ["USA"] * 16,
+        "region": [3] * 16,
+        "subregion": [11] * 16,
+        "alert_date": [
+            "2024-07-02",
+            "2024-07-03",
+            "2024-07-05",
+            "2024-07-07",
+            "2024-07-10",
+            "2024-07-11",
+            "2024-07-12",
+            "2024-07-15",
+            "2024-07-17",
+            "2024-07-19",
+            "2024-07-20",
+            "2024-07-22",
+            "2024-07-25",
+            "2024-07-26",
+            "2024-07-27",
+            "2024-07-30",
+        ],
+        "confidence": ["high"] * 16,
+        "value": [
+            133035.84375,
+            98698.4765625,
+            7198.0087890625,
+            427562.96875,
+            6532.4423828125,
+            427380.8125,
+            177973.953125,
+            10469.333984375,
+            842927.125,
+            325423.5,
+            4577.6240234375,
+            94053.0234375,
+            146477.453125,
+            439116.15625,
+            683501.1875,
+            142804.90625,
+        ],
+        "aoi_id": ["USA.3.11"] * 16,
+        "aoi_type": ["admin"] * 16,
+    }
+    che_data = {
+        "country": ["CHE"] * 16,
+        "region": [3] * 16,
+        "subregion": [11] * 16,
+        "alert_date": [
+            "2024-07-02",
+            "2024-07-03",
+            "2024-07-05",
+            "2024-07-07",
+            "2024-07-10",
+            "2024-07-11",
+            "2024-07-12",
+            "2024-07-15",
+            "2024-07-17",
+            "2024-07-19",
+            "2024-07-20",
+            "2024-07-22",
+            "2024-07-25",
+            "2024-07-26",
+            "2024-07-27",
+            "2024-07-30",
+        ],
+        "confidence": ["high"] * 16,
+        "value": [
+            13335.84375,
+            9898.4765625,
+            798.0087890625,
+            42562.96875,
+            652.4423828125,
+            42380.8125,
+            17973.953125,
+            1049.333984375,
+            84927.125,
+            32423.5,
+            477.6240234375,
+            9453.0234375,
+            14647.453125,
+            43916.15625,
+            68501.1875,
+            14804.90625,
+        ],
+        "aoi_id": ["CHE.2.12"] * 16,
+        "aoi_type": ["admin"] * 16,
+    }
     update = {
         "dataset": {
             "dataset_id": 4,
@@ -85,124 +175,39 @@ async def test_generate_insights_comparison():
         },
         "statistics": [
             Statistics(
+                id="a1b2c3d4-0001-0001-0001-000000000001",
                 dataset_name="Tree cover loss",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/usa-pima-july-2024",
                 start_date="2024-07-01",
                 end_date="2024-07-31",
                 aoi_names=[
                     "Pima, Arizona, United States",
                     "Bern, Switzerland",
                 ],
-                data={
-                    "country": ["USA"] * 16,
-                    "region": [3] * 16,
-                    "subregion": [11] * 16,
-                    "alert_date": [
-                        "2024-07-02",
-                        "2024-07-03",
-                        "2024-07-05",
-                        "2024-07-07",
-                        "2024-07-10",
-                        "2024-07-11",
-                        "2024-07-12",
-                        "2024-07-15",
-                        "2024-07-17",
-                        "2024-07-19",
-                        "2024-07-20",
-                        "2024-07-22",
-                        "2024-07-25",
-                        "2024-07-26",
-                        "2024-07-27",
-                        "2024-07-30",
-                    ],
-                    "confidence": ["high"] * 16,
-                    "value": [
-                        133035.84375,
-                        98698.4765625,
-                        7198.0087890625,
-                        427562.96875,
-                        6532.4423828125,
-                        427380.8125,
-                        177973.953125,
-                        10469.333984375,
-                        842927.125,
-                        325423.5,
-                        4577.6240234375,
-                        94053.0234375,
-                        146477.453125,
-                        439116.15625,
-                        683501.1875,
-                        142804.90625,
-                    ],
-                    "aoi_id": ["USA.3.11"] * 16,
-                    "aoi_type": ["admin"] * 16,
-                },
             ),
             Statistics(
+                id="a1b2c3d4-0001-0001-0001-000000000002",
                 dataset_name="Tree cover loss",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/che-bern-july-2024",
                 start_date="2024-07-01",
                 end_date="2024-07-31",
                 aoi_names=["Bern, Switzerland"],
-                data={
-                    "country": ["CHE"] * 16,
-                    "region": [3] * 16,
-                    "subregion": [11] * 16,
-                    "alert_date": [
-                        "2024-07-02",
-                        "2024-07-03",
-                        "2024-07-05",
-                        "2024-07-07",
-                        "2024-07-10",
-                        "2024-07-11",
-                        "2024-07-12",
-                        "2024-07-15",
-                        "2024-07-17",
-                        "2024-07-19",
-                        "2024-07-20",
-                        "2024-07-22",
-                        "2024-07-25",
-                        "2024-07-26",
-                        "2024-07-27",
-                        "2024-07-30",
-                    ],
-                    "confidence": ["high"] * 16,
-                    "value": [
-                        13335.84375,
-                        9898.4765625,
-                        798.0087890625,
-                        42562.96875,
-                        652.4423828125,
-                        42380.8125,
-                        17973.953125,
-                        1049.333984375,
-                        84927.125,
-                        32423.5,
-                        477.6240234375,
-                        9453.0234375,
-                        14647.453125,
-                        43916.15625,
-                        68501.1875,
-                        14804.90625,
-                    ],
-                    "aoi_id": ["CHE.2.12"] * 16,
-                    "aoi_type": ["admin"] * 16,
-                },
             ),
         ],
     }
     tool_call_id = str(uuid.uuid4())
-    command = await generate_insights.ainvoke(
-        {
-            "type": "tool_call",
-            "name": "generate_insights",
-            "id": tool_call_id,
-            "args": {
-                "query": "Compare tree cover loss in Pima County, Arizona with Bern, Switzerland",
-                "state": update,
-            },
-        }
-    )
+    with patch(_FETCH_PATCH, new=AsyncMock(side_effect=[usa_data, che_data])):
+        command = await generate_insights.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "generate_insights",
+                "id": tool_call_id,
+                "args": {
+                    "query": "Compare tree cover loss in Pima County, Arizona with Bern, Switzerland",
+                    "state": update,
+                },
+            }
+        )
 
     assert "insight_id" in command.update
     assert command.update["insight_id"]
@@ -222,6 +227,17 @@ async def test_generate_insights_comparison():
 
 async def test_simple_line_chart():
     """Test simple line chart generation for time series data."""
+    line_data = {
+        "alert_date": [
+            "2020-01-01",
+            "2021-01-01",
+            "2022-01-01",
+            "2023-01-01",
+        ],
+        "value": [1200, 1450, 1100, 980],
+        "aoi_id": ["BRA.15", "BRA.15", "BRA.15", "BRA.15"],
+        "aoi_type": ["admin", "admin", "admin", "admin"],
+    }
     mock_state_line = {
         "dataset": {
             "dataset_id": 1,
@@ -240,38 +256,29 @@ async def test_simple_line_chart():
         },
         "statistics": [
             Statistics(
+                id="a1b2c3d4-0002-0002-0002-000000000001",
                 dataset_name="Deforestation Alerts",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/deforestation-amazon-2020-2023",
                 start_date="2020-01-01",
                 end_date="2023-12-31",
                 aoi_names=["Amazon Region"],
-                data={
-                    "alert_date": [
-                        "2020-01-01",
-                        "2021-01-01",
-                        "2022-01-01",
-                        "2023-01-01",
-                    ],
-                    "value": [1200, 1450, 1100, 980],
-                    "aoi_id": ["BRA.15", "BRA.15", "BRA.15", "BRA.15"],
-                    "aoi_type": ["admin", "admin", "admin", "admin"],
-                },
             )
         ],
     }
 
     tool_call_id = str(uuid.uuid4())
-    result = await generate_insights.ainvoke(
-        {
-            "type": "tool_call",
-            "name": "generate_insights",
-            "id": tool_call_id,
-            "args": {
-                "query": "What are the trends in deforestation alerts over time?",
-                "state": mock_state_line,
-            },
-        }
-    )
+    with patch(_FETCH_PATCH, new=AsyncMock(return_value=line_data)):
+        result = await generate_insights.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "generate_insights",
+                "id": tool_call_id,
+                "args": {
+                    "query": "What are the trends in deforestation alerts over time?",
+                    "state": mock_state_line,
+                },
+            }
+        )
 
     assert "insight_id" in result.update
     assert result.update["insight_id"]
@@ -281,6 +288,25 @@ async def test_simple_line_chart():
 
 async def test_simple_bar_chart():
     """Test simple bar chart generation for categorical comparison."""
+    bar_data = {
+        "subregion": [
+            "Rayagada",
+            "Khurdha",
+            "Puri",
+            "Koraput",
+            "Ganjam",
+        ],
+        "value": [
+            11568000,
+            6020000,
+            4770000,
+            1630000,
+            1240000,
+        ],
+        "year": [2022, 2022, 2022, 2022, 2022],
+        "aoi_id": ["IND.26"] * 5,
+        "aoi_type": ["admin"] * 5,
+    }
     mock_state_bar = {
         "dataset": {
             "dataset_id": 4,
@@ -299,46 +325,29 @@ async def test_simple_bar_chart():
         },
         "statistics": [
             Statistics(
+                id="a1b2c3d4-0003-0003-0003-000000000001",
                 dataset_name="Tree cover loss",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/tree-cover-loss-odisha-2022",
                 start_date="2022-01-01",
                 end_date="2022-12-31",
                 aoi_names=["Odisha, India"],
-                data={
-                    "subregion": [
-                        "Rayagada",
-                        "Khurdha",
-                        "Puri",
-                        "Koraput",
-                        "Ganjam",
-                    ],
-                    "value": [
-                        11568000,
-                        6020000,
-                        4770000,
-                        1630000,
-                        1240000,
-                    ],
-                    "year": [2022, 2022, 2022, 2022, 2022],
-                    "aoi_id": ["IND.26"] * 5,
-                    "aoi_type": ["admin"] * 5,
-                },
             )
         ],
     }
 
     tool_call_id = str(uuid.uuid4())
-    result = await generate_insights.ainvoke(
-        {
-            "type": "tool_call",
-            "name": "generate_insights",
-            "id": tool_call_id,
-            "args": {
-                "query": "Which district have the highest forest loss in Odisha?",
-                "state": mock_state_bar,
-            },
-        }
-    )
+    with patch(_FETCH_PATCH, new=AsyncMock(return_value=bar_data)):
+        result = await generate_insights.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "generate_insights",
+                "id": tool_call_id,
+                "args": {
+                    "query": "Which district have the highest forest loss in Odisha?",
+                    "state": mock_state_bar,
+                },
+            }
+        )
 
     assert "insight_id" in result.update
     assert result.update["insight_id"]
@@ -348,6 +357,15 @@ async def test_simple_bar_chart():
 
 async def test_stacked_bar_chart():
     """Test stacked bar chart generation for composition data."""
+    stacked_data = {
+        "year": ["2020", "2021", "2022", "2023"],
+        "deforestation": [1200, 1100, 950, 800],
+        "fires": [800, 900, 1200, 1100],
+        "logging": [400, 350, 300, 250],
+        "agriculture": [600, 700, 800, 750],
+        "aoi_id": ["BRA.15"] * 4,
+        "aoi_type": ["admin"] * 4,
+    }
     mock_state_stacked = {
         "dataset": {
             "dataset_id": 5,
@@ -366,36 +384,29 @@ async def test_stacked_bar_chart():
         },
         "statistics": [
             Statistics(
+                id="a1b2c3d4-0004-0004-0004-000000000001",
                 dataset_name="Forest Loss Causes Over Time",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/forest-loss-causes-amazon-2020-2023",
                 start_date="2020-01-01",
                 end_date="2023-12-31",
                 aoi_names=["Amazon Region, Brazil"],
-                data={
-                    "year": ["2020", "2021", "2022", "2023"],
-                    "deforestation": [1200, 1100, 950, 800],
-                    "fires": [800, 900, 1200, 1100],
-                    "logging": [400, 350, 300, 250],
-                    "agriculture": [600, 700, 800, 750],
-                    "aoi_id": ["BRA.15"] * 4,
-                    "aoi_type": ["admin"] * 4,
-                },
             )
         ],
     }
 
     tool_call_id = str(uuid.uuid4())
-    result = await generate_insights.ainvoke(
-        {
-            "type": "tool_call",
-            "name": "generate_insights",
-            "id": tool_call_id,
-            "args": {
-                "query": "Show me the composition of forest loss causes over time as a stacked bar chart",
-                "state": mock_state_stacked,
-            },
-        }
-    )
+    with patch(_FETCH_PATCH, new=AsyncMock(return_value=stacked_data)):
+        result = await generate_insights.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "generate_insights",
+                "id": tool_call_id,
+                "args": {
+                    "query": "Show me the composition of forest loss causes over time as a stacked bar chart",
+                    "state": mock_state_stacked,
+                },
+            }
+        )
 
     assert "insight_id" in result.update
     assert result.update["insight_id"]
@@ -405,6 +416,28 @@ async def test_stacked_bar_chart():
 
 async def test_grouped_bar_chart():
     """Test grouped bar chart generation for multiple metrics comparison."""
+    grouped_data = {
+        "country": [
+            "Brazil",
+            "Brazil",
+            "Indonesia",
+            "Indonesia",
+            "DRC",
+            "DRC",
+        ],
+        "metric": [
+            "Forest Loss",
+            "Fire Incidents",
+            "Forest Loss",
+            "Fire Incidents",
+            "Forest Loss",
+            "Fire Incidents",
+        ],
+        "value": [11568, 8500, 6020, 4200, 4770, 2100],
+        "year": [2022] * 6,
+        "aoi_id": ["BRA", "BRA", "IDN", "IDN", "COD", "COD"],
+        "aoi_type": ["admin"] * 6,
+    }
     mock_state_grouped = {
         "dataset": {
             "dataset_id": 6,
@@ -423,8 +456,9 @@ async def test_grouped_bar_chart():
         },
         "statistics": [
             Statistics(
+                id="a1b2c3d4-0005-0005-0005-000000000001",
                 dataset_name="Forest Loss and Fire Incidents",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/forest-metrics-bra-idn-cod-2022",
                 start_date="2022-01-01",
                 end_date="2022-12-31",
                 aoi_names=[
@@ -432,44 +466,23 @@ async def test_grouped_bar_chart():
                     "Indonesia",
                     "Democratic Republic of Congo",
                 ],
-                data={
-                    "country": [
-                        "Brazil",
-                        "Brazil",
-                        "Indonesia",
-                        "Indonesia",
-                        "DRC",
-                        "DRC",
-                    ],
-                    "metric": [
-                        "Forest Loss",
-                        "Fire Incidents",
-                        "Forest Loss",
-                        "Fire Incidents",
-                        "Forest Loss",
-                        "Fire Incidents",
-                    ],
-                    "value": [11568, 8500, 6020, 4200, 4770, 2100],
-                    "year": [2022] * 6,
-                    "aoi_id": ["BRA", "BRA", "IDN", "IDN", "COD", "COD"],
-                    "aoi_type": ["admin"] * 6,
-                },
             )
         ],
     }
 
     tool_call_id = str(uuid.uuid4())
-    result = await generate_insights.ainvoke(
-        {
-            "type": "tool_call",
-            "name": "generate_insights",
-            "id": tool_call_id,
-            "args": {
-                "query": "Compare forest loss and fire incidents across countries using grouped bars",
-                "state": mock_state_grouped,
-            },
-        }
-    )
+    with patch(_FETCH_PATCH, new=AsyncMock(return_value=grouped_data)):
+        result = await generate_insights.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "generate_insights",
+                "id": tool_call_id,
+                "args": {
+                    "query": "Compare forest loss and fire incidents across countries using grouped bars",
+                    "state": mock_state_grouped,
+                },
+            }
+        )
 
     assert "insight_id" in result.update
     assert result.update["insight_id"]
@@ -479,6 +492,18 @@ async def test_grouped_bar_chart():
 
 async def test_pie_chart():
     """Test pie chart generation for part-to-whole relationship."""
+    pie_data = {
+        "cause": [
+            "Deforestation",
+            "Fires",
+            "Logging",
+            "Agriculture",
+            "Mining",
+        ],
+        "value": [45, 25, 15, 10, 5],
+        "aoi_id": ["GLOBAL"] * 5,
+        "aoi_type": ["global"] * 5,
+    }
     mock_state_pie = {
         "dataset": {
             "dataset_id": 7,
@@ -497,39 +522,29 @@ async def test_pie_chart():
         },
         "statistics": [
             Statistics(
+                id="a1b2c3d4-0006-0006-0006-000000000001",
                 dataset_name="Global Forest Loss Causes",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/forest-loss-causes-global-2022",
                 start_date="2022-01-01",
                 end_date="2022-12-31",
                 aoi_names=["Global"],
-                data={
-                    "cause": [
-                        "Deforestation",
-                        "Fires",
-                        "Logging",
-                        "Agriculture",
-                        "Mining",
-                    ],
-                    "value": [45, 25, 15, 10, 5],
-                    "aoi_id": ["GLOBAL"] * 5,
-                    "aoi_type": ["global"] * 5,
-                },
             )
         ],
     }
 
     tool_call_id = str(uuid.uuid4())
-    result = await generate_insights.ainvoke(
-        {
-            "type": "tool_call",
-            "name": "generate_insights",
-            "id": tool_call_id,
-            "args": {
-                "query": "What are the main causes of forest loss globally? Show as pie chart",
-                "state": mock_state_pie,
-            },
-        }
-    )
+    with patch(_FETCH_PATCH, new=AsyncMock(return_value=pie_data)):
+        result = await generate_insights.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "generate_insights",
+                "id": tool_call_id,
+                "args": {
+                    "query": "What are the main causes of forest loss globally? Show as pie chart",
+                    "state": mock_state_pie,
+                },
+            }
+        )
 
     assert "insight_id" in result.update
     assert result.update["insight_id"]
@@ -544,6 +559,28 @@ async def test_pie_chart():
 
 async def test_generate_insights_creates_two_bar_charts_with_code_instructions():
     """Test multi-chart generation with generic fields and aligned code instructions."""
+    multichart_data = {
+        "year": [
+            2021,
+            2022,
+            2023,
+            2024,
+        ],
+        "metric_primary": [
+            120,
+            150,
+            180,
+            210,
+        ],
+        "metric_secondary": [
+            80,
+            95,
+            110,
+            130,
+        ],
+        "aoi_id": ["REG.1"] * 4,
+        "aoi_type": ["admin"] * 4,
+    }
     mock_state_multichart = {
         "dataset": {
             "dataset_id": 999,
@@ -564,49 +601,29 @@ async def test_generate_insights_creates_two_bar_charts_with_code_instructions()
         },
         "statistics": [
             Statistics(
+                id="a1b2c3d4-0007-0007-0007-000000000001",
                 dataset_name="Generic Annual Metrics",
-                source_url="http://example.com/analytics/bafa3df8-343e-53fe-8c51-9c59c600d72f",
+                source_url="http://example.com/analytics/generic-annual-metrics-reg1-2021-2024",
                 start_date="2021-01-01",
                 end_date="2024-12-31",
                 aoi_names=["Sample Region"],
-                data={
-                    "year": [
-                        2021,
-                        2022,
-                        2023,
-                        2024,
-                    ],
-                    "metric_primary": [
-                        120,
-                        150,
-                        180,
-                        210,
-                    ],
-                    "metric_secondary": [
-                        80,
-                        95,
-                        110,
-                        130,
-                    ],
-                    "aoi_id": ["REG.1"] * 4,
-                    "aoi_type": ["admin"] * 4,
-                },
             )
         ],
     }
 
     tool_call_id = str(uuid.uuid4())
-    result = await generate_insights.ainvoke(
-        {
-            "type": "tool_call",
-            "name": "generate_insights",
-            "id": tool_call_id,
-            "args": {
-                "query": "What is the trend in this region over the last four years?",
-                "state": mock_state_multichart,
-            },
-        }
-    )
+    with patch(_FETCH_PATCH, new=AsyncMock(return_value=multichart_data)):
+        result = await generate_insights.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "generate_insights",
+                "id": tool_call_id,
+                "args": {
+                    "query": "What is the trend in this region over the last four years?",
+                    "state": mock_state_multichart,
+                },
+            }
+        )
 
     assert "charts_data" in result.update
     charts = result.update["charts_data"]

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -25,6 +25,7 @@ from src.agent.tools.generate_insights import (
     MultiChartInsight,
     _extract_statistics_ids,
     generate_insights,
+    prepare_dataframes,
 )
 from src.api.data_models import InsightOrm
 
@@ -413,6 +414,67 @@ async def test_extract_statistics_ids_tracks_new_state_ids():
 
 async def test_extract_statistics_ids_keeps_older_states_compatible():
     assert _extract_statistics_ids([{}, {}, None]) == []
+
+
+async def test_prepare_dataframes_uses_inline_data_for_legacy_stats(
+    monkeypatch,
+):
+    fetch_data = AsyncMock(side_effect=AssertionError("should not fetch"))
+    monkeypatch.setattr(
+        generate_insights_module, "fetch_statistics_from_url", fetch_data
+    )
+
+    dataframes, source_urls = await prepare_dataframes(
+        [
+            {
+                "dataset_name": "Tree cover loss",
+                "start_date": "2020-01-01",
+                "end_date": "2021-12-31",
+                "aoi_names": ["Brazil"],
+                "parameters": None,
+                "context_layer": None,
+                "data": {"year": [2020, 2021], "value": [1, 2]},
+            }
+        ]
+    )
+
+    assert len(dataframes) == 1
+    assert dataframes[0][0].to_dict("list") == {
+        "year": [2020, 2021],
+        "value": [1, 2],
+    }
+    assert source_urls == [""]
+    fetch_data.assert_not_awaited()
+
+
+async def test_prepare_dataframes_fetches_id_backed_stats(monkeypatch):
+    fetch_data = AsyncMock(return_value={"year": [2020], "value": [5]})
+    monkeypatch.setattr(
+        generate_insights_module, "fetch_statistics_from_url", fetch_data
+    )
+
+    dataframes, source_urls = await prepare_dataframes(
+        [
+            {
+                "id": "stat-1",
+                "dataset_name": "Tree cover loss",
+                "source_url": "http://example.com/statistics/stat-1",
+                "start_date": "2020-01-01",
+                "end_date": "2020-12-31",
+                "aoi_names": ["Brazil"],
+                "parameters": None,
+                "context_layer": None,
+                "data": {},
+            }
+        ]
+    )
+
+    assert dataframes[0][0].to_dict("list") == {
+        "year": [2020],
+        "value": [5],
+    }
+    assert source_urls == ["http://example.com/statistics/stat-1"]
+    fetch_data.assert_awaited_once_with("http://example.com/statistics/stat-1")
 
 
 async def test_generate_insights_persists_statistics_provenance(monkeypatch):

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -9,7 +9,11 @@ from sqlalchemy import select
 
 from src.agent.tools.data_handlers.base import DataPullResult
 from src.agent.tools.datasets_config import DATASETS
-from src.agent.tools.pull_data import pull_data, revise_date_range
+from src.agent.tools.pull_data import (
+    fetch_statistics_from_url,
+    pull_data,
+    revise_date_range,
+)
 from src.api.app import app
 from src.api.auth.dependencies import fetch_user_from_rw_api
 from src.api.data_models import StatisticsOrm
@@ -248,7 +252,9 @@ async def test_pull_data_persists_statistics(monkeypatch):
                 analytics_api_url="http://example.com/analytics/statistics",
             )
 
-    async def fake_revise_date_range(start_date, end_date, dataset_id):
+    async def fake_revise_date_range(
+        start_date, end_date, dataset_id, context_layer=None
+    ):
         return start_date, end_date, False
 
     monkeypatch.setattr(
@@ -289,7 +295,11 @@ async def test_pull_data_persists_statistics(monkeypatch):
     statistics = command.update.get("statistics", [])
     assert len(statistics) == 1
     assert statistics[0]["id"]
-    assert statistics[0]["data"]["value"] == [1]
+    assert statistics[0]["data"] == {}
+    assert (
+        statistics[0]["source_url"]
+        == "http://example.com/analytics/statistics"
+    )
 
     async with async_session_maker() as session:
         result = await session.execute(
@@ -438,9 +448,13 @@ async def test_pull_data_custom_area(auth_override, client, structlog_context):
 
     statistics = command.update.get("statistics", {})
 
-    assert aoi_data["src_id"] == statistics[0]["data"]["aoi_id"][0]
-    assert aoi_data["name"] == statistics[0]["data"]["name"][0]
-    assert statistics[0]["data"]["land_cover_class"] == ["Built-up"]
+    assert statistics[0]["id"]
+    assert statistics[0]["data"] == {}
+
+    raw_data = await fetch_statistics_from_url(statistics[0]["source_url"])
+    assert aoi_data["src_id"] == raw_data["aoi_id"][0]
+    assert aoi_data["name"] == raw_data["name"][0]
+    assert raw_data["land_cover_class"] == ["Built-up"]
 
 
 class TestReviseDateRange:


### PR DESCRIPTION
This avoids writing the `raw_data` from data pulls into state.

Now that we are tracking the pull data requests through urls and store metadata in DB, we can avoid writing the actual data into state. This PR does just that, while keeping backwards compatability.