### PR TITLE
bump version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.5.22"
+version = "2026.5.26"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"


### PR DESCRIPTION
Missed bumping version in previous PR so now `lint` on `main` is failing.

Am not sure why that didn't error on that PR.

Also, @yellowcap I see we've moved to a version like `2026.05.22` - are we thinking of versioning by date or so? What happens when we have multiple releases on the same day?