### PR TITLE
Consolidate fetch_zeno_anonymous into fetch_zeno.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.13"
+version = "2026.6.15"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -32,7 +32,6 @@ from sqlalchemy import select
 from src.agent.graph import (
     close_checkpointer_pool,
     fetch_zeno,
-    fetch_zeno_anonymous,
     get_checkpointer_pool,
     get_prompt,
 )
@@ -606,7 +605,7 @@ async def _fetch_agent(
     if use_postgres:
         return await fetch_zeno(system_prompt=system_prompt)
     checkpointer = InMemorySaver() if use_memory else None
-    return await fetch_zeno_anonymous(
+    return await fetch_zeno(
         system_prompt=system_prompt, checkpointer=checkpointer
     )
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from dotenv import load_dotenv
 from langchain.agents import create_agent
@@ -193,35 +193,22 @@ def _build_middleware():
     return middleware
 
 
-async def fetch_zeno_anonymous(
-    user: Optional[dict] = None,
-    system_prompt: Optional[str] = None,
-    checkpointer=None,
-) -> CompiledStateGraph:
-    """Setup the Zeno agent for anonymous users with the provided tools and prompt.
-
-    Pass `checkpointer` (e.g. an in-memory `InMemorySaver`) to keep graph
-    state across turns without the Postgres checkpointer; defaults to None
-    (stateless).
-    """
-    zeno_agent = create_agent(
-        model=MODEL,
-        tools=tools,
-        state_schema=AgentState,
-        system_prompt=system_prompt or get_prompt(user),
-        middleware=_build_middleware(),
-        checkpointer=checkpointer,
-    )
-    return zeno_agent
+_CHECKPOINTER_UNSET = object()
 
 
 async def fetch_zeno(
     user: Optional[dict] = None,
     system_prompt: Optional[str] = None,
+    checkpointer: Any = _CHECKPOINTER_UNSET,
 ) -> CompiledStateGraph:
-    """Setup the Zeno agent with the provided tools and prompt."""
+    """Setup the Zeno agent with the provided tools and prompt.
 
-    checkpointer = await fetch_checkpointer()
+    By default the Postgres checkpointer is used (API and durable CLI runs).
+    Pass an explicit ``checkpointer`` (e.g. ``InMemorySaver()``) for local
+    runs without Postgres, or ``None`` for a stateless single-turn agent.
+    """
+    if checkpointer is _CHECKPOINTER_UNSET:
+        checkpointer = await fetch_checkpointer()
     zeno_agent = create_agent(
         model=MODEL,
         tools=tools,

--- a/tests/agent/test_graph.py
+++ b/tests/agent/test_graph.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from src.agent.datasets.config import DATASETS
-from src.agent.graph import fetch_zeno_anonymous
+from src.agent.graph import fetch_zeno
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -341,7 +341,7 @@ async def run_agent(query: str, thread_id: str | None = None):
     steps = []
 
     # Fetch the agent instance
-    zeno_agent = await fetch_zeno_anonymous()
+    zeno_agent = await fetch_zeno(checkpointer=None)
 
     i = 0
     async for step in zeno_agent.astream(


### PR DESCRIPTION
Removes `fetch_zeno_anonymous` and folds its behavior into `fetch_zeno` via an optional `checkpointer` argument.

The old name was misleading: that function was not used for unauthenticated API traffic (anonymous access is already disabled). It existed so the CLI and tests could build the agent with an in-memory or stateless checkpointer instead of Postgres. `fetch_zeno` and `fetch_zeno_anonymous` were otherwise identical.

`fetch_zeno` now accepts an optional `checkpointer`:
- **Omitted** → Postgres checkpointer (API, CLI with `--checkpoint`) — unchanged production behavior
- **`InMemorySaver()`** → in-memory checkpointing (interactive CLI without `--checkpoint`)
- **`None`** → stateless single-turn agent (CLI `-q`, tests)
