### PR TITLE
Skill/fao fra

### DIFF
--- a/src/agent/datasets/catalog/fao_fra_2025.yml
+++ b/src/agent/datasets/catalog/fao_fra_2025.yml
@@ -1,0 +1,151 @@
+dataset_id: 10
+dataset_name: FAO Global Forest Resources Assessment (FRA) 2025
+# This dataset is accessed via the `query_fra_data` tool inside the `fao-fra`
+# skill, NOT through the pick_dataset → pull_data pipeline. The flag below is
+# advisory: when `src/ingest/embed_datasets.py` is next rebuilt, it should be
+# updated to honor `pick_dataset_excluded` so FAO does not appear in the
+# pick_dataset RAG candidate set.
+pick_dataset_excluded: true
+context_layers: null
+parameters: null
+variables: []
+tile_url: null
+analytics_api_endpoint: null
+function_usage_notes: ''
+license: CC BY-NC-SA 3.0 IGO
+geographic_coverage: 236 countries and territories (global)
+resolution: National level (country-reported statistics)
+update_frequency: Every 5 years
+content_date: 1990–2025 (reporting years 1990, 2000, 2010, 2015, 2020, 2025)
+start_date: '1990-01-01'
+end_date: '2025-12-31'
+content_date_fixed: true
+keywords:
+  - forest area
+  - deforestation
+  - carbon stock
+  - biomass
+  - growing stock
+  - forest ownership
+  - FAO
+  - FRA
+  - national statistics
+  - country-reported
+
+selection_hints: >-
+  Use for nationally-reported, country-level forest statistics including total
+  forest area, carbon stocks, biomass, growing stock, ownership, designated
+  management, and disturbances. This is FAO-standardised country inventory data,
+  NOT remote-sensing pixel data. It does NOT support sub-national analysis or
+  custom date ranges. Use pull_data / GFW datasets for sub-national or
+  time-series analysis. FRA data is the authoritative source for
+  officially-reported national forest figures, FAO statistics, government
+  inventories, and SDG 15 indicators.
+
+prompt_instructions: >-
+  FRA 2025 is country-reported national inventory data covering 236 countries.
+  Reporting years are 1990, 2000, 2010, 2015, 2020, and 2025 only — no
+  intra-period data exists. Area values are in 1000 ha; biomass/carbon in
+  megatonnes; growing stock in million m³. Always clarify that figures are
+  nationally reported (not satellite-derived). Net forest area change is NOT
+  the same as deforestation — net change = deforestation minus forest expansion.
+  Do not use the term "deforestation" unless the user specifically asks about
+  it; prefer "forest area change" or "net forest loss". Do not compare FRA data
+  with GFW/Hansen tree cover datasets — they use different definitions of
+  "forest". For multi-country comparisons use grouped-bar charts; for trends
+  over time use line charts. For composition breakdowns (ownership, biomass
+  pools, management categories) use stacked-bar or pie charts. Never
+  interpolate between reporting years.
+
+code_instructions: |-
+  DATA RULES:
+  - Reporting years are 1990, 2000, 2010, 2015, 2020, 2025 — always treat year
+    as a categorical axis (not continuous) unless making a trend line
+  - Area values are in 1000 ha — label axes accordingly
+  - Biomass and carbon are in megatonnes — label axes accordingly
+  - Growing stock is in million m³ — label axes accordingly
+  - Drop rows where value is null/NaN
+  - The "variable" column contains the sub-category name (e.g. forestArea,
+    naturallyRegeneratingForest, plantedForest, publicOwnership,
+    privateOwnership)
+  - The "country" column contains the ISO3 code; "aoi_name" contains the
+    readable name
+
+  CHART TYPES BY VARIABLE:
+  - forest_area / forest_area_change → line chart (x=year, y=value, series by
+    variable); use wide format with series_fields for multiple sub-categories
+  - carbon_stock / biomass / growing_stock → stacked-bar (x=year, y=value by
+    pool/component) or line for trend of total
+  - ownership / designated_management / management_objectives → stacked-bar or
+    pie (x=variable/category, y=value for most recent year); if showing trend
+    use line
+  - disturbances / fire → bar chart (x=year, y=value by disturbance type)
+  - forest_area_protected → line chart showing protected area share over time
+  - Multi-country comparisons → grouped-bar (group_field=aoi_name or country)
+
+  DO/DON'T:
+  - DO always order year axis chronologically (1990, 2000, 2010, 2015, 2020,
+    2025)
+  - DO label units on all axes
+  - DO NOT interpolate between reporting years
+  - DO NOT combine FRA data with GFW/remote-sensing data in the same chart
+  - DO NOT describe net forest area change as "deforestation"
+
+presentation_instructions: >-
+  FRA 2025 data is country-reported national inventory data, not
+  satellite-derived. Always note this distinction when presenting results.
+  Reporting years are fixed (1990, 2000, 2010, 2015, 2020, 2025) — do not
+  imply continuous data. Net forest area change ≠ deforestation: net change
+  combines deforestation and forest expansion. Use "forest area change" or
+  "net forest loss/gain" not "deforestation". FAO's definition of "forest"
+  differs from GFW/Hansen "tree cover" — do not compare figures across
+  datasets. Data quality varies by country; some nations have high-quality
+  national inventories while others use modelled estimates. When showing
+  composition data (ownership, biomass pools, management), clarify that
+  categories may not sum to 100% due to rounding or missing sub-categories.
+
+description: >-
+  The FAO Global Forest Resources Assessment (FRA) 2025 is the most
+  comprehensive source of nationally reported forest statistics, covering 236
+  countries and territories. Countries report on 22 standardised tables
+  covering forest extent, characteristics, growing stock, biomass and carbon,
+  designated management, ownership, disturbances, and policies. Data reflects
+  official national inventories and government-reported figures as of 2024,
+  compiled by FAO every five years. FRA 2025 covers reporting years 1990,
+  2000, 2010, 2015, 2020, and 2025.
+
+methodology: >-
+  FRA 2025 data is collected through officially nominated national
+  correspondents who compile standardised country reports. 42 desk studies
+  were prepared for countries that did not submit reports (representing 1.6%
+  of total forest area). Countries used FAO-standardised definitions; detailed
+  terms and definitions are in FAO Working Papers 193 and 194. FRA 2025
+  introduced data tiers to document reliability of forest area estimates.
+  Biomass and carbon conversions use country-specific or default biomass
+  conversion and expansion factors (BCEF). Each FRA cycle is independent —
+  countries may revise previously reported data, so figures should not be
+  compared directly across FRA editions.
+
+cautions: >-
+  Data is self-reported by national correspondents; quality and methodology
+  varies by country. Do not compare FRA editions directly — each FRA is
+  independent and historical data may be revised. FRA "forest" definition
+  differs from GFW/Hansen "tree cover": do not compare or combine with
+  remote-sensing datasets. Reporting years are fixed snapshots (1990, 2000,
+  2010, 2015, 2020, 2025); no intra-period data is available. Net forest area
+  change ≠ deforestation — net change reflects deforestation minus forest
+  expansion. Subregional aggregates may not reproduce exactly from
+  country-level data due to gap-filling for missing time series. Biomass and
+  carbon estimates depend on country-specific or default conversion factors,
+  introducing uncertainty. Disturbance data (insects, disease) covers
+  2002–2020; fire data covers 2007–2019. Non-wood forest product data is
+  incomplete and representativeness varies by region.
+
+providers: >-
+  Food and Agriculture Organization of the United Nations (FAO). 2025. Global
+  Forest Resources Assessment 2025. Rome.
+  https://www.fao.org/forest-resources-assessment
+
+citation: >-
+  FAO. 2025. Global Forest Resources Assessment 2025. Rome. FAO.
+  https://doi.org/10.4060/cd6709en

