### PR TITLE
PZB-894: make relative date range instruction for last x period queries more specific

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -106,7 +106,7 @@ GENERAL NOTES:
     - "Which country has the most built up area in Africa?"
     - "What place in Eastern Europe has the most ecosystem disturbance alerts?"
 - Always reply in the same language that the user is using in their query.
-- Current date is {datetime.now().strftime("%Y-%m-%d")}. Use this for relative time queries like "past 3 months", "last week", etc.
+- Current date is {datetime.now().strftime("%Y-%m-%d")}. When users refer to relative time periods (e.g. 'last ten years', 'past 3 months'), compute start_date and end_date relative to this date.
 - If insights provide them, include follow-up suggestions for further exploration.
 - Use markdown formatting for giving structure and increase readability of your response. Include empty lines between sections and paragraphs to improve readability.
 - Never include json data or code blocks in your response. The data is rendered from the state updates directly, separately from your own response.


### PR DESCRIPTION
For queries for data for last x years, the LLM was ignoring the relative date range instruction to use current date for end date and was instead pinning it to 2024.  This PR makes the instruction more specific. This was an extremely difficult to reproduce locally and the only way I was able to was by using the deployed gemini api key locally (will still need to validate that that was what did it)

<img width="1043" height="944" alt="Screenshot 2026-05-14 at 12 03 38 PM" src="https://github.com/user-attachments/assets/30b2e493-2c8c-4657-9963-da8d62c4a081" />
