### PR TITLE
Pull out dataset instructions and repeat on top and bottom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.1.1"
+version = "2026.6.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.2"
+version = "2026.6.2.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -51,6 +51,8 @@ selection_hints: 'Best dataset for near-real-time vegetation disturbance across 
   about recent disturbance, clearing, or conversion alerts. Driver context layer (LDACS) classifies alerts into likely causes — updated quarterly, covers most recent
   12 months, classification NOT available for last 90 days. For historical or long-term tree cover change, prefer Tree Cover
   Loss instead. For driver attribution of tree cover loss specifically, prefer Tree Cover Loss by Dominant Driver.
+  Apply context layers when the query targets a specific ecosystem: grasslands for natural grasslands/shrublands/savannas,
+  natural_lands for natural land classes, driver for likely causes of disturbance, land_cover for specific land cover classes.
 
   '
 code_instructions: "CHART TYPES: - Recent trends over time → line chart (x=alert month, y=area in hectares) - Distribution\

--- a/src/agent/datasets/catalog/global_land_cover.yml
+++ b/src/agent/datasets/catalog/global_land_cover.yml
@@ -53,7 +53,8 @@ prompt_instructions: 'This dataset contains land-cover class snapshots in 2015 a
   '
 selection_hints: 'Best dataset for land cover composition or land cover CHANGE between 2015 and 2024. Reports pixel-level
   class transitions at 30m resolution, measured in hectares. Only shows start (2015) and end (2024) states — NOT an annual
-  timeseries. Does NOT capture classes that remained the same between 2015 and 2024. Classes: bare ground & sparse vegetation,
+  timeseries. Does NOT capture classes that remained the same between 2015 and 2024. Can provide extent of classes in either 2015
+  or 2024. Classes: bare ground & sparse vegetation,
   short vegetation, tree cover, wetlands, water, snow/ice, cropland, cultivated grasslands, built-up land. For tree cover
   loss specifically, prefer Tree Cover Loss dataset. For natural/semi-natural grasslands specifically, prefer the Grasslands
   dataset.

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -59,7 +59,7 @@ async def _get_retriever():
             embedding=embeddings,
         )
         retriever_cache = index.as_retriever(
-            search_type="similarity", search_kwargs={"k": 3}
+            search_type="similarity", search_kwargs={"k": 5}
         )
     return retriever_cache
 
@@ -85,6 +85,25 @@ async def rag_candidate_datasets(query: str, k=3):
     return pd.DataFrame(candidate_datasets)
 
 