--- a/src/agent/datasets/handlers/fao_fra_client.py
+++ b/src/agent/datasets/handlers/fao_fra_client.py
@@ -1,0 +1,191 @@
+"""HTTP client for the FAO FRA 2025 public API.
+
+Endpoint used: GET /explorer/data (open-access published data).
+Swagger spec: https://fra-data.fao.org/api-docs/swagger.json
+
+This client is used directly by `src.agent.tools.query_fra_data` rather than
+through `DataPullOrchestrator` — FAO's response shape and request semantics
+(country-level only, fixed reporting years, no parameter sweeps) don't fit the
+analytics-API contract that handler exposes.
+"""
+
+from typing import Optional
+
+import httpx
+
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+BASE_URL = "https://fra-data.fao.org/api"
+ASSESSMENT_NAME = "fra"
+CYCLE_NAME = "2025"
+TIMEOUT_SECONDS = 15.0
+
+# FRA reporting years are fixed snapshots — never interpolate between them.
+FRA_REPORTING_YEARS = [1990, 2000, 2010, 2015, 2020, 2025]
+
+
+class FAOAPIError(Exception):
+    """FAO API is unreachable or returned a server error."""
+
+
+class FAODataNotFoundError(Exception):
+    """The requested country or variable has no data in FRA 2025."""
+
+
+def _build_source_url(iso3: str, table: str) -> str:
+    return (
+        f"{BASE_URL}/explorer/data"
+        f"?assessmentName={ASSESSMENT_NAME}"
+        f"&countryISOs[]={iso3}"
+        f"&tableNames[]={table}"
+    )
+
+
+def _parse_response(
+    body: dict,
+    iso3: str,
+    table: str,
+    year: Optional[int],
+) -> list[dict]:
+    """Flatten the nested FAO response into a list of records.
+
+    Each record: {"year", "variable", "value", "odp", "country"}.
+
+    Raises FAODataNotFoundError when the country or table is absent.
+    """
+    cycle_data = body.get(ASSESSMENT_NAME, {})
+    if not cycle_data:
+        raise FAODataNotFoundError(f"No FRA data returned for {iso3}.")
+    try:
+        cycle_key = next(iter(cycle_data))
+        country_data = cycle_data[cycle_key].get(iso3)
+    except StopIteration as exc:
+        raise FAODataNotFoundError(
+            f"No FRA data returned for {iso3}."
+        ) from exc
+
+    if not country_data:
+        raise FAODataNotFoundError(
+            f"FRA 2025 does not include data for country '{iso3}'. "
+            "Browse available countries at https://fra-data.fao.org."
+        )
+
+    table_data = country_data.get(table)
+    if not table_data:
+        raise FAODataNotFoundError(
+            f"FRA 2025 does not include data for table '{table}' for "
+            f"{iso3}. Browse available variables at https://fra-data.fao.org."
+        )
+
+    records: list[dict] = []
+    for year_str, variables in table_data.items():
+        try:
+            row_year = int(year_str)
+        except ValueError:
+            continue
+
+        if year is not None and row_year != year:
+            continue
+
+        for var_name, node in variables.items():
+            if not isinstance(node, dict):
+                continue
+            raw = node.get("raw")
+            try:
+                value = float(raw) if raw is not None else None
+            except (TypeError, ValueError):
+                value = None
+            records.append(
+                {
+                    "year": row_year,
+                    "variable": var_name,
+                    "value": value,
+                    "odp": bool(node.get("odp", False)),
+                    "country": iso3,
+                }
+            )
+
+    if not records:
+        raise FAODataNotFoundError(
+            f"FRA 2025 returned no data for table '{table}' for {iso3}."
+        )
+
+    return records
+
+
+async def fetch_fra_data(
+    iso3: str,
+    table: str,
+    variables: list[str],
+    year: Optional[int] = None,
+) -> list[dict]:
+    """Fetch FRA 2025 data for a single country and table.
+
+    Args:
+        iso3: Three-letter ISO country code (e.g. "BRA").
+        table: FAO FRA table name (e.g. "extentOfForest").
+        variables: Variable names to filter on; empty means all variables.
+        year: Optional reporting year (must be one of FRA_REPORTING_YEARS).
+
+    Returns:
+        List of records, one per (year, variable) pair.
+
+    Raises:
+        FAOAPIError: network failure, timeout, or HTTP 5xx.
+        FAODataNotFoundError: country or table absent from FRA 2025.
+    """
+    params: dict = {
+        "assessmentName": ASSESSMENT_NAME,
+        "countryISOs[]": iso3,
+        "tableNames[]": table,
+    }
+    if variables:
+        params["variables[]"] = variables
+    if year is not None:
+        params["columns[]"] = str(year)
+
+    logger.info(
+        f"FAO-CLIENT: GET /explorer/data iso={iso3} table={table} year={year}"
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT_SECONDS) as client:
+            response = await client.get(
+                f"{BASE_URL}/explorer/data", params=params
+            )
+    except httpx.TimeoutException as exc:
+        raise FAOAPIError(
+            "The FAO FRA API did not respond in time. Please try again later."
+        ) from exc
+    except httpx.RequestError as exc:
+        raise FAOAPIError(
+            f"Could not reach the FAO FRA API: {exc}. Please try again later."
+        ) from exc
+
+    if response.status_code >= 500:
+        raise FAOAPIError(
+            f"FAO FRA API returned a server error "
+            f"({response.status_code}). Please try again later."
+        )
+    if response.status_code == 401:
+        raise FAOAPIError(
+            "FAO FRA API requires authentication for this endpoint. "
+            "Please contact the GNW team."
+        )
+    if response.status_code >= 400:
+        raise FAODataNotFoundError(
+            f"FAO FRA API returned {response.status_code} for "
+            f"{iso3} / {table}. The country or variable may not be "
+            "available in FRA 2025."
+        )
+
+    try:
+        body = response.json()
+    except Exception as exc:
+        raise FAOAPIError(
+            "FAO FRA API returned an unexpected response format."
+        ) from exc
+
+    return _parse_response(body, iso3, table, year)

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -19,8 +19,13 @@ from src.agent.llms import FALLBACK_MODELS, MODEL
 from src.agent.middleware import SessionContextMiddleware
 from src.agent.skills import all_skills, read_skill
 from src.agent.state import AgentState
-from src.agent.subagents import generate_insights, pick_aoi, pick_dataset
-from src.agent.tools import pull_data
+from src.agent.subagents import (
+    generate_insights,
+    pick_aoi,
+    pick_dataset,
+    pick_fra_variable,
+)
+from src.agent.tools import pull_data, query_fra_data
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
 
@@ -45,13 +50,15 @@ Call tools one at a time, never in parallel.
 
 # Tools (primitives — call when you need them)
 
-- pull_data(query): fetch data for the AOI and dataset currently in state. Run pick_aoi and pick_dataset first.
+- pull_data(query): fetch WRI data for the AOI and dataset currently in state. Run pick_aoi and pick_dataset first.
+- query_fra_data(variable): fetch FAO FRA 2025 country statistics for the variable picked by pick_fra_variable. Used inside the `fao-fra` skill; requires a country-level AOI.
 - read_skill(name): load a skill's full workflow — call it once, after you have committed to using that skill.
 
 # Subagents (call as tools — each does its own reasoning; just forward the user's intent)
 
 - pick_aoi(question): natural-language geocoder. Pass the place request verbatim ("tree cover loss in Pará, Brazil", "the districts of Odisha", "forest loss worldwide"); it extracts, translates and resolves the place — and any subregions — itself. Updates the AOI in state, or returns a clarifying question.
 - pick_dataset(query): dataset-selection subagent. Picks the dataset, context layer and date range that best answer the request. Call it again whenever the user changes the dataset, context layer or parameters.
+- pick_fra_variable(question): FAO FRA variable-selection subagent. Picks one FAO FRA 2025 variable (forest_area, carbon_stock, ownership, …) for the user's request. Used inside the `fao-fra` skill before query_fra_data.
 - generate_insights(query): analyst subagent. Turns pulled data into one chart insight with follow-up suggestions. Requires pull_data to have run first.
 
 # Skills (multi-step recipes)
@@ -68,6 +75,7 @@ Match the request to exactly one row; do not escalate a dataset / AOI / pull req
 - AOI-only (e.g. "zoom to Pará"): call pick_aoi, then stop unless asked for more.
 - Pull-only (e.g. "pull dist alerts in Bern for last 2 weeks"): read `pull-data`, run pick_aoi → pick_dataset → pull_data, then stop. Do not call generate_insights unless the user asked for a chart or analysis.
 - Full analysis (place + topic → chart/insight): read `analyze` and follow that pipeline.
+- National FAO statistics (country-reported forest area, carbon, ownership, biomass — explicit FAO / FRA mentions, "official" forest figures): read `fao-fra` and follow that pipeline. Not for sub-national or custom date ranges — those still go to `analyze`.
 - Capabilities (what you can do, what data exists): read `capabilities`, then answer in your own words — no analysis tools.
 
 # Policy
@@ -79,8 +87,14 @@ Language and format:
 - Reply in the same language as the user's query.
 - Use markdown with blank lines between sections for readability.
 - Never include raw JSON or code blocks in replies (charts render from state).
-- If insights include follow-up suggestions, surface them in your reply.
-- After `generate_insights`, give a 1–2 sentence summary of the chart in your message.
+
+After `generate_insights`, compose the reply in this exact order:
+1. One short intro sentence naming the topic and the active dataset (read the dataset name from the session block).
+2. The chart marker(s) on their own line(s), per the `Chart placement:` instruction in the analyst's ToolMessage — use the exact UUID provided; do not invent UUIDs.
+3. A short interpretation paraphrasing the Key Finding (one paragraph).
+4. Any skill-defined caveats or methodology notes (from the active skill body).
+5. Data sources: cite `state["dataset"]["citation"]` as a markdown link, plus any extra links the active skill body specifies.
+6. The follow-up suggestions, as short bullets.
 
 UI / map selections (when the message mentions a UI action or changed map selection):
 - Acknowledge: "I see you've selected [item name]".
