### PR TITLE
PZB-931: Ingest Langfuse traces and expose in Zeno API

### DIFF
--- a/db/alembic/versions/8391583bd224_add_langfuse_traces_analytics_view.py
+++ b/db/alembic/versions/8391583bd224_add_langfuse_traces_analytics_view.py
@@ -1,0 +1,68 @@
+"""add langfuse_traces_analytics view
+
+Revision ID: 8391583bd224
+Revises: a7d17cad8386
+Create Date: 2026-06-03 15:15:32.632677
+
+The sanctioned analytics surface over langfuse_traces. It exposes the turn-level
+derived columns plus a computed ``is_final_turn_in_thread`` flag so consumers can
+pick one representative row per thread (for cumulative fields) without re-deriving
+the dedup logic. Session-less traces (null session_id) are treated as singleton
+threads via COALESCE(session_id, id).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8391583bd224"
+down_revision: Union[str, None] = "a7d17cad8386"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_VIEW = "langfuse_traces_analytics"
+
+_CREATE = f"""
+CREATE OR REPLACE VIEW {_VIEW} AS
+SELECT
+    id,
+    session_id,
+    user_id,
+    environment,
+    trace_timestamp,
+    outcome,
+    has_answer,
+    answer_is_refusal,
+    had_tool_call,
+    tool_error_count,
+    aoi_name,
+    aoi_type,
+    primary_dataset_name,
+    has_insight,
+    is_global,
+    insight_id,
+    turn_input_tokens,
+    turn_output_tokens,
+    turn_tokens,
+    turn_tool_calls,
+    latency_seconds,
+    total_cost,
+    prompt,
+    (
+        row_number() OVER (
+            PARTITION BY COALESCE(session_id, id)
+            ORDER BY trace_timestamp DESC NULLS LAST, id DESC
+        ) = 1
+    ) AS is_final_turn_in_thread
+FROM langfuse_traces;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_CREATE)
+
+
+def downgrade() -> None:
+    op.execute(f"DROP VIEW IF EXISTS {_VIEW};")

--- a/db/alembic/versions/a7d17cad8386_add_langfuse_traces.py
+++ b/db/alembic/versions/a7d17cad8386_add_langfuse_traces.py
@@ -1,0 +1,159 @@
+"""add langfuse traces
+
+Revision ID: a7d17cad8386
+Revises: 9f8e7d6c5b4a
+Create Date: 2026-06-03 13:22:04.018053
+
+Hand-written (alembic autogenerate is disabled: env.py sets target_metadata=None).
+Creates langfuse_traces (hybrid raw JSONB + derived columns) and
+langfuse_ingestion_runs (watermark + drift-observability). No FK constraints:
+session_id/user_id/insight_id are soft references.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a7d17cad8386"
+down_revision: Union[str, None] = "c4d5e6f7a8b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _jsonb() -> postgresql.JSONB:
+    return postgresql.JSONB(astext_type=sa.Text())
+
+
+def upgrade() -> None:
+    op.create_table(
+        "langfuse_traces",
+        sa.Column("id", sa.String(), nullable=False),
+        # Soft references (no FK by design)
+        sa.Column("session_id", sa.String(), nullable=True),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("environment", sa.String(), nullable=True),
+        # Trace timestamps (tz-aware UTC)
+        sa.Column(
+            "trace_timestamp", sa.DateTime(timezone=True), nullable=True
+        ),
+        sa.Column(
+            "trace_updated_at", sa.DateTime(timezone=True), nullable=True
+        ),
+        # Raw payload + metadata projection
+        sa.Column("raw", _jsonb(), nullable=False),
+        sa.Column("trace_metadata", _jsonb(), nullable=True),
+        # Turn-level metrics
+        sa.Column("prompt", sa.String(), nullable=True),
+        sa.Column("answer", sa.String(), nullable=True),
+        sa.Column("turn_input_tokens", sa.Integer(), nullable=True),
+        sa.Column("turn_output_tokens", sa.Integer(), nullable=True),
+        sa.Column("turn_tokens", sa.Integer(), nullable=True),
+        sa.Column("turn_tool_calls", sa.Integer(), nullable=True),
+        sa.Column("latency_seconds", sa.Float(), nullable=True),
+        sa.Column("total_cost", sa.Float(), nullable=True),
+        # Outcome primitives + derived label
+        sa.Column("has_answer", sa.Boolean(), nullable=True),
+        sa.Column("answer_finish_reason", sa.String(), nullable=True),
+        sa.Column("answer_is_refusal", sa.Boolean(), nullable=True),
+        sa.Column("had_tool_call", sa.Boolean(), nullable=True),
+        sa.Column("tool_error_count", sa.Integer(), nullable=True),
+        sa.Column("outcome", sa.String(), nullable=True),
+        # Current-state columns
+        sa.Column("aoi_name", sa.String(), nullable=True),
+        sa.Column("aoi_type", sa.String(), nullable=True),
+        sa.Column("primary_dataset_name", sa.String(), nullable=True),
+        sa.Column("has_insight", sa.Boolean(), nullable=True),
+        sa.Column("is_global", sa.Boolean(), nullable=True),
+        sa.Column("insight_id", sa.String(), nullable=True),
+        sa.Column("is_final_turn_in_thread", sa.Boolean(), nullable=True),
+        # Long-tail + cumulative derived
+        sa.Column("derived", _jsonb(), nullable=True),
+        # Bookkeeping / drift detection
+        sa.Column("parser_version", sa.Integer(), nullable=False),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("parsed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("parse_error", sa.String(), nullable=True),
+        sa.Column("recognized_contract", sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_langfuse_traces_trace_timestamp",
+        "langfuse_traces",
+        ["trace_timestamp"],
+    )
+    op.create_index(
+        "ix_langfuse_traces_user_id", "langfuse_traces", ["user_id"]
+    )
+    op.create_index(
+        "ix_langfuse_traces_session_id", "langfuse_traces", ["session_id"]
+    )
+    op.create_index(
+        "ix_langfuse_traces_insight_id", "langfuse_traces", ["insight_id"]
+    )
+    op.create_index(
+        "ix_langfuse_traces_env_ts",
+        "langfuse_traces",
+        ["environment", "trace_timestamp"],
+    )
+
+    op.create_table(
+        "langfuse_ingestion_runs",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("window_end", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("environment", sa.String(), nullable=True),
+        sa.Column(
+            "traces_fetched", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "traces_upserted", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("chunks_total", sa.Integer(), nullable=True),
+        sa.Column("chunks_failed", sa.Integer(), nullable=True),
+        sa.Column("parser_version", sa.Integer(), nullable=True),
+        sa.Column(
+            "status", sa.String(), nullable=False, server_default="running"
+        ),
+        sa.Column("error", sa.String(), nullable=True),
+        sa.Column("watermark", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("fill_rates", _jsonb(), nullable=True),
+        sa.Column("fk_resolve_rates", _jsonb(), nullable=True),
+        sa.Column("unrecognized_contract_rate", sa.Float(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("langfuse_ingestion_runs")
+    op.drop_index("ix_langfuse_traces_env_ts", table_name="langfuse_traces")
+    op.drop_index(
+        "ix_langfuse_traces_insight_id", table_name="langfuse_traces"
+    )
+    op.drop_index(
+        "ix_langfuse_traces_session_id", table_name="langfuse_traces"
+    )
+    op.drop_index("ix_langfuse_traces_user_id", table_name="langfuse_traces")
+    op.drop_index(
+        "ix_langfuse_traces_trace_timestamp", table_name="langfuse_traces"
+    )
+    op.drop_table("langfuse_traces")

--- a/db/alembic/versions/a7d17cad8386_add_langfuse_traces.py
+++ b/db/alembic/versions/a7d17cad8386_add_langfuse_traces.py
@@ -5,9 +5,9 @@ Revises: 9f8e7d6c5b4a
 Create Date: 2026-06-03 13:22:04.018053
 
 Hand-written (alembic autogenerate is disabled: env.py sets target_metadata=None).
-Creates langfuse_traces (hybrid raw JSONB + derived columns) and
-langfuse_ingestion_runs (watermark + drift-observability). No FK constraints:
-session_id/user_id/insight_id are soft references.
+Creates langfuse_traces (derived analytics columns) and langfuse_ingestion_runs
+(watermark + drift-observability). No FK constraints: session_id/user_id/insight_id
+are soft references.
 """
 
 from typing import Sequence, Union
@@ -42,9 +42,6 @@ def upgrade() -> None:
         sa.Column(
             "trace_updated_at", sa.DateTime(timezone=True), nullable=True
         ),
-        # Raw payload + metadata projection
-        sa.Column("raw", _jsonb(), nullable=False),
-        sa.Column("trace_metadata", _jsonb(), nullable=True),
         # Turn-level metrics
         sa.Column("prompt", sa.String(), nullable=True),
         sa.Column("answer", sa.String(), nullable=True),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.13"
+version = "2026.6.15"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.15"
+version = "2026.6.15.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -18,6 +18,7 @@ from src.api.routers import (
     metadata,
     threads,
     thumbnails,
+    traces,
     users,
 )
 from src.shared.database import close_global_pool, initialize_global_pool
@@ -110,3 +111,4 @@ app.include_router(thumbnails.router)
 app.include_router(insights.router)
 app.include_router(metadata.router)
 app.include_router(admin.router)
+app.include_router(traces.router)

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -20,7 +20,7 @@ Usage:
 import asyncio
 import secrets
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import bcrypt
@@ -612,6 +612,126 @@ def list_pro_users_command():
             await db.close()
 
     asyncio.run(_list_pro_users())