+SELECTION_RULES = """- Only choose a dataset if it can usefully answer ALL parts of the user's question.
+- If no candidate can do that, return dataset_id as null and explain in the reason field what data we do have and why it falls short.
+- Use the selection hints above — they are the primary signal for which dataset fits.
+- Select a context layer when its description matches the query (pre-filtered to the AOI).
+- Select parameters only when relevant; use only values listed in the dataset.
+- If the user specifies a date range or time granularity (e.g. monthly, a specific year, daily alerts), only select a dataset if it genuinely supports that.
+- Pick the most granular dataset/context layer/parameters that matches the query.
+- Keep explanations concise. Do not reference dataset IDs."""
+
+
+def _format_selection_hints(candidate_datasets: pd.DataFrame) -> str:
+    lines = []
+    for _, row in candidate_datasets.iterrows():
+        hints = (row.get("selection_hints") or "").strip()
+        if hints:
+            lines.append(f"{row['dataset_name']}:\n{hints}")
+    return "\n\n".join(lines) if lines else ""
+
+
 async def select_best_dataset(
     query: str,
     candidate_datasets: pd.DataFrame,
@@ -97,45 +116,34 @@ async def select_best_dataset(
             ("system", DATASET_SELECTOR_PROMPT),
             (
                 "user",
-                """Only choose a dataset if it can usefully answer all parts of the user's question.
-    If no candidate can do that, return dataset_id as null and clearly explain in the reason field
-    what data we do have and why it falls short.
-    Use all information provided to decide which dataset is the best match, especially the selection hints.
+                """## When to prefer each candidate dataset
 
-    Select a single context layer from the filtered_context_layers in candidate datasets for the dataset if relevant for the user query.
-    Context layers allow differentiating between different types of data within the same dataset. So if a user asks
-    to show something like "show me tree cover loss by driver", you should select a context layer. These are pre-filtered
-    to match the spatiotemporal query constraints.
+{selection_hints}
 
-    Select parameters and values if they are relevant or specified in the user query. Parameters allow further filtering
-    the analysis to better answer the query. Select only values listed in the value field for a parameter. For example,
-    if a user says "show me tree cover loss in forests where canopy cover is greater than 50%", you may select the parameter canopy cover
-    and value 50.
+## Rules
 
-    If the user specifies a date range or time granularity (e.g. monthly, a specific year, daily
-    alerts), only select a dataset if it genuinely supports that. If no candidate does, return null
-    and tell the user what dates and granularity are available instead.
+{rules}
 
-    Pick the most granular dataset/contextual layer/parameters that matches the query.
+## Candidate datasets
 
-    Keep explanations concise. Do not use datset IDs to describe the dataset.
-    For instance, instead of saying "Dataset ID: 123", say "Dataset: Tree Cover Loss".
+{candidate_datasets}
 
-    Use the language of the user query to generate the reason, not the language of any place mentioned in the query.
+## User query
 
-    Candidate datasets:
+{user_query}
 
-    {candidate_datasets}
+## Removed contextual layers
 
-    User query:
+{removed_layers}
 
-    {user_query}
+## Reminder: when to prefer each candidate dataset
 
-    The following contextual layers can not be picked right now for the listed reasons:
+{selection_hints}
 
-    {removed_layers}
+## Reminder: rules
 
-    """,
+{rules}
+""",
             ),
         ]
     )
@@ -156,6 +164,8 @@ async def select_best_dataset(
         candidate_datasets["context_layers"] = filtered_layers
         removed_df = removed_layers.to_csv(index=False)
 
+    selection_hints = _format_selection_hints(candidate_datasets)
+
     return await dataset_selection_chain.ainvoke(
         {
             "candidate_datasets": candidate_datasets[
@@ -163,6 +173,8 @@ async def select_best_dataset(
             ].to_csv(index=False),
             "user_query": query,
             "removed_layers": removed_df,
+            "selection_hints": selection_hints,
+            "rules": SELECTION_RULES,
         }
     )
 

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -1071,13 +1071,13 @@ async def test_queries_return_no_dataset(query, start_date, end_date):
         (
             "Can you show tell me how land has changed since 2000?",
             "2000-01-01",
-            "2025-01-01",
+            "2025-12-31",
         ),
         # Could mean a couple different baselines
         (
-            "What's the baseline extent of natural vegetation before any recent conversions?",
-            None,
-            None,
+            "Brazil deforestation linked to agricultural commodities in 2017?",
+            "2017-01-01",
+            "2017-12-31",
         ),
     ],
 )

--- a/tests/tools/test_pick_dataset.py
+++ b/tests/tools/test_pick_dataset.py
@@ -84,6 +84,7 @@ CARBON_FLUX = "forest greenhouse gas net flux"
 TREE_COVER = "tree cover"
 TREE_COVER_LOSS_BY_DRIVER = "tree cover loss by driver"
 SLUC_EF = "deforestation (sLUC) emission factors by agricultural crop"