@@ -92,7 +106,9 @@ UI / map selections (when the message mentions a UI action or changed map select
 tools = [
     pick_aoi,
     pick_dataset,
+    pick_fra_variable,
     pull_data,
+    query_fra_data,
     generate_insights,
     read_skill,
 ]

--- a/src/agent/skills/skills_md/fao-fra.md
+++ b/src/agent/skills/skills_md/fao-fra.md
@@ -1,0 +1,35 @@
+---
+name: fao-fra
+description: National-scale FAO Forest Resources Assessment 2025 statistics for any country — forest area, carbon, biomass, growing stock, ownership, management, disturbances, fire, restoration. The `pick_fra_variable` subagent enumerates the exact variables.
+when_to_use: User asks about country-reported / officially-reported / FAO forest statistics, total national forest area, nationally-reported carbon stock or biomass, forest ownership or management categories, area affected by fire / pests / disease, degraded forest, or forest restoration. Not for sub-national analysis or custom date ranges — use `analyze` or `pull-data` for those.
+---
+
+# Workflow
+
+1. `pick_aoi` — pass the user's request verbatim. The geocoder resolves the place; for FAO data the resolved AOI MUST be country-level GADM (`subtype=country`). One or more countries is fine.
+2. `pick_fra_variable` — pass the user's request verbatim. The subagent picks exactly one FAO FRA variable (e.g. `forest_area`, `carbon_stock`, `ownership`). Read the chosen variable name from its ToolMessage.
+3. `query_fra_data(variable=...)` — pass the variable name from step 2. Country ISO3 codes come from the AOI selection automatically. Add `year=` only if the user asked for a specific reporting year.
+4. `generate_insights` — produce one chart insight from the pulled FAO statistics.
+
+Call tools **one at a time**, never in parallel.
+
+# Capability limits
+
+- **Country-level only.** FAO FRA 2025 carries national aggregates. If `pick_aoi` returns a sub-national area (state, district, KBA, WDPA, custom geometry), `query_fra_data` will redirect — when this happens, tell the user FAO data is country-only and offer the `analyze` skill (GFW remote-sensing) for sub-national questions.
+- **Fixed reporting years.** Data exists only for 1990, 2000, 2010, 2015, 2020, 2025. Do not promise continuous time-series. If the user asks for an arbitrary date range, explain the limitation and either drop to the nearest reporting year or redirect to `analyze`.
+- **One variable per call.** If the user asks about multiple unrelated FAO variables (e.g. "carbon and ownership"), run the recipe twice — once per variable.
+
+# Wording
+
+- Use "forest area change" or "net forest loss/gain" — **never** call FAO net change "deforestation". Net change = deforestation minus expansion.
+- FAO's "forest" definition differs from GFW/Hansen "tree cover" — do not compare or combine figures across the two datasets in the same answer or chart.
+- Note that FRA data is country-reported (not satellite-derived) when relevant.
+- Do not interpolate between reporting years; do not compare across FRA editions (each edition is independent).
+
+# Citations
+
+The dataset's official citation (DOI) is added automatically per the orchestrator policy (from `state["dataset"]["citation"]`). In addition, link to the [FAO FRA Data Explorer](https://fra-data.fao.org) when pointing the user at where to browse more data for the same country or variable. The [FAO Global Forest Resources Assessment programme page](https://www.fao.org/forest-resources-assessment) is optional context — include it when the user asks about methodology or coverage rather than specific numbers.
+
+# Routing back out
+
+Exit to `analyze` (or `pull-data`) when the AOI is sub-national, the user wants a custom date range, or the request is pixel-level / near-real-time disturbance — FRA only covers country-level fixed reporting years.

--- a/src/agent/subagents/__init__.py
+++ b/src/agent/subagents/__init__.py
@@ -8,12 +8,18 @@ orchestrator's tool calls simple and the domain logic behind a clean boundary.
 from src.agent.subagents.analyst import Analyst, generate_insights
 from src.agent.subagents.pick_aoi import Geocoder, pick_aoi
 from src.agent.subagents.pick_dataset import DatasetSelector, pick_dataset
+from src.agent.subagents.pick_fra_variable import (
+    VariableSelector,
+    pick_fra_variable,
+)
 
 __all__ = [
     "Analyst",
     "DatasetSelector",
     "Geocoder",
+    "VariableSelector",
     "generate_insights",
     "pick_aoi",
     "pick_dataset",
+    "pick_fra_variable",
 ]

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import re
 from typing import Annotated, Dict, List, Optional
 
@@ -361,6 +362,21 @@ class Analyst:
 
         logger.info(f"Generated chart data with {len(result.chart_data)} rows")
 
+        # 5.1. SANITIZE NaN → None for JSON safety.
+        # Postgres JSONB rejects NaN ("invalid input syntax for type json"),
+        # and the same value also fails JSON.parse on the wire to the FE.
+        # Replace any NaN-like floats with None — the FE / Recharts already
+        # handle null y-values by gapping the line / hiding the bar.
+        def _json_safe(v):
+            if isinstance(v, float) and math.isnan(v):
+                return None
+            return v
+
+        result.chart_data = [
+            {k: _json_safe(v) for k, v in row.items()}
+            for row in result.chart_data
+        ]
+
         # 5.5. REPLACE CSV PATHS: Replace CSV file paths with URL-based loading
         # This makes the code blocks runnable in any environment.
         for part in result.parts:
@@ -455,6 +471,32 @@ class Analyst:
 
         insight_id = insight_ids[0] if insight_ids else ""
         logger.info(f"Persisted insight to DB: {insight_id}")
+
+        # Tell the orchestrator how to surface these charts inline.
+        # The frontend (chatStore) splits assistant text on
+        # /\[Chart\s+[a-f0-9-]+\]/gi markers and slots queued chart
+        # widgets in positionally (Nth marker → Nth widget). Without
+        # markers the chart card appears in a separate message block
+        # below the prose; with markers it renders inline.
+        n_charts = len(result.insight.charts)
+        if insight_id and n_charts:
+            marker = f"[Chart {insight_id}]"
+            if n_charts == 1:
+                placement = (
+                    f"Place {marker} in your reply at the point where "
+                    "the chart should appear inline."
+                )
+            else:
+                placement = (
+                    f"Place {marker} {n_charts} times in your reply, "
+                    "one at each point where a chart should appear "
+                    "inline. Charts are injected positionally — the "
+                    "Nth marker becomes the Nth chart."
+                )
+            tool_message += (
+                "\n\nChart placement: "
+                f"{placement} Use this exact UUID; do not invent UUIDs."
+            )
 
         updated_state = {
             "insight_id": insight_id,

--- a/src/agent/subagents/pick_fra_variable/__init__.py
+++ b/src/agent/subagents/pick_fra_variable/__init__.py
@@ -1,0 +1,19 @@
+from src.agent.subagents.pick_fra_variable.tool import (
+    VariableSelection,
+    VariableSelector,
+    pick_fra_variable,
+)
+from src.agent.subagents.pick_fra_variable.variable_map import (
+    VALID_VARIABLES,
+    VARIABLE_MAP,
+    render_variable_table,
+)
+
+__all__ = [
+    "VALID_VARIABLES",
+    "VARIABLE_MAP",
+    "VariableSelection",
+    "VariableSelector",
+    "pick_fra_variable",
+    "render_variable_table",
+]

--- a/src/agent/subagents/pick_fra_variable/prompts.py
+++ b/src/agent/subagents/pick_fra_variable/prompts.py
@@ -1,0 +1,35 @@
+"""System prompt for the FAO-FRA variable-selection subagent.
+
+The orchestrator passes the user's request verbatim. This prompt asks the
+small LLM to pick exactly one variable name from `VARIABLE_MAP`. The full
+variable table is rendered into the prompt at construction time so there is
+one source of truth.
+"""
+
+VARIABLE_SELECTOR_PROMPT = """You are the FAO FRA 2025 variable selector for
+Global Nature Watch. Given the user's request, pick exactly ONE variable name
+from the table below — the variable that best answers what the user is
+actually asking about.
+
+# Rules
+
+- Return one of the variable names verbatim. Do not invent new names.
+- Prefer the most specific variable that fits the request. If the user asks
+  about "primary forest" in particular, prefer `forest_area` (its variable
+  filter includes primaryForest); do not fall back to `forest_characteristics`
+  unless they are asking about composition.
+- If the user asks about "deforestation" or "forest loss" at country level,
+  pick `forest_area_change` (net change). Note: net change ≠ deforestation;
+  the wording is handled downstream — your job is the variable.
+- If the user asks about "carbon" without specifying pools, pick
+  `carbon_stock`. Only pick `carbon_stock_by_pool` when they ask about pools
+  explicitly.
+- If the user asks about "ownership" pick `ownership`. For management
+  intent, pick `management_objectives`. For who manages public forests, pick
+  `management_rights`.
+- If the user query is ambiguous between two variables, pick the broader one.
+
+# Variables
+
+{variable_table}
+"""

--- a/src/agent/subagents/pick_fra_variable/tool.py
+++ b/src/agent/subagents/pick_fra_variable/tool.py
@@ -1,0 +1,156 @@
+"""FAO-FRA variable-selection subagent.
+
+The orchestrator exposes this as the `pick_fra_variable` tool. Internally it
+runs one small-LLM call against `VARIABLE_MAP` to pick the single best
+variable for the user's question. The chosen variable name is surfaced via
+ToolMessage and emitted as a progress event; the orchestrator then passes it
+into `query_fra_data`.
+
+The selection is intentionally returned in the ToolMessage rather than stashed
+in state — the subagent stays pure and re-callable, and the orchestrator can
+re-pick if the first attempt looks wrong downstream.
+"""
+
+from typing import Annotated, Optional
+
+from langchain_core.messages import ToolMessage
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.types import Command
+from pydantic import BaseModel, Field
+
+from src.agent.llms import SMALL_MODEL
+from src.agent.subagents.pick_fra_variable.prompts import (
+    VARIABLE_SELECTOR_PROMPT,
+)
+from src.agent.subagents.pick_fra_variable.variable_map import (
+    VALID_VARIABLES,
+    VARIABLE_MAP,
+    render_variable_table,
+)
+from src.agent.subagents.progress import emit_progress
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+# The set of accepted variable names is the keys of VARIABLE_MAP; mirroring
+# that into a runtime-validated string field is enough — using a Literal
+# would require regenerating the type each time VARIABLE_MAP changes.
+class VariableSelection(BaseModel):
+    """Structured output: the single best FAO FRA variable name."""
+
+    variable: str = Field(
+        description=(
+            "The chosen FAO FRA variable name. MUST be one of the names "
+            "from the variables table; do not invent new names."
+        )
+    )
+    reason: str = Field(
+        description=(
+            "One short sentence explaining the choice, in the language of "
+            "the user's query."
+        )
+    )
+
+
+VARIABLE_SELECTION_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        ("system", VARIABLE_SELECTOR_PROMPT),
+        ("user", "{question}"),
+    ]
+)
+
+
+class VariableSelector:
+    """Picks the FAO FRA variable that best answers the user's question.
+
+    Mirrors the shape of `DatasetSelector` (subagents/pick_dataset). One
+    LLM call against the variable table; returns a `Command` carrying a
+    ToolMessage with the chosen variable name + reason. The orchestrator
+    extracts the variable from that message when it next calls
+    `query_fra_data`.
+    """
+
+    async def resolve(
+        self,
+        question: str,
+        tool_call_id: Optional[str] = None,
+    ) -> Command:
+        logger.info("PICK-FRA-VARIABLE: resolving query")
+        selection = await self._select(question)
+
+        if selection.variable not in VARIABLE_MAP:
+            # The LLM hallucinated a name. Surface the closed set so the
+            # orchestrator can re-call with a hint.
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            content=(
+                                f"'{selection.variable}' is not a recognised "
+                                "FAO FRA variable. Valid options are: "
+                                f"{', '.join(VALID_VARIABLES)}."
+                            ),
+                            tool_call_id=tool_call_id,
+                            status="success",
+                            response_metadata={"msg_type": "human_feedback"},
+                        )
+                    ]
+                }
+            )
+
+        entry = VARIABLE_MAP[selection.variable]
+        emit_progress(
+            "pick_fra_variable",
+            "selected",
+            f"Selected variable: {selection.variable}",
+        )
+
+        tool_message = (
+            f"Selected FAO FRA variable: {selection.variable} "
+            f"({entry['unit']}) — {entry['description']}. "
+            f"Reason: {selection.reason}\n\n"
+            f'Call query_fra_data with variable="{selection.variable}" '
+            "next."
+        )
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(tool_message, tool_call_id=tool_call_id)
+                ]
+            }
+        )
+
+    async def _select(self, question: str) -> VariableSelection:
+        chain = VARIABLE_SELECTION_PROMPT | SMALL_MODEL.with_structured_output(
+            VariableSelection
+        )
+        return await chain.ainvoke(
+            {
+                "question": question,
+                "variable_table": render_variable_table(),
+            }
+        )
+
+
+@tool("pick_fra_variable")
+async def pick_fra_variable(
+    question: str,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Pick the FAO FRA 2025 variable that best answers the user's request.
+
+    Pass the user's question verbatim — e.g. "How much carbon does Brazil's
+    forest store?" or "Forest ownership in Sweden". This subagent picks
+    exactly one variable (carbon_stock, ownership, forest_area, …) by
+    running its own LLM step against the typed VARIABLE_MAP.
+
+    Use this BEFORE calling query_fra_data. The selected variable name is
+    in the ToolMessage; pass it to query_fra_data as the `variable` arg.
+
+    Country-level only — pick_aoi must have resolved a country (gadm
+    subtype=country) first.
+    """
+    return await VariableSelector().resolve(question, tool_call_id)

--- a/src/agent/subagents/pick_fra_variable/variable_map.py
+++ b/src/agent/subagents/pick_fra_variable/variable_map.py
@@ -1,0 +1,208 @@
+"""User-facing FAO FRA variable names → FAO API table + variable identifiers.
+
+Table names correspond to the `tableNames[]` enum in the FAO FRA API Swagger
+spec (https://fra-data.fao.org/api-docs/swagger.json). Empty `variables: []`
+means "fetch all variables for this table" — the FAO API supports this
+natively.
+
+Adding a variable here is the one-line change to expose a new FRA family to
+the agent; the fetch / parse path in `fao_fra_client` is unchanged.
+"""
+
+VARIABLE_MAP: dict[str, dict] = {
+    # --- Forest Extent ---
+    "forest_area": {
+        "table": "extentOfForest",
+        "variables": [
+            "forestArea",
+            "naturallyRegeneratingForest",
+            "plantedForest",
+            "primaryForest",
+        ],
+        "unit": "1000 ha",
+        "description": (
+            "Total forest area by category (naturally regenerating, planted, "
+            "primary)"
+        ),
+    },
+    "forest_area_change": {
+        "table": "forestAreaChange",
+        "variables": [],
+        "unit": "1000 ha/year",
+        "description": (
+            "Annual net forest area change by period (deforestation minus "
+            "expansion)"
+        ),
+    },
+    "forest_area_protected": {
+        "table": "forestAreaWithinProtectedAreas",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Forest area within nationally designated protected areas"
+        ),
+    },
+    "permanent_forest_estate": {
+        "table": "areaOfPermanentForestEstate",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Area designated as permanent forest estate (legally protected "
+            "from conversion)"
+        ),
+    },
+    # --- Forest Characteristics ---
+    "forest_characteristics": {
+        "table": "forestCharacteristics",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Forest composition breakdown including mangroves, bamboo, "
+            "rubber plantations, and other specific forest categories"
+        ),
+    },
+    # --- Growing Stock ---
+    "growing_stock": {
+        "table": "growingStockTotal",
+        "variables": ["total"],
+        "unit": "million m3",
+        "description": "Total growing stock volume",
+    },
+    "growing_stock_per_ha": {
+        "table": "growingStockAvg",
+        "variables": [],
+        "unit": "m3/ha",
+        "description": "Average growing stock volume per hectare",
+    },
+    "growing_stock_composition": {
+        "table": "growingStockComposition2025",
+        "variables": [],
+        "unit": "million m3",
+        "description": "Growing stock by species/genus composition",
+    },
+    # --- Biomass ---
+    "biomass": {
+        "table": "biomassStockTotal",
+        "variables": ["total"],
+        "unit": "megatonnes",
+        "description": (
+            "Total biomass stock (aboveground, belowground, deadwood combined)"
+        ),
+    },
+    "biomass_per_ha": {
+        "table": "biomassStockAvg",
+        "variables": [],
+        "unit": "tonnes/ha",
+        "description": "Average biomass stock per hectare",
+    },
+    # --- Carbon Stock ---
+    "carbon_stock": {
+        "table": "carbonStockTotal",
+        "variables": ["total"],
+        "unit": "megatonnes CO2e",
+        "description": (
+            "Total carbon stock across all five pools (aboveground biomass, "
+            "belowground biomass, dead wood, litter, soil organic matter)"
+        ),
+    },
+    "carbon_stock_by_pool": {
+        "table": "carbonStockTotal",
+        "variables": [],
+        "unit": "megatonnes CO2e",
+        "description": "Carbon stock broken down by all five pools",
+    },
+    "carbon_stock_soil_depth": {
+        "table": "carbonStockSoilDepth",
+        "variables": [],
+        "unit": "megatonnes CO2e",
+        "description": "Soil organic carbon stock by depth layer",
+    },
+    # --- Designated Management & Ownership ---
+    "management_objectives": {
+        "table": "primaryDesignatedManagementObjective",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Forest area by primary designated management objective "
+            "(production, multiple use, conservation, protection, social "
+            "services)"
+        ),
+    },
+    "designated_management": {
+        "table": "totalAreaWithDesignatedManagementObjective",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Total forest area with a formally designated management objective"
+        ),
+    },
+    "management_rights": {
+        "table": "holderOfManagementRights",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Forest area by holder of management rights to public forests "
+            "(government, private, communities, indigenous peoples)"
+        ),
+    },
+    "ownership": {
+        "table": "forestOwnership",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Forest area by ownership category (public, private, "
+            "community/indigenous, other)"
+        ),
+    },
+    # --- Disturbances ---
+    "disturbances": {
+        "table": "disturbances",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Forest area affected by insects, disease, and severe weather "
+            "events (2002–2020)"
+        ),
+    },
+    "fire": {
+        "table": "areaAffectedByFire",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": ("Forest area affected by fire (2007–2019)"),
+    },
+    "degraded_forest": {
+        "table": "degradedForest2025",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Area of degraded forest (based on national definitions, 2025 "
+            "cycle)"
+        ),
+    },
+    # --- Restoration ---
+    "forest_restoration": {
+        "table": "forestRestoration",
+        "variables": [],
+        "unit": "1000 ha",
+        "description": (
+            "Forest area under restoration or reforestation activities"
+        ),
+    },
+}
+
+# Sorted list of valid variable names — used in error messages, the
+# Literal typing for the subagent's output schema, and the table rendered
+# into the variable-selector prompt.
+VALID_VARIABLES = sorted(VARIABLE_MAP.keys())
+
+
+def render_variable_table() -> str:
+    """Render `VARIABLE_MAP` as a compact text table for the LLM prompt.
+
+    Format: `- name (unit) — description`. One line per variable so the
+    selector LLM can read it at a glance.
+    """
+    return "\n".join(
+        f"- {name} ({entry['unit']}) — {entry['description']}"
+        for name, entry in sorted(VARIABLE_MAP.items())
+    )

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -1,5 +1,7 @@
 from .pull_data import pull_data
+from .query_fra_data import query_fra_data
 
 __all__ = [
     "pull_data",
+    "query_fra_data",
 ]

--- a/src/agent/tools/query_fra_data.py
+++ b/src/agent/tools/query_fra_data.py
@@ -1,0 +1,216 @@
+"""Primitive tool that fetches FAO FRA 2025 statistics.
+
+Sits in the orchestrator's tool list alongside `pull_data`. Bypasses
+`pick_dataset` deliberately — the FAO YAML is in `datasets/catalog/` so
+`generate_insights` still receives FAO-specific `presentation_instructions`
+/ `code_instructions` / `cautions`, but it gets there via `state["dataset"]`
+that this tool writes itself.
+
+This is a primitive (no internal LLM step). Variable selection happens in the
+`pick_fra_variable` subagent earlier in the recipe; this tool only validates
+that the variable name is known and forwards it to the FAO client.
+"""
+
+from typing import Annotated, Dict, Optional
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from src.agent.datasets.config import DATASETS
+from src.agent.datasets.handlers import fao_fra_client
+from src.agent.datasets.handlers.fao_fra_client import (
+    FAOAPIError,
+    FAODataNotFoundError,
+)
+from src.agent.subagents.pick_fra_variable.variable_map import (
+    VALID_VARIABLES,
+    VARIABLE_MAP,
+)
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Load the FAO FRA dataset config once at import time so generate_insights
+# receives presentation_instructions / code_instructions / cautions.
+_FRA_DATASET_CONFIG: Optional[dict] = next(
+    (
+        d
+        for d in DATASETS
+        if d.get("dataset_name", "").startswith(
+            "FAO Global Forest Resources Assessment"
+        )
+    ),
+    None,
+)
+
+
+def _human_feedback_message(
+    content: str, tool_call_id: Optional[str]
+) -> ToolMessage:
+    """Build a recoverable ToolMessage — surfaces to the user but not as
+    an agent error, so the orchestrator can keep the conversation going."""
+    return ToolMessage(
+        content=content,
+        tool_call_id=tool_call_id,
+        status="success",
+        response_metadata={"msg_type": "human_feedback"},
+    )
+
+
+def _country_aois(state: Dict) -> list[dict]:
+    """Filter the current AOI selection down to country-level GADM AOIs.
+
+    FAO FRA 2025 only carries country-level statistics. If pick_aoi
+    resolved to a sub-national area (state, district, KBA, …), this
+    returns an empty list and the caller redirects.
+    """
+    selection = state.get("aoi_selection") or {}
+    aois = selection.get("aois") or []
+    return [
+        a
+        for a in aois
+        if a.get("source") == "gadm" and a.get("subtype") == "country"
+    ]
+
+
+@tool("query_fra_data")
+async def query_fra_data(
+    variable: str,
+    state: Annotated[Dict, InjectedState],
+    year: Optional[int] = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Fetch FAO FRA 2025 statistics for the variable picked by
+    `pick_fra_variable`.
+
+    Country-level data only. Reads ISO3 country codes from the AOI selection
+    set by `pick_aoi` (gadm subtype=country). If the AOI is sub-national,
+    the tool returns a redirect message — do not retry with a different
+    `variable`; instead call `pick_aoi` to resolve a country, or fall back
+    to the GFW pipeline via the `analyze` skill.
+
+    Args:
+        variable: One of the FAO FRA variable names (e.g. "forest_area",
+            "carbon_stock", "ownership"). Pass the exact value
+            `pick_fra_variable` selected.
+        year: Optional FRA reporting year (1990, 2000, 2010, 2015, 2020,
+            or 2025). Omit to return all available years.
+    """
+    if variable not in VARIABLE_MAP:
+        return Command(
+            update={
+                "messages": [
+                    _human_feedback_message(
+                        f"'{variable}' is not a recognised FAO FRA variable."
+                        f" Valid options: {', '.join(VALID_VARIABLES)}. "
+                        "Call pick_fra_variable to choose one.",
+                        tool_call_id,
+                    )
+                ]
+            }
+        )
+
+    aois = _country_aois(state)
+    if not aois:
+        return Command(
+            update={
+                "messages": [
+                    _human_feedback_message(
+                        "FAO FRA 2025 only carries country-level statistics. "
+                        "Resolve a country first (call pick_aoi with the "
+                        "country name), or use the `analyze` skill for "
+                        "sub-national / remote-sensing analysis.",
+                        tool_call_id,
+                    )
+                ]
+            }
+        )
+
+    aoi_names = [a["name"] for a in aois]
+    var_config = VARIABLE_MAP[variable]
+    table = var_config["table"]
+    variables_filter = var_config["variables"]
+    unit = var_config["unit"]
+
+    logger.info(
+        f"QUERY-FRA-DATA: variable={variable} table={table} "
+        f"year={year} aois={aoi_names}"
+    )
+
+    all_records: list[dict] = []
+    errors: list[str] = []
+    for aoi in aois:
+        iso3 = aoi["src_id"]
+        try:
+            # Call via the module so tests can monkeypatch
+            # `fao_fra_client.fetch_fra_data` at one unambiguous location.
+            records = await fao_fra_client.fetch_fra_data(
+                iso3=iso3,
+                table=table,
+                variables=variables_filter,
+                year=year,
+            )
+        except FAODataNotFoundError as exc:
+            errors.append(str(exc))
+            continue
+        except FAOAPIError as exc:
+            errors.append(str(exc))
+            continue
+
+        for rec in records:
+            rec["aoi_name"] = aoi["name"]
+        all_records.extend(records)
+
+    if not all_records:
+        error_text = " | ".join(errors) if errors else "No data returned."
+        return Command(
+            update={
+                "messages": [_human_feedback_message(error_text, tool_call_id)]
+            }
+        )
+
+    year_label = str(year) if year else "all reporting years"
+    source_url = fao_fra_client._build_source_url(aois[0]["src_id"], table)
+
+    tool_message_parts = [
+        f"Retrieved FAO FRA 2025 data for {', '.join(aoi_names)}: "
+        f"{var_config['description']} ({year_label})."
+    ]
+    if errors:
+        tool_message_parts.append(
+            "Note: some AOIs had no data: " + " | ".join(errors)
+        )
+
+    tool_message = ToolMessage(
+        content=" ".join(tool_message_parts),
+        tool_call_id=tool_call_id,
+    )
+
+    statistics_entry = {
+        "dataset_name": (
+            f"FAO FRA 2025 — {var_config['description']} ({unit})"
+        ),
+        "start_date": "1990-01-01",
+        "end_date": "2025-12-31",
+        "source_url": source_url,
+        # FAO responses are small (country × years × variables); keep
+        # data inline so the analyst's inline-data path handles it
+        # directly without a second fetch.
+        "data": all_records,
+        "aoi_names": aoi_names,
+        "parameters": None,
+        "context_layer": None,
+    }
+
+    update: dict = {
+        "statistics": [statistics_entry],
+        "messages": [tool_message],
+    }
+
+    if _FRA_DATASET_CONFIG is not None:
+        update["dataset"] = _FRA_DATASET_CONFIG
+
+    return Command(update=update)

--- a/tests/evals/test_fao_routing.py
+++ b/tests/evals/test_fao_routing.py
@@ -1,0 +1,126 @@
+"""Routing evals for the `fao-fra` skill.
+
+These tests run the orchestrator (real LLM) on a small set of queries and
+inspect the first tool call to verify the skill router behaves as the SPEC
+expects:
+
+- Positive cases — queries about country-reported / FAO / FRA statistics —
+  must load the `fao-fra` skill via `read_skill`.
+- Negative cases — sub-national, time-series, or non-FAO queries — must NOT
+  load `fao-fra`.
+
+Routing is the orchestrator's first decision. The first AIMessage either:
+- Calls `read_skill(name=...)` and we assert which skill it loaded, or
+- Calls a primitive directly (`pick_aoi`, `pick_dataset`, …) — counts as
+  "not fao-fra" for the negative cases.
+
+These hit live LLMs (`MODEL` / `SMALL_MODEL`). Run them on demand; treat
+them as gating signal, not unit tests.
+
+TODO — Judge-based golden Q&A evals:
+  Build a `tests/evals/test_fao_golden.py` parametrised over ~20 country /
+  variable pairs. For each pair, run the full skill (pick_aoi →
+  pick_fra_variable → query_fra_data → generate_insights) and use an
+  LLM judge (same shape as `tests/evals/judge.py`) to score: (i) correct
+  variable selected, (ii) reporting years preserved (no interpolation),
+  (iii) wording avoids "deforestation" for net change, (iv) FAO FRA 2025
+  citation present in the insight. Include ~5 adversarial prompts
+  (ambiguous variable, sub-national + FAO mention, custom date range +
+  FAO mention) to verify the redirect paths.
+"""
+
+import uuid
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+
+from src.agent.graph import fetch_zeno_anonymous
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+# --- Cases -----------------------------------------------------------------
+
+# Each positive case must route to the `fao-fra` skill on the first turn.
+POSITIVE_CASES: list[str] = [
+    "How much forest does Brazil have officially according to FAO?",
+    "What does FAO FRA say about forest area in Indonesia?",
+    "Show forest ownership categories in Sweden.",
+    "Carbon stocks in DRC from FRA 2025.",
+    "How has planted forest area changed in Vietnam between 1990 and 2025?",
+    "What share of Brazil's forest is primary forest in the FAO report?",
+]
+
+# Each negative case must NOT route to the `fao-fra` skill. They are
+# variously: sub-national, time-series, non-administrative geography, or
+# clearly remote-sensing.
+NEGATIVE_CASES: list[str] = [
+    "Tree cover loss in Pará between 2020 and 2024.",
+    "Show me deforestation alerts in the Amazon basin.",
+    "Tree cover percentage in São Paulo state.",
+    "Forest loss by driver in Indonesia in 2023.",
+    "What can you do?",  # capabilities
+]
+
+
+# --- Helpers ---------------------------------------------------------------
+
+
+async def _first_tool_calls(query: str) -> list[dict]:
+    """Run one orchestrator turn and return the first AIMessage's tool calls.
+
+    Returns an empty list if the orchestrator answered with plain text
+    (no tool call) — that's a valid routing for some capability questions.
+    """
+    agent = await fetch_zeno_anonymous(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": str(uuid.uuid4())}}
+    input_state = {"messages": [HumanMessage(content=query)]}
+
+    async for mode, payload in agent.astream(
+        input_state,
+        config=config,
+        stream_mode=["updates"],
+        subgraphs=False,
+    ):
+        if mode != "updates":
+            continue
+        for _node, update in payload.items():
+            for msg in update.get("messages", []) or []:
+                if isinstance(msg, AIMessage) and msg.tool_calls:
+                    return msg.tool_calls
+    return []
+
+
+def _skill_name(tool_calls: list[dict]) -> str | None:
+    """Return the skill name from the first `read_skill` call, if any."""
+    for call in tool_calls:
+        if call.get("name") == "read_skill":
+            return (call.get("args") or {}).get("name")
+    return None
+
+
+# --- Positive cases — must route to fao-fra --------------------------------
+
+
+@pytest.mark.parametrize("query", POSITIVE_CASES)
+async def test_routes_to_fao_fra_skill(query: str):
+    tool_calls = await _first_tool_calls(query)
+    skill = _skill_name(tool_calls)
+    assert skill == "fao-fra", (
+        f"Expected `fao-fra` skill for query {query!r}; "
+        f"first tool calls were {tool_calls!r}"
+    )
+
+
+# --- Negative cases — must NOT route to fao-fra ----------------------------
+
+
+@pytest.mark.parametrize("query", NEGATIVE_CASES)
+async def test_does_not_route_to_fao_fra(query: str):
+    tool_calls = await _first_tool_calls(query)
+    skill = _skill_name(tool_calls)
+    assert skill != "fao-fra", (
+        f"Did NOT expect `fao-fra` skill for query {query!r}; "
+        f"first tool calls were {tool_calls!r}"
+    )

--- a/tests/unit/agent/datasets/handlers/test_fao_fra_client.py
+++ b/tests/unit/agent/datasets/handlers/test_fao_fra_client.py
@@ -1,0 +1,272 @@
+"""Unit tests for the FAO FRA HTTP client.
+
+No network. All HTTP is stubbed with httpx.MockTransport so the parsing,
+URL composition, and error mapping are exercised end-to-end.
+"""
+
+import httpx
+import pytest
+
+from src.agent.datasets.handlers import fao_fra_client
+from src.agent.datasets.handlers.fao_fra_client import (
+    FRA_REPORTING_YEARS,
+    FAOAPIError,
+    FAODataNotFoundError,
+    _build_source_url,
+    _parse_response,
+    fetch_fra_data,
+)
+
+
+def _ok_payload(iso3: str, table: str) -> dict:
+    """Realistic minimal FAO response covering three reporting years."""
+    return {
+        "fra": {
+            "2025": {
+                iso3: {
+                    table: {
+                        "1990": {
+                            "forestArea": {
+                                "raw": "493538.00",
+                                "odp": True,
+                            },
+                            "plantedForest": {
+                                "raw": "5210.00",
+                                "odp": False,
+                            },
+                        },
+                        "2000": {
+                            "forestArea": {
+                                "raw": "483418.00",
+                                "odp": True,
+                            },
+                        },
+                        "2025": {
+                            "forestArea": {
+                                "raw": "462700.00",
+                                "odp": True,
+                            },
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+
+def _patch_transport(monkeypatch, handler):
+    """Replace httpx.AsyncClient with one driven by a MockTransport."""
+    transport = httpx.MockTransport(handler)
+    original_init = httpx.AsyncClient.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+
+
+# ---------------------------------------------------------------------------
+# Constants and URL builder
+# ---------------------------------------------------------------------------
+
+
+def test_reporting_years_are_the_five_fra_snapshots():
+    assert FRA_REPORTING_YEARS == [1990, 2000, 2010, 2015, 2020, 2025]
+
+
+def test_build_source_url_includes_iso3_and_table():
+    url = _build_source_url("BRA", "extentOfForest")
+    assert url.startswith("https://fra-data.fao.org/api/explorer/data?")
+    assert "countryISOs[]=BRA" in url
+    assert "tableNames[]=extentOfForest" in url
+    assert "assessmentName=fra" in url
+
+
+# ---------------------------------------------------------------------------
+# _parse_response — happy path and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_parse_response_flattens_years_and_variables():
+    records = _parse_response(
+        _ok_payload("BRA", "extentOfForest"),
+        iso3="BRA",
+        table="extentOfForest",
+        year=None,
+    )
+    # 3 years × variables present in each year (2 + 1 + 1)
+    assert len(records) == 4
+    sample = next(
+        r
+        for r in records
+        if r["year"] == 1990 and r["variable"] == "forestArea"
+    )
+    assert sample["value"] == pytest.approx(493538.0)
+    assert sample["odp"] is True
+    assert sample["country"] == "BRA"
+
+
+def test_parse_response_filters_by_year():
+    records = _parse_response(
+        _ok_payload("BRA", "extentOfForest"),
+        iso3="BRA",
+        table="extentOfForest",
+        year=2000,
+    )
+    assert [r["year"] for r in records] == [2000]
+
+
+def test_parse_response_raises_on_missing_assessment():
+    with pytest.raises(FAODataNotFoundError):
+        _parse_response({}, iso3="BRA", table="extentOfForest", year=None)
+
+
+def test_parse_response_raises_on_missing_country():
+    body = {"fra": {"2025": {"USA": {"extentOfForest": {}}}}}
+    with pytest.raises(FAODataNotFoundError):
+        _parse_response(body, iso3="BRA", table="extentOfForest", year=None)
+
+
+def test_parse_response_raises_on_missing_table():
+    body = {"fra": {"2025": {"BRA": {"someOtherTable": {}}}}}
+    with pytest.raises(FAODataNotFoundError):
+        _parse_response(body, iso3="BRA", table="extentOfForest", year=None)
+
+
+def test_parse_response_coerces_non_numeric_value_to_none():
+    body = {
+        "fra": {
+            "2025": {
+                "BRA": {
+                    "extentOfForest": {
+                        "1990": {
+                            "forestArea": {"raw": "not-a-number", "odp": False}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    records = _parse_response(
+        body, iso3="BRA", table="extentOfForest", year=None
+    )
+    assert records[0]["value"] is None
+
+
+def test_parse_response_skips_non_year_keys_and_non_dict_nodes():
+    body = {
+        "fra": {
+            "2025": {
+                "BRA": {
+                    "extentOfForest": {
+                        "notAYear": {
+                            "forestArea": {"raw": "1.0", "odp": False}
+                        },
+                        "2010": {
+                            "forestArea": "not-a-dict",
+                            "plantedForest": {"raw": "12.5", "odp": False},
+                        },
+                    }
+                }
+            }
+        }
+    }
+    records = _parse_response(
+        body, iso3="BRA", table="extentOfForest", year=None
+    )
+    # The non-year key is skipped; the non-dict variable is skipped; only
+    # the plantedForest record survives.
+    assert len(records) == 1
+    assert records[0]["variable"] == "plantedForest"
+
+
+# ---------------------------------------------------------------------------
+# fetch_fra_data — HTTP behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_fra_data_returns_records_on_200(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json=_ok_payload("BRA", "extentOfForest"))
+
+    _patch_transport(monkeypatch, handler)
+    records = await fetch_fra_data(
+        "BRA", "extentOfForest", variables=["forestArea"], year=None
+    )
+
+    assert len(records) >= 1
+    assert "countryISOs%5B%5D=BRA" in captured["url"]
+    assert "tableNames%5B%5D=extentOfForest" in captured["url"]
+    assert "variables%5B%5D=forestArea" in captured["url"]
+
+
+async def test_fetch_fra_data_passes_columns_for_year_filter(monkeypatch):
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json=_ok_payload("BRA", "extentOfForest"))
+
+    _patch_transport(monkeypatch, handler)
+    # year=2000 is present in _ok_payload so the response yields records
+    await fetch_fra_data("BRA", "extentOfForest", variables=[], year=2000)
+    assert "columns%5B%5D=2000" in captured["url"]
+
+
+async def test_fetch_fra_data_raises_api_error_on_5xx(monkeypatch):
+    _patch_transport(
+        monkeypatch, lambda req: httpx.Response(503, text="service down")
+    )
+    with pytest.raises(FAOAPIError):
+        await fetch_fra_data("BRA", "extentOfForest", variables=[])
+
+
+async def test_fetch_fra_data_raises_api_error_on_401(monkeypatch):
+    _patch_transport(monkeypatch, lambda req: httpx.Response(401))
+    with pytest.raises(FAOAPIError):
+        await fetch_fra_data("BRA", "extentOfForest", variables=[])
+
+
+async def test_fetch_fra_data_raises_not_found_on_4xx(monkeypatch):
+    _patch_transport(monkeypatch, lambda req: httpx.Response(404))
+    with pytest.raises(FAODataNotFoundError):
+        await fetch_fra_data("XXX", "extentOfForest", variables=[])
+
+
+async def test_fetch_fra_data_raises_api_error_on_timeout(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("slow")
+
+    _patch_transport(monkeypatch, handler)
+    with pytest.raises(FAOAPIError):
+        await fetch_fra_data("BRA", "extentOfForest", variables=[])
+
+
+async def test_fetch_fra_data_raises_api_error_on_request_error(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route")
+
+    _patch_transport(monkeypatch, handler)
+    with pytest.raises(FAOAPIError):
+        await fetch_fra_data("BRA", "extentOfForest", variables=[])
+
+
+async def test_fetch_fra_data_raises_api_error_on_unparseable_body(
+    monkeypatch,
+):
+    _patch_transport(
+        monkeypatch,
+        lambda req: httpx.Response(200, content=b"not-json"),
+    )
+    with pytest.raises(FAOAPIError):
+        await fetch_fra_data("BRA", "extentOfForest", variables=[])
+
+
+def test_module_constants_match_documented_base_url():
+    assert fao_fra_client.BASE_URL == "https://fra-data.fao.org/api"
+    assert fao_fra_client.ASSESSMENT_NAME == "fra"
+    assert fao_fra_client.CYCLE_NAME == "2025"

--- a/tests/unit/agent/tools/fao_fra/test_pick_fra_variable.py
+++ b/tests/unit/agent/tools/fao_fra/test_pick_fra_variable.py
@@ -1,0 +1,164 @@
+"""Unit tests for the FAO-FRA variable-selection subagent.
+
+No LLM calls — the structured-output chain is monkeypatched to return canned
+`VariableSelection` instances. We assert (a) the chosen variable surfaces in
+the ToolMessage, (b) hallucinated variable names produce a recoverable
+ToolMessage rather than crashing, and (c) the rendered prompt covers every
+key in `VARIABLE_MAP`.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agent.subagents.pick_fra_variable import (
+    VARIABLE_MAP,
+    VariableSelection,
+    VariableSelector,
+    pick_fra_variable,
+)
+from src.agent.subagents.pick_fra_variable.variable_map import (
+    VALID_VARIABLES,
+    render_variable_table,
+)
+
+# ---------------------------------------------------------------------------
+# Variable map structural shape
+# ---------------------------------------------------------------------------
+
+
+def test_variable_map_has_required_fields_for_every_entry():
+    required = {"table", "variables", "unit", "description"}
+    for name, entry in VARIABLE_MAP.items():
+        missing = required - entry.keys()
+        assert not missing, f"{name} missing fields: {missing}"
+        assert isinstance(entry["table"], str) and entry["table"]
+        assert isinstance(entry["variables"], list)
+        assert isinstance(entry["unit"], str) and entry["unit"]
+        assert isinstance(entry["description"], str) and entry["description"]
+
+
+def test_valid_variables_matches_map_keys():
+    assert VALID_VARIABLES == sorted(VARIABLE_MAP.keys())
+
+
+def test_render_variable_table_includes_every_variable():
+    rendered = render_variable_table()
+    for name in VARIABLE_MAP:
+        assert name in rendered
+    for entry in VARIABLE_MAP.values():
+        assert entry["description"] in rendered
+
+
+# ---------------------------------------------------------------------------
+# VariableSelector — happy path and hallucination handling
+# ---------------------------------------------------------------------------
+
+
+class _StubChain:
+    """Tiny async-invocable that returns a canned VariableSelection."""
+
+    def __init__(self, selection: VariableSelection) -> None:
+        self._selection = selection
+        self.calls: list[dict] = []
+
+    async def ainvoke(self, payload: dict) -> VariableSelection:
+        self.calls.append(payload)
+        return self._selection
+
+
+def _install_stub_chain(
+    monkeypatch, selection: VariableSelection
+) -> _StubChain:
+    """Monkeypatch SMALL_MODEL.with_structured_output to yield our stub chain."""
+    from src.agent.subagents.pick_fra_variable import tool as subagent_mod
+
+    stub = _StubChain(selection)
+    chain_mock = MagicMock()
+    chain_mock.__or__ = MagicMock(return_value=stub)
+
+    structured_model = MagicMock()
+    structured_model.ainvoke = stub.ainvoke
+
+    fake_small_model = MagicMock()
+    fake_small_model.with_structured_output = MagicMock(
+        return_value=structured_model
+    )
+    monkeypatch.setattr(subagent_mod, "SMALL_MODEL", fake_small_model)
+    # The selector also uses the `|` operator on the prompt template. We
+    # patch the chain construction directly by returning `stub` from
+    # `__or__` on the template; simpler is to patch `_select` to call the
+    # stub directly.
+    return stub
+
+
+@pytest.fixture
+def stub_chain(monkeypatch):
+    """Helper that patches the selector's `_select` to return a canned value."""
+
+    def _patch(variable: str, reason: str = "test reason") -> None:
+        from src.agent.subagents.pick_fra_variable import tool as subagent_mod
+
+        async def fake_select(self, question):
+            return VariableSelection(variable=variable, reason=reason)
+
+        monkeypatch.setattr(
+            subagent_mod.VariableSelector, "_select", fake_select
+        )
+
+    return _patch
+
+
+async def test_resolve_returns_tool_message_with_variable_name(stub_chain):
+    stub_chain("carbon_stock", reason="user asked about carbon")
+    cmd = await VariableSelector().resolve(
+        "How much carbon does Brazil's forest store?",
+        tool_call_id="tc-1",
+    )
+    messages = cmd.update["messages"]
+    assert len(messages) == 1
+    content = messages[0].content
+    assert "carbon_stock" in content
+    assert "megatonnes CO2e" in content  # unit surfaced from VARIABLE_MAP
+    assert "Reason: user asked about carbon" in content
+    assert messages[0].tool_call_id == "tc-1"
+
+
+async def test_resolve_handles_hallucinated_variable_name(stub_chain):
+    stub_chain("not_a_real_variable")
+    cmd = await VariableSelector().resolve(
+        "Some question", tool_call_id="tc-2"
+    )
+    messages = cmd.update["messages"]
+    assert len(messages) == 1
+    content = messages[0].content
+    assert "not a recognised FAO FRA variable" in content
+    # All valid variables should be listed in the error so the orchestrator
+    # can retry with a hint.
+    assert "carbon_stock" in content
+    assert "forest_area" in content
+
+
+async def test_resolve_does_not_write_to_state(stub_chain):
+    """The chosen variable lives in the ToolMessage only — not in state.
+    Re-callability depends on this; if the variable were persisted, a
+    second call would fight with the first."""
+    stub_chain("forest_area")
+    cmd = await VariableSelector().resolve("Forest area?", tool_call_id="t")
+    assert set(cmd.update.keys()) == {"messages"}
+
+
+async def test_tool_wrapper_invokes_resolver(stub_chain):
+    stub_chain("ownership", reason="ownership query")
+    cmd = await pick_fra_variable.ainvoke(
+        {
+            "type": "tool_call",
+            "name": "pick_fra_variable",
+            "id": "tc-3",
+            "args": {
+                "question": "Who owns Sweden's forests?",
+                "tool_call_id": "tc-3",
+            },
+        }
+    )
+    assert "ownership" in cmd.update["messages"][0].content

--- a/tests/unit/agent/tools/fao_fra/test_query_fra_data.py
+++ b/tests/unit/agent/tools/fao_fra/test_query_fra_data.py
@@ -1,0 +1,286 @@
+"""Unit tests for the `query_fra_data` primitive tool.
+
+No network. `fetch_fra_data` is monkeypatched so we exercise: state reading
+(country filter + redirect), unknown-variable redirect, multi-country
+aggregation, partial-failure aggregation, and the dataset-injection contract
+that lets `generate_insights` pick up FAO `presentation_instructions`.
+"""
+
+from unittest.mock import AsyncMock
+
+from src.agent.tools.query_fra_data import query_fra_data
+
+
+def _make_state(*aois: dict) -> dict:
+    return {"aoi_selection": {"name": "test", "aois": list(aois)}}
+
+
+def _country(name: str, iso3: str) -> dict:
+    return {
+        "name": name,
+        "src_id": iso3,
+        "source": "gadm",
+        "subtype": "country",
+    }
+
+
+def _records_for(iso3: str) -> list[dict]:
+    return [
+        {
+            "year": 1990,
+            "variable": "forestArea",
+            "value": 100.0,
+            "odp": True,
+            "country": iso3,
+        },
+        {
+            "year": 2025,
+            "variable": "forestArea",
+            "value": 95.0,
+            "odp": True,
+            "country": iso3,
+        },
+    ]
+
+
+async def _invoke(args: dict) -> dict:
+    """Helper: invoke the @tool wrapper and return the Command.update dict."""
+    cmd = await query_fra_data.ainvoke(
+        {
+            "type": "tool_call",
+            "name": "query_fra_data",
+            "id": args.get("tool_call_id", "tc"),
+            "args": {"tool_call_id": "tc", **args},
+        }
+    )
+    return cmd.update
+
+
+# ---------------------------------------------------------------------------
+# Variable validation
+# ---------------------------------------------------------------------------
+
+
+async def test_unknown_variable_returns_human_feedback(monkeypatch):
+    update = await _invoke(
+        {
+            "variable": "not_a_real_variable",
+            "state": _make_state(_country("Brazil", "BRA")),
+        }
+    )
+    msg = update["messages"][0]
+    assert msg.response_metadata["msg_type"] == "human_feedback"
+    assert "not a recognised FAO FRA variable" in msg.content
+    # No statistics or dataset on the redirect path
+    assert "statistics" not in update
+    assert "dataset" not in update
+
+
+# ---------------------------------------------------------------------------
+# AOI gating — country-level only
+# ---------------------------------------------------------------------------
+
+
+async def test_no_aoi_returns_redirect(monkeypatch):
+    update = await _invoke({"variable": "forest_area", "state": _make_state()})
+    msg = update["messages"][0]
+    assert "country-level" in msg.content
+    assert "statistics" not in update
+
+
+async def test_sub_national_aoi_returns_redirect(monkeypatch):
+    state_aoi = {
+        "name": "Amazonas",
+        "src_id": "BRA.4_1",
+        "source": "gadm",
+        "subtype": "state",
+    }
+    update = await _invoke(
+        {"variable": "forest_area", "state": _make_state(state_aoi)}
+    )
+    msg = update["messages"][0]
+    assert "country-level" in msg.content
+    assert "statistics" not in update
+
+
+async def test_non_gadm_aoi_returns_redirect(monkeypatch):
+    kba_aoi = {
+        "name": "Yellowstone KBA",
+        "src_id": "12345",
+        "source": "kba",
+        "subtype": "kba",
+    }
+    update = await _invoke(
+        {"variable": "forest_area", "state": _make_state(kba_aoi)}
+    )
+    assert "country-level" in update["messages"][0].content
+
+
+# ---------------------------------------------------------------------------
+# Happy path — single country
+# ---------------------------------------------------------------------------
+
+
+async def test_single_country_fetches_and_writes_statistics(monkeypatch):
+    fake_fetch = AsyncMock(return_value=_records_for("BRA"))
+    monkeypatch.setattr(
+        "src.agent.datasets.handlers.fao_fra_client.fetch_fra_data", fake_fetch
+    )
+
+    update = await _invoke(
+        {
+            "variable": "forest_area",
+            "state": _make_state(_country("Brazil", "BRA")),
+        }
+    )
+
+    fake_fetch.assert_awaited_once()
+    call = fake_fetch.await_args.kwargs
+    assert call["iso3"] == "BRA"
+    assert call["table"] == "extentOfForest"
+    assert call["year"] is None
+
+    stats = update["statistics"]
+    assert len(stats) == 1
+    entry = stats[0]
+    assert entry["aoi_names"] == ["Brazil"]
+    assert entry["context_layer"] is None
+    assert entry["parameters"] is None
+    # Data is inline (FAO responses are small)
+    assert entry["data"]
+    # Records carry the human-readable aoi_name added by the tool
+    assert all(r.get("aoi_name") == "Brazil" for r in entry["data"])
+
+    # dataset is injected so generate_insights picks up FAO instructions
+    assert update["dataset"]["dataset_id"] == 10
+
+
+async def test_year_arg_propagates_to_client(monkeypatch):
+    fake_fetch = AsyncMock(return_value=_records_for("BRA"))
+    monkeypatch.setattr(
+        "src.agent.datasets.handlers.fao_fra_client.fetch_fra_data", fake_fetch
+    )
+
+    await _invoke(
+        {
+            "variable": "forest_area",
+            "year": 2020,
+            "state": _make_state(_country("Brazil", "BRA")),
+        }
+    )
+    assert fake_fetch.await_args.kwargs["year"] == 2020
+
+
+# ---------------------------------------------------------------------------
+# Multi-country aggregation
+# ---------------------------------------------------------------------------
+
+
+async def test_multi_country_concatenates_records(monkeypatch):
+    side_effects = {"BRA": _records_for("BRA"), "IDN": _records_for("IDN")}
+
+    async def fake_fetch(iso3, table, variables, year=None):
+        return side_effects[iso3]
+
+    monkeypatch.setattr(
+        "src.agent.datasets.handlers.fao_fra_client.fetch_fra_data", fake_fetch
+    )
+
+    update = await _invoke(
+        {
+            "variable": "forest_area",
+            "state": _make_state(
+                _country("Brazil", "BRA"),
+                _country("Indonesia", "IDN"),
+            ),
+        }
+    )
+
+    entry = update["statistics"][0]
+    assert entry["aoi_names"] == ["Brazil", "Indonesia"]
+    aoi_names_in_data = {r["aoi_name"] for r in entry["data"]}
+    assert aoi_names_in_data == {"Brazil", "Indonesia"}
+
+
+# ---------------------------------------------------------------------------
+# Partial failure — one country missing data, others succeed
+# ---------------------------------------------------------------------------
+
+
+async def test_partial_failure_yields_data_plus_note(monkeypatch):
+    from src.agent.datasets.handlers.fao_fra_client import (
+        FAODataNotFoundError,
+    )
+
+    async def fake_fetch(iso3, table, variables, year=None):
+        if iso3 == "XXX":
+            raise FAODataNotFoundError("no data for XXX")
+        return _records_for(iso3)
+
+    monkeypatch.setattr(
+        "src.agent.datasets.handlers.fao_fra_client.fetch_fra_data", fake_fetch
+    )
+
+    update = await _invoke(
+        {
+            "variable": "forest_area",
+            "state": _make_state(
+                _country("Brazil", "BRA"),
+                _country("Nowhereland", "XXX"),
+            ),
+        }
+    )
+
+    # Statistics populated from the successful country
+    entry = update["statistics"][0]
+    assoc_names = {r["aoi_name"] for r in entry["data"]}
+    assert assoc_names == {"Brazil"}
+    # The failing country surfaced in the tool message
+    msg = update["messages"][0].content
+    assert "no data for XXX" in msg
+
+
+async def test_total_failure_returns_human_feedback(monkeypatch):
+    from src.agent.datasets.handlers.fao_fra_client import FAOAPIError
+
+    async def fake_fetch(iso3, table, variables, year=None):
+        raise FAOAPIError("FAO API is down")
+
+    monkeypatch.setattr(
+        "src.agent.datasets.handlers.fao_fra_client.fetch_fra_data", fake_fetch
+    )
+
+    update = await _invoke(
+        {
+            "variable": "forest_area",
+            "state": _make_state(_country("Brazil", "BRA")),
+        }
+    )
+    msg = update["messages"][0]
+    assert msg.response_metadata["msg_type"] == "human_feedback"
+    assert "FAO API is down" in msg.content
+    assert "statistics" not in update
+
+
+# ---------------------------------------------------------------------------
+# Dataset injection contract
+# ---------------------------------------------------------------------------
+
+
+async def test_dataset_is_injected_for_generate_insights(monkeypatch):
+    fake_fetch = AsyncMock(return_value=_records_for("BRA"))
+    monkeypatch.setattr(
+        "src.agent.datasets.handlers.fao_fra_client.fetch_fra_data", fake_fetch
+    )
+
+    update = await _invoke(
+        {
+            "variable": "carbon_stock",
+            "state": _make_state(_country("Brazil", "BRA")),
+        }
+    )
+    dataset = update["dataset"]
+    # generate_insights reads these three keys from state["dataset"]
+    assert dataset["code_instructions"]
+    assert dataset["presentation_instructions"]
+    assert dataset["cautions"]

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -20,12 +20,14 @@ def test_load_skills():
     assert "explore" not in names
 
 
-def test_skills_registry_is_the_three_recipes():
-    # The registry holds exactly the three orchestrator recipes. Tool-owned
-    # guidance and the analyst's executor/wording prompts live elsewhere.
+def test_skills_registry_is_the_expected_recipes():
+    # The registry holds the orchestrator recipes loaded from
+    # skills_md/*.md. Tool-owned guidance and the analyst's
+    # executor/wording prompts live elsewhere.
     assert {s.name for s in all_skills()} == {
         "analyze",
         "capabilities",
+        "fao-fra",
         "pull-data",
     }
 


### PR DESCRIPTION
### Summary 
Adds a new `fao-fra` skill that answers country-reported national forest statistics questions from the FAO Global Forest Resources Assessment 2025 (21 variables across 7 families, all 236 countries).

<img width="1918" height="993" alt="Screenshot 2026-05-25 at 12 16 01" src="https://github.com/user-attachments/assets/c7fdec94-e55d-4e7a-ac03-cc74f09e7749" />

Routing: orchestrator loads the skill on FAO-shaped queries → `pick_aoi` → `pick_fra_variable` (new subagent) → `query_fra_data` (new primitive tool) → `generate_insights`.

Three composability rules were lifted out of the skill into higher layers during integration so they benefit every chart-producing flow, not just FAO:

1. **Universal reply structure** (orchestrator policy): after
   `generate_insights`, compose reply as intro → chart markers → insight
→ skill caveats → sources → follow-ups.
2. **Universal dataset citation** (orchestrator policy): cite `state["dataset"]["citation"]` as a markdown link automatically. Every dataset YAML already has a `citation` field; FAO's skill body now only adds the FRA-unique extras (Data Explorer, Programme page).
3. **Chart-marker convention** (analyst ToolMessage): the analyst emits a `Chart placement:` instruction with the actual `insight_id` so the orchestrator can place `[Chart <uuid>]` markers for inline FE injection.

Also includes a universal analyst hardening (`NaN → None` sanitization before JSONB persist — fixes `asyncpg.InvalidTextRepresentationError` on sparse FAO time-series).

## Layering

| Concern | Lives in |
|---|---|
| Routing | Orchestrator system prompt (`graph.py`) |
| Universal reply structure & citation | Orchestrator policy |
| Chart-marker convention + UUID | Analyst ToolMessage |
| FRA workflow / capability limits / wording | `fao-fra` skill body |
| FRA-unique citation extras (Data Explorer, Programme) | `fao-fra` skill body |
| Variable-selection reasoning | `pick_fra_variable` subagent |
| FAO API contract | `fao_fra_client` + `query_fra_data` |

## What changed

**New (FAO-specific):**
- `src/agent/skills/skills_md/fao-fra.md` — skill recipe
- `src/agent/subagents/pick_fra_variable/{__init__,tool,prompts,variable_map}.py` — variable-selection subagent (21 vars)
- `src/agent/tools/query_fra_data.py` — primitive tool (no internal LLM)
- `src/agent/datasets/catalog/fao_fra_2025.yml` — dataset config
- `src/agent/datasets/handlers/fao_fra_client.py` — async httpx client

**Modified (universal):**
- `src/agent/graph.py` — register new tool/subagent; one Routing row; universal reply structure + universal citation rule in `# Policy`
- `src/agent/subagents/analyst/tool.py` — NaN sanitization + `Chart placement:` instruction with `insight_id`
- `src/agent/{tools,subagents}/__init__.py` — re-exports
- `tests/unit/agent/tools/skills/test_skills.py` — registry now 4 skills

**Tests (new):**
- `tests/unit/agent/datasets/handlers/test_fao_fra_client.py` (18)
- `tests/unit/agent/tools/fao_fra/test_pick_fra_variable.py` (7)
- `tests/unit/agent/tools/fao_fra/test_query_fra_data.py` (10)
- `tests/evals/test_fao_routing.py` (11 cases, live LLM)