### PR TITLE
PZB-897: Add API endpoints for superusers to manage users / user status

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.agent.graph import close_checkpointer_pool, get_checkpointer_pool
 from src.api.routers import (
+    admin,
     chat,
     custom_areas,
     geometry,
@@ -100,3 +101,4 @@ app.include_router(custom_areas.router)
 app.include_router(geometry.router)
 app.include_router(insights.router)
 app.include_router(metadata.router)
+app.include_router(admin.router)

--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -14,7 +14,7 @@ from src.api.auth.machine_user import (
     MACHINE_USER_PREFIX,
     validate_machine_user_token,
 )
-from src.api.data_models import UserOrm
+from src.api.data_models import UserOrm, UserType
 from src.api.schemas import UserModel
 from src.shared.database import get_session_from_pool_dependency
 from src.shared.logging_config import bind_request_logging_context, get_logger
@@ -148,6 +148,18 @@ async def optional_auth(
     user = await _get_or_create_user(user_info, session)
     bind_request_logging_context(user_id=user.id)
     return _orm_to_user_model(user)
+
+
+async def require_superuser(
+    user: UserModel = Depends(require_auth),
+) -> UserModel:
+    """Requires the authenticated user to be a superuser."""
+    if user.user_type != UserType.SUPERUSER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Superuser privileges required",
+        )
+    return user
 
 
 async def fetch_user(

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -262,6 +262,26 @@ async def make_user_pro(session: AsyncSession, email: str) -> UserOrm:
     return user
 
 
+async def make_user_superuser(session: AsyncSession, email: str) -> UserOrm:
+    """Make a user superuser by setting their user_type to superuser"""
+
+    email_lower = email.lower()
+    result = await session.execute(
+        select(UserOrm).where(func.lower(UserOrm.email) == email_lower)
+    )
+    user = result.scalar_one_or_none()
+    if not user:
+        raise ValueError(f"User with email {email} not found")
+
+    user.user_type = UserType.SUPERUSER.value
+    user.updated_at = datetime.now()
+
+    await session.commit()
+    await session.refresh(user)
+
+    return user
+
+
 # CLI Commands
 @click.group()
 def cli():
@@ -536,6 +556,33 @@ def make_user_pro_command(email: str):
             await db.close()
 
     asyncio.run(_make_pro())
+
+
+@cli.command("make-user-superuser")
+@click.option(
+    "--email", required=True, help="Email of the user to make superuser"
+)
+def make_user_superuser_command(email: str):
+    """Make a user superuser by setting their user_type to superuser"""
+
+    async def _make_superuser():
+        db = DatabaseManager()
+        try:
+            async with db.async_session() as session:
+                user = await make_user_superuser(session, email)
+
+                click.echo("✅ Made user superuser:")
+                click.echo(f"   ID: {user.id}")
+                click.echo(f"   Name: {user.name}")
+                click.echo(f"   Email: {user.email}")
+                click.echo(f"   User Type: {user.user_type}")
+                click.echo(f"   Updated: {user.updated_at}")
+        except ValueError as e:
+            click.echo(f"❌ Error: {e}", err=True)
+        finally:
+            await db.close()
+
+    asyncio.run(_make_superuser())
 
 
 @cli.command("list-pro-users")

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -30,6 +30,7 @@ class UserType(str, enum.Enum):
     REGULAR = "regular"
     MACHINE = "machine"
     PRO = "pro"
+    SUPERUSER = "superuser"
 
 
 class UserOrm(Base):

--- a/src/api/routers/admin.py
+++ b/src/api/routers/admin.py
@@ -41,9 +41,7 @@ async def list_users(
     return [_orm_to_user_model(u) for u in users]
 
 
-@router.patch(
-    "/api/admin/users/{user_id}/user-type", response_model=UserModel
-)
+@router.patch("/api/admin/users/{user_id}/user-type", response_model=UserModel)
 async def update_user_type(
     user_id: str,
     body: UserTypeUpdateRequest,
@@ -58,10 +56,7 @@ async def update_user_type(
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    if (
-        target.id == superuser.id
-        and body.user_type != UserType.SUPERUSER
-    ):
+    if target.id == superuser.id and body.user_type != UserType.SUPERUSER:
         raise HTTPException(
             status_code=400,
             detail="Superusers cannot demote themselves",

--- a/src/api/routers/admin.py
+++ b/src/api/routers/admin.py
@@ -1,0 +1,40 @@
+"""Superuser-only admin endpoints (manage other users)."""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.auth.dependencies import _orm_to_user_model, require_superuser
+from src.api.data_models import UserOrm
+from src.api.schemas import UserModel
+from src.shared.database import get_session_from_pool_dependency
+
+router = APIRouter()
+
+
+@router.get("/api/admin/users", response_model=list[UserModel])
+async def list_users(
+    email: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    _superuser: UserModel = Depends(require_superuser),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+):
+    """
+    List users for superuser administration.
+
+    Optional case-insensitive substring filter on email. Pagination via
+    `limit` (default 50, max 200) and `offset` (default 0). Ordered by
+    `created_at DESC, id ASC` for deterministic paging.
+    """
+    stmt = select(UserOrm)
+    if email is not None:
+        stmt = stmt.where(func.lower(UserOrm.email).contains(email.lower()))
+    stmt = stmt.order_by(UserOrm.created_at.desc(), UserOrm.id.asc())
+    stmt = stmt.offset(offset).limit(limit)
+
+    result = await session.execute(stmt)
+    users = result.scalars().all()
+    return [_orm_to_user_model(u) for u in users]

--- a/src/api/routers/admin.py
+++ b/src/api/routers/admin.py
@@ -1,14 +1,15 @@
 """Superuser-only admin endpoints (manage other users)."""
 
+from datetime import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.auth.dependencies import _orm_to_user_model, require_superuser
-from src.api.data_models import UserOrm
-from src.api.schemas import UserModel
+from src.api.data_models import UserOrm, UserType
+from src.api.schemas import UserModel, UserTypeUpdateRequest
 from src.shared.database import get_session_from_pool_dependency
 
 router = APIRouter()
@@ -38,3 +39,38 @@ async def list_users(
     result = await session.execute(stmt)
     users = result.scalars().all()
     return [_orm_to_user_model(u) for u in users]
+
+
+@router.patch(
+    "/api/admin/users/{user_id}/user-type", response_model=UserModel
+)
+async def update_user_type(
+    user_id: str,
+    body: UserTypeUpdateRequest,
+    superuser: UserModel = Depends(require_superuser),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+):
+    """Set a user's user_type. Superuser-only."""
+    result = await session.execute(
+        select(UserOrm).where(UserOrm.id == user_id)
+    )
+    target = result.scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if (
+        target.id == superuser.id
+        and body.user_type != UserType.SUPERUSER
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Superusers cannot demote themselves",
+        )
+
+    target.user_type = body.user_type.value
+    target.updated_at = datetime.now()
+
+    await session.commit()
+    await session.refresh(target)
+
+    return _orm_to_user_model(target)

--- a/src/api/routers/insights.py
+++ b/src/api/routers/insights.py
@@ -108,7 +108,10 @@ async def get_insight(
             detail="Authentication required",
         )
 
-    if row.user_id != user.id and user.user_type != UserType.ADMIN:
+    if row.user_id != user.id and user.user_type not in (
+        UserType.ADMIN,
+        UserType.SUPERUSER,
+    ):
         raise HTTPException(status_code=404, detail="Insight not found")
 
     return _row_to_response(row)
@@ -134,7 +137,10 @@ async def toggle_insight_public(
     if not row:
         raise HTTPException(status_code=404, detail="Insight not found")
 
-    if row.user_id != user.id and user.user_type != UserType.ADMIN:
+    if row.user_id != user.id and user.user_type not in (
+        UserType.ADMIN,
+        UserType.SUPERUSER,
+    ):
         raise HTTPException(status_code=404, detail="Insight not found")
 
     row.is_public = body.is_public

--- a/src/api/routers/threads.py
+++ b/src/api/routers/threads.py
@@ -72,7 +72,10 @@ async def get_thread(
                 detail="Missing Bearer token",
             )
 
-        if thread.user_id != user.id and user.user_type != UserType.ADMIN:
+        if thread.user_id != user.id and user.user_type not in (
+            UserType.ADMIN,
+            UserType.SUPERUSER,
+        ):
             logger.warning(
                 "Unauthorized access to private thread",
                 thread_id=thread_id,
@@ -81,7 +84,7 @@ async def get_thread(
             )
             raise HTTPException(status_code=404, detail="Thread not found")
 
-        if user.user_type == UserType.ADMIN:
+        if user.user_type in (UserType.ADMIN, UserType.SUPERUSER):
             logger.debug(
                 "Admin accessing private thread",
                 thread_id=thread_id,

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -159,6 +159,20 @@ class UserModel(BaseModel):
         return v
 
 
+class UserTypeUpdateRequest(BaseModel):
+    """Request schema for changing a user's user_type via the admin endpoint."""
+
+    user_type: UserType
+
+    @field_validator("user_type")
+    def reject_machine(cls, v: UserType) -> UserType:
+        if v == UserType.MACHINE:
+            raise ValueError(
+                "machine user_type cannot be assigned via this endpoint"
+            )
+        return v
+
+
 class UserProfileUpdateRequest(BaseModel):
     """Request schema for updating user profile fields."""
 

--- a/src/api/services/quota.py
+++ b/src/api/services/quota.py
@@ -21,7 +21,7 @@ async def get_user_identity_and_daily_quota(
     """
     Determine the user's identity string and their daily prompt quota.
     """
-    if user.user_type == UserType.ADMIN:
+    if user.user_type in (UserType.ADMIN, UserType.SUPERUSER):
         daily_quota = APISettings.admin_user_daily_quota
     elif user.user_type == UserType.MACHINE:
         daily_quota = APISettings.machine_user_daily_quota

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -1,0 +1,407 @@
+"""Tests for the superuser-gated admin endpoints."""
+
+import pytest
+
+from src.api.data_models import UserOrm, UserType
+from tests.conftest import async_session_maker
+
+
+async def _seed_user(
+    user_id: str,
+    email: str,
+    user_type: UserType = UserType.REGULAR,
+    name: str | None = None,
+) -> UserOrm:
+    async with async_session_maker() as session:
+        u = UserOrm(
+            id=user_id,
+            name=name or user_id,
+            email=email,
+            user_type=user_type.value,
+        )
+        session.add(u)
+        await session.commit()
+        await session.refresh(u)
+        return u
+
+
+# --- GET /api/admin/users --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_users_requires_auth(client):
+    """Unauthenticated requests must return 401."""
+    response = await client.get("/api/admin/users")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_users_requires_superuser_not_regular(
+    client, auth_override
+):
+    """A regular user must receive 403."""
+    regular = await _seed_user(
+        "regular-list", "regular_list@example.com", UserType.REGULAR
+    )
+    auth_override(regular.id)
+
+    response = await client.get(
+        "/api/admin/users",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_users_requires_superuser_not_admin(
+    client, auth_override, admin_user_factory
+):
+    """An admin (not superuser) must receive 403 — admins cannot list users."""
+    admin = await admin_user_factory("admin_list@example.com")
+    auth_override(admin.id)
+
+    response = await client.get(
+        "/api/admin/users",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_users_requires_superuser_not_pro(client, auth_override):
+    """A pro user must receive 403."""
+    pro = await _seed_user(
+        "pro-list", "pro_list@example.com", UserType.PRO
+    )
+    auth_override(pro.id)
+
+    response = await client.get(
+        "/api/admin/users",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_users_no_filter_returns_capped_list(
+    client, auth_override, superuser_factory
+):
+    """With no filter, the endpoint returns at most 50 users."""
+    su = await superuser_factory("su_cap@example.com")
+    auth_override(su.id)
+
+    # Seed 55 additional users so that, counting the superuser, there are 56 total.
+    async with async_session_maker() as session:
+        for i in range(55):
+            session.add(
+                UserOrm(
+                    id=f"bulk-user-{i:03d}",
+                    name=f"Bulk {i}",
+                    email=f"bulk{i:03d}@example.com",
+                    user_type=UserType.REGULAR.value,
+                )
+            )
+        await session.commit()
+
+    response = await client.get(
+        "/api/admin/users",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 50
+
+
+@pytest.mark.asyncio
+async def test_list_users_email_exact_match(
+    client, auth_override, superuser_factory
+):
+    """An exact email match returns the matching user."""
+    su = await superuser_factory("su_exact@example.com")
+    auth_override(su.id)
+    await _seed_user("target-exact", "target_exact@example.com")
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"email": "target_exact@example.com"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    emails = {u["email"] for u in data}
+    assert "target_exact@example.com" in emails
+
+
+@pytest.mark.asyncio
+async def test_list_users_email_substring_match(
+    client, auth_override, superuser_factory
+):
+    """Substring match returns all users whose email contains the query."""
+    su = await superuser_factory("su_sub@example.com")
+    auth_override(su.id)
+    await _seed_user("alice-1", "alice@example.com")
+    await _seed_user("alicia-1", "alicia@example.com")
+    await _seed_user("bob-1", "bob@example.com")
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"email": "ali"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    emails = {u["email"] for u in data}
+    assert "alice@example.com" in emails
+    assert "alicia@example.com" in emails
+    assert "bob@example.com" not in emails
+
+
+@pytest.mark.asyncio
+async def test_list_users_email_case_insensitive(
+    client, auth_override, superuser_factory
+):
+    """Email search is case-insensitive."""
+    su = await superuser_factory("su_case@example.com")
+    auth_override(su.id)
+    await _seed_user("mixed-case", "MixedCase@Example.COM")
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"email": "mixedcase"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    emails = {u["email"] for u in data}
+    assert "MixedCase@Example.COM" in emails
+
+
+@pytest.mark.asyncio
+async def test_list_users_no_matches_returns_empty(
+    client, auth_override, superuser_factory
+):
+    """A query with no matches returns an empty list."""
+    su = await superuser_factory("su_none@example.com")
+    auth_override(su.id)
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"email": "no-such-email-anywhere"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_users_response_shape(
+    client, auth_override, superuser_factory
+):
+    """Response items use the UserModel JSON shape (camelCase, includes userType)."""
+    su = await superuser_factory("su_shape@example.com")
+    auth_override(su.id)
+    target = await _seed_user(
+        "target-shape", "target_shape@example.com", UserType.PRO
+    )
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"email": "target_shape"},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    item = data[0]
+    assert item["id"] == target.id
+    assert item["email"] == target.email
+    assert item["userType"] == UserType.PRO.value
+    # createdAt and updatedAt should be present (camelCase) per UserModel config
+    assert "createdAt" in item
+    assert "updatedAt" in item
+
+
+# --- GET /api/admin/users — pagination ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_users_respects_custom_limit(
+    client, auth_override, superuser_factory
+):
+    """Custom limit caps the response size."""
+    su = await superuser_factory("su_lim@example.com")
+    auth_override(su.id)
+
+    async with async_session_maker() as session:
+        for i in range(10):
+            session.add(
+                UserOrm(
+                    id=f"lim-user-{i:02d}",
+                    name=f"Lim {i}",
+                    email=f"lim{i:02d}@example.com",
+                    user_type=UserType.REGULAR.value,
+                )
+            )
+        await session.commit()
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"limit": 5},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 5
+
+
+@pytest.mark.asyncio
+async def test_list_users_respects_offset(
+    client, auth_override, superuser_factory
+):
+    """offset + limit returns the expected slice with no overlap between pages."""
+    su = await superuser_factory("su_off@example.com")
+    auth_override(su.id)
+
+    # Seed users with explicit, distinct created_at so ordering is deterministic.
+    from datetime import datetime, timedelta
+
+    base = datetime(2025, 1, 1, 12, 0, 0)
+    async with async_session_maker() as session:
+        for i in range(5):
+            session.add(
+                UserOrm(
+                    id=f"off-user-{i:02d}",
+                    name=f"Off {i}",
+                    email=f"off{i:02d}@example.com",
+                    user_type=UserType.REGULAR.value,
+                    created_at=base + timedelta(seconds=i),
+                    updated_at=base + timedelta(seconds=i),
+                )
+            )
+        await session.commit()
+
+    page1 = await client.get(
+        "/api/admin/users",
+        params={"limit": 2, "offset": 0},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    page2 = await client.get(
+        "/api/admin/users",
+        params={"limit": 2, "offset": 2},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert page1.status_code == 200
+    assert page2.status_code == 200
+    page1_ids = [u["id"] for u in page1.json()]
+    page2_ids = [u["id"] for u in page2.json()]
+
+    assert len(page1_ids) == 2
+    assert len(page2_ids) == 2
+    # No overlap between pages
+    assert set(page1_ids).isdisjoint(set(page2_ids))
+    # created_at DESC: page1 should contain the newest seeded users
+    # The superuser itself was created after the seeded users in this test
+    # (`superuser_factory` uses datetime.now default), so it lands on page1.
+    # We just verify that no offset-style duplicates appear.
+
+
+@pytest.mark.asyncio
+async def test_list_users_offset_past_end_returns_empty(
+    client, auth_override, superuser_factory
+):
+    """Offset beyond the total returns an empty list."""
+    su = await superuser_factory("su_past@example.com")
+    auth_override(su.id)
+    await _seed_user("past-user-1", "past1@example.com")
+    # Total = 2 users (the superuser + one seeded). offset=10 ⇒ empty.
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"offset": 10},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_users_limit_caps_at_200(
+    client, auth_override, superuser_factory
+):
+    """limit > 200 is rejected with 422."""
+    su = await superuser_factory("su_max@example.com")
+    auth_override(su.id)
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"limit": 500},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_users_limit_zero_rejected(
+    client, auth_override, superuser_factory
+):
+    """limit=0 is rejected with 422."""
+    su = await superuser_factory("su_zero@example.com")
+    auth_override(su.id)
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"limit": 0},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_users_negative_offset_rejected(
+    client, auth_override, superuser_factory
+):
+    """offset < 0 is rejected with 422."""
+    su = await superuser_factory("su_neg@example.com")
+    auth_override(su.id)
+
+    response = await client.get(
+        "/api/admin/users",
+        params={"offset": -1},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_users_pagination_with_email_filter(
+    client, auth_override, superuser_factory
+):
+    """Pagination applies on top of an email filter."""
+    su = await superuser_factory("su_combo@example.com")
+    auth_override(su.id)
+
+    for i in range(5):
+        await _seed_user(
+            f"alice-pg-{i}", f"alice_pg_{i}@example.com", UserType.REGULAR
+        )
+
+    page1 = await client.get(
+        "/api/admin/users",
+        params={"email": "alice_pg", "limit": 2, "offset": 0},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    page2 = await client.get(
+        "/api/admin/users",
+        params={"email": "alice_pg", "limit": 2, "offset": 2},
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert page1.status_code == 200
+    assert page2.status_code == 200
+    p1_ids = [u["id"] for u in page1.json()]
+    p2_ids = [u["id"] for u in page2.json()]
+    assert len(p1_ids) == 2
+    assert len(p2_ids) == 2
+    assert set(p1_ids).isdisjoint(set(p2_ids))
+    # All returned users should match the filter (`alice_pg`).
+    for item in page1.json() + page2.json():
+        assert "alice_pg" in item["email"].lower()

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -1,6 +1,7 @@
 """Tests for the superuser-gated admin endpoints."""
 
 import pytest
+from sqlalchemy import select
 
 from src.api.data_models import UserOrm, UserType
 from tests.conftest import async_session_maker
@@ -405,3 +406,304 @@ async def test_list_users_pagination_with_email_filter(
     # All returned users should match the filter (`alice_pg`).
     for item in page1.json() + page2.json():
         assert "alice_pg" in item["email"].lower()
+
+
+# --- PATCH /api/admin/users/{user_id}/user-type ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_requires_auth(client):
+    """Unauthenticated PATCH must return 401."""
+    response = await client.patch(
+        "/api/admin/users/some-id/user-type",
+        json={"user_type": "admin"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_requires_superuser_not_regular(
+    client, auth_override
+):
+    """A regular user must receive 403."""
+    regular = await _seed_user(
+        "reg-patch", "reg_patch@example.com", UserType.REGULAR
+    )
+    target = await _seed_user(
+        "target-patch-r", "target_patch_r@example.com", UserType.REGULAR
+    )
+    auth_override(regular.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "admin"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_requires_superuser_not_admin(
+    client, auth_override, admin_user_factory
+):
+    """An admin (not superuser) must receive 403 — admins cannot promote."""
+    admin = await admin_user_factory("admin_patch@example.com")
+    target = await _seed_user(
+        "target-patch-a", "target_patch_a@example.com", UserType.REGULAR
+    )
+    auth_override(admin.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "pro"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_requires_superuser_not_pro(
+    client, auth_override
+):
+    """A pro user must receive 403."""
+    pro = await _seed_user(
+        "pro-patch", "pro_patch@example.com", UserType.PRO
+    )
+    target = await _seed_user(
+        "target-patch-p", "target_patch_p@example.com", UserType.REGULAR
+    )
+    auth_override(pro.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "admin"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_superuser_can_promote_user_to_admin(
+    client, auth_override, superuser_factory
+):
+    """Superuser promotes a regular user to admin."""
+    su = await superuser_factory("su_promote_a@example.com")
+    target = await _seed_user(
+        "target-promote-a", "target_promote_a@example.com", UserType.REGULAR
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "admin"},
+    )
+    assert response.status_code == 200
+    assert response.json()["userType"] == UserType.ADMIN.value
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(UserOrm).where(UserOrm.id == target.id)
+        )
+        db_user = result.scalar_one()
+        assert db_user.user_type == UserType.ADMIN.value
+
+
+@pytest.mark.asyncio
+async def test_superuser_can_promote_user_to_pro(
+    client, auth_override, superuser_factory
+):
+    """Superuser promotes a regular user to pro."""
+    su = await superuser_factory("su_promote_p@example.com")
+    target = await _seed_user(
+        "target-promote-p", "target_promote_p@example.com", UserType.REGULAR
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "pro"},
+    )
+    assert response.status_code == 200
+    assert response.json()["userType"] == UserType.PRO.value
+
+
+@pytest.mark.asyncio
+async def test_superuser_can_promote_user_to_superuser(
+    client, auth_override, superuser_factory
+):
+    """Superuser promotes another user to superuser (multiple superusers allowed)."""
+    su = await superuser_factory("su_promote_su@example.com")
+    target = await _seed_user(
+        "target-promote-su", "target_promote_su@example.com", UserType.REGULAR
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "superuser"},
+    )
+    assert response.status_code == 200
+    assert response.json()["userType"] == UserType.SUPERUSER.value
+
+
+@pytest.mark.asyncio
+async def test_superuser_can_demote_admin_to_regular(
+    client, auth_override, superuser_factory, admin_user_factory
+):
+    """Superuser demotes an admin back to regular."""
+    su = await superuser_factory("su_demote@example.com")
+    target_admin = await admin_user_factory("demote_me@example.com")
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target_admin.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "regular"},
+    )
+    assert response.status_code == 200
+    assert response.json()["userType"] == UserType.REGULAR.value
+
+
+@pytest.mark.asyncio
+async def test_superuser_cannot_self_demote(
+    client, auth_override, superuser_factory
+):
+    """Superuser cannot demote themselves; expect 400."""
+    su = await superuser_factory("su_self_demote@example.com")
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{su.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "regular"},
+    )
+    assert response.status_code == 400
+
+    # DB unchanged
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(UserOrm).where(UserOrm.id == su.id)
+        )
+        db_user = result.scalar_one()
+        assert db_user.user_type == UserType.SUPERUSER.value
+
+
+@pytest.mark.asyncio
+async def test_superuser_can_set_self_to_superuser(
+    client, auth_override, superuser_factory
+):
+    """A no-op self-update to superuser is allowed."""
+    su = await superuser_factory("su_self_noop@example.com")
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{su.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "superuser"},
+    )
+    assert response.status_code == 200
+    assert response.json()["userType"] == UserType.SUPERUSER.value
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_invalid_value(
+    client, auth_override, superuser_factory
+):
+    """Unknown user_type value is rejected with 422."""
+    su = await superuser_factory("su_invalid@example.com")
+    target = await _seed_user(
+        "target-invalid", "target_invalid@example.com", UserType.REGULAR
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "moderator"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_machine_rejected(
+    client, auth_override, superuser_factory
+):
+    """`machine` is not a valid promotion target; expect 422."""
+    su = await superuser_factory("su_machine@example.com")
+    target = await _seed_user(
+        "target-machine", "target_machine@example.com", UserType.REGULAR
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "machine"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_user_not_found(
+    client, auth_override, superuser_factory
+):
+    """PATCH on unknown user_id returns 404."""
+    su = await superuser_factory("su_404@example.com")
+    auth_override(su.id)
+
+    response = await client.patch(
+        "/api/admin/users/does-not-exist/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "admin"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_user_type_response_shape(
+    client, auth_override, superuser_factory
+):
+    """Response is the updated user serialized as UserModel (camelCase)."""
+    su = await superuser_factory("su_shape_patch@example.com")
+    target = await _seed_user(
+        "target-shape-patch",
+        "target_shape_patch@example.com",
+        UserType.REGULAR,
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/user-type",
+        headers={"Authorization": "Bearer test-token"},
+        json={"user_type": "pro"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == target.id
+    assert data["email"] == target.email
+    assert data["userType"] == UserType.PRO.value
+    assert "createdAt" in data
+    assert "updatedAt" in data
+
+
+@pytest.mark.asyncio
+async def test_superuser_can_view_other_users_private_threads(
+    client, auth_override, superuser_factory, thread_factory
+):
+    """Smoke test for superset-of-admin: superusers inherit admin privileges
+    (e.g. accessing other users' private threads)."""
+    owner_id = "thread-owner-su"
+    auth_override(owner_id)
+    thread = await thread_factory(owner_id)
+
+    su = await superuser_factory("su_view_thread@example.com")
+    auth_override(su.id)
+
+    response = await client.get(
+        f"/api/threads/{thread.id}",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -71,9 +71,7 @@ async def test_list_users_requires_superuser_not_admin(
 @pytest.mark.asyncio
 async def test_list_users_requires_superuser_not_pro(client, auth_override):
     """A pro user must receive 403."""
-    pro = await _seed_user(
-        "pro-list", "pro_list@example.com", UserType.PRO
-    )
+    pro = await _seed_user("pro-list", "pro_list@example.com", UserType.PRO)
     auth_override(pro.id)
 
     response = await client.get(
@@ -466,9 +464,7 @@ async def test_patch_user_type_requires_superuser_not_pro(
     client, auth_override
 ):
     """A pro user must receive 403."""
-    pro = await _seed_user(
-        "pro-patch", "pro_patch@example.com", UserType.PRO
-    )
+    pro = await _seed_user("pro-patch", "pro_patch@example.com", UserType.PRO)
     target = await _seed_user(
         "target-patch-p", "target_patch_p@example.com", UserType.REGULAR
     )

--- a/tests/cli/test_machine_user_cli.py
+++ b/tests/cli/test_machine_user_cli.py
@@ -16,6 +16,7 @@ from src.api.cli import (
     list_api_keys,
     list_machine_users,
     make_user_admin,
+    make_user_superuser,
     revoke_api_key,
     rotate_api_key,
 )
@@ -709,5 +710,141 @@ class TestUserManagementCLICommands:
         assert (
             result.exit_code == 0
         )  # Click doesn't change exit code for our error handling
+        assert "❌ Error:" in result.output
+        assert "not found" in result.output
+
+
+class TestUserSuperuserFunctions:
+    """Test user superuser management functions."""
+
+    @pytest.mark.asyncio
+    async def test_make_user_superuser_success(self):
+        """Test successful user superuser conversion."""
+        async with async_session_maker() as session:
+            user = UserOrm(
+                id="user_su_1",
+                name="Test User",
+                email="test_su@example.com",
+                user_type=UserType.REGULAR.value,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+            session.add(user)
+            await session.commit()
+
+            updated = await make_user_superuser(session, "test_su@example.com")
+
+            assert updated.id == user.id
+            assert updated.user_type == UserType.SUPERUSER.value
+            assert updated.updated_at >= user.created_at
+
+    @pytest.mark.asyncio
+    async def test_make_user_superuser_user_not_found(self):
+        """Test making non-existent user superuser fails."""
+        async with async_session_maker() as session:
+            with pytest.raises(ValueError, match="not found"):
+                await make_user_superuser(session, "nope_su@example.com")
+
+    @pytest.mark.asyncio
+    async def test_make_user_superuser_idempotent(self):
+        """Test making an already-superuser user superuser again works."""
+        async with async_session_maker() as session:
+            user = UserOrm(
+                id="user_su_2",
+                name="Already Super",
+                email="already_su@example.com",
+                user_type=UserType.SUPERUSER.value,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+            session.add(user)
+            await session.commit()
+            original_updated_at = user.updated_at
+
+            updated = await make_user_superuser(
+                session, "already_su@example.com"
+            )
+
+            assert updated.user_type == UserType.SUPERUSER.value
+            assert updated.updated_at >= original_updated_at
+
+    @pytest.mark.asyncio
+    async def test_make_user_superuser_case_insensitive(self):
+        """Email lookup is case-insensitive."""
+        async with async_session_maker() as session:
+            user = UserOrm(
+                id="user_su_3",
+                name="Mixed Case",
+                email="CaseTest_SU@Example.COM",
+                user_type=UserType.REGULAR.value,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+            )
+            session.add(user)
+            await session.commit()
+
+            updated = await make_user_superuser(
+                session, "casetest_su@example.com"
+            )
+
+            assert updated.id == user.id
+            assert updated.email == "CaseTest_SU@Example.COM"
+            assert updated.user_type == UserType.SUPERUSER.value
+
+
+class TestUserSuperuserCLI:
+    """Test the make-user-superuser CLI command."""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+
+    @patch("src.api.cli.DatabaseManager")
+    @patch("src.api.cli.make_user_superuser")
+    def test_make_user_superuser_command_success(
+        self, mock_make_su, mock_db_manager
+    ):
+        """Test make-user-superuser CLI command success."""
+        mock_session = AsyncMock()
+        mock_db_manager.return_value.async_session.return_value.__aenter__.return_value = mock_session
+        mock_db_manager.return_value.close = AsyncMock()
+
+        mock_user = AsyncMock()
+        mock_user.id = "user_su_cli"
+        mock_user.name = "Test User"
+        mock_user.email = "test_su_cli@example.com"
+        mock_user.user_type = UserType.SUPERUSER.value
+        mock_user.updated_at = datetime.now()
+        mock_make_su.return_value = mock_user
+
+        result = self.runner.invoke(
+            cli,
+            ["make-user-superuser", "--email", "test_su_cli@example.com"],
+        )
+
+        assert result.exit_code == 0
+        assert "test_su_cli@example.com" in result.output
+        assert UserType.SUPERUSER.value in result.output
+        mock_make_su.assert_called_once()
+
+    @patch("src.api.cli.DatabaseManager")
+    @patch("src.api.cli.make_user_superuser")
+    def test_make_user_superuser_command_user_not_found(
+        self, mock_make_su, mock_db_manager
+    ):
+        """Test make-user-superuser CLI command with non-existent user."""
+        mock_session = AsyncMock()
+        mock_db_manager.return_value.async_session.return_value.__aenter__.return_value = mock_session
+        mock_db_manager.return_value.close = AsyncMock()
+
+        mock_make_su.side_effect = ValueError(
+            "User with email nope_su@example.com not found"
+        )
+
+        result = self.runner.invoke(
+            cli,
+            ["make-user-superuser", "--email", "nope_su@example.com"],
+        )
+
+        assert result.exit_code == 0
         assert "❌ Error:" in result.output
         assert "not found" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,3 +252,23 @@ async def admin_user_factory():
             return admin_user
 
     return _admin_user
+
+
+@pytest_asyncio.fixture(scope="function")
+async def superuser_factory():
+    """Create superuser fixture."""
+
+    async def _superuser(email: str):
+        async with async_session_maker() as session:
+            superuser = UserOrm(
+                id=f"superuser-{email.split('@')[0]}",
+                name=f"Superuser {email.split('@')[0]}",
+                email=email,
+                user_type=UserType.SUPERUSER.value,
+            )
+            session.add(superuser)
+            await session.commit()
+            await session.refresh(superuser)
+            return superuser
+
+    return _superuser


### PR DESCRIPTION
Adds a new `superuser` type, in addition to the existing `regular`, `pro` and `admin` types. Superusers have the ability to list existing users and change the user_type of existing users.

Adds a CLI command to promote a user to superuser (needed to make the first superuser).

Adds two endpoints:

 - GET /api/admin/users: Lists existing users, can be filtered with a `?email=` query parameter, available only to superusers, does pagination with `offset` / `limit`, defaults to 50 per page
 - PATCH /api/admin/users/<user-id>/user_type - with a payload like `{ "user_type": "admin" }` to set a user user type for user with id (will return a 403 if user is not superuser). **Question**: Am a bit unsure if this should be `/api/admin/users/<user-id>/user_type` or just ` /api/admin/users/<user-id>` with the only action allowed being this PATCH .. I think the `/user_type/` feels easier to reason about, but feels less "RESTful" 

Adds tests for CLI command and the API endpoints.

For all places on the API where we allow "admins" to do an action, also ensure we allow "superuser" users. This is non-ideal and starts getting a bit messy - we should probably discuss the `UserType` handling and if there's anything we want to change here - this did grow a bit ad-hoc with needs - I _think_ its fine, and better than hard-coding prompt amounts to users, but maybe some things can be consolidated better - definitely checking for ADMIN or SUPERUSER felt ugly.

Would be nice to go ahead with this approach though and save any larger refactor of user handling for later - I'd like to get this basic admin interface into the frontend and then we can easily iterate on both sides.

My process: Spent some time creating the entire plan with Claude, then split it up into smaller steps with tests coming before implementation. Reviewed each step, iterated a bit, and committed each logical step. I found enforcing the smaller commits and granular steps of manual review to be quite useful in catching little things.

cc @yellowcap @gtempus 