### PR TITLE
PZB-910: Fix chart axis configuration for multi-series charts

### DIFF
--- a/src/agent/datasets/catalog/deforestation_sluc_emission_factors_by_agricultural_crop.yml
+++ b/src/agent/datasets/catalog/deforestation_sluc_emission_factors_by_agricultural_crop.yml
@@ -48,16 +48,13 @@ selection_hints: 'Provides sLUC (statistical land use change) emission factors f
   output possible. Not all crops available in all regions.
 
   '
-code_instructions: "CHART TYPES: - Proportional emissions by gas type (CO2, CH4, N2O) → pie chart\n  (single crop, single\
-  \ year, single admin unit)\n- Changes in EF, emissions, or production over time → bar chart\n  (single crop, single admin\
-  \ unit)\n- Multiple crops in one location or one crop across locations → table - Summary of EF + emissions + production\
-  \ → table DATA RULES: - Default year = 2024 unless user specifies otherwise - Column names: emissions_tCO2e (total emissions),\
-  \ emissions_factor_tCO2e_per_tonne_production\n  (emission factor), production_tonnes (production volume)\n- MUST include\
-  \ units in all output: tCO2e for emissions, tonnes for production DO/DON'T: - DO NOT combine EF + total emissions + production\
-  \ volume on the same bar chart - If user asks for a map or spatial visualization: REFUSE — this dataset is tabular\n  only,\
-  \ no spatial output is possible. Suggest Tree Cover Loss or DIST alerts for\n  spatial analysis of deforestation impacts.\n\
-  - When showing emission factors, also show total emissions and production volume\n  used to calculate them\n- Always clarify\
-  \ the reporting year (2020-2024)\n"
+code_instructions: "CHART TYPES:\n- Proportional emissions by gas type (CO2, CH4, N2O) → pie chart (single crop)\n- Multiple\
+  \ crops in one location, or one crop across locations → table\n- Summary of EF + emissions → table\nDATA RULES:\n- Actual\
+  \ column names in data: crop, gas_type, emissions_tco2e, emission_factor_tco2e_per_tonne\n- For pie chart: group by gas_type,\
+  \ sum emissions_tco2e. Use name=gas_type, value=emissions_tco2e in chart data.\n- For table (multiple crops): group by crop,\
+  \ sum emissions_tco2e and sum emission_factor_tco2e_per_tonne. Save ALL rows to chart_data.csv.\n- Always include units\
+  \ in output: tCO2e for emissions\nDO/DON'T:\n- DO NOT combine EF + total emissions on the same bar chart\n- If user asks\
+  \ for a map or spatial visualization: REFUSE — this dataset is tabular only\n- Always clarify the reporting year (2020-2024)\n"
 presentation_instructions: 'Always include units: tCO2e for emissions, tonnes for production volume. Note: tCO2e = MgCO2e
   (metric tonnes of CO2 equivalent). Clarify the reporting year (default 2024). Note that emission factors quantify emissions
   from deforestation linked to agricultural expansion, not all land use emissions. Not all crops are available for all regions.

--- a/src/agent/datasets/catalog/sbtn_natural_lands_map.yml
+++ b/src/agent/datasets/catalog/sbtn_natural_lands_map.yml
@@ -37,14 +37,15 @@ selection_hints: 'Single-year baseline map of natural vs non-natural lands for 2
   Use this dataset for questions about the area or presence of any of these classes.
 
   '
