### PR TITLE
Move version bump to pre-commit

### DIFF
--- a/.github/workflows/calver-bump.yml
+++ b/.github/workflows/calver-bump.yml
@@ -1,52 +1,24 @@
-name: CalVer Bump
+name: CalVer Check
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
 jobs:
-  bump:
+  check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
-      - name: Checkout code
+      - name: Checkout PR branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
-      - name: Compute CalVer version
-        id: calver
-        run: |
-          python3 - <<'EOF'
-          import tomllib, os
-          from datetime import datetime, timezone
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.8"
 
-          today = datetime.now(timezone.utc).date()
-          base = f"{today.year}.{today.month}.{today.day}"
-
-          with open("pyproject.toml", "rb") as f:
-              current = tomllib.load(f)["project"]["version"]
-
-          new = base if current != base else current
-
-          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
-              out.write(f"version={new}\n")
-              out.write(f"current={current}\n")
-          EOF
-
-      - name: Update pyproject.toml
-        run: |
-          sed -i 's/^version = ".*"/version = "${{ steps.calver.outputs.version }}"/' pyproject.toml
-
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          if git diff --staged --quiet; then
-            echo "Version already up to date, skipping commit."
-          else
-            git commit -m "chore: bump version to ${{ steps.calver.outputs.version }}"
-            git push
-          fi
+      - name: Verify CalVer version
+        run: uvx pre-commit run bump-calver --all-files

--- a/.github/workflows/calver-bump.yml
+++ b/.github/workflows/calver-bump.yml
@@ -20,5 +20,8 @@ jobs:
         with:
           python-version: "3.12.8"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Verify CalVer version
         run: uvx pre-commit run bump-calver --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,90 @@
 repos:
+  - repo: local
+    hooks:
+      - id: bump-calver
+        name: bump CalVer version when ahead of main
+        language: system
+        pass_filenames: false
+        always_run: true
+        entry: bash
+        args:
+          - -c
+          - |
+            python3 - <<'EOF'
+            import io
+            import re
+            import subprocess
+            import sys
+            import tomllib
+            from datetime import UTC, datetime
+            from pathlib import Path
+
+            pyproject = Path("pyproject.toml")
+            if not pyproject.exists():
+                raise SystemExit(0)
+
+            today = datetime.now(UTC).date()
+            calver = f"{today.year}.{today.month}.{today.day}"
+
+            subprocess.run(
+                ["git", "fetch", "origin", "main", "--quiet"],
+                check=False,
+                capture_output=True,
+            )
+
+            main_version = None
+            for ref in ("origin/main", "main"):
+                result = subprocess.run(
+                    ["git", "show", f"{ref}:pyproject.toml"],
+                    check=False,
+                    capture_output=True,
+                )
+                if result.returncode == 0:
+                    main_version = tomllib.load(io.BytesIO(result.stdout))["project"]["version"]
+                    break
+
+            if main_version is None:
+                print(
+                    "Could not read version from origin/main or main; "
+                    "fetch origin/main and retry.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+
+            local_version = tomllib.load(pyproject.open("rb"))["project"]["version"]
+            if local_version != main_version:
+                raise SystemExit(0)
+
+            if main_version == calver:
+                new_version = f"{calver}.1"
+            elif main_version.startswith(f"{calver}."):
+                build = int(main_version.rsplit(".", 1)[1])
+                new_version = f"{calver}.{build + 1}"
+            else:
+                new_version = calver
+
+            if new_version == local_version:
+                raise SystemExit(0)
+
+            content = pyproject.read_text()
+            updated, count = re.subn(
+                r'^(version = ")[^"]*(")',
+                rf'\g<1>{new_version}\g<2>',
+                content,
+                count=1,
+                flags=re.MULTILINE,
+            )
+            if count == 0:
+                print('version field not found in "pyproject.toml"', file=sys.stderr)
+                raise SystemExit(1)
+
+            if updated != content:
+                pyproject.write_text(updated)
+                print(f'Bumped version to "{new_version}"', file=sys.stderr)
+                raise SystemExit(1)
+
+            raise SystemExit(0)
+            EOF
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ for STAC can be found in the [gnw-stac](https://github.com/wri/gnw-stac) reposit
 
 This project uses [Calendar Versioning (CalVer)](https://calver.org/) with the format `YYYY.M.D`.
 
-Version bumps are **fully automatic** — on every merge to `main` the CI workflow (`calver-bump.yml`)
-updates `pyproject.toml` and commits the new version directly to `main`. No manual version changes are needed.
+Version bumps happen automatically via the `bump-calver` pre-commit hook. When you commit on a branch
+that is at the same version as `main`, the hook updates `pyproject.toml` to today's CalVer date and
+stages the change (causing the commit to fail once so you re-run it with the bumped version included).
+If two commits land on the same day, a build suffix is appended (`YYYY.M.D.1`, `YYYY.M.D.2`, …).
+
+The CI workflow (`calver-bump.yml`) runs on pull requests and verifies that the version was already
+bumped by the hook — it does **not** commit to `main`. No manual version changes are needed.
 The current version is always readable at the `/api/v1/version` endpoint.
 
 ## Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.5.20"
+version = "2026.5.22"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"


### PR DESCRIPTION
This adds a pre-commit hook that bumps version. Works similar to ruff formatting.

The current post PR hook on github actions is not working because main branch is protected. So the direct commit fails.

Local flow (same as Ruff): first commit attempt bumps and fails → git add pyproject.toml → commit again → passes.

### Hook

- Bumps pyproject.toml when local version still matches main
- Exits 1 after bumping (same as other pre-commit auto-fix hooks)
- Exits 0 when no bump is needed (local != main, or already at target)

### CI

- Runs uvx pre-commit run bump-calver --all-files
- Passes (0) when the PR already has a bumped version
- Fails (1) if it still has to bump — meaning pre-commit wasn’t run locally before push

