### PR TITLE
allow Content-Disposition header via CORS

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -45,6 +45,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
 )
 
 


### PR DESCRIPTION
In https://github.com/wri/project-zeno/blob/main/src/api/routers/admin.py#L145 we set Content-Disposition headers for the backend to generate a name for the downloaded file. Currently, the frontend cannot read this header due to default CORS restrictions.

This PR adds `Content-Disposition` to `expose_headers` which will set `Access-Control-Expose-Headers` allowing Content-Disposition to be read by the frontend when making a CORS request.

The alternative to doing this is generating the filename on the frontend - this is also probably fine, but then we should take out the setting of Content Disposition on the backend to not be doing it twice.

I do prefer the filename being set on the backend though, and don't see any issue with making this CORS change to allow the frontend to read this header.

cc @yellowcap 