### PR TITLE
Avoid version bump on main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,15 @@ repos:
             if not pyproject.exists():
                 raise SystemExit(0)
 
+            branch_result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if branch_result.returncode == 0 and branch_result.stdout.strip() == "main":
+                raise SystemExit(0)
+
             today = datetime.now(UTC).date()
             calver = f"{today.year}.{today.month}.{today.day}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.5.26"
+version = "2026.5.26.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"


### PR DESCRIPTION
## Summary

The `bump-calver` pre-commit hook bumps the version when `local_version == main_version`, which is the right signal on feature branches (“this PR hasn’t bumped yet”). After merge, that same condition is true on `main`, so the hook was trying to bump again on every commit and lint run there.

This adds an early exit: if the current branch is `main`, the hook skips and leaves the version unchanged.

## Problem

The hook treats `local_version == main_version` as “needs a bump.” That works on PR branches, but on `main` after merge both versions match by design — so the hook would bump again unnecessarily.

## Fix

Skip the hook when `git rev-parse --abbrev-ref HEAD` returns `main`:

```python
branch_result = subprocess.run(
    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
    check=False,
    capture_output=True,
    text=True,
)
if branch_result.returncode == 0 and branch_result.stdout.strip() == "main":
    raise SystemExit(0)
```

## Behavior

| Branch | `local_version == main_version` | Result |
|--------|----------------------------------|--------|
| Feature branch | Yes | Bump as before |
| Feature branch | No | Pass (already bumped) |
| `main` | Yes | Pass (same version is OK) |
| `main` | No | Pass (no bump on main) |