-code_instructions: "CHART TYPES: - Natural vs non-natural proportions → bar chart or pie chart DATA RULES: - Natural forests\
-  \ = classes 2, 5, 8, 9 (natural forest + mangrove + wetland natural\n  forest + natural peat forest) — combine into one\
-  \ \"Natural forest\" category when\n  user asks about natural forests\n- Non-natural tree cover = classes 14, 17, 18 - All\
-  \ areas in hectares (ha) DO/DON'T: - This is a SINGLE YEAR (2020) snapshot — do NOT attempt timeseries or change analysis\
-  \ - These data do NOT represent protection status or legality of land TEMPORAL CONSTRAINT: - If user asks about change,\
-  \ trends, or temporal patterns: you MUST include ALL of:\n  (a) State that this dataset cannot show change — it is a single\
-  \ 2020 snapshot\n  (b) Recommend the Global Land Cover dataset by name for change analysis\n  (c) This recommendation is\
-  \ REQUIRED, not optional\n"
+code_instructions: "CHART TYPES: - Natural vs non-natural proportions → bar chart or pie chart DATA RULES: - Natural forests
+  = classes 2, 5, 8, 9 (natural forest + mangrove + wetland natural\n  forest + natural peat forest) — combine into one
+  \"Natural forest\" category when\n  user asks about natural forests\n- Non-natural tree cover = classes 14, 17, 18 - All
+   areas in hectares (ha) - For natural vs non-natural queries: ALWAYS group by the is_natural column (True → label 'Natural',
+   False → label 'Non-natural'), sum area_ha across groups. Chart data MUST have exactly two rows. DO/DON'T: - This is a
+   SINGLE YEAR (2020) snapshot — do NOT attempt timeseries or change analysis - These data do NOT represent protection status
+   or legality of land TEMPORAL CONSTRAINT: - If user asks about change, trends, or temporal patterns: you MUST include ALL
+  of:\n  (a) State that this dataset cannot show change — it is a single 2020 snapshot\n  (b) Recommend the Global Land
+  Cover dataset by name for change analysis\n  (c) This recommendation is REQUIRED, not optional\n"
 presentation_instructions: 'Clarify this is a 2020 baseline snapshot, not a timeseries. "Natural" follows the AFi definition:
   land that substantially resembles what would be found without major human impacts, including managed or degraded ecosystems.
   Does not represent legal protection status. For change analysis, suggest the Global Land Cover dataset. When reporting natural

--- a/src/agent/subagents/analyst/code_executors/base.py
+++ b/src/agent/subagents/analyst/code_executors/base.py
@@ -5,7 +5,9 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+CHART_TYPES_WITHOUT_AXIS = {"pie", "table"}
 
 
 class ChartInsight(BaseModel):
@@ -21,7 +23,8 @@ class ChartInsight(BaseModel):
         description="Name of the field to use for X-axis (for applicable chart types)"
     )
     y_axis: str = Field(
-        description="Name of the field to use for Y-axis (for applicable chart types)"
+        default="",
+        description="Name of the field to use for Y-axis. Required for single-series charts. Leave empty for multi-series charts and populate series_fields instead.",
     )
     color_field: str = Field(
         default="",
@@ -37,8 +40,19 @@ class ChartInsight(BaseModel):
     )
     series_fields: List[str] = Field(
         default=[],
-        description="List of field names for multiple data series (for multi-bar charts)",
+        description="List of field names for multiple data series (for multi-series charts). Required when y_axis is empty.",
     )
+
+    @model_validator(mode="after")
+    def validate_axis_config(self) -> "ChartInsight":
+        if self.chart_type not in CHART_TYPES_WITHOUT_AXIS:
+            if not self.y_axis and not self.series_fields:
+                raise ValueError(
+                    f"Chart '{self.title}' (type '{self.chart_type}') is missing axis "
+                    "configuration: set 'y_axis' for single-series charts or "
+                    "'series_fields' for multi-series charts"
+                )
+        return self
 
 
 class MultiChartInsight(BaseModel):

--- a/src/agent/subagents/analyst/prompts.py
+++ b/src/agent/subagents/analyst/prompts.py
@@ -47,14 +47,15 @@ Now prepare the data for visualization in Recharts.js:
       5. **Grouping fields**: Group only by categorical, readable label columns such as names, dates, periods, classes, or metric labels. Do not group by numeric measure/value columns like 'value', 'count', 'area', 'sum', or continuous numeric readings unless the user explicitly asks for a distribution or histogram; aggregate those numeric columns instead.
       6. **Data format by chart type**:
          - **Single-series line/bar**: [{"date": "2020-01", "value": 100}]
-           → One metric column, use y_axis="value"
+           → One metric column, use y_axis="value" (REQUIRED — must not be empty)
          - **Multi-series line/bar/area**: [{"year": "2020", "metric1": 100, "metric2": 50}]
            → Multiple metric columns in WIDE format
-           → Use series_fields=["metric1", "metric2"], leave y_axis empty
+           → Use series_fields=["metric1", "metric2"], leave y_axis="" (REQUIRED — series_fields must not be empty)
          - **Stacked-bar**: [{"category": "Region A", "forest": 100, "grassland": 50, "urban": 30}]
