### PR TITLE
PZB-913: Suggest datasets instead of always choosing one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.5.27.1"
+version = "2026.5.27.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -47,8 +47,8 @@ prompt_instructions: 'Use this dataset to show recent vegetation changes across 
 
   '
 selection_hints: 'Best dataset for near-real-time vegetation disturbance across ALL ecosystems (not just forests). Covers
-  Dec 2023 to present at 30m resolution, measured in hectares. Prefer when user asks about recent disturbance, clearing, or
-  conversion alerts. Driver context layer (LDACS) classifies alerts into likely causes — updated quarterly, covers most recent
+  Dec 2023 to present at 30m resolution, measured in hectares, and provides both low and high confidence alerts. Prefer when user asks 
+  about recent disturbance, clearing, or conversion alerts. Driver context layer (LDACS) classifies alerts into likely causes — updated quarterly, covers most recent
   12 months, classification NOT available for last 90 days. For historical or long-term tree cover change, prefer Tree Cover
   Loss instead. For driver attribution of tree cover loss specifically, prefer Tree Cover Loss by Dominant Driver.
 

--- a/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -47,7 +47,7 @@ prompt_instructions: 'Use this dataset to show recent vegetation changes across 
 
   '
 selection_hints: 'Best dataset for near-real-time vegetation disturbance across ALL ecosystems (not just forests). Covers
-  Dec 2023 to present at 30m resolution, measured in hectares, and provides both low and high confidence alerts. Prefer when user asks 
+  Dec 2023 to present at 30m resolution, measured in hectares, and provides both low and high confidence alerts. Prefer when user asks
   about recent disturbance, clearing, or conversion alerts. Driver context layer (LDACS) classifies alerts into likely causes — updated quarterly, covers most recent
   12 months, classification NOT available for last 90 days. For historical or long-term tree cover change, prefer Tree Cover
   Loss instead. For driver attribution of tree cover loss specifically, prefer Tree Cover Loss by Dominant Driver.

--- a/src/agent/datasets/catalog/tree_cover_loss_by_dominant_driver.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss_by_dominant_driver.yml
@@ -51,9 +51,10 @@ prompt_instructions: "Shows the delta of the primary driver or cause of tree cov
   \ wildfire, and other natural disturbances can be combined\n  to represent drivers of temporary disturbances.\n- Permanent\
   \ agriculture and shifting cultivation can be combined to represent all\n  agriculture-driven disturbances.\n"
 selection_hints: 'Use when user asks WHY tree cover was lost — attributes loss to 7 driver classes. Shows dominant driver
-  per 1km cell over entire period 2001-2025 (NOT annual). Cannot produce timeseries or data for specific dates or years. Resolution is ~1km (coarser than 30m TCL) — not suitable for local/parcel
-  analysis. Drivers: permanent agriculture, hard commodities, shifting cultivation, logging, wildfire, settlements & infrastructure,
-  other natural disturbances.
+  of loss over entire period 2001-2025 (NOT annual). Cannot produce timeseries or data for specific dates or years. 1 km
+  drivers are overlayed on 30m loss pixel data to classify each pixel, which provides a class per loss pixel but may be
+  inaccurate when examining small land parcels. Drivers: permanent agriculture, hard commodities, shifting cultivation, logging, wildfire, settlements & infrastructure,
+  other natural disturbances, and unknown (for any unclassified loss pixel). All drivers combined add to the total tree cover loss.
 
   '
 code_instructions: "CHART TYPES: - Driver breakdown → pie chart or table ONLY - DO NOT attempt a timeseries — this is a single-period\

--- a/src/agent/datasets/catalog/tree_cover_loss_by_dominant_driver.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss_by_dominant_driver.yml
@@ -51,8 +51,7 @@ prompt_instructions: "Shows the delta of the primary driver or cause of tree cov
   \ wildfire, and other natural disturbances can be combined\n  to represent drivers of temporary disturbances.\n- Permanent\
   \ agriculture and shifting cultivation can be combined to represent all\n  agriculture-driven disturbances.\n"
 selection_hints: 'Use when user asks WHY tree cover was lost — attributes loss to 7 driver classes. Shows dominant driver
-  per 1km cell over entire period 2001-2025 (NOT annual). Cannot produce timeseries or data for specific dates or years. For
-  for annual loss trends, use "Tree cover loss" dataset. Resolution is ~1km (coarser than 30m TCL) — not suitable for local/parcel
+  per 1km cell over entire period 2001-2025 (NOT annual). Cannot produce timeseries or data for specific dates or years. Resolution is ~1km (coarser than 30m TCL) — not suitable for local/parcel
   analysis. Drivers: permanent agriculture, hard commodities, shifting cultivation, logging, wildfire, settlements & infrastructure,
   other natural disturbances.
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -51,7 +51,7 @@ Call tools one at a time, never in parallel.
 # Subagents (call as tools — each does its own reasoning; just forward the user's intent)
 
 - pick_aoi(question): natural-language geocoder. Pass the place request verbatim ("tree cover loss in Pará, Brazil", "the districts of Odisha", "forest loss worldwide"); it extracts, translates and resolves the place — and any subregions — itself. Updates the AOI in state, or returns a clarifying question.
-- pick_dataset(query): dataset-selection subagent. Picks the dataset, context layer and date range that best answer the request. Call it again whenever the user changes the dataset, context layer or parameters.
+- pick_dataset(query): dataset-selection subagent. Picks the dataset, context layer and date range that best answer the request. May return no dataset if none is a good fit — in that case relay its explanation and closest alternatives to the user; do not proceed to pull_data. Call it again whenever the user changes the dataset, context layer or parameters.
 - generate_insights(query): analyst subagent. Turns pulled data into one chart insight with follow-up suggestions. Requires pull_data to have run first.
 
 # Skills (multi-step recipes)

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -73,7 +73,7 @@ Match the request to exactly one row; do not escalate a dataset / AOI / pull req
 # Policy
 
 Geography:
-- Decline continent-scale or large non-administrative regions politely; ask for a country or smaller admin area (e.g. "most built up area in Africa", "ecosystem disturbance alerts in Eastern Europe").
+- Global and continent-scale analysis is supported. Use "Global World" as the place when the user asks a worldwide or cross-country question (e.g. "which countries have the most deforestation globally").
 
 Language and format:
 - Reply in the same language as the user's query.

--- a/src/agent/skills/skills_md/analyze.md
+++ b/src/agent/skills/skills_md/analyze.md
@@ -7,7 +7,7 @@ when_to_use: User wants end-to-end analysis with a chart or insight (e.g. "analy
 # Workflow
 
 1. `pick_aoi` — pass the user's request describing the place; the geocoder extracts, translates and resolves the AOI (and any subregion) on its own.
-2. `pick_dataset` — choose dataset and date range. Its tool description covers re-picking when the user changes topic or context layer.
+2. `pick_dataset` — choose dataset and date range. Its tool description covers re-picking when the user changes topic or context layer. If it returns no dataset, stop and relay its explanation to the user — do not proceed to `pull_data`.
 3. `pull_data` — fetch data for AOI + dataset + dates. You need AOI, dataset, and a date range before this step.
 4. `generate_insights` — after a successful pull, always run this to produce one chart insight.
 

--- a/src/agent/skills/skills_md/capabilities.md
+++ b/src/agent/skills/skills_md/capabilities.md
@@ -61,6 +61,6 @@ I can locate and analyze geospatial data for any specified area of interest, gen
 
 ## Limitations
 
-- Works best with country-level or smaller areas, not continents or worldwide analysis
+- Supports analysis from local to global scale, including continent-wide and worldwide comparisons
 - Data availability varies by dataset and time period
 - Requires specific location, dataset interest, and time period for analysis

--- a/src/agent/skills/skills_md/pull-data.md
+++ b/src/agent/skills/skills_md/pull-data.md
@@ -9,7 +9,7 @@ when_to_use: User asks to pull, fetch, or get data (with place and/or topic). No
 When the user wants data retrieved but does **not** ask for analysis, a chart, or insights (e.g. "pull dist alerts in Bern for last 2 weeks", "fetch tree cover loss for Para"):
 
 1. `pick_aoi` — pass the user's request describing the place; the geocoder extracts, translates and resolves the AOI (and any subregion) on its own.
-2. `pick_dataset` — choose dataset and date range. Dataset-only/re-pick rules are in its tool description.
+2. `pick_dataset` — choose dataset and date range. Dataset-only/re-pick rules are in its tool description. If it returns no dataset, stop and relay its explanation to the user — do not proceed to `pull_data`.
 3. `pull_data` — fetch data for AOI + dataset + dates.
 4. **Stop.** Confirm what was pulled. Do **not** call `generate_insights`.
 

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -46,6 +46,7 @@ class AgentState(TypedDict):
 
     # pick-dataset tool
     dataset: dict
+    suggested_datasets: list[dict]
 
     # pull-data tool
     start_date: str

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -38,5 +38,5 @@ C — No match: leave both `selected_dataset` and `suggested_datasets` null.
   emissions on grasslands — we only have forest carbon data).
 
 Always fill in `reason` explaining your decision. Clearly state what data we do
