### PR TITLE
Implement option for context layers to be vector layers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.4"
+version = "2026.6.9"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/datasets/catalog/tree_cover_loss.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss.yml
@@ -8,7 +8,8 @@ context_layers:
   start_date: '2002-01-01'
 - value: intact_forest
   description: Tree cover loss within intact forest landscapes (IFLs) — large, undisturbed natural forest expanses free of significant human activity. Use this layer when the user explicitly asks for intact forest loss, or as the default context layer for deforestation/forest loss requests when primary_forest is not available for the AOI.
-  tile_url: https://tiles.globalforestwatch.org/ifl_intact_forest_landscapes/v2025/default/{z}/{x}/{y}.png
+  tile_url: https://tiles.globalforestwatch.org/ifl_intact_forest_landscapes/v2021/default/{z}/{x}/{y}.pbf
+  source_layer: vector
   start_date: '2000-01-01'
 parameters:
 - name: canopy_cover

--- a/src/agent/datasets/catalog/tree_cover_loss.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss.yml
@@ -9,7 +9,7 @@ context_layers:
 - value: intact_forest
   description: Tree cover loss within intact forest landscapes (IFLs) — large, undisturbed natural forest expanses free of significant human activity. Use this layer when the user explicitly asks for intact forest loss, or as the default context layer for deforestation/forest loss requests when primary_forest is not available for the AOI.
   tile_url: https://tiles.globalforestwatch.org/ifl_intact_forest_landscapes/v2021/default/{z}/{x}/{y}.pbf
-  source_layer: vector
+  source_layer: ifl_intact_forest_landscapes
   start_date: '2000-01-01'
 parameters:
 - name: canopy_cover

--- a/src/agent/datasets/catalog/tree_cover_loss_from_fires.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss_from_fires.yml
@@ -8,7 +8,8 @@ context_layers:
   start_date: '2002-01-01'
 - value: intact_forest
   description: Tree cover loss due to fires within intact forest landscapes (IFLs) — large, undisturbed natural forest expanses free of significant human activity. Use this layer when the user explicitly asks for intact forest loss, or as the default context layer for deforestation/forest loss requests when primary_forest is not available for the AOI.
-  tile_url: https://tiles.globalforestwatch.org/ifl_intact_forest_landscapes/v2025/default/{z}/{x}/{y}.png
+  tile_url: https://tiles.globalforestwatch.org/ifl_intact_forest_landscapes/v2021/default/{z}/{x}/{y}.pbf
+  source_layer: vector
   start_date: '2000-01-01'
 parameters:
 - name: canopy_cover

--- a/src/agent/datasets/catalog/tree_cover_loss_from_fires.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss_from_fires.yml
@@ -9,7 +9,7 @@ context_layers:
 - value: intact_forest
   description: Tree cover loss due to fires within intact forest landscapes (IFLs) — large, undisturbed natural forest expanses free of significant human activity. Use this layer when the user explicitly asks for intact forest loss, or as the default context layer for deforestation/forest loss requests when primary_forest is not available for the AOI.
   tile_url: https://tiles.globalforestwatch.org/ifl_intact_forest_landscapes/v2021/default/{z}/{x}/{y}.pbf
-  source_layer: vector
+  source_layer: ifl_intact_forest_landscapes
   start_date: '2000-01-01'
 parameters:
 - name: canopy_cover

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -16,8 +16,8 @@ class DatasetParameter(BaseModel):
 
 class ContextLayer(BaseModel):
     name: str
-    tile_url: Optional[str]
-    source_layer: Optional[str]
+    tile_url: Optional[str] = None
+    source_layer: Optional[str] = None
 
 
 class DatasetOption(BaseModel):

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -17,6 +17,7 @@ class DatasetParameter(BaseModel):
 class ContextLayer(BaseModel):
     name: str
     tile_url: Optional[str]
+    source_layer: Optional[str]
 
 
 class DatasetOption(BaseModel):

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Literal, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -17,7 +17,7 @@ class DatasetParameter(BaseModel):
 class ContextLayer(BaseModel):
     name: str
     tile_url: Optional[str]
-    source_layer: Literal["vector"] | None = None
+    source_layer: Optional[str]
 
 
 class DatasetOption(BaseModel):

--- a/src/agent/subagents/pick_dataset/schema.py
+++ b/src/agent/subagents/pick_dataset/schema.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -17,7 +17,7 @@ class DatasetParameter(BaseModel):
 class ContextLayer(BaseModel):
     name: str
     tile_url: Optional[str]
-    source_layer: Optional[str]
+    source_layer: Literal["vector"] | None = None
 
 
 class DatasetOption(BaseModel):

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -460,6 +460,7 @@ def get_tile_services_for_dataset(
         context_layer = ContextLayer(
             name=selected_context_layer.get("value"),
             tile_url=selected_context_layer.get("tile_url"),
+            source_layer=selected_context_layer.get("source_layer", None),
         )
         context_layers.append(context_layer)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2807,7 +2807,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.3"
+version = "2026.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This updates the png endpoints for IFL to vector layers (pbf).

For the frontend to know when a context layer is a vector layer, the `ContextLayer` class now has a new field called `source_layer` that needs to be set to the name of the layer in the protobuffer response. [edit: before it was `vector`]

This is the backend implementation of https://github.com/wri/project-zeno-next/pull/516