-           → Use series_fields, leave y_axis empty
-         - **Grouped-bar**: long format with group_field and y_axis="value"
+           → Use series_fields=["forest", "grassland", "urban"], leave y_axis="" (REQUIRED — series_fields must not be empty)
+         - **Grouped-bar**: long format with group_field and y_axis="value" (REQUIRED — both must not be empty)
          - **Pie**: [{"name": "Category A", "value": 100}], max 6–8 slices
+         - **IMPORTANT**: For every non-pie/non-table chart, either y_axis OR series_fields MUST be set. Never leave both empty.
 
    c) **SAVE THE DATA**: Save as `chart_data.csv` — pipeline only reads this file. Final step must call `to_csv('chart_data.csv', index=False)`.
 

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -106,6 +106,24 @@ def _extract_statistics_ids(statistics: list[dict]) -> list[str]:
     ]
 
 
+def _filter_chart_data(
+    chart_data: list[dict], x_axis: str, y_axis: str, series_fields: list[str]
+) -> list[dict]:
+    """Return only the columns relevant to a single chart.
+
+    Each chart in a multi-chart insight shares the same underlying CSV but
+    plots different columns. Keeping unrelated columns causes formatChartData
+    (frontend) to auto-discover them as extra series, producing wrong charts.
+    """
+    keep = {x_axis}
+    if y_axis:
+        keep.add(y_axis)
+    keep.update(series_fields)
+    if len(keep) <= 1:
+        return chart_data
+    return [{k: v for k, v in row.items() if k in keep} for row in chart_data]
+
+
 def replace_csv_paths_with_urls(
     code_block: str, source_urls: List[str]
 ) -> str:
@@ -399,13 +417,19 @@ class Analyst:
         encoded_parts = result.get_encoded_parts()
         charts_data = []
         for idx, chart in enumerate(result.insight.charts):
