### PR TITLE
Require version bump for merging

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,24 @@
+name: Version Bump
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        run: |
+          BASE=$(git show origin/main:pyproject.toml | python3 -c "import sys,tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])")
+          CURRENT=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$BASE" = "$CURRENT" ]; then
+            echo "ERROR: Version not bumped ($CURRENT). Update pyproject.toml before merging." >&2
+            exit 1
+          fi
+          echo "OK: version bumped $BASE -> $CURRENT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "0.1.0"
+version = "0.2.0"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -20,6 +20,7 @@ from src.api.routers import (
 )
 from src.shared.database import close_global_pool, initialize_global_pool
 from src.shared.logging_config import get_logger
+from src.shared.version import get_version
 
 logger = get_logger(__name__)
 
@@ -37,7 +38,7 @@ app = FastAPI(
     lifespan=lifespan,
     title="Zeno API",
     description="API for Zeno LangGraph-based agent workflow",
-    version="0.1.0",
+    version=get_version(),
 )
 
 app.add_middleware(

--- a/src/api/routers/metadata.py
+++ b/src/api/routers/metadata.py
@@ -9,6 +9,7 @@ from src.shared.geocoding_helpers import (
     SOURCE_ID_MAPPING,
     SUBREGION_TO_SUBTYPE_MAPPING,
 )
+from src.shared.version import get_version
 
 router = APIRouter()
 
@@ -27,7 +28,7 @@ async def api_metadata() -> dict:
     small_model_name = AgentSettings.small_model.lower()
 
     return {
-        "version": "0.1.0",
+        "version": get_version(),
         "layer_id_mapping": {
             key: value["id_column"] for key, value in SOURCE_ID_MAPPING.items()
         },

--- a/src/shared/version.py
+++ b/src/shared/version.py
@@ -1,0 +1,14 @@
+from importlib.metadata import PackageNotFoundError, version
+
+
+def get_version() -> str:
+    try:
+        return version("project-zeno")
+    except PackageNotFoundError:
+        # Fallback for environments where the package is not installed
+        import tomllib
+        from pathlib import Path
+
+        root = Path(__file__).parent.parent.parent
+        with open(root / "pyproject.toml", "rb") as f:
+            return tomllib.load(f)["project"]["version"]

--- a/tests/api/test_metadata.py
+++ b/tests/api/test_metadata.py
@@ -1,5 +1,7 @@
 """Tests for the /api/metadata endpoint."""
 
+import tomllib
+
 import pytest
 
 
@@ -38,6 +40,18 @@ async def test_metadata_no_auth_required(client):
     # No Authorization header
     response = await client.get("/api/metadata")
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_metadata_version_matches_pyproject(client):
+    """Version returned by the API matches the version in pyproject.toml."""
+    with open("pyproject.toml", "rb") as f:
+        expected = tomllib.load(f)["project"]["version"]
+
+    response = await client.get("/api/metadata")
+
+    assert response.status_code == 200
+    assert response.json()["version"] == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This adds a gh action that checks for a version bump. This will help us version the application properly. Useful for evals for instance, where we can compare versions.