+
+
+def _parse_cli_dt(s: str) -> datetime:
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+@cli.command("ingest-langfuse-traces")
+@click.option(
+    "--since",
+    help="ISO start (overrides watermark). Required with --backfill.",
+)
+@click.option("--until", help="ISO end (default: now).")
+@click.option(
+    "--backfill", is_flag=True, help="Historical backfill from --since."
+)
+@click.option(
+    "--environment",
+    "environments",
+    multiple=True,
+    help="Filter to environment(s); repeatable. Default: all.",
+)
+@click.option(
+    "--overlap-hours",
+    type=int,
+    default=12,
+    help="Re-scan overlap before watermark.",
+)
+@click.option(
+    "--chunk-hours",
+    type=int,
+    default=24,
+    help="Window chunk size for backfill.",
+)
+@click.option(
+    "--batch-size",
+    type=int,
+    default=300,
+    help="Fetch page / upsert batch size.",
+)
+@click.option(
+    "--reparse",
+    is_flag=True,
+    help="Re-derive from stored raw (no Langfuse fetch).",
+)
+@click.option(
+    "--dry-run", is_flag=True, help="Fetch + parse but do not write."
+)
+def ingest_langfuse_traces_command(
+    since: Optional[str],
+    until: Optional[str],
+    backfill: bool,
+    environments: tuple,
+    overlap_hours: int,
+    chunk_hours: int,
+    batch_size: int,
+    reparse: bool,
+    dry_run: bool,
+):
+    """Ingest Langfuse traces into Postgres (idempotent upsert)."""
+    from src.api.services.langfuse.ingest import (
+        reparse_stored,
+        resolve_start_watermark,
+        run_ingestion,
+    )
+
+    async def _run():
+        db = DatabaseManager()
+        try:
+            async with db.async_session() as session:
+                if reparse:
+                    n = await reparse_stored(session, batch_size=batch_size)
+                    click.echo(
+                        f"✅ Reparsed {n} traces to parser_version current"
+                    )
+                    return
+
+                until_dt = (
+                    _parse_cli_dt(until)
+                    if until
+                    else datetime.now(timezone.utc)
+                )
+                envs = list(environments) or [None]
+                for env in envs:
+                    if since:
+                        since_dt = _parse_cli_dt(since)
+                    elif backfill:
+                        raise click.UsageError("--backfill requires --since")
+                    else:
+                        wm = await resolve_start_watermark(session, env)
+                        if wm is None:
+                            since_dt = until_dt - timedelta(hours=24)
+                            click.echo(
+                                "ℹ️  No watermark; defaulting to last 24h "
+                                "(use --backfill --since for history)."
+                            )
+                        else:
+                            since_dt = wm - timedelta(hours=overlap_hours)
+
+                    result = await run_ingestion(
+                        session,
+                        since=since_dt,
+                        until=until_dt,
+                        environment=env,
+                        chunk_hours=chunk_hours,
+                        batch_size=batch_size,
+                        dry_run=dry_run,
+                    )
+                    click.echo(
+                        f"[{env or 'all'}] {since_dt.isoformat()} → {until_dt.isoformat()} | "
+                        f"fetched={result.fetched} upserted={result.upserted} "
+                        f"chunks={result.chunks_total} failed={result.chunks_failed} "
+                        f"status={result.status} watermark={result.watermark}"
+                    )
+        finally:
+            await db.close()
+
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -655,11 +655,6 @@ def _parse_cli_dt(s: str) -> datetime:
     help="Fetch page / upsert batch size.",
 )
 @click.option(
-    "--reparse",
-    is_flag=True,
-    help="Re-derive from stored raw (no Langfuse fetch).",
-)
-@click.option(
     "--dry-run", is_flag=True, help="Fetch + parse but do not write."
 )
 def ingest_langfuse_traces_command(
@@ -670,12 +665,10 @@ def ingest_langfuse_traces_command(
     overlap_hours: int,
     chunk_hours: int,
     batch_size: int,
-    reparse: bool,
     dry_run: bool,
 ):
     """Ingest Langfuse traces into Postgres (idempotent upsert)."""
     from src.api.services.langfuse.ingest import (
-        reparse_stored,
         resolve_start_watermark,
         run_ingestion,
     )
@@ -684,13 +677,6 @@ def ingest_langfuse_traces_command(
         db = DatabaseManager()
         try:
             async with db.async_session() as session:
-                if reparse:
-                    n = await reparse_stored(session, batch_size=batch_size)
-                    click.echo(
-                        f"✅ Reparsed {n} traces to parser_version current"
-                    )
-                    return
-
                 until_dt = (
                     _parse_cli_dt(until)
                     if until

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any
 
 from sqlalchemy import (
@@ -11,7 +11,9 @@ from sqlalchemy import (
     Column,
     Date,
     DateTime,
+    Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     UniqueConstraint,
@@ -295,3 +297,133 @@ class JobResourceOrm(Base):
     created_at = Column(DateTime, nullable=False, default=datetime.now)
 
     job = relationship("JobOrm", back_populates="resources")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class LangfuseTraceOrm(Base):
+    """A Langfuse trace (= one agent turn) ingested into Postgres.
+
+    Hybrid storage: the full raw payload lives in ``raw`` (single source of
+    truth — it already nests input/output/metadata), plus a flat set of derived
+    columns for the analytics axes. Domain fields are parsed against the agent's
+    own ``AgentState`` contract (src/agent/state.py); turn-level metrics are
+    computed from the active-turn message window (NOT the whole accumulated
+    history). ``session_id``/``user_id``/``insight_id`` are SOFT references
+    (nullable, no FK) — many traces won't match (machine users, dev envs,
+    deleted threads), so all joins are LEFT JOINs and resolve-rate is monitored.
+    """
+
+    __tablename__ = "langfuse_traces"
+
+    # Langfuse trace id
+    id = Column(String, primary_key=True, nullable=False)
+
+    # Soft references (no FK by design)
+    session_id = Column(String, nullable=True)  # == threads.id
+    user_id = Column(String, nullable=True)  # == users.id
+    environment = Column(String, nullable=True)
+
+    # Timestamps from the trace (tz-aware UTC — deliberately not the naive
+    # datetime.now convention used by older tables in this module).
+    trace_timestamp = Column(DateTime(timezone=True), nullable=True)
+    trace_updated_at = Column(DateTime(timezone=True), nullable=True)
+
+    # Raw payload (single source of truth) + thin metadata projection.
+    raw = Column(JSONB, nullable=False)
+    trace_metadata = Column(
+        JSONB, nullable=True
+    )  # trace.metadata (reserved name)
+
+    # --- Turn-level metrics (from the active-turn window) ---
+    prompt = Column(String, nullable=True)
+    answer = Column(String, nullable=True)
+    turn_input_tokens = Column(Integer, nullable=True)
+    turn_output_tokens = Column(Integer, nullable=True)
+    turn_tokens = Column(Integer, nullable=True)
+    turn_tool_calls = Column(Integer, nullable=True)
+    # Passthrough per-turn fields from the trace top level.
+    latency_seconds = Column(Float, nullable=True)
+    total_cost = Column(Float, nullable=True)
+
+    # Outcome primitives (durable, auditable signals). ``outcome`` is the label
+    # derived FROM these — retuning the rule is a recompute, not a reparse.
+    has_answer = Column(Boolean, nullable=True)
+    answer_finish_reason = Column(String, nullable=True)
+    answer_is_refusal = Column(Boolean, nullable=True)
+    had_tool_call = Column(Boolean, nullable=True)
+    tool_error_count = Column(Integer, nullable=True)
+    outcome = Column(String, nullable=True)
+
+    # --- Current-state columns (per-turn-meaningful, from output snapshot) ---
+    aoi_name = Column(String, nullable=True)
+    aoi_type = Column(String, nullable=True)
+    primary_dataset_name = Column(String, nullable=True)
+    has_insight = Column(Boolean, nullable=True)
+    is_global = Column(Boolean, nullable=True)
+    insight_id = Column(String, nullable=True)  # soft FK -> insights.id
+    is_final_turn_in_thread = Column(Boolean, nullable=True)
+
+    # Long-tail + cumulative derived fields, kept out of the column set to keep
+    # migrations rare. Includes turn_tools_used, turn_datasets, aoi_source,
+    # aoi_count, aois, primary_dataset_id, analysis_start/end_date,
+    # cache_read_tokens, language(+confidence), datasets_analysed_cumulative,
+    # statistics_ids, state_snapshot, and unknown_output_keys (drift detector).
+    derived = Column(JSONB, nullable=True)
+
+    # Bookkeeping / drift detection
+    parser_version = Column(Integer, nullable=False, default=1)
+    ingested_at = Column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    parsed_at = Column(DateTime(timezone=True), nullable=True)
+    parse_error = Column(String, nullable=True)
+    recognized_contract = Column(Boolean, nullable=True)
+
+    __table_args__ = (
+        Index("ix_langfuse_traces_trace_timestamp", "trace_timestamp"),
+        Index("ix_langfuse_traces_user_id", "user_id"),
+        Index("ix_langfuse_traces_session_id", "session_id"),
+        Index("ix_langfuse_traces_insight_id", "insight_id"),
+        Index("ix_langfuse_traces_env_ts", "environment", "trace_timestamp"),
+    )
+
+
+class LangfuseIngestionRunOrm(Base):
+    """One ingestion run (or backfill chunk): watermark bookkeeping + drift
+    observability. ``fill_rates``/``fk_resolve_rates``/``unrecognized_contract_rate``
+    are the primary defense against silent contract drift — alert on day-over-day
+    deltas, not just on status=failed."""
+
+    __tablename__ = "langfuse_ingestion_runs"
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    started_at = Column(
+        DateTime(timezone=True), nullable=False, default=_utcnow
+    )
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    window_start = Column(DateTime(timezone=True), nullable=True)
+    window_end = Column(DateTime(timezone=True), nullable=True)
+    environment = Column(String, nullable=True)  # null = all environments
+
+    traces_fetched = Column(Integer, nullable=False, default=0)
+    traces_upserted = Column(Integer, nullable=False, default=0)
+    chunks_total = Column(Integer, nullable=True)
+    chunks_failed = Column(Integer, nullable=True)
+
+    parser_version = Column(Integer, nullable=True)
+    status = Column(String, nullable=False, default="running")
+    error = Column(String, nullable=True)
+    # Max trace_timestamp successfully ingested as part of a contiguous window.
+    watermark = Column(DateTime(timezone=True), nullable=True)
+
+    # Drift observability
+    fill_rates = Column(JSONB, nullable=True)
+    fk_resolve_rates = Column(JSONB, nullable=True)
+    unrecognized_contract_rate = Column(Float, nullable=True)

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -304,16 +304,16 @@ def _utcnow() -> datetime:
 
 
 class LangfuseTraceOrm(Base):
-    """A Langfuse trace (= one agent turn) ingested into Postgres.
+    """Derived analytics for one Langfuse trace (= one agent turn).
 
-    Hybrid storage: the full raw payload lives in ``raw`` (single source of
-    truth — it already nests input/output/metadata), plus a flat set of derived
-    columns for the analytics axes. Domain fields are parsed against the agent's
-    own ``AgentState`` contract (src/agent/state.py); turn-level metrics are
-    computed from the active-turn message window (NOT the whole accumulated
-    history). ``session_id``/``user_id``/``insight_id`` are SOFT references
-    (nullable, no FK) — many traces won't match (machine users, dev envs,
-    deleted threads), so all joins are LEFT JOINs and resolve-rate is monitored.
+    Stores only the small derived/analytics columns — Langfuse remains the store
+    of record for the full raw trace, fetched on demand for the detail view.
+    Domain fields are parsed against the agent's own ``AgentState`` contract
+    (src/agent/state.py); turn-level metrics are computed from the active-turn
+    message window (NOT the whole accumulated history). ``session_id`` /
+    ``user_id`` / ``insight_id`` are SOFT references (nullable, no FK) — many
+    traces won't match (machine users, dev envs, deleted threads), so all joins
+    are LEFT JOINs and resolve-rate is monitored.
     """
 
     __tablename__ = "langfuse_traces"
@@ -330,12 +330,6 @@ class LangfuseTraceOrm(Base):
     # datetime.now convention used by older tables in this module).
     trace_timestamp = Column(DateTime(timezone=True), nullable=True)
     trace_updated_at = Column(DateTime(timezone=True), nullable=True)
-
-    # Raw payload (single source of truth) + thin metadata projection.
-    raw = Column(JSONB, nullable=False)
-    trace_metadata = Column(
-        JSONB, nullable=True
-    )  # trace.metadata (reserved name)
 
     # --- Turn-level metrics (from the active-turn window) ---
     prompt = Column(String, nullable=True)

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -1,0 +1,216 @@
+"""Superuser-only endpoints for exploring ingested Langfuse traces.
+
+Read path over ``langfuse_traces`` (see src/api/services/langfuse for ingestion).
+List/detail here; analytics + conversation views live alongside. All derived
+fields are turn-level (per the parser); cumulative thread state lives under
+``derived`` and the analytics surface dedups per session.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.auth.dependencies import require_superuser
+from src.api.data_models import LangfuseTraceOrm
+from src.api.schemas import UserModel
+from src.shared.database import get_session_from_pool_dependency
+
+router = APIRouter(prefix="/api/traces", tags=["traces"])
+
+
+# --------------------------------------------------------------------------- #
+# Response models
+# --------------------------------------------------------------------------- #
+class TraceListItem(BaseModel):
+    id: str
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
+    environment: Optional[str] = None
+    trace_timestamp: Optional[datetime] = None
+    outcome: Optional[str] = None
+    prompt: Optional[str] = None
+    aoi_name: Optional[str] = None
+    aoi_type: Optional[str] = None
+    primary_dataset_name: Optional[str] = None
+    has_insight: Optional[bool] = None
+    is_global: Optional[bool] = None
+    turn_tokens: Optional[int] = None
+    turn_tool_calls: Optional[int] = None
+    tool_error_count: Optional[int] = None
+    latency_seconds: Optional[float] = None
+    total_cost: Optional[float] = None
+
+
+class TraceListResponse(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    items: list[TraceListItem]
+
+
+class TraceDetail(TraceListItem):
+    answer: Optional[str] = None
+    has_answer: Optional[bool] = None
+    answer_finish_reason: Optional[str] = None
+    answer_is_refusal: Optional[bool] = None
+    had_tool_call: Optional[bool] = None
+    insight_id: Optional[str] = None
+    turn_input_tokens: Optional[int] = None
+    turn_output_tokens: Optional[int] = None
+    parser_version: Optional[int] = None
+    parse_error: Optional[str] = None
+    recognized_contract: Optional[bool] = None
+    derived: Optional[dict[str, Any]] = None
+    metadata: Optional[dict[str, Any]] = None
+    input: Optional[Any] = None
+    output: Optional[Any] = None
+
+
+_LIST_COLUMNS = (
+    LangfuseTraceOrm.id,
+    LangfuseTraceOrm.session_id,
+    LangfuseTraceOrm.user_id,
+    LangfuseTraceOrm.environment,
+    LangfuseTraceOrm.trace_timestamp,
+    LangfuseTraceOrm.outcome,
+    LangfuseTraceOrm.prompt,
+    LangfuseTraceOrm.aoi_name,
+    LangfuseTraceOrm.aoi_type,
+    LangfuseTraceOrm.primary_dataset_name,
+    LangfuseTraceOrm.has_insight,
+    LangfuseTraceOrm.is_global,
+    LangfuseTraceOrm.turn_tokens,
+    LangfuseTraceOrm.turn_tool_calls,
+    LangfuseTraceOrm.tool_error_count,
+    LangfuseTraceOrm.latency_seconds,
+    LangfuseTraceOrm.total_cost,
+)
+
+
+def _filters(
+    environment: Optional[str],
+    outcome: Optional[str],
+    user_id: Optional[str],
+    session_id: Optional[str],
+    start: Optional[datetime],
+    end: Optional[datetime],
+    prompt_contains: Optional[str],
+) -> list[Any]:
+    conds: list[Any] = []
+    if environment:
+        conds.append(LangfuseTraceOrm.environment == environment)
+    if outcome:
+        conds.append(LangfuseTraceOrm.outcome == outcome)
+    if user_id:
+        conds.append(LangfuseTraceOrm.user_id == user_id)
+    if session_id:
+        conds.append(LangfuseTraceOrm.session_id == session_id)
+    if start:
+        conds.append(LangfuseTraceOrm.trace_timestamp >= start)
+    if end:
+        conds.append(LangfuseTraceOrm.trace_timestamp < end)
+    if prompt_contains:
+        conds.append(LangfuseTraceOrm.prompt.ilike(f"%{prompt_contains}%"))
+    return conds
+
+
+@router.get("", response_model=TraceListResponse)
+async def list_traces(
+    environment: Optional[str] = Query(None),
+    outcome: Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    session_id: Optional[str] = Query(None),
+    start: Optional[datetime] = Query(
+        None, description="trace_timestamp >= (ISO)"
+    ),
+    end: Optional[datetime] = Query(
+        None, description="trace_timestamp < (ISO)"
+    ),
+    prompt_contains: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    _superuser: UserModel = Depends(require_superuser),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+) -> TraceListResponse:
+    """List/filter traces (derived columns only — never raw/output)."""
+    conds = _filters(
+        environment, outcome, user_id, session_id, start, end, prompt_contains
+    )
+
+    count_stmt = select(func.count()).select_from(LangfuseTraceOrm)
+    for c in conds:
+        count_stmt = count_stmt.where(c)
+    total = int((await session.execute(count_stmt)).scalar() or 0)
+
+    stmt = select(*_LIST_COLUMNS)
+    for c in conds:
+        stmt = stmt.where(c)
+    stmt = stmt.order_by(LangfuseTraceOrm.trace_timestamp.desc().nullslast())
+    stmt = stmt.limit(limit).offset(offset)
+    rows = (await session.execute(stmt)).mappings().all()
+
+    return TraceListResponse(
+        total=total,
+        limit=limit,
+        offset=offset,
+        items=[TraceListItem(**dict(r)) for r in rows],
+    )
+
+
+@router.get("/{trace_id}", response_model=TraceDetail)
+async def get_trace(
+    trace_id: str,
+    _superuser: UserModel = Depends(require_superuser),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+) -> TraceDetail:
+    """Full detail for one trace, including input/output (the AgentState
+    snapshot) and the derived bundle."""
+    row = (
+        await session.execute(
+            select(LangfuseTraceOrm).where(LangfuseTraceOrm.id == trace_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Trace not found")
+
+    raw = row.raw if isinstance(row.raw, dict) else {}
+    return TraceDetail(
+        id=row.id,
+        session_id=row.session_id,
+        user_id=row.user_id,
+        environment=row.environment,
+        trace_timestamp=row.trace_timestamp,
+        outcome=row.outcome,
+        prompt=row.prompt,
+        answer=row.answer,
+        has_answer=row.has_answer,
+        answer_finish_reason=row.answer_finish_reason,
+        answer_is_refusal=row.answer_is_refusal,
+        had_tool_call=row.had_tool_call,
+        aoi_name=row.aoi_name,
+        aoi_type=row.aoi_type,
+        primary_dataset_name=row.primary_dataset_name,
+        has_insight=row.has_insight,
+        is_global=row.is_global,
+        insight_id=row.insight_id,
+        turn_tokens=row.turn_tokens,
+        turn_input_tokens=row.turn_input_tokens,
+        turn_output_tokens=row.turn_output_tokens,
+        turn_tool_calls=row.turn_tool_calls,
+        tool_error_count=row.tool_error_count,
+        latency_seconds=row.latency_seconds,
+        total_cost=row.total_cost,
+        parser_version=row.parser_version,
+        parse_error=row.parse_error,
+        recognized_contract=row.recognized_contract,
+        derived=row.derived,
+        metadata=row.trace_metadata,
+        input=raw.get("input"),
+        output=raw.get("output"),
+    )

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -47,6 +47,10 @@ class TraceListItem(BaseModel):
     tool_error_count: Optional[int] = None
     latency_seconds: Optional[float] = None
     total_cost: Optional[float] = None
+    # Sourced from the ``derived`` JSONB (long-tail fields kept out of columns).
+    datasets_analysed: Optional[list[str]] = None
+    language: Optional[str] = None
+    language_confidence: Optional[float] = None
 
 
 class TraceListResponse(BaseModel):
@@ -94,7 +98,23 @@ _LIST_COLUMNS = (
     LangfuseTraceOrm.tool_error_count,
     LangfuseTraceOrm.latency_seconds,
     LangfuseTraceOrm.total_cost,
+    # Selected so the list response can surface the derived fields below without
+    # a per-trace detail fetch (datasets_analysed/language live in JSONB).
+    LangfuseTraceOrm.derived,
 )
+
+
+def _list_item_from_row(r: dict[str, Any]) -> TraceListItem:
+    """Build a list item from a row mapping, lifting the three derived fields
+    out of the ``derived`` JSONB and dropping it from the column kwargs."""
+    derived = r.get("derived") or {}
+    cols = {k: v for k, v in r.items() if k != "derived"}
+    return TraceListItem(
+        **cols,
+        datasets_analysed=derived.get("datasets_analysed_cumulative"),
+        language=derived.get("language"),
+        language_confidence=derived.get("language_confidence"),
+    )
 
 
 def _filters(
@@ -163,7 +183,7 @@ async def list_traces(
         total=total,
         limit=limit,
         offset=offset,
-        items=[TraceListItem(**dict(r)) for r in rows],
+        items=[_list_item_from_row(dict(r)) for r in rows],
     )
 
 
@@ -447,6 +467,8 @@ async def get_trace(
     raw_available = isinstance(trace, dict)
     trace = trace or {}
 
+    derived = row.derived or {}
+
     return TraceDetail(
         id=row.id,
         session_id=row.session_id,
@@ -473,6 +495,9 @@ async def get_trace(
         tool_error_count=row.tool_error_count,
         latency_seconds=row.latency_seconds,
         total_cost=row.total_cost,
+        datasets_analysed=derived.get("datasets_analysed_cumulative"),
+        language=derived.get("language"),
+        language_confidence=derived.get("language_confidence"),
         parser_version=row.parser_version,
         parse_error=row.parse_error,
         recognized_contract=row.recognized_contract,

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -8,12 +8,12 @@ fields are turn-level (per the parser); cumulative thread state lives under
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.auth.dependencies import require_superuser
@@ -160,6 +160,263 @@ async def list_traces(
         limit=limit,
         offset=offset,
         items=[TraceListItem(**dict(r)) for r in rows],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Analytics + sessions (declared BEFORE /{trace_id} so literals aren't shadowed)
+# --------------------------------------------------------------------------- #
+class NamedCount(BaseModel):
+    value: Optional[str] = None
+    count: int
+
+
+class DailyCount(BaseModel):
+    day: date
+    count: int
+
+
+class TraceAnalytics(BaseModel):
+    total_traces: int
+    unique_sessions: int
+    unique_users: int
+    outcome_breakdown: list[NamedCount]
+    daily_volume: list[DailyCount]
+    aoi_type_breakdown: list[NamedCount]
+    latency: dict[str, Optional[float]]
+    cost: dict[str, Optional[float]]
+    tokens: dict[str, Optional[float]]
+    tool_usage: dict[str, Optional[float]]
+
+
+class SessionItem(BaseModel):
+    session_id: str
+    user_id: Optional[str] = None
+    environment: Optional[str] = None
+    first_prompt: Optional[str] = None
+    first_timestamp: Optional[datetime] = None
+    last_timestamp: Optional[datetime] = None
+    turn_count: int
+
+
+class SessionListResponse(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    items: list[SessionItem]
+
+
+def _where_sql(
+    environment: Optional[str],
+    outcome: Optional[str],
+    user_id: Optional[str],
+    start: Optional[datetime],
+    end: Optional[datetime],
+    *,
+    require_session: bool = False,
+) -> tuple[str, dict[str, Any]]:
+    """Build a parameterised WHERE clause (bound params — no injection)."""
+    clauses: list[str] = []
+    params: dict[str, Any] = {}
+    if require_session:
+        clauses.append("session_id IS NOT NULL")
+    if environment:
+        clauses.append("environment = :environment")
+        params["environment"] = environment
+    if outcome:
+        clauses.append("outcome = :outcome")
+        params["outcome"] = outcome
+    if user_id:
+        clauses.append("user_id = :user_id")
+        params["user_id"] = user_id
+    if start:
+        clauses.append("trace_timestamp >= :start")
+        params["start"] = start
+    if end:
+        clauses.append("trace_timestamp < :end")
+        params["end"] = end
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    return where, params
+
+
+def _f(x: Any) -> Optional[float]:
+    return round(float(x), 4) if x is not None else None
+
+
+@router.get("/analytics", response_model=TraceAnalytics)
+async def trace_analytics(
+    environment: Optional[str] = Query(None),
+    outcome: Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    start: Optional[datetime] = Query(None),
+    end: Optional[datetime] = Query(None),
+    _superuser: UserModel = Depends(require_superuser),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+) -> TraceAnalytics:
+    """Server-side aggregates over the filtered trace set. All metrics are
+    turn-level (one row per trace), so counts/sums are not double-counted."""
+    where, params = _where_sql(environment, outcome, user_id, start, end)
+
+    summary = (
+        (
+            await session.execute(
+                text(
+                    f"""
+                SELECT
+                  count(*) AS total,
+                  count(DISTINCT session_id) AS sessions,
+                  count(DISTINCT user_id) AS users,
+                  avg(latency_seconds) AS lat_avg,
+                  percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_seconds) AS lat_p50,
+                  percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_seconds) AS lat_p95,
+                  avg(total_cost) AS cost_avg,
+                  percentile_cont(0.95) WITHIN GROUP (ORDER BY total_cost) AS cost_p95,
+                  sum(total_cost) AS cost_total,
+                  avg(turn_tokens) AS tok_avg,
+                  sum(turn_tokens) AS tok_total,
+                  avg(turn_tool_calls) AS tool_avg,
+                  avg(CASE WHEN tool_error_count > 0 THEN 1.0 ELSE 0.0 END) AS tool_err_rate
+                FROM langfuse_traces{where}
+                """
+                ),
+                params,
+            )
+        )
+        .mappings()
+        .one()
+    )
+
+    outcomes = (
+        (
+            await session.execute(
+                text(
+                    f"SELECT outcome AS value, count(*) AS count FROM langfuse_traces"
+                    f"{where} GROUP BY outcome ORDER BY count DESC"
+                ),
+                params,
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    daily = (
+        (
+            await session.execute(
+                text(
+                    f"SELECT date_trunc('day', trace_timestamp)::date AS day, "
+                    f"count(*) AS count FROM langfuse_traces{where} "
+                    f"GROUP BY day ORDER BY day"
+                ),
+                params,
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    aoi = (
+        (
+            await session.execute(
+                text(
+                    f"SELECT aoi_type AS value, count(*) AS count FROM langfuse_traces"
+                    f"{where}{' AND' if where else ' WHERE'} aoi_type IS NOT NULL "
+                    f"GROUP BY aoi_type ORDER BY count DESC"
+                ),
+                params,
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    return TraceAnalytics(
+        total_traces=int(summary["total"] or 0),
+        unique_sessions=int(summary["sessions"] or 0),
+        unique_users=int(summary["users"] or 0),
+        outcome_breakdown=[NamedCount(**dict(r)) for r in outcomes],
+        daily_volume=[DailyCount(**dict(r)) for r in daily],
+        aoi_type_breakdown=[NamedCount(**dict(r)) for r in aoi],
+        latency={
+            "avg": _f(summary["lat_avg"]),
+            "p50": _f(summary["lat_p50"]),
+            "p95": _f(summary["lat_p95"]),
+        },
+        cost={
+            "avg": _f(summary["cost_avg"]),
+            "p95": _f(summary["cost_p95"]),
+            "total": _f(summary["cost_total"]),
+        },
+        tokens={
+            "avg_turn_tokens": _f(summary["tok_avg"]),
+            "total_turn_tokens": _f(summary["tok_total"]),
+        },
+        tool_usage={
+            "avg_tool_calls": _f(summary["tool_avg"]),
+            "tool_error_rate": _f(summary["tool_err_rate"]),
+        },
+    )
+
+
+@router.get("/sessions", response_model=SessionListResponse)
+async def list_sessions(
+    environment: Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    start: Optional[datetime] = Query(None),
+    end: Optional[datetime] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    _superuser: UserModel = Depends(require_superuser),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+) -> SessionListResponse:
+    """Conversation browser: one row per session (thread), newest first, with the
+    first prompt of the thread and a turn count."""
+    where, params = _where_sql(
+        environment, None, user_id, start, end, require_session=True
+    )
+
+    total = int(
+        (
+            await session.execute(
+                text(
+                    f"SELECT count(DISTINCT session_id) FROM langfuse_traces{where}"
+                ),
+                params,
+            )
+        ).scalar()
+        or 0
+    )
+
+    rows = (
+        (
+            await session.execute(
+                text(
+                    f"""
+                SELECT session_id,
+                       max(user_id) AS user_id,
+                       max(environment) AS environment,
+                       (array_agg(prompt ORDER BY trace_timestamp ASC))[1] AS first_prompt,
+                       min(trace_timestamp) AS first_timestamp,
+                       max(trace_timestamp) AS last_timestamp,
+                       count(*) AS turn_count
+                FROM langfuse_traces{where}
+                GROUP BY session_id
+                ORDER BY max(trace_timestamp) DESC NULLS LAST
+                LIMIT :limit OFFSET :offset
+                """
+                ),
+                {**params, "limit": limit, "offset": offset},
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    return SessionListResponse(
+        total=total,
+        limit=limit,
+        offset=offset,
+        items=[SessionItem(**dict(r)) for r in rows],
     )
 
 

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -8,6 +8,7 @@ fields are turn-level (per the parser); cumulative thread state lives under
 
 from __future__ import annotations
 
+import asyncio
 from datetime import date, datetime
 from typing import Any, Optional
 
@@ -19,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.auth.dependencies import require_superuser
 from src.api.data_models import LangfuseTraceOrm
 from src.api.schemas import UserModel
+from src.api.services.langfuse.fetch import LangfuseClient
 from src.shared.database import get_session_from_pool_dependency
 
 router = APIRouter(prefix="/api/traces", tags=["traces"])
@@ -67,7 +69,9 @@ class TraceDetail(TraceListItem):
     parse_error: Optional[str] = None
     recognized_contract: Optional[bool] = None
     derived: Optional[dict[str, Any]] = None
-    metadata: Optional[dict[str, Any]] = None
+    # input/output are fetched live from Langfuse (the raw-trace store of record);
+    # raw_available is False if Langfuse 404s or is unreachable.
+    raw_available: bool = False
     input: Optional[Any] = None
     output: Optional[Any] = None
 
@@ -426,8 +430,9 @@ async def get_trace(
     _superuser: UserModel = Depends(require_superuser),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceDetail:
-    """Full detail for one trace, including input/output (the AgentState
-    snapshot) and the derived bundle."""
+    """Full detail for one trace: our derived columns from Postgres, plus the
+    `input`/`output` (the AgentState snapshot) fetched live from Langfuse, which
+    is the store of record for the raw trace."""
     row = (
         await session.execute(
             select(LangfuseTraceOrm).where(LangfuseTraceOrm.id == trace_id)
@@ -436,7 +441,12 @@ async def get_trace(
     if row is None:
         raise HTTPException(status_code=404, detail="Trace not found")
 
-    raw = row.raw if isinstance(row.raw, dict) else {}
+    trace = await asyncio.to_thread(
+        LangfuseClient.from_env().fetch_trace, trace_id
+    )
+    raw_available = isinstance(trace, dict)
+    trace = trace or {}
+
     return TraceDetail(
         id=row.id,
         session_id=row.session_id,
@@ -467,7 +477,7 @@ async def get_trace(
         parse_error=row.parse_error,
         recognized_contract=row.recognized_contract,
         derived=row.derived,
-        metadata=row.trace_metadata,
-        input=raw.get("input"),
-        output=raw.get("output"),
+        raw_available=raw_available,
+        input=trace.get("input"),
+        output=trace.get("output"),
     )

--- a/src/api/services/langfuse/__init__.py
+++ b/src/api/services/langfuse/__init__.py
@@ -1,0 +1,7 @@
+"""Langfuse trace ingestion: parse traces into structured Postgres rows,
+fetch them from the Langfuse API, and orchestrate the daily/backfill ingestion.
+
+The parser (`parse`) reads ``trace.output`` as the agent's own ``AgentState``
+snapshot (src/agent/state.py) rather than scraping message text. See the plan
+at ~/.claude/plans for the full design rationale.
+"""

--- a/src/api/services/langfuse/__init__.py
+++ b/src/api/services/langfuse/__init__.py
@@ -2,6 +2,6 @@
 fetch them from the Langfuse API, and orchestrate the daily/backfill ingestion.
 
 The parser (`parse`) reads ``trace.output`` as the agent's own ``AgentState``
-snapshot (src/agent/state.py) rather than scraping message text. See the plan
-at ~/.claude/plans for the full design rationale.
+snapshot (src/agent/state.py) rather than scraping message text.
+
 """

--- a/src/api/services/langfuse/fetch.py
+++ b/src/api/services/langfuse/fetch.py
@@ -1,0 +1,197 @@
+"""Resilient client for the Langfuse ``/api/public/traces`` list endpoint.
+
+Design notes (validated against the staging instance, which 500s / hits
+ClickHouse memory limits under load):
+
+* Fetch over **closed, ascending time windows** (``fromTimestamp``/
+  ``toTimestamp`` + ``orderBy=timestamp.asc``). Never page-number over an
+  open-ended ``desc`` set — new traces arriving mid-run would shift offsets and
+  silently skip rows.
+* Retry 429 (honouring ``Retry-After``) and network errors with backoff.
+* On persistent 5xx, **halve the page size (floor 1) and restart the window**;
+  id-dedup makes the refetch safe. If it still fails at size 1, raise loudly
+  (``LangfuseFetchError``) so the caller records a failed chunk rather than
+  silently dropping data.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_TRACES_PATH = "/api/public/traces"
+
+
+class LangfuseFetchError(RuntimeError):
+    """Raised when a window cannot be fetched after retries + page-halving."""
+
+
+class _ServerError(Exception):
+    """Internal: a persistent 5xx for one page (triggers page-halving)."""
+
+
+def _iso(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _backoff(attempt: int) -> float:
+    # exponential with jitter, capped
+    return min(30.0, (2**attempt) + random.uniform(0, 1.0))
+
+
+@dataclass
+class LangfuseClient:
+    host: str
+    public_key: str
+    secret_key: str
+    timeout: float = 60.0
+    max_retries: int = 6
+
+    @classmethod
+    def from_env(cls) -> "LangfuseClient":
+        """Build from LANGFUSE_HOST/PUBLIC_KEY/SECRET_KEY (KeyError if missing)."""
+        return cls(
+            host=os.environ["LANGFUSE_HOST"].rstrip("/"),
+            public_key=os.environ["LANGFUSE_PUBLIC_KEY"],
+            secret_key=os.environ["LANGFUSE_SECRET_KEY"],
+        )
+
+    # -- public API -------------------------------------------------------- #
+    def fetch_window(
+        self,
+        from_ts: datetime,
+        to_ts: datetime,
+        environment: Optional[str] = None,
+        page_size: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return all traces with ``from_ts <= timestamp < to_ts`` (ascending),
+        de-duplicated by id. Raises ``LangfuseFetchError`` on unrecoverable
+        failure."""
+        limit = page_size
+        with httpx.Client(timeout=self.timeout) as client:
+            while True:
+                try:
+                    return self._fetch_all_pages(
+                        client, from_ts, to_ts, environment, limit
+                    )
+                except _ServerError as e:
+                    if limit <= 1:
+                        raise LangfuseFetchError(
+                            f"Langfuse 5xx at page size 1 for window "
+                            f"[{_iso(from_ts)}, {_iso(to_ts)}): {e}"
+                        ) from e
+                    new_limit = max(1, limit // 2)
+                    logger.warning(
+                        "langfuse_fetch_halving_page_size",
+                        old_limit=limit,
+                        new_limit=new_limit,
+                        window_start=_iso(from_ts),
+                    )
+                    limit = new_limit
+
+    # -- internals --------------------------------------------------------- #
+    def _fetch_all_pages(
+        self,
+        client: httpx.Client,
+        from_ts: datetime,
+        to_ts: datetime,
+        environment: Optional[str],
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        seen: set[str] = set()
+        out: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            data = self._get_page(
+                client, page, limit, from_ts, to_ts, environment
+            )
+            rows = data.get("data") or []
+            for r in rows:
+                rid = r.get("id")
+                if rid and rid not in seen:
+                    seen.add(rid)
+                    out.append(r)
+            meta = data.get("meta") or {}
+            total_pages = meta.get("totalPages")
+            if not rows or (total_pages is not None and page >= total_pages):
+                return out
+            page += 1
+
+    def _get_page(
+        self,
+        client: httpx.Client,
+        page: int,
+        limit: int,
+        from_ts: datetime,
+        to_ts: datetime,
+        environment: Optional[str],
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {
+            "page": page,
+            "limit": limit,
+            "orderBy": "timestamp.asc",
+            "fromTimestamp": _iso(from_ts),
+            "toTimestamp": _iso(to_ts),
+        }
+        if environment:
+            params["environment"] = environment
+
+        attempt = 0
+        server_errors = 0
+        while True:
+            try:
+                resp = client.get(
+                    self.host + _TRACES_PATH,
+                    params=params,
+                    auth=(self.public_key, self.secret_key),
+                )
+            except httpx.RequestError as e:
+                attempt += 1
+                if attempt > self.max_retries:
+                    raise LangfuseFetchError(
+                        f"network error after {attempt} attempts: {e}"
+                    ) from e
+                time.sleep(_backoff(attempt))
+                continue
+
+            if resp.status_code == 429:
+                wait = _retry_after(resp) or _backoff(attempt)
+                attempt += 1
+                if attempt > self.max_retries:
+                    raise LangfuseFetchError("rate-limited past max_retries")
+                logger.warning("langfuse_rate_limited", wait_s=round(wait, 1))
+                time.sleep(wait)
+                continue
+
+            if resp.status_code >= 500:
+                server_errors += 1
+                if server_errors > 2:
+                    # let the window halve its page size
+                    raise _ServerError(f"{resp.status_code} x{server_errors}")
+                time.sleep(_backoff(server_errors))
+                continue
+
+            resp.raise_for_status()
+            return resp.json()
+
+
+def _retry_after(resp: httpx.Response) -> Optional[float]:
+    raw = resp.headers.get("Retry-After")
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None

--- a/src/api/services/langfuse/fetch.py
+++ b/src/api/services/langfuse/fetch.py
@@ -101,6 +101,42 @@ class LangfuseClient:
                     )
                     limit = new_limit
 
+    def fetch_trace(self, trace_id: str) -> Optional[dict[str, Any]]:
+        """Fetch a single trace by id (the cheap/reliable path). Returns the
+        trace dict, or None if it doesn't exist (404). Raises
+        ``LangfuseFetchError`` only on persistent transport/server failure."""
+        url = f"{self.host}{_TRACES_PATH}/{trace_id}"
+        attempt = 0
+        with httpx.Client(timeout=self.timeout) as client:
+            while True:
+                try:
+                    resp = client.get(
+                        url, auth=(self.public_key, self.secret_key)
+                    )
+                except httpx.RequestError as e:
+                    attempt += 1
+                    if attempt > self.max_retries:
+                        raise LangfuseFetchError(
+                            f"network error fetching {trace_id}: {e}"
+                        ) from e
+                    time.sleep(_backoff(attempt))
+                    continue
+
+                if resp.status_code == 404:
+                    return None
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    attempt += 1
+                    if attempt > self.max_retries:
+                        raise LangfuseFetchError(
+                            f"{resp.status_code} fetching {trace_id} "
+                            f"past max_retries"
+                        )
+                    time.sleep(_retry_after(resp) or _backoff(attempt))
+                    continue
+
+                resp.raise_for_status()
+                return resp.json()
+
     # -- internals --------------------------------------------------------- #
     def _fetch_all_pages(
         self,

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -1,0 +1,403 @@
+"""Orchestrate Langfuse trace ingestion into Postgres.
+
+Fetch a closed time window (ascending), parse each trace against the AgentState
+contract, idempotently upsert rows, and record a ``langfuse_ingestion_runs`` row
+with watermark + drift-observability metrics (fill rates, soft-FK resolve rates,
+unrecognized-contract rate).
+
+Watermark advances only at a fully-completed window/chunk boundary; a chunk that
+fails after retries aborts the run (no silent gaps), leaving the watermark on the
+last contiguous good chunk so the next run resumes there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Optional
+
+from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.data_models import LangfuseIngestionRunOrm, LangfuseTraceOrm
+from src.api.services.langfuse import parse as P
+from src.api.services.langfuse.fetch import LangfuseClient, LangfuseFetchError
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Langfuse caps list page size (a 300 request 400s); 50 is proven-safe.
+MAX_PAGE_SIZE = 50
+
+# Real columns whose population we monitor for drift (fill-rate per run).
+MONITORED_COLS = (
+    "prompt",
+    "answer",
+    "outcome",
+    "aoi_name",
+    "aoi_type",
+    "primary_dataset_name",
+    "insight_id",
+    "turn_tokens",
+    "has_answer",
+)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_dt(raw: Any) -> Optional[datetime]:
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    s = raw.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Row building
+# --------------------------------------------------------------------------- #
+def build_row(trace: dict[str, Any]) -> dict[str, Any]:
+    """Map a raw trace to a langfuse_traces row dict. Parse failures still yield
+    a row (raw + parse_error) so one bad trace never aborts the batch."""
+    row: dict[str, Any] = {
+        "id": trace.get("id"),
+        "session_id": trace.get("sessionId"),
+        "user_id": trace.get("userId"),
+        "environment": trace.get("environment"),
+        "trace_timestamp": _parse_dt(trace.get("timestamp")),
+        "trace_updated_at": _parse_dt(trace.get("updatedAt")),
+        "raw": trace,
+        "trace_metadata": trace.get("metadata"),
+        "latency_seconds": trace.get("latency"),
+        "total_cost": trace.get("totalCost"),
+        "parsed_at": _utcnow(),
+        "parse_error": None,
+    }
+    try:
+        parsed = P.parse_trace(trace)
+        for col in P.COLUMN_KEYS:
+            row[col] = parsed.get(col)
+        row["derived"] = parsed["derived"]
+        row["recognized_contract"] = parsed["recognized_contract"]
+        row["parser_version"] = parsed["parser_version"]
+    except Exception as e:  # defensive: never let one trace kill the batch
+        logger.warning(
+            "trace_parse_failed", trace_id=trace.get("id"), error=str(e)
+        )
+        row["parse_error"] = str(e)[:500]
+        row["parser_version"] = P.PARSER_VERSION
+        row["recognized_contract"] = None
+    return row
+
+
+# --------------------------------------------------------------------------- #
+# Upsert
+# --------------------------------------------------------------------------- #
+async def _upsert(session: AsyncSession, rows: list[dict[str, Any]]) -> int:
+    if not rows:
+        return 0
+    keys: set[str] = set()
+    for r in rows:
+        keys.update(r.keys())
+    stmt = pg_insert(LangfuseTraceOrm).values(rows)
+    update_cols = {k: stmt.excluded[k] for k in keys if k != "id"}
+    stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_cols)
+    await session.execute(stmt)
+    return len(rows)
+
+
+# --------------------------------------------------------------------------- #
+# Per-run metric accumulation
+# --------------------------------------------------------------------------- #
+@dataclass
+class _Metrics:
+    n_rows: int = 0
+    fill_counts: dict[str, int] = field(
+        default_factory=lambda: {c: 0 for c in MONITORED_COLS}
+    )
+    # soft-FK: key -> [present, resolved]
+    fk: dict[str, list[int]] = field(
+        default_factory=lambda: {
+            "session_id": [0, 0],
+            "user_id": [0, 0],
+            "insight_id": [0, 0],
+        }
+    )
+    contract_applicable: int = 0
+    contract_bad: int = 0
+
+    def add_rows(self, rows: list[dict[str, Any]]) -> None:
+        self.n_rows += len(rows)
+        for r in rows:
+            for c in MONITORED_COLS:
+                if r.get(c) is not None:
+                    self.fill_counts[c] += 1
+            rc = r.get("recognized_contract")
+            if rc is not None:
+                self.contract_applicable += 1
+                if rc is False:
+                    self.contract_bad += 1
+
+    def fill_rates(self) -> dict[str, float]:
+        if not self.n_rows:
+            return {}
+        return {
+            c: round(self.fill_counts[c] / self.n_rows, 4)
+            for c in MONITORED_COLS
+        }
+
+    def fk_resolve_rates(self) -> dict[str, float]:
+        return {k: round(v[1] / v[0], 4) for k, v in self.fk.items() if v[0]}
+
+    def unrecognized_rate(self) -> Optional[float]:
+        if not self.contract_applicable:
+            return None
+        return round(self.contract_bad / self.contract_applicable, 4)
+
+
+async def _count_existing(
+    session: AsyncSession, table: str, col: str, ids: set[str]
+) -> int:
+    if not ids:
+        return 0
+    # table/col are fixed internal constants (not user input).
+    sql = text(
+        f"SELECT count(DISTINCT {col}) FROM {table} WHERE {col}::text = ANY(:ids)"
+    )
+    res = await session.execute(sql, {"ids": list(ids)})
+    return int(res.scalar() or 0)
+
+
+async def _accumulate_fk(
+    session: AsyncSession, rows: list[dict[str, Any]], m: _Metrics
+) -> None:
+    """Best-effort soft-FK resolve-rate sampling. Never fails ingestion."""
+    try:
+        for key, (tbl, col) in {
+            "session_id": ("threads", "id"),
+            "user_id": ("users", "id"),
+            "insight_id": ("insights", "id"),
+        }.items():
+            ids = {r[key] for r in rows if r.get(key)}
+            if not ids:
+                continue
+            resolved = await _count_existing(session, tbl, col, ids)
+            m.fk[key][0] += len(ids)
+            m.fk[key][1] += resolved
+    except Exception as e:  # monitoring must not break ingestion
+        logger.warning("fk_resolve_sampling_failed", error=str(e))
+
+
+# --------------------------------------------------------------------------- #
+# Window ingestion
+# --------------------------------------------------------------------------- #
+@dataclass
+class WindowStats:
+    fetched: int = 0
+    upserted: int = 0
+    max_ts: Optional[datetime] = None
+
+
+async def ingest_window(
+    session: AsyncSession,
+    client: LangfuseClient,
+    from_ts: datetime,
+    to_ts: datetime,
+    environment: Optional[str],
+    metrics: _Metrics,
+    *,
+    batch_size: int = 300,
+    dry_run: bool = False,
+) -> WindowStats:
+    """Fetch one closed window, parse, and upsert (chunked). The sync fetch runs
+    in a thread so it doesn't block the event loop. Fetch page size is clamped to
+    the Langfuse API max (100); the upsert batch size is independent."""
+    page_size = min(batch_size, MAX_PAGE_SIZE)
+    traces = await asyncio.to_thread(
+        client.fetch_window, from_ts, to_ts, environment, page_size
+    )
+    stats = WindowStats(fetched=len(traces))
+    batch: list[dict[str, Any]] = []
+    for t in traces:
+        row = build_row(t)
+        if row["trace_timestamp"] is not None:
+            if stats.max_ts is None or row["trace_timestamp"] > stats.max_ts:
+                stats.max_ts = row["trace_timestamp"]
+        batch.append(row)
+        if len(batch) >= batch_size:
+            await _flush(session, batch, metrics, stats, dry_run)
+            batch = []
+    if batch:
+        await _flush(session, batch, metrics, stats, dry_run)
+    return stats
+
+
+async def _flush(
+    session: AsyncSession,
+    batch: list[dict[str, Any]],
+    metrics: _Metrics,
+    stats: WindowStats,
+    dry_run: bool,
+) -> None:
+    metrics.add_rows(batch)
+    await _accumulate_fk(session, batch, metrics)
+    if not dry_run:
+        stats.upserted += await _upsert(session, batch)
+
+
+# --------------------------------------------------------------------------- #
+# Watermark + windows
+# --------------------------------------------------------------------------- #
+async def resolve_start_watermark(
+    session: AsyncSession, environment: Optional[str]
+) -> Optional[datetime]:
+    stmt = select(func.max(LangfuseIngestionRunOrm.watermark)).where(
+        LangfuseIngestionRunOrm.status.in_(("success", "partial"))
+    )
+    if environment:
+        stmt = stmt.where(LangfuseIngestionRunOrm.environment == environment)
+    res = await session.execute(stmt)
+    return res.scalar()
+
+
+def _chunks(
+    since: datetime, until: datetime, chunk_hours: int
+) -> Iterable[tuple[datetime, datetime]]:
+    cur = since
+    step = timedelta(hours=chunk_hours)
+    while cur < until:
+        nxt = min(cur + step, until)
+        yield cur, nxt
+        cur = nxt
+
+
+# --------------------------------------------------------------------------- #
+# Top-level run
+# --------------------------------------------------------------------------- #
+@dataclass
+class RunResult:
+    fetched: int = 0
+    upserted: int = 0
+    chunks_total: int = 0
+    chunks_failed: int = 0
+    status: str = "success"
+    watermark: Optional[datetime] = None
+
+
+async def run_ingestion(
+    session: AsyncSession,
+    *,
+    since: datetime,
+    until: datetime,
+    environment: Optional[str] = None,
+    chunk_hours: int = 24,
+    batch_size: int = 300,
+    dry_run: bool = False,
+) -> RunResult:
+    """Ingest [since, until) in ascending chunks, with one run row recording
+    counts, watermark, and drift metrics. Aborts (status=partial) on the first
+    chunk that fails after retries, leaving the watermark on the last good chunk.
+    """
+    client = LangfuseClient.from_env()
+    run = LangfuseIngestionRunOrm(
+        window_start=since,
+        window_end=until,
+        environment=environment,
+        parser_version=P.PARSER_VERSION,
+        status="running",
+    )
+    session.add(run)
+    await session.flush()  # get run.id
+
+    metrics = _Metrics()
+    result = RunResult()
+
+    for cfrom, cto in _chunks(since, until, chunk_hours):
+        result.chunks_total += 1
+        try:
+            ws = await ingest_window(
+                session,
+                client,
+                cfrom,
+                cto,
+                environment,
+                metrics,
+                batch_size=batch_size,
+                dry_run=dry_run,
+            )
+        except LangfuseFetchError as e:
+            logger.error(
+                "ingest_chunk_failed",
+                window_start=cfrom.isoformat(),
+                error=str(e),
+            )
+            result.chunks_failed += 1
+            result.status = "partial"
+            break
+        result.fetched += ws.fetched
+        result.upserted += ws.upserted
+        if not dry_run:
+            await session.commit()  # persist chunk before advancing watermark
+        result.watermark = cto  # contiguous advance
+        logger.info(
+            "ingest_chunk_done",
+            window_start=cfrom.isoformat(),
+            fetched=ws.fetched,
+            upserted=ws.upserted,
+        )
+
+    run.finished_at = _utcnow()
+    run.traces_fetched = result.fetched
+    run.traces_upserted = result.upserted
+    run.chunks_total = result.chunks_total
+    run.chunks_failed = result.chunks_failed
+    run.status = result.status if not dry_run else "success"
+    run.watermark = result.watermark
+    run.fill_rates = metrics.fill_rates()
+    run.fk_resolve_rates = metrics.fk_resolve_rates()
+    run.unrecognized_contract_rate = metrics.unrecognized_rate()
+    if not dry_run:
+        await session.commit()
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Reparse (no Langfuse re-fetch)
+# --------------------------------------------------------------------------- #
+async def reparse_stored(
+    session: AsyncSession,
+    *,
+    batch_size: int = 300,
+    limit: Optional[int] = None,
+) -> int:
+    """Re-derive columns from stored ``raw`` for rows below the current
+    PARSER_VERSION. Date-bounded/limited and chunked; never one big transaction."""
+    total = 0
+    while True:
+        stmt = (
+            select(LangfuseTraceOrm.id, LangfuseTraceOrm.raw)
+            .where(LangfuseTraceOrm.parser_version < P.PARSER_VERSION)
+            .limit(batch_size)
+        )
+        rows = (await session.execute(stmt)).all()
+        if not rows:
+            break
+        updates = []
+        for tid, raw in rows:
+            new = build_row(raw)
+            new["id"] = tid
+            updates.append(new)
+        await _upsert(session, updates)
+        await session.commit()
+        total += len(updates)
+        if limit is not None and total >= limit:
+            break
+    return total

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -65,8 +65,9 @@ def _parse_dt(raw: Any) -> Optional[datetime]:
 # Row building
 # --------------------------------------------------------------------------- #
 def build_row(trace: dict[str, Any]) -> dict[str, Any]:
-    """Map a raw trace to a langfuse_traces row dict. Parse failures still yield
-    a row (raw + parse_error) so one bad trace never aborts the batch."""
+    """Map a trace to a langfuse_traces (derived analytics) row dict. Parse
+    failures still yield a row (identity + parse_error) so one bad trace never
+    aborts the batch."""
     row: dict[str, Any] = {
         "id": trace.get("id"),
         "session_id": trace.get("sessionId"),
@@ -74,8 +75,6 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         "environment": trace.get("environment"),
         "trace_timestamp": _parse_dt(trace.get("timestamp")),
         "trace_updated_at": _parse_dt(trace.get("updatedAt")),
-        "raw": trace,
-        "trace_metadata": trace.get("metadata"),
         "latency_seconds": trace.get("latency"),
         "total_cost": trace.get("totalCost"),
         "parsed_at": _utcnow(),
@@ -367,37 +366,3 @@ async def run_ingestion(
     if not dry_run:
         await session.commit()
     return result
-
-
-# --------------------------------------------------------------------------- #
-# Reparse (no Langfuse re-fetch)
-# --------------------------------------------------------------------------- #
-async def reparse_stored(
-    session: AsyncSession,
-    *,
-    batch_size: int = 300,
-    limit: Optional[int] = None,
-) -> int:
-    """Re-derive columns from stored ``raw`` for rows below the current
-    PARSER_VERSION. Date-bounded/limited and chunked; never one big transaction."""
-    total = 0
-    while True:
-        stmt = (
-            select(LangfuseTraceOrm.id, LangfuseTraceOrm.raw)
-            .where(LangfuseTraceOrm.parser_version < P.PARSER_VERSION)
-            .limit(batch_size)
-        )
-        rows = (await session.execute(stmt)).all()
-        if not rows:
-            break
-        updates = []
-        for tid, raw in rows:
-            new = build_row(raw)
-            new["id"] = tid
-            updates.append(new)
-        await _upsert(session, updates)
-        await session.commit()
-        total += len(updates)
-        if limit is not None and total >= limit:
-            break
-    return total

--- a/src/api/services/langfuse/parse.py
+++ b/src/api/services/langfuse/parse.py
@@ -1,0 +1,488 @@
+"""Parse Langfuse traces into structured rows.
+
+A Langfuse trace corresponds to one agent *turn*. Its ``output`` is the full
+final ``AgentState`` snapshot (src/agent/state.py) — carrying ``aoi_selection``,
+``dataset``, ``statistics``, ``insight_id`` etc. alongside ``messages`` — so the
+structured domain fields are read directly from that contract (no regex).
+
+Two important correctness points, validated against real staging traces:
+
+* ``output`` (and ``output.messages``) is **thread-cumulative** (state uses
+  ``operator.add``). So per-turn metrics (tokens, tool calls) are computed over
+  the **active-turn window** of the message stream, NOT the whole history —
+  otherwise late turns get inflated counts.
+* A single tool result with ``status="error"`` is common (~30% of turns) and the
+  agent usually recovers, so it must NOT by itself mark the turn a failure. We
+  record ``tool_error_count`` as a separate signal and classify the outcome from
+  the final active-turn AI message.
+
+These functions are pure (no IO). ``parse_trace`` returns derived column values
+plus a ``derived`` JSONB bundle; ``ingest`` adds identity/raw fields.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# Bump on any change to derivation logic, then run `ingest-langfuse-traces
+# --reparse`. Keep PARSER_CHANGELOG in sync so reparse can target affected work.
+PARSER_VERSION = 1
+PARSER_CHANGELOG = {
+    1: "Initial: AgentState-contract state parsing + active-turn-window metrics.",
+}
+
+# Top-level keys we expect on ``trace.output`` (the AgentState snapshot).
+# Used for drift detection: unknown keys => additive drift (benign, logged);
+# a sharp drop in a known key's fill-rate => subtractive drift (investigate).
+EXPECTED_STATE_KEYS = frozenset(
+    {
+        "messages",
+        "user_persona",
+        "aoi_selection",
+        "dataset",
+        "suggested_datasets",
+        "start_date",
+        "end_date",
+        "statistics",
+        "insight",
+        "insight_id",
+        "follow_up_suggestions",
+        "charts_data",
+        "codeact_parts",
+    }
+)
+
+# Display name(s) the agent uses for a global (all-countries) selection. Defined
+# here to keep this module dependency-free; a contract test asserts it still
+# matches GLOBAL_AOI_SELECTION_NAME in src/agent/.../global_queries.py so a
+# rename there fails CI loudly rather than silently flipping is_global.
+GLOBAL_AOI_NAMES = frozenset(
+    {"All countries in the world", "Selected all countries in the world"}
+)
+
+_REFUSAL_NEEDLES = (
+    "i can't",
+    "i cannot",
+    "i'm sorry",
+    "i am sorry",
+    "i'm unable",
+    "i am unable",
+    "unable to",
+    "apologi",  # apologize / apologies
+)
+
+# Optional language detection (low-value, isolated). Works without the dep.
+try:  # pragma: no cover - exercised only when langid is installed
+    import langid as _langid
+except Exception:  # pragma: no cover
+    _langid = None
+
+
+# --------------------------------------------------------------------------- #
+# Message helpers
+# --------------------------------------------------------------------------- #
+def _mtype(m: dict[str, Any]) -> str:
+    t = (m.get("type") or m.get("role") or "").lower()
+    return {"assistant": "ai", "user": "human"}.get(t, t)
+
+
+def _text(content: Any) -> str:
+    """Flatten message content (string or list of content blocks) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out: list[str] = []
+        for c in content:
+            if isinstance(c, str):
+                out.append(c)
+            elif isinstance(c, dict):
+                v = c.get("text") or c.get("content")
+                if isinstance(v, str):
+                    out.append(v)
+        return "\n".join(o for o in out if o)
+    if isinstance(content, dict):
+        v = content.get("text") or content.get("content")
+        return v if isinstance(v, str) else ""
+    return ""
+
+
+def _finish_reason(m: dict[str, Any]) -> str:
+    meta = m.get("response_metadata") or {}
+    fr = (
+        meta.get("finish_reason")
+        or meta.get("stop_reason")
+        or m.get("finish_reason")
+        or m.get("stop_reason")
+        or ""
+    )
+    return str(fr).lower()
+
+
+def _is_meaningful_human(text: str) -> bool:
+    """Skip synthetic UI-action human messages ('User selected ...')."""
+    if not text or not text.strip():
+        return False
+    t = text.strip().lower()
+    synthetic_prefixes = (
+        "user selected",
+        "user clicked",
+        "user chose",
+        "user set",
+        "user changed",
+        "user uploaded",
+        "user drew",
+        "user toggled",
+        "selected aoi",
+        "selected dataset",
+    )
+    if t.startswith(synthetic_prefixes):
+        return False
+    return any(ch.isalnum() for ch in text)
+
+
+def _usage(m: dict[str, Any]) -> tuple[int, int, int, int]:
+    """Return (input, output, total, cache_read) tokens for an AI message,
+    tolerant of Gemini/LangChain and OpenAI key shapes."""
+    u = m.get("usage_metadata") or m.get("usage") or {}
+    if not isinstance(u, dict):
+        return 0, 0, 0, 0
+    inp = int(u.get("input_tokens") or u.get("prompt_tokens") or 0)
+    out = int(u.get("output_tokens") or u.get("completion_tokens") or 0)
+    total = int(u.get("total_tokens") or (inp + out))
+    details = u.get("input_token_details") or {}
+    cache = int(
+        details.get("cache_read")
+        or details.get("cache_read_input_tokens")
+        or 0
+    )
+    return inp, out, total, cache
+
+
+def _looks_like_refusal(text: str) -> bool:
+    t = (text or "").strip().lower()
+    return bool(t) and any(n in t for n in _REFUSAL_NEEDLES)
+
+
+# --------------------------------------------------------------------------- #
+# Active-turn windowing
+# --------------------------------------------------------------------------- #
+def _last_meaningful_human(
+    msgs: list[dict[str, Any]], lo: int, hi: int
+) -> Optional[int]:
+    for j in range(hi, lo - 1, -1):
+        m = msgs[j]
+        if _mtype(m) == "human" and _is_meaningful_human(
+            _text(m.get("content"))
+        ):
+            return j
+    return None
+
+
+def active_turn_window(
+    msgs: list[dict[str, Any]],
+) -> tuple[Optional[int], Optional[int]]:
+    """Inclusive (start, end) indices of the latest turn within ``msgs``.
+
+    A turn ends at an AI message that finished (``end_turn``, or ``stop``
+    followed by a human / end of list) and starts at the latest meaningful human
+    message before it. Returns (None, None) for empty input.
+    """
+    if not msgs:
+        return None, None
+
+    end_idxs: list[int] = []
+    for i, m in enumerate(msgs):
+        if _mtype(m) != "ai":
+            continue
+        fr = _finish_reason(m)
+        if fr == "end_turn":
+            end_idxs.append(i)
+        elif fr == "stop":
+            nxt = i + 1
+            if nxt >= len(msgs) or _mtype(msgs[nxt]) == "human":
+                end_idxs.append(i)
+
+    if not end_idxs:
+        start = _last_meaningful_human(msgs, 0, len(msgs) - 1)
+        return start, len(msgs) - 1
+
+    end = end_idxs[-1]
+    prev_end = end_idxs[-2] if len(end_idxs) > 1 else -1
+    start = _last_meaningful_human(msgs, prev_end + 1, end - 1)
+    if start is None:
+        start = prev_end + 1 if prev_end + 1 <= end else end
+    return start, end
+
+
+# --------------------------------------------------------------------------- #
+# State parsing (the AgentState contract)
+# --------------------------------------------------------------------------- #
+def parse_state(output: Any) -> dict[str, Any]:
+    """Derive domain fields from ``trace.output`` (the AgentState snapshot).
+
+    Current-state fields (aoi/dataset/insight) are per-turn-meaningful (the
+    selection in effect this turn). Cumulative fields (datasets/statistics ids)
+    reflect the whole thread and are named/kept accordingly.
+    """
+    out = output if isinstance(output, dict) else {}
+    unknown = sorted(set(out) - EXPECTED_STATE_KEYS)
+    # None => not applicable (output absent, ~6% of traces — not a contract
+    # violation). True/False only when output IS a dict, so the drift metric
+    # (unrecognized_contract_rate) flags genuinely malformed AgentState shapes.
+    recognized = ("messages" in out) if isinstance(output, dict) else None
+
+    aoi_sel = out.get("aoi_selection") or {}
+    aois = aoi_sel.get("aois") or []
+    aois = [a for a in aois if isinstance(a, dict)]
+    primary_aoi = aois[0] if aois else {}
+    aoi_name = aoi_sel.get("name") or primary_aoi.get("name")
+    is_global = (
+        bool(aoi_sel.get("name") in GLOBAL_AOI_NAMES) if aoi_sel else False
+    )
+
+    dataset = out.get("dataset") or {}
+    if not isinstance(dataset, dict):
+        dataset = {}
+
+    stats = [s for s in (out.get("statistics") or []) if isinstance(s, dict)]
+    datasets_cumulative = list(
+        dict.fromkeys(
+            s.get("dataset_name") for s in stats if s.get("dataset_name")
+        )
+    )
+    statistics_ids = [s.get("id") for s in stats if s.get("id")]
+
+    primary_dataset_name = dataset.get("dataset_name") or (
+        datasets_cumulative[-1] if datasets_cumulative else None
+    )
+
+    insight_id = out.get("insight_id") or None
+    has_insight = bool(insight_id) or bool(out.get("insight"))
+
+    return {
+        # current-state columns
+        "aoi_name": aoi_name or None,
+        "aoi_type": primary_aoi.get("subtype") or None,
+        "primary_dataset_name": primary_dataset_name or None,
+        "has_insight": has_insight,
+        "is_global": is_global,
+        "insight_id": insight_id,
+        # long-tail / cumulative (-> derived JSONB)
+        "aoi_source": primary_aoi.get("source") or None,
+        "aoi_count": len(aois),
+        "aois": [
+            {
+                "name": a.get("name"),
+                "type": a.get("subtype"),
+                "source": a.get("source"),
+            }
+            for a in aois
+        ],
+        "primary_dataset_id": dataset.get("dataset_id"),
+        "analysis_start_date": out.get("start_date") or None,
+        "analysis_end_date": out.get("end_date") or None,
+        "datasets_analysed_cumulative": datasets_cumulative,
+        "statistics_ids": statistics_ids,
+        # drift signals
+        "unknown_output_keys": unknown,
+        "recognized_contract": recognized,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Message parsing (active-turn metrics + outcome primitives)
+# --------------------------------------------------------------------------- #
+_DATASET_ARG_KEYS = ("dataset_name", "dataset", "dataset_id")
+
+
+def parse_messages(
+    output_messages: Any, input_messages: Any
+) -> dict[str, Any]:
+    """Derive prompt/answer, outcome primitives and per-turn metrics from the
+    active-turn window of ``output.messages``."""
+    msgs = [m for m in (output_messages or []) if isinstance(m, dict)]
+    in_msgs = [m for m in (input_messages or []) if isinstance(m, dict)]
+
+    start, end = active_turn_window(msgs)
+    window = (
+        msgs[start : end + 1] if start is not None and end is not None else []
+    )
+
+    # prompt: active-turn human, else first meaningful human in input/output
+    prompt = ""
+    if window and _mtype(window[0]) == "human":
+        prompt = _text(window[0].get("content")).strip()
+    if not prompt:
+        for m in in_msgs + msgs:
+            if _mtype(m) == "human" and _is_meaningful_human(
+                _text(m.get("content"))
+            ):
+                prompt = _text(m.get("content")).strip()
+                break
+
+    # final AI message of the window -> answer + finish_reason
+    answer = ""
+    answer_finish_reason = None
+    had_ai_message = False
+    for m in reversed(window):
+        if _mtype(m) == "ai":
+            had_ai_message = True
+            answer = _text(m.get("content")).strip()
+            answer_finish_reason = _finish_reason(m) or None
+            if answer:
+                break
+
+    # per-turn metrics over the window
+    t_in = t_out = t_total = t_cache = 0
+    tool_calls = 0
+    tool_error_count = 0
+    tools_used: list[str] = []
+    turn_datasets: list[str] = []
+    had_tool_call = False
+    for m in window:
+        mt = _mtype(m)
+        if mt == "ai":
+            i, o, tot, c = _usage(m)
+            t_in += i
+            t_out += o
+            t_total += tot
+            t_cache += c
+            for tc in m.get("tool_calls") or []:
+                if not isinstance(tc, dict):
+                    continue
+                had_tool_call = True
+                tool_calls += 1
+                name = tc.get("name")
+                if name and name not in tools_used:
+                    tools_used.append(name)
+                args = tc.get("args") or {}
+                if isinstance(args, dict):
+                    for k in _DATASET_ARG_KEYS:
+                        v = args.get(k)
+                        if (
+                            isinstance(v, str)
+                            and v.strip()
+                            and v not in turn_datasets
+                        ):
+                            turn_datasets.append(v.strip())
+        elif mt == "tool":
+            had_tool_call = True
+            if str(m.get("status") or "").lower() == "error":
+                tool_error_count += 1
+
+    has_answer = bool(answer)
+    answer_is_refusal = _looks_like_refusal(answer)
+    outcome = derive_outcome(
+        has_answer=has_answer,
+        had_ai_message=had_ai_message,
+        answer_is_refusal=answer_is_refusal,
+        had_tool_call=had_tool_call,
+    )
+    language, language_confidence = _detect_language(prompt)
+
+    return {
+        "prompt": prompt or None,
+        "answer": answer or None,
+        # outcome primitives + derived label
+        "has_answer": has_answer,
+        "answer_finish_reason": answer_finish_reason,
+        "answer_is_refusal": answer_is_refusal,
+        "had_tool_call": had_tool_call,
+        "tool_error_count": tool_error_count,
+        "outcome": outcome,
+        # per-turn metrics
+        "turn_input_tokens": t_in,
+        "turn_output_tokens": t_out,
+        "turn_tokens": t_total,
+        "turn_tool_calls": tool_calls,
+        # long-tail (-> derived JSONB)
+        "cache_read_tokens": t_cache,
+        "turn_tools_used": tools_used,
+        "turn_datasets": turn_datasets,
+        "had_ai_message": had_ai_message,
+        "language": language,
+        "language_confidence": language_confidence,
+    }
+
+
+def derive_outcome(
+    *,
+    has_answer: bool,
+    had_ai_message: bool,
+    answer_is_refusal: bool,
+    had_tool_call: bool,
+) -> str:
+    """Turn-level outcome from primitives (re-derivable; not an opaque enum)."""
+    if not has_answer:
+        return "ERROR" if had_ai_message else "EMPTY"
+    if answer_is_refusal:
+        return "SOFT_ERROR"
+    if not had_tool_call:
+        return "DEFER"
+    return "ANSWER"
+
+
+def _detect_language(
+    text: Optional[str],
+) -> tuple[Optional[str], Optional[float]]:
+    if not _langid or not text or len(text.strip()) < 12:
+        return None, None
+    try:  # pragma: no cover - depends on optional dep
+        lang, score = _langid.classify(text)
+        return str(lang), float(score)
+    except Exception:  # pragma: no cover
+        return None, None
+
+
+# --------------------------------------------------------------------------- #
+# Top-level
+# --------------------------------------------------------------------------- #
+# Column-valued keys produced by parse_trace (everything else goes to `derived`).
+COLUMN_KEYS = frozenset(
+    {
+        "prompt",
+        "answer",
+        "turn_input_tokens",
+        "turn_output_tokens",
+        "turn_tokens",
+        "turn_tool_calls",
+        "has_answer",
+        "answer_finish_reason",
+        "answer_is_refusal",
+        "had_tool_call",
+        "tool_error_count",
+        "outcome",
+        "aoi_name",
+        "aoi_type",
+        "primary_dataset_name",
+        "has_insight",
+        "is_global",
+        "insight_id",
+    }
+)
+
+
+def parse_trace(trace: dict[str, Any]) -> dict[str, Any]:
+    """Parse one trace into ``{<column>: value, ..., "derived": {...},
+    "recognized_contract": bool, "parser_version": int}``.
+
+    Identity/raw/timestamp fields are added by the ingest layer, not here.
+    """
+    output = trace.get("output")
+    state = parse_state(output)
+    msgs = output.get("messages") if isinstance(output, dict) else None
+    inp = trace.get("input") or {}
+    in_msgs = inp.get("messages") if isinstance(inp, dict) else None
+    msg = parse_messages(msgs or [], in_msgs or [])
+
+    combined = {**state, **msg}
+    row = {k: combined[k] for k in COLUMN_KEYS if k in combined}
+    derived = {k: v for k, v in combined.items() if k not in COLUMN_KEYS}
+    derived.pop("recognized_contract", None)
+
+    return {
+        **row,
+        "derived": derived,
+        "recognized_contract": state["recognized_contract"],
+        "parser_version": PARSER_VERSION,
+    }

--- a/src/api/services/langfuse/parse.py
+++ b/src/api/services/langfuse/parse.py
@@ -24,12 +24,9 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-# Bump on any change to derivation logic, then run `ingest-langfuse-traces
-# --reparse`. Keep PARSER_CHANGELOG in sync so reparse can target affected work.
+# Bump on any change to derivation logic; to apply it to existing rows, re-run
+# ingestion for the affected window (`ingest-langfuse-traces --backfill --since`).
 PARSER_VERSION = 1
-PARSER_CHANGELOG = {
-    1: "Initial: AgentState-contract state parsing + active-turn-window metrics.",
-}
 
 # Top-level keys we expect on ``trace.output`` (the AgentState snapshot).
 # Used for drift detection: unknown keys => additive drift (benign, logged);

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -125,3 +125,113 @@ async def test_detail_404(client, auth_override, superuser_factory):
     su = await superuser_factory("su_404@example.com")
     auth_override(su.id)
     assert (await client.get("/api/traces/nope", headers=H)).status_code == 404
+
+
+# --- analytics -------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_analytics(client, auth_override, superuser_factory):
+    su = await superuser_factory("su_an@example.com")
+    auth_override(su.id)
+    await _seed_trace(
+        "a1",
+        outcome="ANSWER",
+        aoi_type="country",
+        user_id="u1",
+        session_id="s1",
+        latency_seconds=1.0,
+        total_cost=0.01,
+        turn_tokens=100,
+        turn_tool_calls=2,
+        tool_error_count=0,
+        trace_timestamp=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    await _seed_trace(
+        "a2",
+        outcome="ANSWER",
+        aoi_type="state-province",
+        user_id="u1",
+        session_id="s1",
+        latency_seconds=3.0,
+        total_cost=0.03,
+        turn_tokens=200,
+        turn_tool_calls=1,
+        tool_error_count=1,
+        trace_timestamp=datetime(2026, 6, 1, 2, tzinfo=timezone.utc),
+    )
+    await _seed_trace(
+        "a3",
+        outcome="ERROR",
+        user_id="u2",
+        session_id="s2",
+        latency_seconds=2.0,
+        total_cost=0.02,
+        turn_tokens=0,
+        turn_tool_calls=0,
+        tool_error_count=0,
+        trace_timestamp=datetime(2026, 6, 2, tzinfo=timezone.utc),
+    )
+
+    # the literal /analytics route must not be shadowed by /{trace_id}
+    resp = await client.get("/api/traces/analytics", headers=H)
+    assert resp.status_code == 200
+    b = resp.json()
+    assert b["total_traces"] == 3
+    assert b["unique_sessions"] == 2
+    assert b["unique_users"] == 2
+    assert {o["value"]: o["count"] for o in b["outcome_breakdown"]} == {
+        "ANSWER": 2,
+        "ERROR": 1,
+    }
+    assert {a["value"]: a["count"] for a in b["aoi_type_breakdown"]} == {
+        "country": 1,
+        "state-province": 1,
+    }
+    assert len(b["daily_volume"]) == 2
+    assert b["latency"]["avg"] == 2.0
+    assert b["cost"]["total"] == 0.06
+    assert b["tokens"]["total_turn_tokens"] == 300.0
+    assert round(b["tool_usage"]["tool_error_rate"], 2) == 0.33
+
+
+@pytest.mark.asyncio
+async def test_analytics_requires_superuser(client, auth_override, user):
+    auth_override(user.id)
+    assert (
+        await client.get("/api/traces/analytics", headers=H)
+    ).status_code == 403
+
+
+# --- sessions --------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_sessions(client, auth_override, superuser_factory):
+    su = await superuser_factory("su_sess@example.com")
+    auth_override(su.id)
+    await _seed_trace(
+        "sx1",
+        session_id="sx",
+        user_id="u1",
+        prompt="first question",
+        trace_timestamp=datetime(2026, 6, 1, 0, tzinfo=timezone.utc),
+    )
+    await _seed_trace(
+        "sx2",
+        session_id="sx",
+        user_id="u1",
+        prompt="second question",
+        trace_timestamp=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+    )
+    await _seed_trace(
+        "sy1",
+        session_id="sy",
+        user_id="u2",
+        prompt="other thread",
+        trace_timestamp=datetime(2026, 6, 2, tzinfo=timezone.utc),
+    )
+
+    b = (await client.get("/api/traces/sessions", headers=H)).json()
+    assert b["total"] == 2
+    # newest session first (sy at day 2)
+    assert b["items"][0]["session_id"] == "sy"
+    sx = next(s for s in b["items"] if s["session_id"] == "sx")
+    assert sx["turn_count"] == 2
+    assert sx["first_prompt"] == "first question"  # earliest turn's prompt

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -1,0 +1,127 @@
+"""Tests for the superuser-gated Langfuse trace explorer endpoints."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.data_models import LangfuseTraceOrm
+from tests.conftest import async_session_maker
+
+H = {"Authorization": "Bearer test-token"}
+
+
+async def _seed_trace(trace_id: str, **kw) -> None:
+    raw = kw.pop(
+        "raw", {"input": {"messages": []}, "output": {"messages": []}}
+    )
+    async with async_session_maker() as session:
+        session.add(
+            LangfuseTraceOrm(id=trace_id, raw=raw, parser_version=1, **kw)
+        )
+        await session.commit()
+
+
+# --- auth ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_list_requires_auth(client):
+    assert (await client.get("/api/traces")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_requires_superuser_not_regular(
+    client, auth_override, user
+):
+    auth_override(user.id)
+    assert (await client.get("/api/traces", headers=H)).status_code == 403
+
+
+# --- list / filter ---------------------------------------------------------
+@pytest.mark.asyncio
+async def test_list_and_filter(client, auth_override, superuser_factory):
+    su = await superuser_factory("su_traces@example.com")
+    auth_override(su.id)
+    await _seed_trace(
+        "t1",
+        environment="production",
+        outcome="ANSWER",
+        user_id="u1",
+        session_id="s1",
+        prompt="deforestation in Brazil",
+        trace_timestamp=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    await _seed_trace(
+        "t2",
+        environment="production",
+        outcome="ERROR",
+        user_id="u2",
+        session_id="s2",
+        prompt="forest loss elsewhere",
+        trace_timestamp=datetime(2026, 6, 2, tzinfo=timezone.utc),
+    )
+
+    body = (await client.get("/api/traces", headers=H)).json()
+    assert body["total"] == 2
+    # newest first, and list never leaks raw/output
+    assert body["items"][0]["id"] == "t2"
+    assert "output" not in body["items"][0]
+    assert "raw" not in body["items"][0]
+
+    by_outcome = (
+        await client.get("/api/traces?outcome=ANSWER", headers=H)
+    ).json()
+    assert by_outcome["total"] == 1 and by_outcome["items"][0]["id"] == "t1"
+
+    by_prompt = (
+        await client.get("/api/traces?prompt_contains=brazil", headers=H)
+    ).json()
+    assert by_prompt["total"] == 1 and by_prompt["items"][0]["id"] == "t1"
+
+    by_user = (await client.get("/api/traces?user_id=u2", headers=H)).json()
+    assert by_user["total"] == 1 and by_user["items"][0]["id"] == "t2"
+
+
+@pytest.mark.asyncio
+async def test_list_pagination(client, auth_override, superuser_factory):
+    su = await superuser_factory("su_page@example.com")
+    auth_override(su.id)
+    for i in range(5):
+        await _seed_trace(
+            f"p{i}",
+            trace_timestamp=datetime(2026, 6, 1, i, tzinfo=timezone.utc),
+        )
+    body = (await client.get("/api/traces?limit=2&offset=0", headers=H)).json()
+    assert body["total"] == 5
+    assert len(body["items"]) == 2
+    assert body["items"][0]["id"] == "p4"  # newest
+
+
+# --- detail ----------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_detail_returns_input_output_derived(
+    client, auth_override, superuser_factory
+):
+    su = await superuser_factory("su_detail@example.com")
+    auth_override(su.id)
+    raw = {
+        "input": {"messages": [{"type": "human", "content": "hi"}]},
+        "output": {"messages": [], "aoi_selection": {"name": "Brazil"}},
+    }
+    await _seed_trace(
+        "d1",
+        outcome="ANSWER",
+        answer="the answer",
+        raw=raw,
+        derived={"aoi_count": 1},
+    )
+    b = (await client.get("/api/traces/d1", headers=H)).json()
+    assert b["answer"] == "the answer"
+    assert b["output"]["aoi_selection"]["name"] == "Brazil"
+    assert b["input"]["messages"][0]["content"] == "hi"
+    assert b["derived"]["aoi_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_detail_404(client, auth_override, superuser_factory):
+    su = await superuser_factory("su_404@example.com")
+    auth_override(su.id)
+    assert (await client.get("/api/traces/nope", headers=H)).status_code == 404

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -11,14 +11,23 @@ H = {"Authorization": "Bearer test-token"}
 
 
 async def _seed_trace(trace_id: str, **kw) -> None:
-    raw = kw.pop(
-        "raw", {"input": {"messages": []}, "output": {"messages": []}}
-    )
     async with async_session_maker() as session:
-        session.add(
-            LangfuseTraceOrm(id=trace_id, raw=raw, parser_version=1, **kw)
-        )
+        session.add(LangfuseTraceOrm(id=trace_id, parser_version=1, **kw))
         await session.commit()
+
+
+def _stub_langfuse_fetch(monkeypatch, trace):
+    """Stub the on-demand single-trace Langfuse fetch the detail endpoint uses."""
+
+    class _Stub:
+        @classmethod
+        def from_env(cls):
+            return cls()
+
+        def fetch_trace(self, trace_id):
+            return trace
+
+    monkeypatch.setattr("src.api.routers.traces.LangfuseClient", _Stub)
 
 
 # --- auth ------------------------------------------------------------------
@@ -97,27 +106,42 @@ async def test_list_pagination(client, auth_override, superuser_factory):
 
 # --- detail ----------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_detail_returns_input_output_derived(
-    client, auth_override, superuser_factory
+async def test_detail_returns_derived_from_db_and_io_from_langfuse(
+    client, auth_override, superuser_factory, monkeypatch
 ):
     su = await superuser_factory("su_detail@example.com")
     auth_override(su.id)
-    raw = {
-        "input": {"messages": [{"type": "human", "content": "hi"}]},
-        "output": {"messages": [], "aoi_selection": {"name": "Brazil"}},
-    }
     await _seed_trace(
-        "d1",
-        outcome="ANSWER",
-        answer="the answer",
-        raw=raw,
-        derived={"aoi_count": 1},
+        "d1", outcome="ANSWER", answer="the answer", derived={"aoi_count": 1}
+    )
+    # input/output come live from Langfuse, not our DB
+    _stub_langfuse_fetch(
+        monkeypatch,
+        {
+            "input": {"messages": [{"type": "human", "content": "hi"}]},
+            "output": {"messages": [], "aoi_selection": {"name": "Brazil"}},
+        },
     )
     b = (await client.get("/api/traces/d1", headers=H)).json()
-    assert b["answer"] == "the answer"
-    assert b["output"]["aoi_selection"]["name"] == "Brazil"
-    assert b["input"]["messages"][0]["content"] == "hi"
-    assert b["derived"]["aoi_count"] == 1
+    assert b["answer"] == "the answer"  # from our DB
+    assert b["derived"]["aoi_count"] == 1  # from our DB
+    assert b["raw_available"] is True
+    assert b["output"]["aoi_selection"]["name"] == "Brazil"  # from Langfuse
+    assert b["input"]["messages"][0]["content"] == "hi"  # from Langfuse
+
+
+@pytest.mark.asyncio
+async def test_detail_raw_unavailable(
+    client, auth_override, superuser_factory, monkeypatch
+):
+    su = await superuser_factory("su_unavail@example.com")
+    auth_override(su.id)
+    await _seed_trace("d2", outcome="ANSWER", answer="kept")
+    _stub_langfuse_fetch(monkeypatch, None)  # Langfuse 404 / unreachable
+    b = (await client.get("/api/traces/d2", headers=H)).json()
+    assert b["raw_available"] is False
+    assert b["input"] is None and b["output"] is None
+    assert b["answer"] == "kept"  # derived columns still served
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -104,6 +104,45 @@ async def test_list_pagination(client, auth_override, superuser_factory):
     assert body["items"][0]["id"] == "p4"  # newest
 
 
+@pytest.mark.asyncio
+async def test_list_surfaces_derived_fields(
+    client, auth_override, superuser_factory
+):
+    """datasets_analysed/language/language_confidence are lifted from the
+    ``derived`` JSONB onto each list item (so tracey's analytics can build its
+    dataframe in one paginated fetch)."""
+    su = await superuser_factory("su_derived@example.com")
+    auth_override(su.id)
+    await _seed_trace(
+        "dv1",
+        prompt="deforestation in Brazil",
+        trace_timestamp=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        derived={
+            "datasets_analysed_cumulative": ["tree_cover_loss", "land_cover"],
+            "language": "en",
+            "language_confidence": 0.97,
+        },
+    )
+    # a trace with no derived payload still serializes (fields default to None)
+    await _seed_trace(
+        "dv2",
+        prompt="no derived here",
+        trace_timestamp=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+
+    body = (await client.get("/api/traces", headers=H)).json()
+    item = next(i for i in body["items"] if i["id"] == "dv1")
+    assert item["datasets_analysed"] == ["tree_cover_loss", "land_cover"]
+    assert item["language"] == "en"
+    assert item["language_confidence"] == 0.97
+    # derived itself is never leaked on the list item
+    assert "derived" not in item
+
+    empty = next(i for i in body["items"] if i["id"] == "dv2")
+    assert empty["datasets_analysed"] is None
+    assert empty["language"] is None
+
+
 # --- detail ----------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_detail_returns_derived_from_db_and_io_from_langfuse(

--- a/tests/unit/test_langfuse_parse.py
+++ b/tests/unit/test_langfuse_parse.py
@@ -1,0 +1,293 @@
+"""Unit tests for the Langfuse trace parser (src/api/services/langfuse/parse.py).
+
+Fixtures are synthetic but mirror the real ``AgentState`` snapshot shape (no real
+user text committed). The contract tests at the bottom bind to the live
+src/agent contract so a drift there fails CI loudly.
+"""
+
+from src.api.services.langfuse import parse as P
+
+
+# --------------------------------------------------------------------------- #
+# message builders (mirror real trace message shapes)
+# --------------------------------------------------------------------------- #
+def human(text):
+    return {"type": "human", "content": text}
+
+
+def ai(text, tool_calls=None, finish="stop", usage=None):
+    m = {
+        "type": "ai",
+        "content": text,
+        "response_metadata": {"finish_reason": finish},
+    }
+    if tool_calls is not None:
+        m["tool_calls"] = tool_calls
+    if usage is not None:
+        m["usage_metadata"] = usage
+    return m
+
+
+def tool(name, content="", status="success", tcid="tc"):
+    return {
+        "type": "tool",
+        "name": name,
+        "content": content,
+        "status": status,
+        "tool_call_id": tcid,
+    }
+
+
+def usage(i, o, cache=0):
+    return {
+        "input_tokens": i,
+        "output_tokens": o,
+        "total_tokens": i + o,
+        "input_token_details": {"cache_read": cache},
+    }
+
+
+def trace(output, inp=None):
+    return {"output": output, "input": inp or {"messages": []}}
+
+
+# --------------------------------------------------------------------------- #
+# outcome classification
+# --------------------------------------------------------------------------- #
+def test_answer_with_tools():
+    out = {
+        "messages": [
+            human("Analyse tree cover loss in Brazil"),
+            ai(
+                "",
+                tool_calls=[{"name": "pull_data", "id": "1", "args": {}}],
+                usage=usage(100, 5),
+            ),
+            tool("pull_data", "ok"),
+            ai(
+                "Here is the analysis.", finish="end_turn", usage=usage(50, 30)
+            ),
+        ],
+        "aoi_selection": {
+            "name": "Brazil",
+            "aois": [
+                {"name": "Brazil", "subtype": "country", "source": "gadm"}
+            ],
+        },
+        "statistics": [{"id": "s1", "dataset_name": "Tree cover loss"}],
+        "insight_id": "ins-1",
+        "insight": "...",
+    }
+    r = P.parse_trace(trace(out))
+    assert r["outcome"] == "ANSWER"
+    assert r["has_answer"] is True
+    assert r["had_tool_call"] is True
+    assert r["aoi_name"] == "Brazil"
+    assert r["aoi_type"] == "country"
+    assert r["has_insight"] is True
+    assert r["insight_id"] == "ins-1"
+    assert r["primary_dataset_name"] == "Tree cover loss"
+    assert r["derived"]["statistics_ids"] == ["s1"]
+    assert r["recognized_contract"] is True
+
+
+def test_defer_no_tools():
+    out = {
+        "messages": [
+            human("What can you do?"),
+            ai(
+                "I can analyse land data.",
+                finish="end_turn",
+                usage=usage(10, 5),
+            ),
+        ]
+    }
+    r = P.parse_trace(trace(out))
+    assert r["outcome"] == "DEFER"
+    assert r["had_tool_call"] is False
+
+
+def test_refusal_is_soft_error():
+    out = {
+        "messages": [
+            human("Do X"),
+            ai(
+                "I'm sorry, I cannot help with that.",
+                finish="end_turn",
+                usage=usage(10, 5),
+            ),
+        ]
+    }
+    r = P.parse_trace(trace(out))
+    assert r["answer_is_refusal"] is True
+    assert r["outcome"] == "SOFT_ERROR"
+
+
+def test_recovered_tool_error_is_not_error():
+    """A tool result with status=error inside the active turn must NOT flip the
+    outcome to ERROR when the agent still produced a good answer (tracey's bug)."""
+    out = {
+        "messages": [
+            human("Analyse X"),
+            ai(
+                "",
+                tool_calls=[
+                    {"name": "generate_insights", "id": "1", "args": {}}
+                ],
+                usage=usage(10, 2),
+            ),
+            tool("generate_insights", "Analysis failed: 503", status="error"),
+            ai(
+                "Here is the analysis anyway.",
+                finish="end_turn",
+                usage=usage(20, 8),
+            ),
+        ]
+    }
+    r = P.parse_trace(trace(out))
+    assert r["tool_error_count"] == 1
+    assert r["has_answer"] is True
+    assert r["outcome"] == "ANSWER"
+
+
+def test_empty_output_is_empty_outcome_and_na_contract():
+    r = P.parse_trace(
+        trace(None, inp={"messages": [human("How much forest was lost?")]})
+    )
+    assert r["outcome"] == "EMPTY"
+    assert r["has_answer"] is False
+    # prompt still recovered from input
+    assert r["prompt"] == "How much forest was lost?"
+    # output absent => contract recognition is N/A, not a violation
+    assert r["recognized_contract"] is None
+
+
+# --------------------------------------------------------------------------- #
+# turn-level attribution (the key correctness property)
+# --------------------------------------------------------------------------- #
+def test_turn_level_tokens_not_inflated_across_thread():
+    """output.messages carries the whole thread; per-turn metrics must reflect
+    only the active (latest) turn, not the accumulated history."""
+    out = {
+        "messages": [
+            # --- turn 1 (should be excluded) ---
+            human("Question 1"),
+            ai(
+                "",
+                tool_calls=[{"name": "pull_data", "id": "1", "args": {}}],
+                usage=usage(1000, 100),
+            ),
+            tool("pull_data", "ok"),
+            ai("Answer 1", finish="end_turn", usage=usage(500, 200)),
+            # --- turn 2 (the active turn) ---
+            human("Question 2"),
+            ai("Answer 2", finish="end_turn", usage=usage(30, 5)),
+        ]
+    }
+    r = P.parse_trace(trace(out))
+    assert r["prompt"] == "Question 2"
+    assert r["answer"] == "Answer 2"
+    assert r["turn_input_tokens"] == 30  # NOT 1000+500+30
+    assert r["turn_output_tokens"] == 5  # NOT 100+200+5
+    assert r["turn_tool_calls"] == 0  # turn 2 used no tools
+
+
+def test_synthetic_human_message_skipped_for_prompt():
+    out = {
+        "messages": [
+            human("User selected AOI: Brazil"),
+            human("Show me real deforestation data"),
+            ai("Here you go.", finish="end_turn", usage=usage(10, 5)),
+        ]
+    }
+    r = P.parse_trace(trace(out))
+    assert r["prompt"] == "Show me real deforestation data"
+
+
+# --------------------------------------------------------------------------- #
+# state parsing
+# --------------------------------------------------------------------------- #
+def test_global_aoi():
+    out = {
+        "messages": [
+            human("Compare all countries"),
+            ai("Done.", finish="end_turn", usage=usage(5, 5)),
+        ],
+        "aoi_selection": {
+            "name": "All countries in the world",
+            "aois": [
+                {"name": "Brazil", "subtype": "country", "source": "gadm"}
+            ],
+        },
+    }
+    r = P.parse_trace(trace(out))
+    assert r["is_global"] is True
+
+
+def test_cumulative_datasets_and_ids():
+    out = {
+        "messages": [
+            human("Q"),
+            ai("A", finish="end_turn", usage=usage(5, 5)),
+        ],
+        "statistics": [
+            {"id": "s1", "dataset_name": "Dataset A"},
+            {"id": "s2", "dataset_name": "Dataset B"},
+            {"id": "s3", "dataset_name": "Dataset A"},  # dup name
+        ],
+    }
+    r = P.parse_trace(trace(out))
+    assert r["derived"]["statistics_ids"] == ["s1", "s2", "s3"]
+    assert r["derived"]["datasets_analysed_cumulative"] == [
+        "Dataset A",
+        "Dataset B",
+    ]
+
+
+def test_unknown_output_key_is_flagged_but_recognized():
+    out = {
+        "messages": [
+            human("Q"),
+            ai("A", finish="end_turn", usage=usage(5, 5)),
+        ],
+        "forecast": {"some": "new state key"},  # additive drift
+    }
+    r = P.parse_trace(trace(out))
+    assert r["derived"]["unknown_output_keys"] == ["forecast"]
+    assert r["recognized_contract"] is True
+
+
+def test_malformed_dict_output_flags_unrecognized():
+    # a dict output without 'messages' is a genuine contract anomaly
+    r = P.parse_trace(
+        {"output": {"aoi_selection": {}}, "input": {"messages": []}}
+    )
+    assert r["recognized_contract"] is False
+
+
+def test_does_not_crash_on_garbage():
+    for bad in [{}, {"output": []}, {"output": {"messages": [None, "x", 3]}}]:
+        P.parse_trace(bad)  # should not raise
+
+
+# --------------------------------------------------------------------------- #
+# contract tests: bind to the live agent contract so drift fails CI
+# --------------------------------------------------------------------------- #
+def test_expected_state_keys_match_agent_state():
+    from src.agent.state import AgentState
+
+    assert P.EXPECTED_STATE_KEYS == set(AgentState.__annotations__), (
+        "AgentState changed: update EXPECTED_STATE_KEYS in parse.py (and consider "
+        "whether the new/removed key needs parsing + a PARSER_VERSION bump)."
+    )
+
+
+def test_global_aoi_name_matches_agent_constant():
+    from src.agent.subagents.pick_aoi.global_queries import (
+        GLOBAL_AOI_SELECTION_NAME,
+    )
+
+    assert GLOBAL_AOI_SELECTION_NAME in P.GLOBAL_AOI_NAMES, (
+        "GLOBAL_AOI_SELECTION_NAME changed in the agent: update GLOBAL_AOI_NAMES "
+        "in parse.py or is_global will silently break."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2807,7 +2807,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.3"
+version = "2026.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -2807,7 +2807,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.8"
+version = "2026.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This adds:

 - Schemas to hold langfuse traces in the postgres db
 - An ingest CLI command (that will be run as a daily cron or so) to fetch trace data from Langfuse and ingest into Postgres
 - API endpoints (auth-gated) to fetch trace data from the API as well as aggregated analytics

This tries to replicate the functionality in https://github.com/01painadam/tracey, but bringing it into our db and API.

This bit was heavily Claude-d, and I think I need to spend some time reviewing this closely. Once we are reasonably satisfied with this, next steps would be:

 - Deploy this. Manually run CLI to fetch traces, test that API endpoints seem alright
 - Create k8s CronJob to update with traces every day (or more frequently if we want)
 - Move the `tracey` streamlit app to reading from our API instead of querying Langfuse directly

Once that all works and seems good, we can discuss / ticket if we want to make some of the trace analysis available in our frontend.

cc @01painadam 