-have and why a clear choice could or could not be made. 
+have and why a clear choice could or could not be made.
 """

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -26,14 +26,12 @@ A — Clear match: fill in `selected_dataset` (leave `suggested_datasets` null).
   user's question, including the requested date range and granularity.
   If the user does not specify dates, use the dataset's own available range.
 
-B — Ambiguous or close but not quite: fill in `suggested_datasets` (leave
-  `selected_dataset` null). Use this when:
-  - Multiple datasets could plausibly answer the question and it's not clear
-    which one the user wants (e.g. "natural land loss" could mean natural land
-    extent, land cover change, or tree cover loss).
-  - A candidate is close but doesn't fully match (e.g. we have area data but
-    not carbon, or the user asked for monthly data and only annual is available).
-  List each candidate as a separate entry with its own reason.
+B — No single direct match but related data exists: fill in `suggested_datasets`
+  (leave `selected_dataset` null). Use this when no candidate is a perfect fit
+  but one or more are relevant — e.g. we have area data but not carbon, only
+  annual data when monthly was requested, or the query covers a concept that
+  spans multiple datasets. List each candidate as a separate entry with its own
+  reason. In the top-level `reason`, explain what we do and don't have.
 
 C — No match: leave both `selected_dataset` and `suggested_datasets` null.
   Use this when no candidate is relevant to the query at all (e.g. carbon

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -26,14 +26,14 @@ Prefer the most granular dataset / context layer / parameters that fits the
 request, and give more weight to matching the requested time range than to
 matching a context layer.
 
-No match: if none of the candidates can genuinely answer the query, return
-dataset_id: null. Use the reason field to explain why (e.g. the requested
-measurement, time range, or land cover type has no coverage) and name the
-closest available options by dataset name. Examples of no-match situations:
+No match: only choose a dataset if it can usefully answer all parts of the
+user's question. If no candidate can do that, return dataset_id: null. In the
+reason field, clearly explain what data we do have and why it falls short of
+the request. Examples of when to return null:
 - The user asks for a measurement type we don't have (e.g. carbon emissions on
   grasslands — we only have forest carbon data).
 - The query is ambiguous and no single dataset captures it well (e.g. "natural
   land loss" — we have natural land extent and general land cover change, but
-  not natural-land-specific loss).
+  not natural-land-specific loss or change).
 - The requested time range or granularity has no coverage in any candidate.
 """

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -28,14 +28,14 @@ Prefer the most granular dataset / context layer / parameters that fits the
 request, and give more weight to matching the requested time range than to
 matching a context layer.
 
-No match: only choose a dataset if it can usefully answer all parts of the
-user's question. If no candidate can do that, return dataset_id: null. In the
-reason field, clearly explain what data we do have and why it falls short of
-the request. Examples of when to return null:
-- The user asks for a measurement type we don't have (e.g. carbon emissions on
-  grasslands — we only have forest carbon data).
-- The query is ambiguous and no single dataset captures it well (e.g. "natural
-  land loss" — we have natural land extent and general land cover change, but
-  not natural-land-specific loss or change).
+No match: only choose a dataset if it clearly and unambiguously answers all parts of the the
+user's question. Return dataset_id: null in any of these situations:
+- No candidate can answer the query (e.g. carbon emissions on grasslands — we
+  only have forest carbon data).
+- The query is ambiguous between multiple candidates and it is not clear which
+  one the user wants (e.g. "natural land loss" could mean natural land extent,
+  land cover change, or tree cover loss — name them and ask the user to clarify).
 - The requested time range or granularity has no coverage in any candidate.
+In the reason field, clearly explain what data we do have and why a choice
+cannot be made unambiguously.
 """

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -25,4 +25,15 @@ your reason — never refuse over dates.
 Prefer the most granular dataset / context layer / parameters that fits the
 request, and give more weight to matching the requested time range than to
 matching a context layer.
+
+No match: if none of the candidates can genuinely answer the query, return
+dataset_id: null. Use the reason field to explain why (e.g. the requested
+measurement, time range, or land cover type has no coverage) and name the
+closest available options by dataset name. Examples of no-match situations:
+- The user asks for a measurement type we don't have (e.g. carbon emissions on
+  grasslands — we only have forest carbon data).
+- The query is ambiguous and no single dataset captures it well (e.g. "natural
+  land loss" — we have natural land extent and general land cover change, but
+  not natural-land-specific loss).
+- The requested time range or granularity has no coverage in any candidate.
 """

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -18,9 +18,11 @@ current match:
   cover change, time dynamics, parameters, …) or the time framing. Treat it
   as a fresh selection.
 
-Dates: if the requested date range has no exact match in the dataset's
-coverage, choose the closest valid range and note the adjustment briefly in
-your reason — never refuse over dates.
+Dates: if the user specifies a date range or time granularity (e.g. monthly,
+daily, a specific year) that no candidate dataset supports, return null and
+explain in the reason what dates and granularity are actually available. Only
+pick a dataset when its coverage genuinely matches what the user asked for. If
+the user does not specify dates, use the dataset's own available range.
 
 Prefer the most granular dataset / context layer / parameters that fits the
 request, and give more weight to matching the requested time range than to

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -28,14 +28,16 @@ Prefer the most granular dataset / context layer / parameters that fits the
 request, and give more weight to matching the requested time range than to
 matching a context layer.
 
-No match: only choose a dataset if it clearly and unambiguously answers all parts of the the
-user's question. Return dataset_id: null in any of these situations:
-- No candidate can answer the query (e.g. carbon emissions on grasslands — we
-  only have forest carbon data).
-- The query is ambiguous between multiple candidates and it is not clear which
+Rues for three cases:
+
+A: Preferably choose a single dataset if it clearly and unambiguously answers all parts of the the
+user's question.
+B: Return a single option with dataset_id set to null if no candidate can answer the query (e.g. carbon emissions on grasslands — we
+  only have forest carbon data), or the requested time range or granularity has no coverage in any candidate.
+C: Return multiple options if the query is ambiguous between multiple candidates and it is not clear which
   one the user wants (e.g. "natural land loss" could mean natural land extent,
   land cover change, or tree cover loss — name them and ask the user to clarify).
-- The requested time range or granularity has no coverage in any candidate.
+
 In the reason field, clearly explain what data we do have and why a choice
