### PR TITLE
PZB-922: Client disconnect handling

### DIFF
--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -11,6 +11,7 @@ from src.api.data_models import ThreadOrm
 from src.api.schemas import ChatRequest, QuotaModel, UserModel
 from src.api.services.chat import generate_thread_name, stream_chat
 from src.api.services.quota import check_quota, enforce_quota
+from src.api.streaming import guarded_stream
 from src.api.user_profile_configs.sectors import SECTOR_ROLES, SECTORS
 from src.shared.database import get_session_from_pool_dependency
 from src.shared.logging_config import bind_request_logging_context, get_logger
@@ -93,14 +94,17 @@ async def chat(
                 ]
 
         return StreamingResponse(
-            stream_chat(
-                query=chat_request.query,
-                user_persona=chat_request.user_persona,
-                thread_id=thread_id,
-                ui_context=chat_request.ui_context,
-                ui_action_only=chat_request.ui_action_only,
-                langfuse_metadata=langfuse_metadata,
-                user=user_dict,
+            guarded_stream(
+                request,
+                stream_chat(
+                    query=chat_request.query,
+                    user_persona=chat_request.user_persona,
+                    thread_id=thread_id,
+                    ui_context=chat_request.ui_context,
+                    ui_action_only=chat_request.ui_action_only,
+                    langfuse_metadata=langfuse_metadata,
+                    user=user_dict,
+                ),
             ),
             media_type="application/x-ndjson",
             headers=headers if headers else None,

--- a/src/api/streaming.py
+++ b/src/api/streaming.py
@@ -1,0 +1,18 @@
+"""Streaming utilities for FastAPI endpoints."""
+
+from fastapi import Request
+
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def guarded_stream(request: Request, gen):
+    try:
+        async for chunk in gen:
+            if await request.is_disconnected():
+                logger.info("Client disconnected, aborting stream")
+                break
+            yield chunk
+    finally:
+        await gen.aclose()

--- a/tests/api/test_deployment_phases.py
+++ b/tests/api/test_deployment_phases.py
@@ -17,8 +17,11 @@ async def test_chat_requires_authentication(client):
 @pytest.mark.asyncio
 async def test_chat_allows_authenticated_user(client, auth_override):
     auth_override("test-user-wri")
-    with patch("src.api.routers.chat.stream_chat") as mock_stream:
-        mock_stream.return_value = iter([b'{"response": "Hello!"}\n'])
+
+    async def _mock_stream(*args, **kwargs):
+        yield b'{"response": "Hello!"}\n'
+
+    with patch("src.api.routers.chat.stream_chat", _mock_stream):
         response = await client.post(
             "/api/chat",
             json={"query": "Hello", "thread_id": "auth-thread"},

--- a/tests/api/test_quotas.py
+++ b/tests/api/test_quotas.py
@@ -37,8 +37,10 @@ async def test_chat_quota_headers_for_authenticated_user(client):
         mock_client = mock_client_class.return_value.__aenter__.return_value
         mock_client.get.return_value = mock_rw_api_response("Test User")
 
-        with patch("src.api.routers.chat.stream_chat") as mock_stream:
-            mock_stream.return_value = iter([b'{"response": "Hello!"}\n'])
+        async def _mock_stream(*args, **kwargs):
+            yield b'{"response": "Hello!"}\n'
+
+        with patch("src.api.routers.chat.stream_chat", _mock_stream):
             response = await client.post(
                 "/api/chat",
                 json={"query": "Test message", "thread_id": "quota-thread"},

--- a/tests/unit/test_guarded_stream.py
+++ b/tests/unit/test_guarded_stream.py
@@ -1,0 +1,112 @@
+"""Unit tests for guarded_stream disconnect handling."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.api.streaming import guarded_stream
+
+
+def make_request(*, disconnected_after: int = 999) -> MagicMock:
+    """Return a mock Request whose is_disconnected() flips True after N calls."""
+    request = MagicMock()
+    call_count = 0
+
+    async def is_disconnected():
+        nonlocal call_count
+        call_count += 1
+        return call_count > disconnected_after
+
+    request.is_disconnected = is_disconnected
+    return request
+
+
+class TrackingGen:
+    """Async-iterable wrapper that records whether aclose() was called."""
+
+    def __init__(self, *chunks):
+        self._chunks = chunks
+        self.aclose_called = False
+        self._gen = self._source()
+
+    async def _source(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._gen.__anext__()
+
+    async def aclose(self):
+        self.aclose_called = True
+        await self._gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_yields_all_chunks_when_connected():
+    request = make_request(disconnected_after=999)
+    gen = TrackingGen("a", "b", "c")
+
+    chunks = [chunk async for chunk in guarded_stream(request, gen)]
+
+    assert chunks == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_stops_on_disconnect():
+    """Disconnects after the first chunk; subsequent chunks must not be yielded."""
+    request = make_request(disconnected_after=1)
+    gen = TrackingGen("a", "b", "c")
+
+    chunks = [chunk async for chunk in guarded_stream(request, gen)]
+
+    assert chunks == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_aclose_called_on_disconnect():
+    """The upstream generator must be closed when the client disconnects."""
+    request = make_request(disconnected_after=1)
+    gen = TrackingGen("a", "b", "c")
+
+    async for _ in guarded_stream(request, gen):
+        pass
+
+    assert gen.aclose_called
+
+
+@pytest.mark.asyncio
+async def test_aclose_called_on_normal_completion():
+    """The upstream generator must be closed even when the stream finishes normally."""
+    request = make_request(disconnected_after=999)
+    gen = TrackingGen("a", "b")
+
+    async for _ in guarded_stream(request, gen):
+        pass
+
+    assert gen.aclose_called
+
+
+@pytest.mark.asyncio
+async def test_empty_generator():
+    request = make_request()
+    gen = TrackingGen()
+
+    chunks = [chunk async for chunk in guarded_stream(request, gen)]
+
+    assert chunks == []
+    assert gen.aclose_called
+
+
+@pytest.mark.asyncio
+async def test_disconnect_before_first_chunk():
+    """If already disconnected before yielding anything, no chunks come through."""
+    request = make_request(disconnected_after=0)
+    gen = TrackingGen("a", "b", "c")
+
+    chunks = [chunk async for chunk in guarded_stream(request, gen)]
+
+    assert chunks == []
+    assert gen.aclose_called


### PR DESCRIPTION
## What

  When a client disconnects mid-stream (tab closed, user hits stop), the LangGraph graph was continuing to run and
  burning tokens. The StreamingResponse generator kept executing inside the server with no way to abort it.

##   Abort on client disconnect



  A new guarded_stream wrapper (src/api/streaming.py) polls request.is_disconnected() between each yielded chunk. When  the client is gone, it breaks out of the loop and calls aclose() on the upstream generator, which propagates a GeneratorExit into LangGraph and cancels the in-flight LLM call.

##   Why now

  This is a cheap change that has outsized operational impact — disconnect handling prevents wasted LLM spend on  abandoned sessions, and will allow a stop button imlementation that is purely client side.

##   Changes

```

  ┌───────────────────────────────────┬──────────────────────────────────────────────┐
  │               File                │                    Change                    │
  ├───────────────────────────────────┼──────────────────────────────────────────────┤
  │ src/api/streaming.py              │ New — guarded_stream async generator         │
  ├───────────────────────────────────┼──────────────────────────────────────────────┤
  │ src/api/routers/chat.py           │ Wrap stream_chat with guarded_stream         │
    ├───────────────────────────────────┼──────────────────────────────────────────────┤
  │ tests/unit/test_guarded_stream.py │ 6 unit tests for disconnect/aclose behaviour │
    └───────────────────────────────────┴──────────────────────────────────────────────┘

```

##   Testing

```
uv run pytest tests/unit/test_guarded_stream.py tests/unit/test_stream_chat.py -v
```