+TREE_COVER_LOSS_FROM_FIRES = "tree cover loss by fires"
 
 lookup = {
     0: DIST_ALERT,
@@ -96,6 +97,7 @@ lookup = {
     7: TREE_COVER,
     8: TREE_COVER_LOSS_BY_DRIVER,
     9: SLUC_EF,
+    10: TREE_COVER_LOSS_FROM_FIRES,
 }
 
 
@@ -143,7 +145,7 @@ def _query_case_id(param):
             LAND_COVER_CHANGE,
         ),
         (
-            "I'm studying urbanization patterns in sub-Saharan Africa between 2020 and 2024",
+            "I'm studying urbanization patterns in sub-Saharan Africa between 2015 and 2024",
             LAND_COVER_CHANGE,
         ),
         (
@@ -198,14 +200,20 @@ def _query_case_id(param):
         (
             "What areas of forest are acting as net carbon sinks versus sources?",
             CARBON_FLUX,
+            "2000-01-01",
+            "2025-12-31",
         ),
         (
             "Show me forest carbon emissions and removals in the Congo Basin",
             CARBON_FLUX,
+            "2000-01-01",
+            "2025-12-31",
         ),
         (
             "Which forest regions contribute most to greenhouse gas emissions?",
             CARBON_FLUX,
+            "2000-01-01",
+            "2025-12-31",
         ),
         # Dataset 7 queries (Tree cover) - baseline tree canopy density
         (
@@ -223,7 +231,7 @@ def _query_case_id(param):
         # Dataset 8 queries (Tree cover loss by driver) - tree cover loss by driver
         (
             "What areas of forest are experiencing the most tree cover loss due to wildfire?",
-            TREE_COVER_LOSS_BY_DRIVER,
+            TREE_COVER_LOSS_FROM_FIRES,
         ),
         (
             "Show me areas of tree cover loss by driver in the Congo Basin",
@@ -235,7 +243,7 @@ def _query_case_id(param):
         ),
         (
             "What regions experienced the most fire-related tree cover loss?",
-            TREE_COVER_LOSS_BY_DRIVER,
+            TREE_COVER_LOSS_FROM_FIRES,
         ),
         # ------------------------------------------------------------------
         # Tiered selection_hints (mirrors test_pick_dataset_tiered.py)


### PR DESCRIPTION
I've been playing around with a couple ideas to improve dataset suggestions and selection. While reading some [prompt guidance](https://developers.openai.com/cookbook/examples/gpt4-1_prompting_guide), I found the tip (although might not apply to newer/bigger models):

"Especially in long context usage, placement of instructions and context can impact performance. If you have long context in your prompt, ideally place your instructions at both the beginning and end of the provided context, as we found this to perform better than only above or below. If you’d prefer to only have your instructions once, then above the provided context works better than below."

I wanted to try it out quickly, and I also noticed all our dataset-specific instructions are actual stuffed in the middle in a nested csv structure. That might be why we've struggled a lot with it following instructions in the dataset YAML; it viewed the instructions as "data" and not as "rules".

I tested a few things, but I found below significantly increased the quality of dataset selection and suggestions:
- Consolidate the existing rules into a smaller bullets
- Pull out the selection hints from the candidate datasets structure 
- Put all the rules and selections hints both on top and bottom of the full dataset info

See evals below on three new evals I added to ask vague questions expecting suggestions. I did 5 trials, and found staging very inconsistent and score poorly on 2/3 questions, whereas my local changes now score perfectly. This does increase the context size, but not sure if it's significant enough for this internal model call to matter in terms of latency or cost.

Against local:
[eval_results_gold_sample_3_workers_9_offset_93_20260602_160058_summary.csv](https://github.com/user-attachments/files/28529550/eval_results_gold_sample_3_workers_9_offset_93_20260602_160058_summary.csv)
Against staging:
[eval_results_gold_sample_3_workers_9_offset_93_20260602_160058_summary.csv](https://github.com/user-attachments/files/28529567/eval_results_gold_sample_3_workers_9_offset_93_20260602_160058_summary.csv)

Also made a few test and YAML changes, since now it started always following selection hints, pointing out a few weird questions/instructions, and I think also we forgot to update to use TCL from fires instead of drivers for fire-related questions.