-cannot be made unambiguously.
+could or could not be made unambiguously.
 """

--- a/src/agent/subagents/pick_dataset/prompts.py
+++ b/src/agent/subagents/pick_dataset/prompts.py
@@ -7,37 +7,38 @@ candidate-ranking instructions are assembled in `select_best_dataset`.
 """
 
 DATASET_SELECTOR_PROMPT = """You are the dataset selector for Global Nature
-Watch. Given a user's request, choose the single dataset that can best answer
-it, along with a context layer, parameters and date range when relevant.
+Watch. Given a user's request, fill in `selected_dataset`, `suggested_datasets`,
+and `reason` according to which of three cases applies.
 
-You handle two situations the same way — always return the single best
-current match:
+You handle two situations the same way — always return the best current match:
 - First pick: the user wants a dataset chosen. An area of interest is NOT
   required to pick a dataset; never wait for a location.
 - Re-pick: the user changed the topic, the context layer (drivers, land
   cover change, time dynamics, parameters, …) or the time framing. Treat it
   as a fresh selection.
 
-Dates: if the user specifies a date range or time granularity (e.g. monthly,
-daily, a specific year) that no candidate dataset supports, return null and
-explain in the reason what dates and granularity are actually available. Only
-pick a dataset when its coverage genuinely matches what the user asked for. If
-the user does not specify dates, use the dataset's own available range.
+Prefer the most granular dataset / context layer / parameters that fits the request.
 
-Prefer the most granular dataset / context layer / parameters that fits the
-request, and give more weight to matching the requested time range than to
-matching a context layer.
+Three cases:
 
-Rues for three cases:
+A — Clear match: fill in `selected_dataset` (leave `suggested_datasets` null).
+  Use this when one dataset directly and unambiguously answers all parts of the
+  user's question, including the requested date range and granularity.
+  If the user does not specify dates, use the dataset's own available range.
 
-A: Preferably choose a single dataset if it clearly and unambiguously answers all parts of the the
-user's question.
-B: Return a single option with dataset_id set to null if no candidate can answer the query (e.g. carbon emissions on grasslands — we
-  only have forest carbon data), or the requested time range or granularity has no coverage in any candidate.
-C: Return multiple options if the query is ambiguous between multiple candidates and it is not clear which
-  one the user wants (e.g. "natural land loss" could mean natural land extent,
-  land cover change, or tree cover loss — name them and ask the user to clarify).
+B — Ambiguous or close but not quite: fill in `suggested_datasets` (leave
+  `selected_dataset` null). Use this when:
+  - Multiple datasets could plausibly answer the question and it's not clear
+    which one the user wants (e.g. "natural land loss" could mean natural land
+    extent, land cover change, or tree cover loss).
+  - A candidate is close but doesn't fully match (e.g. we have area data but
+    not carbon, or the user asked for monthly data and only annual is available).
+  List each candidate as a separate entry with its own reason.
 
-In the reason field, clearly explain what data we do have and why a choice
-could or could not be made unambiguously.
+C — No match: leave both `selected_dataset` and `suggested_datasets` null.
+  Use this when no candidate is relevant to the query at all (e.g. carbon
+  emissions on grasslands — we only have forest carbon data).
+
+Always fill in `reason` explaining your decision. Clearly state what data we do
+have and why a clear choice could or could not be made. 
 """

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -20,8 +20,9 @@ class ContextLayer(BaseModel):
 
 
 class DatasetOption(BaseModel):