+            filtered_data = _filter_chart_data(
+                result.chart_data,
+                chart.x_axis,
+                chart.y_axis,
+                chart.series_fields,
+            )
             charts_data.append(
                 {
                     "id": f"chart_{idx}",
                     "title": chart.title,
                     "type": chart.chart_type,
                     "insight": result.insight.primary_insight,
-                    "data": result.chart_data,
+                    "data": filtered_data,
                     "xAxis": chart.x_axis,
                     "yAxis": chart.y_axis,
                     "colorField": chart.color_field,
@@ -433,6 +457,12 @@ class Analyst:
             await session.flush()
 
             for idx, chart in enumerate(result.insight.charts):
+                filtered_data = _filter_chart_data(
+                    result.chart_data,
+                    chart.x_axis,
+                    chart.y_axis,
+                    chart.series_fields,
+                )
                 session.add(
                     InsightChartOrm(
                         insight_id=insight_row.id,
@@ -445,7 +475,7 @@ class Analyst:
                         stack_field=chart.stack_field,
                         group_field=chart.group_field,
                         series_fields=chart.series_fields,
-                        chart_data=result.chart_data,
+                        chart_data=filtered_data,
                     )
                 )
 

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -106,24 +106,6 @@ def _extract_statistics_ids(statistics: list[dict]) -> list[str]:
     ]
 
 
-def _filter_chart_data(
-    chart_data: list[dict], x_axis: str, y_axis: str, series_fields: list[str]
-) -> list[dict]:
-    """Return only the columns relevant to a single chart.
-
-    Each chart in a multi-chart insight shares the same underlying CSV but
-    plots different columns. Keeping unrelated columns causes formatChartData
-    (frontend) to auto-discover them as extra series, producing wrong charts.
-    """
-    keep = {x_axis}
-    if y_axis:
-        keep.add(y_axis)
-    keep.update(series_fields)
-    if len(keep) <= 1:
-        return chart_data
-    return [{k: v for k, v in row.items() if k in keep} for row in chart_data]
-
-
 def replace_csv_paths_with_urls(
     code_block: str, source_urls: List[str]
 ) -> str:
@@ -417,19 +399,13 @@ class Analyst:
         encoded_parts = result.get_encoded_parts()
         charts_data = []
         for idx, chart in enumerate(result.insight.charts):
-            filtered_data = _filter_chart_data(
-                result.chart_data,
-                chart.x_axis,
-                chart.y_axis,
-                chart.series_fields,
-            )
             charts_data.append(
                 {
                     "id": f"chart_{idx}",
                     "title": chart.title,
                     "type": chart.chart_type,
                     "insight": result.insight.primary_insight,
-                    "data": filtered_data,
+                    "data": result.chart_data,
                     "xAxis": chart.x_axis,
                     "yAxis": chart.y_axis,
                     "colorField": chart.color_field,
@@ -457,12 +433,6 @@ class Analyst:
             await session.flush()
 
             for idx, chart in enumerate(result.insight.charts):
-                filtered_data = _filter_chart_data(
-                    result.chart_data,
-                    chart.x_axis,
-                    chart.y_axis,
-                    chart.series_fields,
-                )
                 session.add(
                     InsightChartOrm(
                         insight_id=insight_row.id,
@@ -475,7 +445,7 @@ class Analyst:
                         stack_field=chart.stack_field,
                         group_field=chart.group_field,
                         series_fields=chart.series_fields,
-                        chart_data=filtered_data,
+                        chart_data=result.chart_data,
                     )
                 )
 

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -14,11 +14,11 @@ import sys
 import uuid
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.agent.datasets.config import DATASETS
 from src.agent.state import Statistics
 from src.agent.subagents.analyst.tool import (
     ChartInsight,
@@ -537,44 +537,13 @@ async def test_generate_insights_persists_statistics_provenance(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Dataset fixtures — realistic metadata matching analytics_datasets.yml
+# Dataset fixtures — loaded directly from the YAML catalog so they stay in sync
 # ---------------------------------------------------------------------------
-GHG_FLUX_DATASET: dict[str, Any] = {
-    "dataset_id": 6,
-    "context_layer": None,
-    "context_layers": [],
-    "parameters": None,
-    "reason": "GHG flux dataset matches.",
-    "tile_url": "https://tiles.globalforestwatch.org/gfw_forest_carbon_net_flux/latest/dynamic/{z}/{x}/{y}.png",
-    "dataset_name": "Forest greenhouse gas net flux",
-    "analytics_api_endpoint": "/v0/land_change/carbon_flux/analytics",
-    "content_date": "2001-2024",
-    "selection_hints": None,
-    "description": "Maps the balance between emissions from forest disturbances and carbon removals from forest growth between 2001 and 2024.",
-    "prompt_instructions": (
-        "DO NOT show trends over time or annual values. Show net flux as a split bar chart, "
-        "with emissions in the positive y-axis and removals in the negative. Use sink/source terminology."
-    ),
-    "methodology": "Globally consistent model of forest carbon flux.",
-    "cautions": (
-        "Net flux reflects the total over the model period of 2001-2024, not an annual time series."
-    ),
-    "function_usage_notes": "Shows forest carbon balance.\n",
-    "citation": "Harris et al., 2021.",
-    "code_instructions": (
-        "CHART TYPES:\n"
-        "- Net flux → split/diverging bar chart (emissions positive y-axis, removals negative)\n"
-        "DATA RULES:\n"
-        "- Values are TOTALS over model period 2001-2024\n"
-        "- Do NOT divide by 24 in code\n"
-        "DO/DON'T:\n"
-        "- REFUSE any request for annual timeseries or year-by-year breakdown"
-    ),
-    "presentation_instructions": (
-        'Use "net sink" for negative values, "net source" for positive values. '
-        "Mention that users can divide by 24 to estimate annual average."
-    ),
-}
+def _ds(dataset_id: int) -> dict:
+    return next(d for d in DATASETS if d["dataset_id"] == dataset_id)
+
+
+GHG_FLUX_DATASET = _ds(6)
 
 GHG_FLUX_STATS: list[dict] = [
     Statistics(
@@ -588,37 +557,7 @@ GHG_FLUX_STATS: list[dict] = [
     )
 ]
 
-GRASSLAND_DATASET: dict[str, Any] = {
-    "dataset_id": 2,
-    "context_layer": None,
-    "context_layers": [],
-    "parameters": None,
-    "reason": "Grasslands dataset matches.",
-    "tile_url": "https://tiles.globalforestwatch.org/gnsg/latest/dynamic/{z}/{x}/{y}.png",
-    "dataset_name": "Global natural/semi-natural grassland extent",
-    "analytics_api_endpoint": "/v0/land_change/grasslands/analytics",
-    "content_date": "2000-2022, annual",
-    "selection_hints": None,
-    "description": "Annual 30 m maps of global natural/semi-natural grassland extent from 2000 to 2022.",
-    "prompt_instructions": (
-        "Natural/semi-natural grassland extent and change for each year from 2000 to 2022. "
-        "Use bar or line charts to show total area over time."
-    ),
-    "methodology": "Random Forest classification of Landsat imagery.",
-    "cautions": "Classification errors exist especially between grasslands and croplands.",
-    "function_usage_notes": "Shows grassland extent.\n",
-    "citation": "Parente et al., 2022.",
-    "code_instructions": (
-        "CHART TYPES:\n"
-        "- Area over time → bar chart or line chart (x=year, y=area_ha)\n"
-        "DATA RULES:\n"
-        "- Exclude rows where area_ha = 0 or missing\n"
-        "- All areas in hectares (ha)"
-    ),
-    "presentation_instructions": (
-        'Clarify that "natural/semi-natural grassland" includes grasslands, shrublands, and savannas.'
-    ),
-}
+GRASSLAND_DATASET = _ds(2)
 
 GRASSLAND_STATS: list[dict] = [
     Statistics(
@@ -645,42 +584,7 @@ GRASSLAND_STATS_WITH_ZEROS: list[dict] = [
     )
 ]
 
-TREE_COVER_DATASET: dict[str, Any] = {
-    "dataset_id": 7,
-    "context_layer": None,
-    "context_layers": [],
-    "parameters": None,
-    "reason": "Tree cover dataset matches.",
-    "tile_url": "https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/latest/dynamic/{z}/{x}/{y}.png",
-    "dataset_name": "Tree cover",
-    "analytics_api_endpoint": "/v0/land_change/tree_cover/analytics",
-    "content_date": "2000",
-    "selection_hints": None,
-    "description": "Global percent tree canopy cover at 30-meter resolution for year 2000.",
-    "prompt_instructions": (
-        'Only use the term "tree cover", not "forest" unless primary forest layer is active. '
-        "Show tree cover area by canopy density bin."
-    ),
-    "methodology": "Landsat 7 imagery classification.",
-    "cautions": (
-        '"Tree cover" is defined as all vegetation taller than 5 meters and may include plantations.'
-    ),
-    "function_usage_notes": "Shows tree cover extent.\n",
-    "citation": "Hansen et al., 2013.",
-    "code_instructions": (
-        "CHART TYPES:\n"
-        "- Tree cover area by canopy-density bin → bar chart or pie chart\n"
-        "- Values MUST be area in hectares (ha), NOT percentages\n"
-        "DATA RULES:\n"
-        "- Year 2000 data only — single snapshot\n"
-        "- Exclude the 0% canopy density bin\n"
-        "- Exclude rows where area_ha = 0"
-    ),
-    "presentation_instructions": (
-        'Use "tree cover" not "forest". Tree cover includes plantations, not just natural forest. '
-        "For change analysis, direct to Tree Cover Loss or Tree Cover Gain datasets."
-    ),
-}
+TREE_COVER_DATASET = _ds(7)
 
 TREE_COVER_STATS: list[dict] = [
     Statistics(
@@ -694,46 +598,7 @@ TREE_COVER_STATS: list[dict] = [
     )
 ]
 
-TREE_COVER_GAIN_DATASET: dict[str, Any] = {
-    "dataset_id": 5,
-    "context_layer": None,
-    "context_layers": [],
-    "parameters": None,
-    "reason": "Tree cover gain dataset matches.",
-    "tile_url": "https://tiles.globalforestwatch.org/umd_tree_cover_gain/latest/dynamic/{z}/{x}/{y}.png",
-    "dataset_name": "Tree cover gain",
-    "analytics_api_endpoint": "/v0/land_change/tree_cover_gain/analytics",
-    "content_date": "2000-2020 five year intervals",
-    "selection_hints": None,
-    "description": "Tree Cover Gain identifies areas where new tree canopy was established between 2000 and 2020.",
-    "prompt_instructions": (
-        "Shows cumulative tree cover gain over the periods 2000-2020, 2005-2020, 2010-2020 or 2015-2020. "
-        'Avoid using the term "restoration". '
-        "Net change cannot be calculated by subtracting gain from loss — methodologies differ between the two datasets. "
-        "If the user asks for net gain/loss or net change, refuse and explain that they cannot be combined for net change."
-    ),
-    "methodology": "Landsat 7 imagery classification.",
-    "cautions": (
-        "Tree cover gain does not equate directly to restoration, afforestation or reforestation."
-    ),
-    "function_usage_notes": "Shows tree cover gain.\n",
-    "citation": "Hansen et al., 2013.",
-    "code_instructions": (
-        "CHART TYPES:\n"
-        "- Default: bar chart with one bar per CUMULATIVE period\n"
-        "- X-axis labels MUST use the raw cumulative period labels\n"
-        "DO/DON'T:\n"
-        "- If user asks for net gain/loss or net change: REFUSE — methodologies differ; "
-        "cannot combine gain and loss for net change\n"
-        "- REFUSE any attempt to subtract loss from gain\n"
-        '- Use "tree cover gain" not "restoration"'
-    ),
-    "presentation_instructions": (
-        'Use "tree cover gain" not "restoration". Gain includes plantation cycles, '
-        "natural regrowth, and land abandonment. "
-        "Cannot be subtracted from tree cover loss for net change — different methodologies; do not imply net figures."
-    ),
-}
+TREE_COVER_GAIN_DATASET = _ds(5)
 
 TREE_COVER_GAIN_STATS: list[dict] = [
     Statistics(
@@ -747,40 +612,7 @@ TREE_COVER_GAIN_STATS: list[dict] = [
     )
 ]
 
-LAND_COVER_DATASET: dict[str, Any] = {
-    "dataset_id": 1,
-    "context_layer": None,
-    "context_layers": [],
-    "parameters": None,
-    "reason": "Land cover dataset matches.",
-    "tile_url": "https://tiles.globalforestwatch.org/wur_radd_alerts/latest/dynamic/{z}/{x}/{y}.png",
-    "dataset_name": "Global land cover",
-    "analytics_api_endpoint": "/v0/land_change/land_cover/analytics",
-    "content_date": "2015-2024",
-    "selection_hints": None,
-    "description": "Annual global land cover classification at 30m resolution.",
-    "prompt_instructions": (
-        "Land cover transitions between 2015 and 2024. When user asks about agriculture, "
-        "combine cropland and cultivated grassland. For transition queries, use a table."
-    ),
-    "methodology": "ESA CCI Land Cover classification.",
-    "cautions": "Only two time snapshots available (2015 and 2024). Cannot show annual timeseries.",
-    "function_usage_notes": "Shows land cover composition.\n",
-    "citation": "ESA CCI, 2024.",
-    "code_instructions": (
-        "CHART TYPES:\n"
-        "- Land cover composition → pie chart\n"
-        "- Transitions between classes → table (columns: start_class, end_class, area_ha)\n"
-        "DATA RULES:\n"
-        "- Agriculture = Cropland + Cultivated grassland (combine them)\n"
-        "- Only 2 snapshots: 2015 and 2024. REFUSE annual timeseries requests\n"
-        "DO/DON'T:\n"
-        "- REFUSE any request for annual or yearly data between 2015-2024"
-    ),
-    "presentation_instructions": (
-        "Only two snapshots exist (2015 and 2024). When asked for annual data, explain the limitation."
-    ),
-}
+LAND_COVER_DATASET = _ds(1)
 
 LAND_COVER_TRANSITION_STATS: list[dict] = [
     Statistics(
@@ -806,38 +638,7 @@ LAND_COVER_COMPOSITION_STATS: list[dict] = [
     )
 ]
 
-NATURAL_LANDS_DATASET: dict[str, Any] = {
-    "dataset_id": 3,
-    "context_layer": None,
-    "context_layers": [],
-    "parameters": None,
-    "reason": "Natural lands dataset matches.",
-    "tile_url": "https://tiles.globalforestwatch.org/sbtn_natural_lands/latest/dynamic/{z}/{x}/{y}.png",
-    "dataset_name": "SBTN Natural Lands Map",
-    "analytics_api_endpoint": "/v0/land_change/natural_lands/analytics",
-    "content_date": "2020",
-    "selection_hints": None,
-    "description": "2020 baseline map of natural and non-natural land covers.",
-    "prompt_instructions": (
-        "Natural and non-natural lands in 2020. For natural forests, combine classes 2,5,8,9."
-    ),
-    "methodology": "SBTN classification.",
-    "cautions": "Single-year snapshot (2020). Cannot show change over time.",
-    "function_usage_notes": "Shows natural lands baseline.\n",
-    "citation": "SBTN, 2024.",
-    "code_instructions": (
-        "CHART TYPES:\n"
-        "- Natural vs non-natural proportions → bar chart or pie chart\n"
-        "DATA RULES:\n"
-        "- Natural forests = classes 2, 5, 8, 9\n"
-        "- Non-natural tree cover = classes 14, 17, 18\n"
-        "DO/DON'T:\n"
-        "- REFUSE change-over-time requests — suggest Global Land Cover dataset instead"
-    ),
-    "presentation_instructions": (
-        "This is a 2020 baseline snapshot. For change analysis, suggest the Global Land Cover dataset."
-    ),
-}
+NATURAL_LANDS_DATASET = _ds(3)
 
 NATURAL_LANDS_STATS: list[dict] = [
     Statistics(
@@ -851,40 +652,7 @@ NATURAL_LANDS_STATS: list[dict] = [
     )
 ]
 
-SLUC_EF_DATASET: dict[str, Any] = {
-    "dataset_id": 9,
-    "context_layer": None,
-    "context_layers": [],
-    "parameters": None,
-    "reason": "sLUC EF dataset matches.",
-    "tile_url": "",
-    "dataset_name": "Deforestation (sLUC) Emission Factors by Agricultural Crop",
-    "analytics_api_endpoint": "/v0/land_change/deforestation_luc_emissions_factor/analytics",
-    "content_date": "2020-2024",
-    "selection_hints": None,
-    "description": "sLUC emission factors for 42 agricultural crops across multiple spatial scales.",
-    "prompt_instructions": (
-        "Emission factors quantify total greenhouse gas emissions in tCO2e per tonne of product. "
-        "Use table for multiple crops. Use pie for gas type breakdown."
-    ),
-    "methodology": "Fitts et al., 2025.",
-    "cautions": "Data resolution varies. Not all crops available for every region.",
-    "function_usage_notes": "Shows deforestation emission factors.\n",
-    "citation": "Fitts et al., 2025.",
-    "code_instructions": (
-        "CHART TYPES:\n"
-        "- Proportional emissions by gas type → pie chart (single crop)\n"
-        "- Multiple crops in one location → table\n"
-        "DATA RULES:\n"
-        "- Include units in data values: tCO2e for emissions, tonnes for production\n"
-        "DO/DON'T:\n"
-        "- REFUSE map requests — this data is tabular only, no spatial information"
-    ),
-    "presentation_instructions": (
-        "Always include units: tCO2e for emissions, tonnes for production volume. "
-        "Clarify the reporting year (default 2024). This data is tabular only — cannot be mapped."
-    ),
-}
+SLUC_EF_DATASET = _ds(9)
 
 SLUC_EF_GAS_STATS: list[dict] = [
     Statistics(

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -32,7 +32,10 @@ from src.api.data_models import InsightOrm
 generate_insights_module = importlib.import_module(
     "src.agent.subagents.analyst.tool"
 )
-pytestmark = pytest.mark.asyncio(loop_scope="session")
+pytestmark = [
+    pytest.mark.asyncio(loop_scope="session"),
+    pytest.mark.flaky(reruns=2, reruns_delay=1),
+]
 
 _last_insight_row: InsightOrm | None = None
 


### PR DESCRIPTION
## Summary

- Added a `model_validator` to `ChartInsight` that rejects any non-pie/table chart where both `y_axis` and `series_fields` are empty, catching degenerate LLM output at parse time before it reaches state or the DB.
- Tightened executor prompt language to make explicit that `series_fields` must be populated for multi-series charts and `y_axis` must be set for single-series charts.

## Root cause

When the analyst generates two charts from the same dataset (e.g. tree cover loss area and emissions), both charts previously shared the identical `chart_data` array containing all metric columns. `formatChartData` on the frontend — when `yAxis` is empty — treats every non-x column as a series, so each chart would display all four metric columns instead of its intended two.

The paired frontend fix (project-zeno-next) relaxes the axis guard so charts with `yAxis=""` and multi-series data render correctly rather than showing "Chart is missing axis configuration."