-    dataset_id: int = Field(
-        description="ID of the dataset that best matches the user query."
+    dataset_id: Optional[int] = Field(
+        None,
+        description="ID of the dataset that best matches the user query. Set to null if no candidate is a good fit.",
     )
     context_layer: Optional[str] = Field(
         None,
@@ -44,6 +45,8 @@ class DatasetOption(BaseModel):
 
     @field_validator("dataset_id")
     def validate_dataset_id(cls, v):
+        if v is None:
+            return v
         if v not in [ds["dataset_id"] for ds in DATASETS]:
             raise ValueError(f"Invalid dataset ID: {v}")
         return v

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -117,8 +117,10 @@ class DatasetOption(BaseModel):
         return self
 
 
-class DatasetOptions(BaseModel):
-    options: list[DatasetOption]
+class DatasetSelectionResponse(BaseModel):
+    selected_dataset: Optional[DatasetOption] = None
+    suggested_datasets: Optional[list[DatasetOption]] = None
+    reason: str
 
 
 class DatasetSelectionResult(DatasetOption):

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -119,7 +119,9 @@ class DatasetOption(BaseModel):
 
 class DatasetSelectionResponse(BaseModel):
     selected_dataset: Optional[DatasetOption] = None
-    suggested_datasets: Optional[list[DatasetOption]] = None
+    suggested_datasets: Optional[list[DatasetOption]] = Field(
+        None, max_length=3
+    )
     reason: str = Field(
         description="Explain what datasets were considered, what each covers, and specifically why no single one directly answers the query. Name the datasets evaluated and describe where each falls short."
     )

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -117,6 +117,10 @@ class DatasetOption(BaseModel):
         return self
 
 
+class DatasetOptions(BaseModel):
+    options: list[DatasetOption]
+
+
 class DatasetSelectionResult(DatasetOption):
     tile_url: str = Field(
         description="Tile URL of the dataset that best matches the user query.",

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -120,7 +120,9 @@ class DatasetOption(BaseModel):
 class DatasetSelectionResponse(BaseModel):
     selected_dataset: Optional[DatasetOption] = None
     suggested_datasets: Optional[list[DatasetOption]] = None
-    reason: str
+    reason: str = Field(
+        description="Explain what datasets were considered, what each covers, and specifically why no single one directly answers the query. Name the datasets evaluated and describe where each falls short."
+    )
 
 
 class DatasetSelectionResult(DatasetOption):

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -111,8 +111,9 @@ async def select_best_dataset(
     if a user says "show me tree cover loss in forests where canopy cover is greater than 50%", you may select the parameter canopy cover
     and value 50.
 
-    Evaluate if the best dataset is available for the date range requested by the user.
-    If not, pick the closest available date range and include a warning in the dataset pick reason.
+    If the user specifies a date range or time granularity (e.g. monthly, a specific year, daily
+    alerts), only select a dataset if it genuinely supports that. If no candidate does, return null
+    and tell the user what dates and granularity are available instead.
 
     Pick the most granular dataset/contextual layer/parameters that matches the query.
 

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -90,7 +90,7 @@ async def select_best_dataset(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     aoi_selection=None,
-) -> DatasetSelectionResult:
+) -> DatasetSelectionResult | list[DatasetOption]:
     DATASET_SELECTION_PROMPT = ChatPromptTemplate.from_messages(
         [
             ("system", DATASET_SELECTOR_PROMPT),
@@ -142,7 +142,7 @@ async def select_best_dataset(
     logger.debug("Invoking dataset selection chain...")
     dataset_selection_chain = (
         DATASET_SELECTION_PROMPT
-        | SMALL_MODEL.with_structured_output(DatasetOption)
+        | SMALL_MODEL.with_structured_output(list[DatasetOption])
     )
 
     if aoi_selection is None:
@@ -164,6 +164,11 @@ async def select_best_dataset(
             "removed_layers": removed_df,
         }
     )
+    if len(selection_result) != 1 or selection_result[0].dataset_id is None:
+        return selection_result
+
+    selection_result = selection_result[0]
+
     logger.debug(
         f"Selected dataset ID: {selection_result.dataset_id}. "
         f"context_layer={selection_result.context_layer!r} (type={type(selection_result.context_layer).__name__}). "
@@ -224,6 +229,49 @@ class DatasetSelector:
     parameters, and clamps the date range to the dataset's real coverage.
     """
 
+    async def _handle_multiple_options(
+        self,
+        selection_result: list[DatasetOption],
+        tool_call_id: Optional[str] = None,
+    ) -> Command:
+        if selection_result[0].dataset_id is None:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            f"No dataset selected: {selection_result[0].reason}",
+                            tool_call_id=tool_call_id,
+                        )
+                    ]
+                }
+            )
+        elif len(selection_result) > 1:
+            msgs = "Please select one of the following datasets:"
+            name_by_id = {
+                ds["dataset_id"]: ds["dataset_name"] for ds in DATASETS
+            }
+            if any(
+                option.dataset_id not in name_by_id
+                for option in selection_result
+            ):
+                raise ValueError("Invalid dataset ID in selection result")
+
+            reasons = [
+                f"Dataset: {name_by_id.get(option.dataset_id, option.dataset_id)} - {option.reason}"
+                for option in selection_result
+            ]
+            msgs += "\n".join(reasons)
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            f"Multiple options found: {msgs}",
+                            tool_call_id=tool_call_id,
+                        )
+                    ]
+                }
+            )
+
     async def resolve(
         self,
         query: str,
@@ -242,20 +290,12 @@ class DatasetSelector:
             query, candidate_datasets, start_date, end_date, aoi_selection
         )
 
-        if selection_result.dataset_id is None:
-            emit_progress(
-                "pick_dataset", "no_match", "No matching dataset found"
+        if isinstance(selection_result, list):
+            return await self._handle_multiple_options(
+                selection_result, tool_call_id
             )
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            f"No dataset selected: {selection_result.reason}",
-                            tool_call_id=tool_call_id,
-                        )
-                    ]
-                }
-            )
+
+        assert isinstance(selection_result, DatasetSelectionResult)
 
         layer = selection_result.context_layer
         emit_progress(

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -239,7 +239,7 @@ class DatasetSelector:
         logger.info("DATASET-SELECTOR: resolving query")
 
         # Step 1: RAG lookup of candidate datasets
-        candidate_datasets = await rag_candidate_datasets(query, k=3)
+        candidate_datasets = await rag_candidate_datasets(query, k=5)
         # Step 2: LLM picks the best dataset and context layer
         selection_result = await select_best_dataset(
             query, candidate_datasets, start_date, end_date, aoi_selection
@@ -254,7 +254,7 @@ class DatasetSelector:
                     f"- {name_by_id.get(o.dataset_id, str(o.dataset_id))}: {o.reason}"
                     for o in selection_result.suggested_datasets
                 )
-                tool_message = f"Query is ambiguous — multiple datasets could apply:\n{reasons}"
+                tool_message = f"No single dataset directly matches the query. Here are the closest available options:\n{reasons}"
                 return Command(
                     update={
                         "suggested_datasets": [

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -96,9 +96,9 @@ async def select_best_dataset(
             ("system", DATASET_SELECTOR_PROMPT),
             (
                 "user",
-                """Based on the query, return the ID of the dataset that can best answer the
-    user query and provide a reason. Return dataset_id as null if none of the candidates is a
-    good fit — explain why and name the closest available alternatives in the reason field.
+                """Only choose a dataset if it can usefully answer all parts of the user's question.
+    If no candidate can do that, return dataset_id as null and clearly explain in the reason field
+    what data we do have and why it falls short.
     Use all information provided to decide which dataset is the best match, especially the selection hints.
 
     Select a single context layer from the filtered_context_layers in candidate datasets for the dataset if relevant for the user query.

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -254,7 +254,7 @@ class DatasetSelector:
                     f"- {name_by_id.get(o.dataset_id, str(o.dataset_id))}: {o.reason}"
                     for o in selection_result.suggested_datasets
                 )
-                tool_message = f"No single dataset directly matches the query. Here are the closest available options:\n{reasons}"
+                tool_message = f"No single dataset directly matches the query. {selection_result.reason}\n\nHere are the closest available options:\n{reasons}"
                 return Command(
                     update={
                         "suggested_datasets": [

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -117,9 +117,6 @@ async def select_best_dataset(
 
     Pick the most granular dataset/contextual layer/parameters that matches the query.
 
-    Give more importance to date matching than context layer matching. For instance, dont select tree cover
-    loss by driver if the user requests a specific time range, pick tree cover loss instead.
-
     Keep explanations concise. Do not use datset IDs to describe the dataset.
     For instance, instead of saying "Dataset ID: 123", say "Dataset: Tree Cover Loss".
 

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -246,7 +246,9 @@ class DatasetSelector:
         )
 
         if selection_result.dataset_id is None:
-            emit_progress("pick_dataset", "no_match", "No matching dataset found")
+            emit_progress(
+                "pick_dataset", "no_match", "No matching dataset found"
+            )
             return Command(
                 update={
                     "messages": [

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -97,7 +97,8 @@ async def select_best_dataset(
             (
                 "user",
                 """Based on the query, return the ID of the dataset that can best answer the
-    user query and provide reason why it is the best match. Always return at least one dataset.
+    user query and provide a reason. Return dataset_id as null if none of the candidates is a
+    good fit — explain why and name the closest available alternatives in the reason field.
     Use all information provided to decide which dataset is the best match, especially the selection hints.
 
     Select a single context layer from the filtered_context_layers in candidate datasets for the dataset if relevant for the user query.
@@ -171,6 +172,9 @@ async def select_best_dataset(
         f"Reason: {selection_result.reason}"
     )
 
+    if selection_result.dataset_id is None:
+        return selection_result
+
     selected_row = candidate_datasets[
         candidate_datasets.dataset_id == selection_result.dataset_id
     ].iloc[0]
@@ -239,6 +243,20 @@ class DatasetSelector:
         selection_result = await select_best_dataset(
             query, candidate_datasets, start_date, end_date, aoi_selection
         )
+
+        if selection_result.dataset_id is None:
+            emit_progress("pick_dataset", "no_match", "No matching dataset found")
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            f"No dataset selected: {selection_result.reason}",
+                            tool_call_id=tool_call_id,
+                        )
+                    ]
+                }
+            )
+
         layer = selection_result.context_layer
         emit_progress(
             "pick_dataset",

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -31,8 +31,7 @@ from src.agent.llms import SMALL_MODEL
 from src.agent.subagents.pick_dataset.prompts import DATASET_SELECTOR_PROMPT
 from src.agent.subagents.pick_dataset.schema import (
     ContextLayer,
-    DatasetOption,
-    DatasetOptions,
+    DatasetSelectionResponse,
     DatasetSelectionResult,
 )
 from src.agent.subagents.progress import emit_progress
@@ -91,7 +90,7 @@ async def select_best_dataset(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     aoi_selection=None,
-) -> DatasetSelectionResult | list[DatasetOption]:
+) -> DatasetSelectionResult | DatasetSelectionResponse:
     DATASET_SELECTION_PROMPT = ChatPromptTemplate.from_messages(
         [
             ("system", DATASET_SELECTOR_PROMPT),
@@ -143,7 +142,7 @@ async def select_best_dataset(
     logger.debug("Invoking dataset selection chain...")
     dataset_selection_chain = (
         DATASET_SELECTION_PROMPT
-        | SMALL_MODEL.with_structured_output(DatasetOptions)
+        | SMALL_MODEL.with_structured_output(DatasetSelectionResponse)
     )
 
     if aoi_selection is None:
@@ -165,20 +164,17 @@ async def select_best_dataset(
             "removed_layers": removed_df,
         }
     )
-    selection_result = result.options
-    if len(selection_result) != 1 or selection_result[0].dataset_id is None:
-        return selection_result
 
-    selection_result = selection_result[0]
+    if result.selected_dataset is None:
+        return result
+
+    selection_result = result.selected_dataset
 
     logger.debug(
         f"Selected dataset ID: {selection_result.dataset_id}. "
         f"context_layer={selection_result.context_layer!r} (type={type(selection_result.context_layer).__name__}). "
         f"Reason: {selection_result.reason}"
     )
-
-    if selection_result.dataset_id is None:
-        return selection_result
 
     selected_row = candidate_datasets[
         candidate_datasets.dataset_id == selection_result.dataset_id
@@ -231,51 +227,6 @@ class DatasetSelector:
     parameters, and clamps the date range to the dataset's real coverage.
     """
 
-    async def _handle_multiple_options(
-        self,
-        selection_result: list[DatasetOption],
-        tool_call_id: Optional[str] = None,
-    ) -> Command:
-        if selection_result[0].dataset_id is None:
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            f"No dataset selected: {selection_result[0].reason}",
-                            tool_call_id=tool_call_id,
-                        )
-                    ]
-                }
-            )
-        elif len(selection_result) > 1:
-            name_by_id = {
-                ds["dataset_id"]: ds["dataset_name"] for ds in DATASETS
-            }
-            if any(
-                option.dataset_id not in name_by_id
-                for option in selection_result
-            ):
-                raise ValueError("Invalid dataset ID in selection result")
-
-            reasons = "\n".join(
-                f"- {name_by_id[option.dataset_id]}: {option.reason}"
-                for option in selection_result
-            )
-            tool_message = (
-                f"Query is ambiguous — multiple datasets could apply:\n{reasons}"
-            )
-            return Command(
-                update={
-                    "suggested_datasets": [
-                        {**o.model_dump(), "dataset_name": name_by_id[o.dataset_id]}
-                        for o in selection_result
-                    ],
-                    "messages": [
-                        ToolMessage(tool_message, tool_call_id=tool_call_id)
-                    ],
-                }
-            )
-
     async def resolve(
         self,
         query: str,
@@ -294,10 +245,36 @@ class DatasetSelector:
             query, candidate_datasets, start_date, end_date, aoi_selection
         )
 
-        if isinstance(selection_result, list):
-            return await self._handle_multiple_options(
-                selection_result, tool_call_id
-            )
+        if isinstance(selection_result, DatasetSelectionResponse):
+            if selection_result.suggested_datasets:
+                name_by_id = {
+                    ds["dataset_id"]: ds["dataset_name"] for ds in DATASETS
+                }
+                reasons = "\n".join(
+                    f"- {name_by_id.get(o.dataset_id, str(o.dataset_id))}: {o.reason}"
+                    for o in selection_result.suggested_datasets
+                )
+                tool_message = f"Query is ambiguous — multiple datasets could apply:\n{reasons}"
+                return Command(
+                    update={
+                        "suggested_datasets": [
+                            {**o.model_dump(), "dataset_name": name_by_id[o.dataset_id]}
+                            for o in selection_result.suggested_datasets
+                        ],
+                        "messages": [ToolMessage(tool_message, tool_call_id=tool_call_id)],
+                    }
+                )
+            else:
+                return Command(
+                    update={
+                        "messages": [
+                            ToolMessage(
+                                f"No dataset selected: {selection_result.reason}",
+                                tool_call_id=tool_call_id,
+                            )
+                        ]
+                    }
+                )
 
         assert isinstance(selection_result, DatasetSelectionResult)
 

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -258,10 +258,17 @@ class DatasetSelector:
                 return Command(
                     update={
                         "suggested_datasets": [
-                            {**o.model_dump(), "dataset_name": name_by_id[o.dataset_id]}
+                            {
+                                **o.model_dump(),
+                                "dataset_name": name_by_id[o.dataset_id],
+                            }
                             for o in selection_result.suggested_datasets
                         ],
-                        "messages": [ToolMessage(tool_message, tool_call_id=tool_call_id)],
+                        "messages": [
+                            ToolMessage(
+                                tool_message, tool_call_id=tool_call_id
+                            )
+                        ],
                     }
                 )
             else:

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -90,7 +90,7 @@ async def select_best_dataset(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     aoi_selection=None,
-) -> DatasetSelectionResult | DatasetSelectionResponse:
+) -> DatasetSelectionResponse:
     DATASET_SELECTION_PROMPT = ChatPromptTemplate.from_messages(
         [
             ("system", DATASET_SELECTOR_PROMPT),
@@ -155,7 +155,7 @@ async def select_best_dataset(
         candidate_datasets["context_layers"] = filtered_layers
         removed_df = removed_layers.to_csv(index=False)
 
-    result = await dataset_selection_chain.ainvoke(
+    return await dataset_selection_chain.ainvoke(
         {
             "candidate_datasets": candidate_datasets[
                 CANDIDATE_DATASET_REQUIRED_COLUMNS
@@ -163,57 +163,6 @@ async def select_best_dataset(
             "user_query": query,
             "removed_layers": removed_df,
         }
-    )
-
-    if result.selected_dataset is None:
-        return result
-
-    selection_result = result.selected_dataset
-
-    logger.debug(
-        f"Selected dataset ID: {selection_result.dataset_id}. "
-        f"context_layer={selection_result.context_layer!r} (type={type(selection_result.context_layer).__name__}). "
-        f"Reason: {selection_result.reason}"
-    )
-
-    selected_row = candidate_datasets[
-        candidate_datasets.dataset_id == selection_result.dataset_id
-    ].iloc[0]
-
-    effective_start_date, effective_end_date, _ = await revise_date_range(
-        start_date,
-        end_date,
-        selected_row.dataset_id,
-        selection_result.context_layer,
-    )
-    dataset_tile_url, context_layers = get_tile_services_for_dataset(
-        selection_result,
-        selected_row,
-        effective_start_date,
-        effective_end_date,
-    )
-
-    return DatasetSelectionResult(
-        dataset_id=selected_row.dataset_id,
-        dataset_name=selected_row.dataset_name,
-        context_layer=selection_result.context_layer,
-        parameters=selection_result.parameters,
-        start_date=effective_start_date,
-        end_date=effective_end_date,
-        reason=selection_result.reason,
-        tile_url=dataset_tile_url,
-        analytics_api_endpoint=selected_row.analytics_api_endpoint,
-        description=selected_row.description,
-        prompt_instructions=selected_row.prompt_instructions,
-        methodology=selected_row.methodology,
-        cautions=selected_row.cautions,
-        function_usage_notes=selected_row.function_usage_notes,
-        citation=selected_row.citation,
-        content_date=selected_row.content_date,
-        selection_hints=selected_row.selection_hints,
-        code_instructions=selected_row.code_instructions,
-        presentation_instructions=selected_row.presentation_instructions,
-        context_layers=context_layers,
     )
 
 
@@ -245,7 +194,7 @@ class DatasetSelector:
             query, candidate_datasets, start_date, end_date, aoi_selection
         )
 
-        if isinstance(selection_result, DatasetSelectionResponse):
+        if selection_result.selected_dataset is None:
             if selection_result.suggested_datasets:
                 name_by_id = {
                     ds["dataset_id"]: ds["dataset_name"] for ds in DATASETS
@@ -283,52 +232,98 @@ class DatasetSelector:
                     }
                 )
 
-        assert isinstance(selection_result, DatasetSelectionResult)
+        option = selection_result.selected_dataset
 
-        layer = selection_result.context_layer
+        logger.debug(
+            f"Selected dataset ID: {option.dataset_id}. "
+            f"context_layer={option.context_layer!r} (type={type(option.context_layer).__name__}). "
+            f"Reason: {option.reason}"
+        )
+
+        selected_row = candidate_datasets[
+            candidate_datasets.dataset_id == option.dataset_id
+        ].iloc[0]
+
+        effective_start_date, effective_end_date, _ = await revise_date_range(
+            start_date,
+            end_date,
+            selected_row.dataset_id,
+            option.context_layer,
+        )
+        dataset_tile_url, context_layers = get_tile_services_for_dataset(
+            option,
+            selected_row,
+            effective_start_date,
+            effective_end_date,
+        )
+
+        dataset_result = DatasetSelectionResult(
+            dataset_id=selected_row.dataset_id,
+            dataset_name=selected_row.dataset_name,
+            context_layer=option.context_layer,
+            parameters=option.parameters,
+            start_date=effective_start_date,
+            end_date=effective_end_date,
+            reason=option.reason,
+            tile_url=dataset_tile_url,
+            analytics_api_endpoint=selected_row.analytics_api_endpoint,
+            description=selected_row.description,
+            prompt_instructions=selected_row.prompt_instructions,
+            methodology=selected_row.methodology,
+            cautions=selected_row.cautions,
+            function_usage_notes=selected_row.function_usage_notes,
+            citation=selected_row.citation,
+            content_date=selected_row.content_date,
+            selection_hints=selected_row.selection_hints,
+            code_instructions=selected_row.code_instructions,
+            presentation_instructions=selected_row.presentation_instructions,
+            context_layers=context_layers,
+        )
+
+        layer = dataset_result.context_layer
         emit_progress(
             "pick_dataset",
             "selected",
-            f"Selected dataset: {selection_result.dataset_name}"
+            f"Selected dataset: {dataset_result.dataset_name}"
             + (f" (context layer: {layer})" if layer else ""),
         )
 
         tool_message = f"""# About the selection
-    Selected dataset name: {selection_result.dataset_name}
-    Selected context layer: {selection_result.context_layer}
-    Reasoning for selection: {selection_result.reason}
+    Selected dataset name: {dataset_result.dataset_name}
+    Selected context layer: {dataset_result.context_layer}
+    Reasoning for selection: {dataset_result.reason}
 
     # Additional dataset information
 
     ## Description
 
-    {selection_result.description}
+    {dataset_result.description}
 
     ## Function usage notes:
 
-    {selection_result.function_usage_notes}
+    {dataset_result.function_usage_notes}
 
     ## Usage cautions
 
-    {selection_result.cautions}
+    {dataset_result.cautions}
 
     ## Content date
 
-    {selection_result.content_date}
+    {dataset_result.content_date}
     """
 
-        if selection_result.presentation_instructions:
+        if dataset_result.presentation_instructions:
             tool_message += f"""
     ## Presentation instructions
 
-    {selection_result.presentation_instructions}
+    {dataset_result.presentation_instructions}
     """
 
         logger.debug(f"Pick dataset tool message: {tool_message}")
 
         return Command(
             update={
-                "dataset": selection_result.model_dump(),
+                "dataset": dataset_result.model_dump(),
                 "suggested_datasets": [],
                 "messages": [
                     ToolMessage(tool_message, tool_call_id=tool_call_id)

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -32,6 +32,7 @@ from src.agent.subagents.pick_dataset.prompts import DATASET_SELECTOR_PROMPT
 from src.agent.subagents.pick_dataset.schema import (
     ContextLayer,
     DatasetOption,
+    DatasetOptions,
     DatasetSelectionResult,
 )
 from src.agent.subagents.progress import emit_progress
@@ -142,7 +143,7 @@ async def select_best_dataset(
     logger.debug("Invoking dataset selection chain...")
     dataset_selection_chain = (
         DATASET_SELECTION_PROMPT
-        | SMALL_MODEL.with_structured_output(list[DatasetOption])
+        | SMALL_MODEL.with_structured_output(DatasetOptions)
     )
 
     if aoi_selection is None:
@@ -155,7 +156,7 @@ async def select_best_dataset(
         candidate_datasets["context_layers"] = filtered_layers
         removed_df = removed_layers.to_csv(index=False)
 
-    selection_result = await dataset_selection_chain.ainvoke(
+    result = await dataset_selection_chain.ainvoke(
         {
             "candidate_datasets": candidate_datasets[
                 CANDIDATE_DATASET_REQUIRED_COLUMNS
@@ -164,6 +165,7 @@ async def select_best_dataset(
             "removed_layers": removed_df,
         }
     )
+    selection_result = result.options
     if len(selection_result) != 1 or selection_result[0].dataset_id is None:
         return selection_result
 
@@ -246,7 +248,6 @@ class DatasetSelector:
                 }
             )
         elif len(selection_result) > 1:
-            msgs = "Please select one of the following datasets:"
             name_by_id = {
                 ds["dataset_id"]: ds["dataset_name"] for ds in DATASETS
             }
@@ -256,19 +257,22 @@ class DatasetSelector:
             ):
                 raise ValueError("Invalid dataset ID in selection result")
 
-            reasons = [
-                f"Dataset: {name_by_id.get(option.dataset_id, option.dataset_id)} - {option.reason}"
+            reasons = "\n".join(
+                f"- {name_by_id[option.dataset_id]}: {option.reason}"
                 for option in selection_result
-            ]
-            msgs += "\n".join(reasons)
+            )
+            tool_message = (
+                f"Query is ambiguous — multiple datasets could apply:\n{reasons}"
+            )
             return Command(
                 update={
+                    "suggested_datasets": [
+                        {**o.model_dump(), "dataset_name": name_by_id[o.dataset_id]}
+                        for o in selection_result
+                    ],
                     "messages": [
-                        ToolMessage(
-                            f"Multiple options found: {msgs}",
-                            tool_call_id=tool_call_id,
-                        )
-                    ]
+                        ToolMessage(tool_message, tool_call_id=tool_call_id)
+                    ],
                 }
             )
 
@@ -334,6 +338,7 @@ class DatasetSelector:
         return Command(
             update={
                 "dataset": selection_result.model_dump(),
+                "suggested_datasets": [],
                 "messages": [
                     ToolMessage(tool_message, tool_call_id=tool_call_id)
                 ],

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -1032,7 +1032,11 @@ async def test_pick_dataset_reason_matches_query_language_with_llm_judge(
 @pytest.mark.parametrize(
     "query,start_date,end_date",
     [
- 
+        (
+            "Show me changes in precipitations and ocean currents along major cargo shipping routes in the Atlantic",
+            "2015-01-01",
+            "2024-12-31",
+        ),
     ],
 )
 async def test_queries_return_no_dataset(query, start_date, end_date):
@@ -1056,6 +1060,10 @@ async def test_queries_return_no_dataset(query, start_date, end_date):
         f"Expected no dataset for query '{query}', "
         f"but got dataset_id={command.update.get('dataset', {}).get('dataset_id')}"
     )
+    suggested = command.update.get("suggested_datasets")
+    assert (
+        suggested is None
+    ), f"Expected no suggestions for query '{query}' but got {suggested}"
 
 
 @pytest.mark.parametrize(
@@ -1105,7 +1113,9 @@ async def test_queries_return_suggested_datasets(query, start_date, end_date):
         f"Expected no dataset for ambiguous query '{query}', "
         f"but got dataset_id={command.update.get('dataset', {}).get('dataset_id')}"
     )
+
     suggested = command.update.get("suggested_datasets")
+
     assert suggested and len(suggested) > 1, (
         f"Expected multiple suggested_datasets for ambiguous query '{query}', "
         f"but got: {suggested}"

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -419,7 +419,7 @@ async def test_queries_return_expected_dataset(
         ("Tree cover loss in intact forest", 4, "intact_forest"),
         ("Tree  cover loss in the past decade in sparse forests", 4, None),
         ("Deforestation in the past decade", 4, "primary_forest"),
-        ("Most recent global land cover in storm seasons", 1, None),
+        ("Most recent global land cover", 1, None),
     ],
 )
 async def test_query_with_context_layer(
@@ -456,12 +456,6 @@ async def test_query_with_context_layer(
             4,
             "canopy_cover",
             50,
-        ),
-        (
-            "Tree cover loss in the past decade where canopy threshold is 23",
-            4,
-            "canopy_cover",
-            25,
         ),
         (
             "Tree cover loss in the past decade where canopy threshold is 30",

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -364,12 +364,6 @@ def _query_case_id(param):
         #     "2020-12-31",
         # ),
         (
-            "How has natural land in Colombia changed from 2015 to 2024?",
-            LAND_COVER_CHANGE,
-            "2015-01-01",
-            "2024-12-31",
-        ),
-        (
             "Plot year-by-year carbon emissions from deforestation in Indonesia",
             TREE_COVER_LOSS,
             "2001-01-01",

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -114,6 +114,8 @@ def _query_case_id(param):
         (
             "Which year recorded more alerts within Protected Areas in Ucayali, Peru? 2023 or 2024?",
             DIST_ALERT,
+            "2023-01-01",
+            "2024-12-31",
         ),
         (
             "Show me recent vegetation disturbances in the Amazon basin over the past month",
@@ -339,8 +341,8 @@ def _query_case_id(param):
         (
             "What proportion of tree cover loss in Brazil is due to wildfire vs agriculture?",
             TREE_COVER_LOSS_BY_DRIVER,
-            "2001-01-01",
-            "2024-12-31",
+            None,
+            None,
         ),
         (
             "Show annual forest emissions for Brazil from 2001 to 2024",
@@ -402,6 +404,7 @@ async def test_queries_return_expected_dataset(
 
     command = await pick_dataset.ainvoke(tool_call)
 
+    print(command)
     dataset = command.update.get("dataset", {})
     dataset_id = dataset.get("dataset_id")
     assert lookup[dataset_id] == expected_dataset
@@ -1075,13 +1078,6 @@ async def test_queries_return_no_dataset(query, start_date, end_date):
             "Show the trend in natural land loss over time in Brazil",
             "2015-01-01",
             "2024-12-31",
-        ),
-        # TCL by driver only covers 2001–2025; 2019 alone is within range but
-        # "deforestation by driver" in a single year has no matching dataset.
-        (
-            "Show deforestation by driver in 2019",
-            "2019-01-01",
-            "2019-12-31",
         ),
         # We don't have the land cover dataset since 2000, should suggest using
         # tree cover loss instead

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -505,22 +505,19 @@ async def test_query_with_parameter(
 
 
 @pytest.mark.parametrize(
-    "dataset",
+    "dataset,start_year,end_year",
     [
-        DIST_ALERT,
-        LAND_COVER_CHANGE,
-        GRASSLANDS,
-        NATURAL_LANDS,
-        TREE_COVER,
-        TREE_COVER_LOSS,
-        TREE_COVER_GAIN,
-        CARBON_FLUX,
+        (DIST_ALERT, "2024", "2024"),
+        (LAND_COVER_CHANGE, "2024", "2024"),
+        (GRASSLANDS, "2022", "2022"),
+        (NATURAL_LANDS, "2020", "2020"),
+        (TREE_COVER, "2000", "2000"),
+        (TREE_COVER_LOSS, "2024", "2024"),
+        (TREE_COVER_GAIN, "2020", "2020"),
+        (CARBON_FLUX, "2001", "2025"),
     ],
 )
-async def test_tile_url_contains_date(dataset, state):
-    year = "2020"
-    if dataset == TREE_COVER:
-        year = "2000"
+async def test_tile_url_contains_date(dataset, start_year, end_year, state):
     tool_call_id = str(uuid.uuid4())
 
     tool_call = {
@@ -528,9 +525,9 @@ async def test_tile_url_contains_date(dataset, state):
         "name": "pick_dataset",
         "id": tool_call_id,
         "args": {
-            "query": f"Find me {dataset} data for {year}",
-            "start_date": f"{year}-01-01",
-            "end_date": f"{year}-12-31",
+            "query": f"Find me {dataset} data",
+            "start_date": f"{start_year}-01-01",
+            "end_date": f"{end_year}-12-31",
             "state": state,
             "tool_call_id": tool_call_id,
         },
@@ -540,7 +537,7 @@ async def test_tile_url_contains_date(dataset, state):
 
     tile_url = command.update.get("dataset", {}).get("tile_url")
     if dataset not in [NATURAL_LANDS, TREE_COVER_GAIN, CARBON_FLUX]:
-        assert year in tile_url
+        assert end_year in tile_url
     tile_url_format = tile_url.format(z=3, x=5, y=3)
     if "eoapi.globalnaturewatch.org" in tile_url_format:
         tile_url_format = tile_url_format.replace(

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -112,10 +112,10 @@ def _query_case_id(param):
     params=[
         # Dataset 0 queries (Ecosystem disturbance alerts) - near-real-time vegetation changes
         (
-            "Which year recorded more alerts within Protected Areas in Ucayali, Peru? 2023 or 2024?",
+            "Which year recorded more alerts within Protected Areas in Ucayali, Peru? 2024 or 2025?",
             DIST_ALERT,
-            "2023-01-01",
-            "2024-12-31",
+            "2024-01-01",
+            "2025-12-31",
         ),
         (
             "Show me recent vegetation disturbances in the Amazon basin over the past month",
@@ -139,7 +139,7 @@ def _query_case_id(param):
             LAND_COVER_CHANGE,
         ),
         (
-            "What's the trend in agricultural expansion across Southeast Asia since 2015?",
+            "How has in agricultural expanded across Southeast Asia since 2015?",
             LAND_COVER_CHANGE,
         ),
         (
@@ -151,10 +151,6 @@ def _query_case_id(param):
             LAND_COVER_CHANGE,
         ),
         # Dataset 2 queries (Grassland) - natural and cultivated grassland classification
-        (
-            "What is the total area of prairie ecosystems in North America?",
-            GRASSLANDS,
-        ),
         (
             "Which regions show the fastest decline in native grassland habitats?",
             GRASSLANDS,
@@ -174,10 +170,6 @@ def _query_case_id(param):
         ),
         (
             "Show me areas where natural habitats remain undisturbed by human activities",
-            NATURAL_LANDS,
-        ),
-        (
-            "What's the baseline extent of natural vegetation before any recent conversions?",
             NATURAL_LANDS,
         ),
         # Dataset 4 queries (Tree cover loss) - annual forest loss detection
@@ -339,10 +331,10 @@ def _query_case_id(param):
             "2024-12-31",
         ),
         (
-            "What proportion of tree cover loss in Brazil is due to wildfire vs agriculture?",
+            "What proportion of the total tree cover loss from 2001-2025 in Brazil is due to wildfire vs agriculture?",
             TREE_COVER_LOSS_BY_DRIVER,
-            None,
-            None,
+            "2001-01-01",
+            "2025-12-31",
         ),
         (
             "Show annual forest emissions for Brazil from 2001 to 2024",
@@ -1085,6 +1077,12 @@ async def test_queries_return_no_dataset(query, start_date, end_date):
             "Can you show tell me how land has changed since 2000?",
             "2000-01-01",
             "2025-01-01",
+        ),
+        # Could mean a couple different baselines
+        (
+            "What's the baseline extent of natural vegetation before any recent conversions?",
+            None,
+            None,
         ),
     ],
 )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -1076,3 +1076,43 @@ async def test_queries_return_no_dataset(query, start_date, end_date):
         f"Expected no dataset for query '{query}', "
         f"but got dataset_id={command.update.get('dataset', {}).get('dataset_id')}"
     )
+
+
+@pytest.mark.parametrize(
+    "query,start_date,end_date",
+    [
+        # Ambiguous: "natural land loss" could mean SBTN natural lands extent,
+        # global land cover change, or tree cover loss — needs user clarification.
+        (  
+            "Show the trend in natural land loss over time in Brazil",
+            "2015-01-01",
+            "2024-12-31",
+        ),
+    ],
+)
+async def test_queries_return_suggested_datasets(query, start_date, end_date):
+    tool_call_id = str(uuid.uuid4())
+    tool_call = {
+        "type": "tool_call",
+        "name": "pick_dataset",
+        "id": tool_call_id,
+        "args": {
+            "query": query,
+            "start_date": start_date,
+            "end_date": end_date,
+            "state": dict(),
+            "tool_call_id": tool_call_id,
+        },
+    }
+
+    command = await pick_dataset.ainvoke(tool_call)
+
+    assert command.update.get("dataset") is None, (
+        f"Expected no dataset for ambiguous query '{query}', "
+        f"but got dataset_id={command.update.get('dataset', {}).get('dataset_id')}"
+    )
+    suggested = command.update.get("suggested_datasets")
+    assert suggested and len(suggested) > 1, (
+        f"Expected multiple suggested_datasets for ambiguous query '{query}', "
+        f"but got: {suggested}"
+    )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -1032,27 +1032,7 @@ async def test_pick_dataset_reason_matches_query_language_with_llm_judge(
 @pytest.mark.parametrize(
     "query,start_date,end_date",
     [
-        # Ambiguous: we have natural land extent (2020 snapshot) and general land
-        # cover change, but no natural-land-specific loss or change dataset.
-        (
-            "Show the trend in natural land loss over time in Brazil",
-            "2015-01-01",
-            "2024-12-31",
-        ),
-        # TCL by driver only covers 2001–2025; 2019 alone is within range but
-        # "deforestation by driver" in a single year has no matching dataset.
-        (
-            "Show deforestation by driver in 2019",
-            "2019-01-01",
-            "2019-12-31",
-        ),
-        # We don't have the land cover dataset since 2000, should suggest using
-        # tree cover loss instead
-        (
-            "Can you show tell me how land has changed since 2000?",
-            "2000-01-01",
-            "2025-01-01",
-        ),
+ 
     ],
 )
 async def test_queries_return_no_dataset(query, start_date, end_date):
@@ -1081,12 +1061,26 @@ async def test_queries_return_no_dataset(query, start_date, end_date):
 @pytest.mark.parametrize(
     "query,start_date,end_date",
     [
-        # Ambiguous: "natural land loss" could mean SBTN natural lands extent,
-        # global land cover change, or tree cover loss — needs user clarification.
-        (  
+        # Ambiguous: we have natural land extent (2020 snapshot) and general land
+        # cover change, but no natural-land-specific loss or change dataset.
+        (
             "Show the trend in natural land loss over time in Brazil",
             "2015-01-01",
             "2024-12-31",
+        ),
+        # TCL by driver only covers 2001–2025; 2019 alone is within range but
+        # "deforestation by driver" in a single year has no matching dataset.
+        (
+            "Show deforestation by driver in 2019",
+            "2019-01-01",
+            "2019-12-31",
+        ),
+        # We don't have the land cover dataset since 2000, should suggest using
+        # tree cover loss instead
+        (
+            "Can you show tell me how land has changed since 2000?",
+            "2000-01-01",
+            "2025-01-01",
         ),
     ],
 )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -162,16 +162,12 @@ def _query_case_id(param):
             GRASSLANDS,
         ),
         (
-            "Where are the largest intact grassland ecosystems globally?",
+            "Where are the largest grassland ecosystems globally?",
             GRASSLANDS,
         ),
         # Dataset 3 queries (Natural lands) - SBTN baseline for conversion monitoring
         (
             "What percentage of land area in Brazil consists of natural ecosystems according to the 2020 baseline?",
-            NATURAL_LANDS,
-        ),
-        (
-            "Which provinces in Canada have the highest proportion of intact landscapes?",
             NATURAL_LANDS,
         ),
         (
@@ -194,10 +190,6 @@ def _query_case_id(param):
         (
             "I need to track forest plantations harvesting cycles in northern Europe",
             TREE_COVER_LOSS,
-        ),
-        (
-            "Show deforestation by driver in 2019",
-            TREE_COVER_LOSS,  # By driver is total, so we want this query to pick plain TCL
         ),
         # Dataset 5 queries (Tree cover gain) - cumulative forest regrowth
         (
@@ -374,12 +366,6 @@ def _query_case_id(param):
         (
             "How has natural land in Colombia changed from 2015 to 2024?",
             LAND_COVER_CHANGE,
-            "2015-01-01",
-            "2024-12-31",
-        ),
-        (
-            "Show the trend in natural land loss over time in Brazil",
-            TREE_COVER_LOSS,
             "2015-01-01",
             "2024-12-31",
         ),
@@ -1046,4 +1032,53 @@ async def test_pick_dataset_reason_matches_query_language_with_llm_judge(
     assert judged_language == expected_language, (
         f"Expected reason language '{expected_language}', "
         f"but judge returned '{judged_language}'. Reason: {reason}"
+    )
+
+
+@pytest.mark.parametrize(
+    "query,start_date,end_date",
+    [
+        # Ambiguous: we have natural land extent (2020 snapshot) and general land
+        # cover change, but no natural-land-specific loss or change dataset.
+        (
+            "Show the trend in natural land loss over time in Brazil",
+            "2015-01-01",
+            "2024-12-31",
+        ),
+        # TCL by driver only covers 2001–2025; 2019 alone is within range but
+        # "deforestation by driver" in a single year has no matching dataset.
+        (
+            "Show deforestation by driver in 2019",
+            "2019-01-01",
+            "2019-12-31",
+        ),
+        # We don't have the land cover dataset since 2000, should suggest using
+        # tree cover loss instead
+        (
+            "Can you show tell me how land has changed since 2000?",
+            "2000-01-01",
+            "2025-01-01",
+        ),
+    ],
+)
+async def test_queries_return_no_dataset(query, start_date, end_date):
+    tool_call_id = str(uuid.uuid4())
+    tool_call = {
+        "type": "tool_call",
+        "name": "pick_dataset",
+        "id": tool_call_id,
+        "args": {
+            "query": query,
+            "start_date": start_date,
+            "end_date": end_date,
+            "state": dict(),
+            "tool_call_id": tool_call_id,
+        },
+    }
+
+    command = await pick_dataset.ainvoke(tool_call)
+
+    assert command.update.get("dataset") is None, (
+        f"Expected no dataset for query '{query}', "
+        f"but got dataset_id={command.update.get('dataset', {}).get('dataset_id')}"
     )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -76,7 +76,7 @@ def state():
 
 DIST_ALERT = "ecosystem disturbance alerts"
 LAND_COVER_CHANGE = "land cover change"
-GRASSLANDS = "grasslands"
+GRASSLANDS = "natural grasslands"
 NATURAL_LANDS = "natural lands"
 TREE_COVER_LOSS = "tree cover loss"
 TREE_COVER_GAIN = "tree cover gain"
@@ -179,10 +179,6 @@ def _query_case_id(param):
         ),
         (
             "Which country had the most deforestation in 2018?",
-            TREE_COVER_LOSS,
-        ),
-        (
-            "I need to track forest plantations harvesting cycles in northern Europe",
             TREE_COVER_LOSS,
         ),
         # Dataset 5 queries (Tree cover gain) - cumulative forest regrowth


### PR DESCRIPTION
In anticipation of more conflicting datasets like TCL by fires vs. TCL driver wildfire class vs. DIST from fires, introducing what I think @01painadam was saying of returning suggestions to the user if we don't have an appropriate dataset to match their query. This mainly involves adjusting prompting to return null for dataset_id if there's no good match, but I discovered through some other out-of-date prompts like still some places where we say not to analyze dataset globally.

This PR will be a big user experience change, but largely for the better. Now the agent returns much faster and is much clearer when your query can't be answered by our data or requires further input. It provides good suggestions that help users understand what data is available. This also means our dataset YAMLs can focus on providing clear descriptions of use cases instead of too many instruction prompts on how to choose the right dataset. The only downside is it may eat into user's daily prompts more, but the same happens if we don't provide the data the user was looking for.

@01painadam I'd recommend if you have time to load this up locally and play around a bit to see if it feels alright. If we do want to limit it only to fires, we could temporarily include an instruction under "No Match" that says only use this option for fire-related queries. @yellowcap you mentioned about how we might want to try a more skills-based approach, so feel free to comment here if there was an alternative approach you were thinking. 