### PR TITLE
Agent tool profiles

### DIFF
--- a/db/alembic/versions/d5e6f7a8b9c0_add_agent_profile_column.py
+++ b/db/alembic/versions/d5e6f7a8b9c0_add_agent_profile_column.py
@@ -1,0 +1,35 @@
+"""add agent_profile column
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-06-15 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: Union[str, None] = "c4d5e6f7a8b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users",
+        sa.Column(
+            "agent_profile",
+            sa.String(),
+            nullable=False,
+            server_default="default",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("users", "agent_profile")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.13"
+version = "2026.6.15"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.15.1"
+version = "2026.6.15.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -17,23 +17,36 @@ from psycopg_pool import AsyncConnectionPool
 
 from src.agent.llms import FALLBACK_MODELS, MODEL
 from src.agent.middleware import SessionContextMiddleware
-from src.agent.skills import all_skills, read_skill
 from src.agent.state import AgentState
-from src.agent.subagents import generate_insights, pick_aoi, pick_dataset
-from src.agent.tools import pull_data
+from src.agent.tool_profiles import (
+    resolve_profile_name,
+    skills_for_profile,
+    tool_descriptions_for_profile,
+    tools_for_profile,
+)
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 
-def get_prompt(user: Optional[dict] = None) -> str:
-    """Generate the system prompt with the current date. (Ignores user info.)"""
+def get_prompt(
+    user: Optional[dict] = None, profile: Optional[str] = None
+) -> str:
+    """Generate the system prompt with the current date and the profile's tools.
+
+    The Tools/Subagents sections are rendered from the same profile that decides
+    which tools are bound, so the prompt never drifts from the bound tool set.
+    (User info is otherwise ignored.)
+    """
+    if profile is None:
+        profile = resolve_profile_name(user)
     skill_lines = [
         f"- {s.name}: {s.description} (use when: {s.when_to_use})"
-        for s in all_skills()
+        for s in skills_for_profile(profile)
     ]
     skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
+    tool_descriptions = tool_descriptions_for_profile(profile)
     today = datetime.now().strftime("%Y-%m-%d")
     return f"""You are Global Nature Watch's Geospatial Agent. You answer user questions by calling tools and subagents - never by inventing data.
 
@@ -43,16 +56,7 @@ A [Session — date] system message is prepended to every model call with the li
 
 Call tools one at a time, never in parallel.
 
-# Tools (primitives — call when you need them)
-
-- pull_data(query): fetch data for the AOI and dataset currently in state. Run pick_aoi and pick_dataset first.
-- read_skill(name): load a skill's full workflow — call it once, after you have committed to using that skill.
-
-# Subagents (call as tools — each does its own reasoning; just forward the user's intent)
-
-- pick_aoi(question): natural-language geocoder. Pass the place request verbatim ("tree cover loss in Pará, Brazil", "the districts of Odisha", "forest loss worldwide"); it extracts, translates and resolves the place — and any subregions — itself. Updates the AOI in state, or returns a clarifying question.
-- pick_dataset(query): dataset-selection subagent. Picks the dataset, context layer and date range that best answer the request. May return no dataset if none is a good fit — in that case relay its explanation and closest alternatives to the user; do not proceed to pull_data. Call it again whenever the user changes the dataset, context layer or parameters.
-- generate_insights(query): analyst subagent. Turns pulled data into one chart insight with follow-up suggestions. Requires pull_data to have run first.
+{tool_descriptions}
 
 # Skills (multi-step recipes)
 
@@ -88,14 +92,6 @@ UI / map selections (when the message mentions a UI action or changed map select
 - If the user asks to change selections, override prior UI selections.
 """
 
-
-tools = [
-    pick_aoi,
-    pick_dataset,
-    pull_data,
-    generate_insights,
-    read_skill,
-]
 
 load_dotenv()
 
@@ -197,18 +193,22 @@ async def fetch_zeno_anonymous(
     user: Optional[dict] = None,
     system_prompt: Optional[str] = None,
     checkpointer=None,
+    profile: Optional[str] = None,
 ) -> CompiledStateGraph:
     """Setup the Zeno agent for anonymous users with the provided tools and prompt.
 
-    Pass `checkpointer` (e.g. an in-memory `InMemorySaver`) to keep graph
-    state across turns without the Postgres checkpointer; defaults to None
-    (stateless).
+    The tool profile is resolved from `user` unless one is passed explicitly
+    (anonymous users get the default profile). Pass `checkpointer` (e.g. an
+    in-memory `InMemorySaver`) to keep graph state across turns without the
+    Postgres checkpointer; defaults to None (stateless).
     """
+    if profile is None:
+        profile = resolve_profile_name(user)
     zeno_agent = create_agent(
         model=MODEL,
-        tools=tools,
+        tools=tools_for_profile(profile),
         state_schema=AgentState,
-        system_prompt=system_prompt or get_prompt(user),
+        system_prompt=system_prompt or get_prompt(user, profile),
         middleware=_build_middleware(),
         checkpointer=checkpointer,
     )
@@ -218,15 +218,21 @@ async def fetch_zeno_anonymous(
 async def fetch_zeno(
     user: Optional[dict] = None,
     system_prompt: Optional[str] = None,
+    profile: Optional[str] = None,
 ) -> CompiledStateGraph:
-    """Setup the Zeno agent with the provided tools and prompt."""
+    """Setup the Zeno agent with the tools and prompt for the user's profile.
 
+    The tool profile is resolved from `user` (e.g. opted-in testers get the
+    experimental profile) unless one is passed explicitly.
+    """
+    if profile is None:
+        profile = resolve_profile_name(user)
     checkpointer = await fetch_checkpointer()
     zeno_agent = create_agent(
         model=MODEL,
-        tools=tools,
+        tools=tools_for_profile(profile),
         state_schema=AgentState,
-        system_prompt=system_prompt or get_prompt(user),
+        system_prompt=system_prompt or get_prompt(user, profile),
         middleware=_build_middleware(),
         checkpointer=checkpointer,
     )

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -18,12 +18,7 @@ from psycopg_pool import AsyncConnectionPool
 from src.agent.llms import FALLBACK_MODELS, MODEL
 from src.agent.middleware import SessionContextMiddleware
 from src.agent.state import AgentState
-from src.agent.tool_profiles import (
-    resolve_profile_name,
-    skills_for_profile,
-    tool_descriptions_for_profile,
-    tools_for_profile,
-)
+from src.agent.tool_profiles import Profile, resolve_profile
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
 
@@ -31,7 +26,7 @@ logger = get_logger(__name__)
 
 
 def get_prompt(
-    user: Optional[dict] = None, profile: Optional[str] = None
+    user: Optional[dict] = None, profile: Optional[Profile] = None
 ) -> str:
     """Generate the system prompt with the current date and the profile's tools.
 
@@ -40,13 +35,13 @@ def get_prompt(
     (User info is otherwise ignored.)
     """
     if profile is None:
-        profile = resolve_profile_name(user)
+        profile = resolve_profile(user)
     skill_lines = [
         f"- {s.name}: {s.description} (use when: {s.when_to_use})"
-        for s in skills_for_profile(profile)
+        for s in profile.skills()
     ]
     skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
-    tool_descriptions = tool_descriptions_for_profile(profile)
+    tool_descriptions = profile.tool_descriptions()
     today = datetime.now().strftime("%Y-%m-%d")
     return f"""You are Global Nature Watch's Geospatial Agent. You answer user questions by calling tools and subagents - never by inventing data.
 
@@ -193,7 +188,7 @@ async def fetch_zeno_anonymous(
     user: Optional[dict] = None,
     system_prompt: Optional[str] = None,
     checkpointer=None,
-    profile: Optional[str] = None,
+    profile: Optional[Profile] = None,
 ) -> CompiledStateGraph:
     """Setup the Zeno agent for anonymous users with the provided tools and prompt.
 
@@ -203,10 +198,10 @@ async def fetch_zeno_anonymous(
     Postgres checkpointer; defaults to None (stateless).
     """
     if profile is None:
-        profile = resolve_profile_name(user)
+        profile = resolve_profile(user)
     zeno_agent = create_agent(
         model=MODEL,
-        tools=tools_for_profile(profile),
+        tools=profile.tools(),
         state_schema=AgentState,
         system_prompt=system_prompt or get_prompt(user, profile),
         middleware=_build_middleware(),
@@ -218,7 +213,7 @@ async def fetch_zeno_anonymous(
 async def fetch_zeno(
     user: Optional[dict] = None,
     system_prompt: Optional[str] = None,
-    profile: Optional[str] = None,
+    profile: Optional[Profile] = None,
 ) -> CompiledStateGraph:
     """Setup the Zeno agent with the tools and prompt for the user's profile.
 
@@ -226,11 +221,11 @@ async def fetch_zeno(
     experimental profile) unless one is passed explicitly.
     """
     if profile is None:
-        profile = resolve_profile_name(user)
+        profile = resolve_profile(user)
     checkpointer = await fetch_checkpointer()
     zeno_agent = create_agent(
         model=MODEL,
-        tools=tools_for_profile(profile),
+        tools=profile.tools(),
         state_schema=AgentState,
         system_prompt=system_prompt or get_prompt(user, profile),
         middleware=_build_middleware(),

--- a/src/agent/skills/loader.py
+++ b/src/agent/skills/loader.py
@@ -12,6 +12,9 @@ class SkillMeta:
     description: str
     when_to_use: str
     body: str
+    # Tools the skill's workflow requires; the skill is only advertised in a
+    # profile that binds all of them. Empty for informational skills.
+    requires: tuple[str, ...] = ()
 
 
 def _parse(path: Path) -> SkillMeta | None:
@@ -30,11 +33,15 @@ def _parse(path: Path) -> SkillMeta | None:
         k, _, v = line.partition(":")
         meta[k.strip()] = v.strip()
     name = meta.get("name") or path.stem
+    requires = tuple(
+        t.strip() for t in meta.get("requires", "").split(",") if t.strip()
+    )
     return SkillMeta(
         name=name,
         description=meta.get("description", ""),
         when_to_use=meta.get("when_to_use", ""),
         body=body,
+        requires=requires,
     )
 
 

--- a/src/agent/skills/skills_md/analyze.md
+++ b/src/agent/skills/skills_md/analyze.md
@@ -2,6 +2,7 @@
 name: analyze
 description: Full pipeline — resolve AOI, pick dataset, pull data, generate chart insight.
 when_to_use: User wants end-to-end analysis with a chart or insight (e.g. "analyze", "show a chart"). Not when they only say pull/fetch/get data — use `pull-data` instead.
+requires: pick_aoi, pick_dataset, pull_data, generate_insights
 ---
 
 # Workflow

--- a/src/agent/skills/skills_md/pull-data.md
+++ b/src/agent/skills/skills_md/pull-data.md
@@ -2,6 +2,7 @@
 name: pull-data
 description: Fetch data for a place and dataset — no chart or insight unless the user asks.
 when_to_use: User asks to pull, fetch, or get data (with place and/or topic). Not for full analysis, charts, or "analyze" requests — use skill `analyze` only when they want a chart/insight.
+requires: pick_aoi, pick_dataset, pull_data
 ---
 
 # Pull-only requests

--- a/src/agent/tool_profiles.py
+++ b/src/agent/tool_profiles.py
@@ -7,7 +7,7 @@ bound (or omit one that is) — the two are derived from the same source.
 The profile is chosen per conversation from the user:
 - testers who opted in via ``help_test_features`` get the ``experimental``
   profile, which adds experimental tools on top of the production set;
-- everyone else (including anonymous users) gets the production ``default``.
+- everyone else gets the production ``default``.
 
 To expose a new experimental tool, register it in ``TOOL_REGISTRY`` and add its
 name to ``_EXPERIMENTAL_TOOLS``. Promote it to ``_CORE_TOOLS`` once it ships to
@@ -169,7 +169,7 @@ def resolve_profile(user: Optional[dict] = None) -> Profile:
     """Pick the tool profile for a conversation based on the user.
 
     Testers who opted in via ``help_test_features`` get the experimental
-    profile; everyone else (including anonymous users) gets the production
+    profile; everyone else gets the production
     default.
     """
     if user and user.get("help_test_features"):

--- a/src/agent/tool_profiles.py
+++ b/src/agent/tool_profiles.py
@@ -4,10 +4,10 @@ A *profile* bundles a set of tools together with the prompt fragment that
 describes each one, so the system prompt can never describe a tool that isn't
 bound (or omit one that is) — the two are derived from the same source.
 
-The profile is chosen per conversation from the user:
-- testers who opted in via ``help_test_features`` get the ``experimental``
-  profile, which adds experimental tools on top of the production set;
-- everyone else gets the production ``default``.
+The profile is chosen per conversation from the user's ``agent_profile`` field:
+- users set to ``experimental`` get that profile, which adds experimental tools
+  on top of the production set;
+- everyone else (incl. anonymous) gets the production ``default``.
 
 To expose a new experimental tool, register it in ``TOOL_REGISTRY`` and add its
 name to ``_EXPERIMENTAL_TOOLS``. Promote it to ``_CORE_TOOLS`` once it ships to
@@ -23,6 +23,7 @@ from langchain_core.tools import BaseTool
 from src.agent.skills import SkillMeta, all_skills, read_skill
 from src.agent.subagents import generate_insights, pick_aoi, pick_dataset
 from src.agent.tools import pull_data
+from src.api.data_models import AgentProfile
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -79,8 +80,8 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
 }
 
-DEFAULT_PROFILE = "default"
-EXPERIMENTAL_PROFILE = "experimental"
+DEFAULT_PROFILE = AgentProfile.DEFAULT.value
+EXPERIMENTAL_PROFILE = AgentProfile.EXPERIMENTAL.value
 
 # Tools every user gets in production.
 _CORE_TOOLS = [
@@ -91,7 +92,7 @@ _CORE_TOOLS = [
     "read_skill",
 ]
 
-# Experimental tools, exposed only to opted-in testers (help_test_features).
+# Experimental tools, exposed only to users with agent_profile=experimental.
 # Add new tools here first (e.g. "show_imagery"); promote to _CORE_TOOLS to ship.
 _EXPERIMENTAL_TOOLS: list[str] = []
 
@@ -166,12 +167,10 @@ def get_profile(name: str) -> Profile:
 
 
 def resolve_profile(user: Optional[dict] = None) -> Profile:
-    """Pick the tool profile for a conversation based on the user.
+    """Pick the tool profile for a conversation from the user's agent_profile.
 
-    Testers who opted in via ``help_test_features`` get the experimental
-    profile; everyone else gets the production
-    default.
+    Reads the user's ``agent_profile`` field; unknown or missing values (incl.
+    anonymous users) fall back to the production default via ``get_profile``.
     """
-    if user and user.get("help_test_features"):
-        return PROFILES[EXPERIMENTAL_PROFILE]
-    return PROFILES[DEFAULT_PROFILE]
+    name = (user or {}).get("agent_profile") or DEFAULT_PROFILE
+    return get_profile(str(name))

--- a/src/agent/tool_profiles.py
+++ b/src/agent/tool_profiles.py
@@ -95,13 +95,77 @@ _CORE_TOOLS = [
 # Add new tools here first (e.g. "show_imagery"); promote to _CORE_TOOLS to ship.
 _EXPERIMENTAL_TOOLS: list[str] = []
 
-PROFILES: dict[str, list[str]] = {
-    DEFAULT_PROFILE: _CORE_TOOLS,
-    EXPERIMENTAL_PROFILE: _CORE_TOOLS + _EXPERIMENTAL_TOOLS,
+
+@dataclass(frozen=True)
+class Profile:
+    """A named tool set the agent loads for a conversation.
+
+    Holds only the tool *names*; the tool objects, their prompt fragments and
+    the skill registry stay single-sourced in ``TOOL_REGISTRY`` / ``all_skills``.
+    Add fields here (e.g. a model override or extra prompt block) to parametrize
+    profiles further.
+    """
+
+    name: str
+    tool_names: tuple[str, ...]
+
+    def tools(self) -> list[BaseTool]:
+        """The tool objects bound to the agent for this profile."""
+        return [TOOL_REGISTRY[name].tool for name in self.tool_names]
+
+    def tool_descriptions(self) -> str:
+        """Render the Tools + Subagents prompt sections for this profile.
+
+        Grouped by category so the prompt only ever describes tools that are
+        actually bound for this profile.
+        """
+        blocks = []
+        for category in ToolCategory:
+            fragments = [
+                TOOL_REGISTRY[name].prompt_fragment
+                for name in self.tool_names
+                if TOOL_REGISTRY[name].category == category
+            ]
+            if fragments:
+                blocks.append(
+                    _CATEGORY_HEADERS[category] + "\n\n" + "\n".join(fragments)
+                )
+        return "\n\n".join(blocks)
+
+    def skills(self) -> list[SkillMeta]:
+        """Skills whose required tools are all bound in this profile.
+
+        A skill recipe directs the model to call specific tools (declared in its
+        ``requires`` frontmatter), so we only advertise a skill when this
+        profile binds every tool it needs — otherwise the workflow would tell
+        the model to call a tool that isn't available.
+        """
+        available = set(self.tool_names)
+        return [s for s in all_skills() if set(s.requires) <= available]
+
+
+PROFILES: dict[str, Profile] = {
+    DEFAULT_PROFILE: Profile(DEFAULT_PROFILE, tuple(_CORE_TOOLS)),
+    EXPERIMENTAL_PROFILE: Profile(
+        EXPERIMENTAL_PROFILE, tuple(_CORE_TOOLS + _EXPERIMENTAL_TOOLS)
+    ),
 }
 
 
-def resolve_profile_name(user: Optional[dict] = None) -> str:
+def get_profile(name: str) -> Profile:
+    """Look up a profile by name, falling back to the default if unknown."""
+    profile = PROFILES.get(name)
+    if profile is None:
+        logger.warning(
+            "Unknown tool profile %r, falling back to %r",
+            name,
+            DEFAULT_PROFILE,
+        )
+        return PROFILES[DEFAULT_PROFILE]
+    return profile
+
+
+def resolve_profile(user: Optional[dict] = None) -> Profile:
     """Pick the tool profile for a conversation based on the user.
 
     Testers who opted in via ``help_test_features`` get the experimental
@@ -109,54 +173,5 @@ def resolve_profile_name(user: Optional[dict] = None) -> str:
     default.
     """
     if user and user.get("help_test_features"):
-        return EXPERIMENTAL_PROFILE
-    return DEFAULT_PROFILE
-
-
-def _profile_tool_names(profile: str) -> list[str]:
-    if profile not in PROFILES:
-        logger.warning(
-            "Unknown tool profile %r, falling back to %r",
-            profile,
-            DEFAULT_PROFILE,
-        )
-        profile = DEFAULT_PROFILE
-    return PROFILES[profile]
-
-
-def tools_for_profile(profile: str) -> list[BaseTool]:
-    """The tool objects bound to the agent for a profile."""
-    return [TOOL_REGISTRY[name].tool for name in _profile_tool_names(profile)]
-
-
-def tool_descriptions_for_profile(profile: str) -> str:
-    """Render the Tools + Subagents prompt sections for a profile's tools.
-
-    Grouped by category so the prompt only ever describes tools that are
-    actually bound for this profile.
-    """
-    names = _profile_tool_names(profile)
-    blocks = []
-    for category in ToolCategory:
-        fragments = [
-            TOOL_REGISTRY[name].prompt_fragment
-            for name in names
-            if TOOL_REGISTRY[name].category == category
-        ]
-        if fragments:
-            blocks.append(
-                _CATEGORY_HEADERS[category] + "\n\n" + "\n".join(fragments)
-            )
-    return "\n\n".join(blocks)
-
-
-def skills_for_profile(profile: str) -> list[SkillMeta]:
-    """Skills whose required tools are all bound in this profile.
-
-    A skill recipe directs the model to call specific tools (declared in its
-    ``requires`` frontmatter), so we only advertise a skill when the active
-    profile binds every tool it needs — otherwise the workflow would tell the
-    model to call a tool that isn't available.
-    """
-    available = set(_profile_tool_names(profile))
-    return [s for s in all_skills() if set(s.requires) <= available]
+        return PROFILES[EXPERIMENTAL_PROFILE]
+    return PROFILES[DEFAULT_PROFILE]

--- a/src/agent/tool_profiles.py
+++ b/src/agent/tool_profiles.py
@@ -1,0 +1,162 @@
+"""Agent tool profiles: which tools (and their prompt descriptions) load per conversation.
+
+A *profile* bundles a set of tools together with the prompt fragment that
+describes each one, so the system prompt can never describe a tool that isn't
+bound (or omit one that is) — the two are derived from the same source.
+
+The profile is chosen per conversation from the user:
+- testers who opted in via ``help_test_features`` get the ``experimental``
+  profile, which adds experimental tools on top of the production set;
+- everyone else (including anonymous users) gets the production ``default``.
+
+To expose a new experimental tool, register it in ``TOOL_REGISTRY`` and add its
+name to ``_EXPERIMENTAL_TOOLS``. Promote it to ``_CORE_TOOLS`` once it ships to
+production.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from langchain_core.tools import BaseTool
+
+from src.agent.skills import SkillMeta, all_skills, read_skill
+from src.agent.subagents import generate_insights, pick_aoi, pick_dataset
+from src.agent.tools import pull_data
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class ToolCategory(str, Enum):
+    """How a tool is grouped under a heading in the system prompt."""
+
+    PRIMITIVE = "primitive"
+    SUBAGENT = "subagent"
+
+
+_CATEGORY_HEADERS = {
+    ToolCategory.PRIMITIVE: "# Tools (primitives — call when you need them)",
+    ToolCategory.SUBAGENT: "# Subagents (call as tools — each does its own reasoning; just forward the user's intent)",
+}
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """A tool plus the prompt fragment that teaches the model to use it."""
+
+    tool: BaseTool
+    category: ToolCategory
+    prompt_fragment: str
+
+
+# Every tool the agent can load, keyed by name. Profiles reference these names.
+TOOL_REGISTRY: dict[str, ToolSpec] = {
+    "pull_data": ToolSpec(
+        pull_data,
+        ToolCategory.PRIMITIVE,
+        "- pull_data(query): fetch data for the AOI and dataset currently in state. Run pick_aoi and pick_dataset first.",
+    ),
+    "read_skill": ToolSpec(
+        read_skill,
+        ToolCategory.PRIMITIVE,
+        "- read_skill(name): load a skill's full workflow — call it once, after you have committed to using that skill.",
+    ),
+    "pick_aoi": ToolSpec(
+        pick_aoi,
+        ToolCategory.SUBAGENT,
+        '- pick_aoi(question): natural-language geocoder. Pass the place request verbatim ("tree cover loss in Pará, Brazil", "the districts of Odisha", "forest loss worldwide"); it extracts, translates and resolves the place — and any subregions — itself. Updates the AOI in state, or returns a clarifying question.',
+    ),
+    "pick_dataset": ToolSpec(
+        pick_dataset,
+        ToolCategory.SUBAGENT,
+        "- pick_dataset(query): dataset-selection subagent. Picks the dataset, context layer and date range that best answer the request. May return no dataset if none is a good fit — in that case relay its explanation and closest alternatives to the user; do not proceed to pull_data. Call it again whenever the user changes the dataset, context layer or parameters.",
+    ),
+    "generate_insights": ToolSpec(
+        generate_insights,
+        ToolCategory.SUBAGENT,
+        "- generate_insights(query): analyst subagent. Turns pulled data into one chart insight with follow-up suggestions. Requires pull_data to have run first.",
+    ),
+}
+
+DEFAULT_PROFILE = "default"
+EXPERIMENTAL_PROFILE = "experimental"
+
+# Tools every user gets in production.
+_CORE_TOOLS = [
+    "pick_aoi",
+    "pick_dataset",
+    "pull_data",
+    "generate_insights",
+    "read_skill",
+]
+
+# Experimental tools, exposed only to opted-in testers (help_test_features).
+# Add new tools here first (e.g. "show_imagery"); promote to _CORE_TOOLS to ship.
+_EXPERIMENTAL_TOOLS: list[str] = []
+
+PROFILES: dict[str, list[str]] = {
+    DEFAULT_PROFILE: _CORE_TOOLS,
+    EXPERIMENTAL_PROFILE: _CORE_TOOLS + _EXPERIMENTAL_TOOLS,
+}
+
+
+def resolve_profile_name(user: Optional[dict] = None) -> str:
+    """Pick the tool profile for a conversation based on the user.
+
+    Testers who opted in via ``help_test_features`` get the experimental
+    profile; everyone else (including anonymous users) gets the production
+    default.
+    """
+    if user and user.get("help_test_features"):
+        return EXPERIMENTAL_PROFILE
+    return DEFAULT_PROFILE
+
+
+def _profile_tool_names(profile: str) -> list[str]:
+    if profile not in PROFILES:
+        logger.warning(
+            "Unknown tool profile %r, falling back to %r",
+            profile,
+            DEFAULT_PROFILE,
+        )
+        profile = DEFAULT_PROFILE
+    return PROFILES[profile]
+
+
+def tools_for_profile(profile: str) -> list[BaseTool]:
+    """The tool objects bound to the agent for a profile."""
+    return [TOOL_REGISTRY[name].tool for name in _profile_tool_names(profile)]
+
+
+def tool_descriptions_for_profile(profile: str) -> str:
+    """Render the Tools + Subagents prompt sections for a profile's tools.
+
+    Grouped by category so the prompt only ever describes tools that are
+    actually bound for this profile.
+    """
+    names = _profile_tool_names(profile)
+    blocks = []
+    for category in ToolCategory:
+        fragments = [
+            TOOL_REGISTRY[name].prompt_fragment
+            for name in names
+            if TOOL_REGISTRY[name].category == category
+        ]
+        if fragments:
+            blocks.append(
+                _CATEGORY_HEADERS[category] + "\n\n" + "\n".join(fragments)
+            )
+    return "\n\n".join(blocks)
+
+
+def skills_for_profile(profile: str) -> list[SkillMeta]:
+    """Skills whose required tools are all bound in this profile.
+
+    A skill recipe directs the model to call specific tools (declared in its
+    ``requires`` frontmatter), so we only advertise a skill when the active
+    profile binds every tool it needs — otherwise the workflow would tell the
+    model to call a tool that isn't available.
+    """
+    available = set(_profile_tool_names(profile))
+    return [s for s in all_skills() if set(s.requires) <= available]

--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -87,6 +87,7 @@ def _orm_to_user_model(user: UserOrm) -> UserModel:
         created_at=user.created_at,
         updated_at=user.updated_at,
         user_type=user.user_type,
+        agent_profile=user.agent_profile,
         first_name=user.first_name,
         last_name=user.last_name,
         profile_description=user.profile_description,

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -33,6 +33,11 @@ class UserType(str, enum.Enum):
     SUPERUSER = "superuser"
 
 
+class AgentProfile(str, enum.Enum):
+    DEFAULT = "default"
+    EXPERIMENTAL = "experimental"
+
+
 class UserOrm(Base):
     __tablename__ = "users"
 
@@ -44,6 +49,9 @@ class UserOrm(Base):
         DateTime, nullable=False, default=datetime.now, onupdate=datetime.now
     )
     user_type = Column(String, nullable=False, default=UserType.REGULAR.value)
+    agent_profile = Column(
+        String, nullable=False, default=AgentProfile.DEFAULT.value
+    )
 
     # New profile fields - Basic
     first_name = Column(String, nullable=True)

--- a/src/api/routers/admin.py
+++ b/src/api/routers/admin.py
@@ -11,7 +11,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.auth.dependencies import _orm_to_user_model, require_superuser
 from src.api.data_models import UserOrm, UserType
-from src.api.schemas import UserModel, UserTypeUpdateRequest
+from src.api.schemas import (
+    AgentProfileUpdateRequest,
+    UserModel,
+    UserTypeUpdateRequest,
+)
 from src.shared.database import get_session_from_pool_dependency
 
 router = APIRouter()
@@ -23,6 +27,7 @@ _EXPORT_COLUMNS: tuple[str, ...] = (
     "created_at",
     "updated_at",
     "user_type",
+    "agent_profile",
     "first_name",
     "last_name",
     "profile_description",
@@ -99,6 +104,32 @@ async def update_user_type(
         )
 
     target.user_type = body.user_type.value
+    target.updated_at = datetime.now()
+
+    await session.commit()
+    await session.refresh(target)
+
+    return _orm_to_user_model(target)
+
+
+@router.patch(
+    "/api/admin/users/{user_id}/agent-profile", response_model=UserModel
+)
+async def update_agent_profile(
+    user_id: str,
+    body: AgentProfileUpdateRequest,
+    _superuser: UserModel = Depends(require_superuser),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+):
+    """Set a user's agent_profile. Superuser-only."""
+    result = await session.execute(
+        select(UserOrm).where(UserOrm.id == user_id)
+    )
+    target = result.scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    target.agent_profile = body.agent_profile.value
     target.updated_at = datetime.now()
 
     await session.commit()

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -83,8 +83,8 @@ async def chat(
             "country_code": user.country_code,
             "preferred_language_code": user.preferred_language_code,
             "areas_of_interest": user.areas_of_interest,
-            # Selects the agent tool profile (experimental tools for opted-in testers).
-            "help_test_features": user.help_test_features,
+            # Selects which agent tool profile (default/experimental) to load.
+            "agent_profile": user.agent_profile.value,
         }
         if user.sector_code and user.sector_code in SECTORS:
             user_dict["sector_code"] = SECTORS[user.sector_code]

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -83,6 +83,8 @@ async def chat(
             "country_code": user.country_code,
             "preferred_language_code": user.preferred_language_code,
             "areas_of_interest": user.areas_of_interest,
+            # Selects the agent tool profile (experimental tools for opted-in testers).
+            "help_test_features": user.help_test_features,
         }
         if user.sector_code and user.sector_code in SECTORS:
             user_dict["sector_code"] = SECTORS[user.sector_code]

--- a/src/api/routers/users.py
+++ b/src/api/routers/users.py
@@ -79,6 +79,7 @@ async def update_user_profile(
         created_at=db_user.created_at,
         updated_at=db_user.updated_at,
         user_type=db_user.user_type,
+        agent_profile=db_user.agent_profile,
         threads=[],
         first_name=db_user.first_name,
         last_name=db_user.last_name,

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -11,7 +11,7 @@ from pydantic import (
     field_validator,
 )
 
-from src.api.data_models import UserType
+from src.api.data_models import AgentProfile, UserType
 from src.api.user_profile_configs.countries import COUNTRIES
 from src.api.user_profile_configs.gis_expertise import GIS_EXPERTISE_LEVELS
 from src.api.user_profile_configs.languages import LANGUAGES
@@ -80,6 +80,7 @@ class UserModel(BaseModel):
     updated_at: datetime
     threads: list[ThreadModel] = []
     user_type: UserType = UserType.REGULAR
+    agent_profile: AgentProfile = AgentProfile.DEFAULT
 
     # New profile fields - Basic
     first_name: Optional[str] = None
@@ -171,6 +172,12 @@ class UserTypeUpdateRequest(BaseModel):
                 "machine user_type cannot be assigned via this endpoint"
             )
         return v
+
+
+class AgentProfileUpdateRequest(BaseModel):
+    """Request schema for changing a user's agent_profile (admin endpoint)."""
+
+    agent_profile: AgentProfile
 
 
 class UserProfileUpdateRequest(BaseModel):

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -711,6 +711,110 @@ async def test_superuser_can_view_other_users_private_threads(
     assert response.status_code == 200
 
 
+# --- PATCH /api/admin/users/{user_id}/agent-profile -----------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_profile_requires_auth(client):
+    """Unauthenticated PATCH must return 401."""
+    response = await client.patch(
+        "/api/admin/users/some-id/agent-profile",
+        json={"agent_profile": "experimental"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_profile_requires_superuser_not_regular(
+    client, auth_override
+):
+    """A regular user must receive 403."""
+    regular = await _seed_user(
+        "reg-ap", "reg_ap@example.com", UserType.REGULAR
+    )
+    target = await _seed_user(
+        "target-ap-r", "target_ap_r@example.com", UserType.REGULAR
+    )
+    auth_override(regular.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/agent-profile",
+        headers={"Authorization": "Bearer test-token"},
+        json={"agent_profile": "experimental"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_superuser_can_set_agent_profile(
+    client, auth_override, superuser_factory
+):
+    """Superuser switches a user to the experimental profile and back."""
+    su = await superuser_factory("su_ap@example.com")
+    target = await _seed_user(
+        "target-ap", "target_ap@example.com", UserType.REGULAR
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/agent-profile",
+        headers={"Authorization": "Bearer test-token"},
+        json={"agent_profile": "experimental"},
+    )
+    assert response.status_code == 200
+    assert response.json()["agentProfile"] == "experimental"
+
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(UserOrm).where(UserOrm.id == target.id)
+        )
+        db_user = result.scalar_one()
+        assert db_user.agent_profile == "experimental"
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/agent-profile",
+        headers={"Authorization": "Bearer test-token"},
+        json={"agent_profile": "default"},
+    )
+    assert response.status_code == 200
+    assert response.json()["agentProfile"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_profile_invalid_value(
+    client, auth_override, superuser_factory
+):
+    """Unknown agent_profile value is rejected with 422."""
+    su = await superuser_factory("su_ap_invalid@example.com")
+    target = await _seed_user(
+        "target-ap-invalid", "target_ap_invalid@example.com", UserType.REGULAR
+    )
+    auth_override(su.id)
+
+    response = await client.patch(
+        f"/api/admin/users/{target.id}/agent-profile",
+        headers={"Authorization": "Bearer test-token"},
+        json={"agent_profile": "bogus"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_agent_profile_user_not_found(
+    client, auth_override, superuser_factory
+):
+    """PATCH on unknown user_id returns 404."""
+    su = await superuser_factory("su_ap_404@example.com")
+    auth_override(su.id)
+
+    response = await client.patch(
+        "/api/admin/users/does-not-exist/agent-profile",
+        headers={"Authorization": "Bearer test-token"},
+        json={"agent_profile": "experimental"},
+    )
+    assert response.status_code == 404
+
+
 # --- GET /api/admin/users/export ------------------------------------------
 
 EXPORT_COLUMNS = [
@@ -720,6 +824,7 @@ EXPORT_COLUMNS = [
     "created_at",
     "updated_at",
     "user_type",
+    "agent_profile",
     "first_name",
     "last_name",
     "profile_description",
@@ -848,7 +953,7 @@ async def test_export_users_response_headers(
 async def test_export_users_header_row(
     client, auth_override, superuser_factory
 ):
-    """First CSV row is the expected 21-column header in exact order."""
+    """First CSV row is the expected 22-column header in exact order."""
     su = await superuser_factory("su-export-header-row@example.test")
     auth_override(su.id)
 

--- a/tests/unit/agent/test_tool_profiles.py
+++ b/tests/unit/agent/test_tool_profiles.py
@@ -6,48 +6,46 @@ from src.agent.tool_profiles import (
     EXPERIMENTAL_PROFILE,
     PROFILES,
     TOOL_REGISTRY,
-    resolve_profile_name,
-    skills_for_profile,
-    tool_descriptions_for_profile,
-    tools_for_profile,
+    get_profile,
+    resolve_profile,
 )
 
 
 def test_resolve_profile_gates_on_help_test_features():
-    assert resolve_profile_name(None) == DEFAULT_PROFILE
-    assert resolve_profile_name({}) == DEFAULT_PROFILE
+    assert resolve_profile(None).name == DEFAULT_PROFILE
+    assert resolve_profile({}).name == DEFAULT_PROFILE
     assert (
-        resolve_profile_name({"help_test_features": False}) == DEFAULT_PROFILE
+        resolve_profile({"help_test_features": False}).name == DEFAULT_PROFILE
     )
     assert (
-        resolve_profile_name({"help_test_features": True})
+        resolve_profile({"help_test_features": True}).name
         == EXPERIMENTAL_PROFILE
     )
 
 
 def test_experimental_is_a_superset_of_default():
-    default = set(PROFILES[DEFAULT_PROFILE])
-    experimental = set(PROFILES[EXPERIMENTAL_PROFILE])
+    default = set(PROFILES[DEFAULT_PROFILE].tool_names)
+    experimental = set(PROFILES[EXPERIMENTAL_PROFILE].tool_names)
     assert default <= experimental
 
 
 def test_profiles_only_reference_registered_tools():
-    for names in PROFILES.values():
-        for name in names:
+    for profile in PROFILES.values():
+        for name in profile.tool_names:
             assert name in TOOL_REGISTRY
 
 
 def test_unknown_profile_falls_back_to_default():
-    assert tools_for_profile("nope") == tools_for_profile(DEFAULT_PROFILE)
+    assert get_profile("nope") is PROFILES[DEFAULT_PROFILE]
 
 
 def test_prompt_describes_exactly_the_bound_tools():
     """The prompt must mention every bound tool and no unbound one — this is
     the invariant that keeps the prompt from drifting from the tool set."""
-    for profile, names in PROFILES.items():
-        descriptions = tool_descriptions_for_profile(profile)
-        bound = {t.name for t in tools_for_profile(profile)}
-        for name in names:
+    for profile in PROFILES.values():
+        descriptions = profile.tool_descriptions()
+        bound = {t.name for t in profile.tools()}
+        for name in profile.tool_names:
             assert name in descriptions
         # A tool that is registered but not in this profile must not appear.
         for name in TOOL_REGISTRY:
@@ -66,20 +64,20 @@ def test_skill_dependencies_reference_registered_tools():
 
 
 def test_skills_only_advertised_when_their_tools_are_bound():
-    for profile, names in PROFILES.items():
-        bound = set(names)
-        for skill in skills_for_profile(profile):
+    for profile in PROFILES.values():
+        bound = set(profile.tool_names)
+        for skill in profile.skills():
             assert set(skill.requires) <= bound
         # Skills whose deps are unmet are filtered out.
         unmet = [s for s in all_skills() if not set(s.requires) <= bound]
-        advertised = {s.name for s in skills_for_profile(profile)}
+        advertised = {s.name for s in profile.skills()}
         for s in unmet:
             assert s.name not in advertised
 
 
 def test_default_profile_advertises_all_three_recipes():
     # All three recipes' tool deps are met by the default profile today.
-    assert {s.name for s in skills_for_profile(DEFAULT_PROFILE)} == {
+    assert {s.name for s in PROFILES[DEFAULT_PROFILE].skills()} == {
         "analyze",
         "capabilities",
         "pull-data",

--- a/tests/unit/agent/test_tool_profiles.py
+++ b/tests/unit/agent/test_tool_profiles.py
@@ -11,16 +11,20 @@ from src.agent.tool_profiles import (
 )
 
 
-def test_resolve_profile_gates_on_help_test_features():
+def test_resolve_profile_gates_on_agent_profile():
     assert resolve_profile(None).name == DEFAULT_PROFILE
     assert resolve_profile({}).name == DEFAULT_PROFILE
+    assert resolve_profile({"agent_profile": None}).name == DEFAULT_PROFILE
     assert (
-        resolve_profile({"help_test_features": False}).name == DEFAULT_PROFILE
+        resolve_profile({"agent_profile": DEFAULT_PROFILE}).name
+        == DEFAULT_PROFILE
     )
     assert (
-        resolve_profile({"help_test_features": True}).name
+        resolve_profile({"agent_profile": EXPERIMENTAL_PROFILE}).name
         == EXPERIMENTAL_PROFILE
     )
+    # Unknown profile names fall back to the default.
+    assert resolve_profile({"agent_profile": "bogus"}).name == DEFAULT_PROFILE
 
 
 def test_experimental_is_a_superset_of_default():

--- a/tests/unit/agent/test_tool_profiles.py
+++ b/tests/unit/agent/test_tool_profiles.py
@@ -1,0 +1,86 @@
+"""Tests for agent tool profiles: gating and prompt/tool consistency."""
+
+from src.agent.skills import all_skills
+from src.agent.tool_profiles import (
+    DEFAULT_PROFILE,
+    EXPERIMENTAL_PROFILE,
+    PROFILES,
+    TOOL_REGISTRY,
+    resolve_profile_name,
+    skills_for_profile,
+    tool_descriptions_for_profile,
+    tools_for_profile,
+)
+
+
+def test_resolve_profile_gates_on_help_test_features():
+    assert resolve_profile_name(None) == DEFAULT_PROFILE
+    assert resolve_profile_name({}) == DEFAULT_PROFILE
+    assert (
+        resolve_profile_name({"help_test_features": False}) == DEFAULT_PROFILE
+    )
+    assert (
+        resolve_profile_name({"help_test_features": True})
+        == EXPERIMENTAL_PROFILE
+    )
+
+
+def test_experimental_is_a_superset_of_default():
+    default = set(PROFILES[DEFAULT_PROFILE])
+    experimental = set(PROFILES[EXPERIMENTAL_PROFILE])
+    assert default <= experimental
+
+
+def test_profiles_only_reference_registered_tools():
+    for names in PROFILES.values():
+        for name in names:
+            assert name in TOOL_REGISTRY
+
+
+def test_unknown_profile_falls_back_to_default():
+    assert tools_for_profile("nope") == tools_for_profile(DEFAULT_PROFILE)
+
+
+def test_prompt_describes_exactly_the_bound_tools():
+    """The prompt must mention every bound tool and no unbound one — this is
+    the invariant that keeps the prompt from drifting from the tool set."""
+    for profile, names in PROFILES.items():
+        descriptions = tool_descriptions_for_profile(profile)
+        bound = {t.name for t in tools_for_profile(profile)}
+        for name in names:
+            assert name in descriptions
+        # A tool that is registered but not in this profile must not appear.
+        for name in TOOL_REGISTRY:
+            if name not in bound:
+                assert name not in descriptions
+
+
+def test_skill_dependencies_reference_registered_tools():
+    """Every tool a skill declares it requires must exist in the registry,
+    or the skill could never be advertised in any profile."""
+    for skill in all_skills():
+        for tool_name in skill.requires:
+            assert (
+                tool_name in TOOL_REGISTRY
+            ), f"skill {skill.name!r} requires unknown tool {tool_name!r}"
+
+
+def test_skills_only_advertised_when_their_tools_are_bound():
+    for profile, names in PROFILES.items():
+        bound = set(names)
+        for skill in skills_for_profile(profile):
+            assert set(skill.requires) <= bound
+        # Skills whose deps are unmet are filtered out.
+        unmet = [s for s in all_skills() if not set(s.requires) <= bound]
+        advertised = {s.name for s in skills_for_profile(profile)}
+        for s in unmet:
+            assert s.name not in advertised
+
+
+def test_default_profile_advertises_all_three_recipes():
+    # All three recipes' tool deps are met by the default profile today.
+    assert {s.name for s in skills_for_profile(DEFAULT_PROFILE)} == {
+        "analyze",
+        "capabilities",
+        "pull-data",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -2807,7 +2807,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.13"
+version = "2026.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -2807,7 +2807,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.15"
+version = "2026.6.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -2807,7 +2807,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.3"
+version = "2026.6.13"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Agent tool profiles gated by `help_test_features`

  ### Why

We want to ship experimental agent tools to opt-in testers without exposing them in production.

This is in preparation for two PRs that want to add new tooling that must be evaluated first:

- https://github.com/wri/project-zeno/pull/707
- https://github.com/wri/project-zeno/pull/710

 
### What

  Introduce a **tool-profile registry**. A `Profile` bundles a tool set with the prompt fragment that documents each tool, so the prompt is generated from the same source
  that binds the tools and can't drift.

  - **Two profiles:** `default` (production) and `experimental` (default + opt-in tools).
  - **Gating:** resolved per conversation from the user's existing `help_test_features` flag — testers get `experimental`, everyone else (incl. anonymous) gets `default`. No
  API-level profile selection; the flag is set via the existing `PATCH /api/auth/profile`.
  - **Profiles are objects:** `Profile` is a frozen dataclass holding the tool-name tuple and exposing `tools()`, `tool_descriptions()` and `skills()`.
  `resolve_profile(user)` returns a `Profile`; `get_profile(name)` does name lookup + fallback. This gives future per-profile parameters (model override, extra prompt block,
  tool cap) a home on the dataclass instead of more `_for_profile(name)` functions. `Profile` holds only tool *names* — `TOOL_REGISTRY` / `all_skills()` stay the single
  source of truth.
  - **Skills fold in too:** each skill declares its required tools via a `requires:` frontmatter field; a skill is only advertised in a profile that binds all of its tools,
  so recipes never reference unbound tools. (Forward-looking: a future `show-imagery` skill requiring `show_imagery` auto-scopes to `experimental`, no manual per-profile
  list.)

  To add an experimental tool later: register a `ToolSpec` in `TOOL_REGISTRY` and add its name to `_EXPERIMENTAL_TOOLS`; promote to `_CORE_TOOLS` to ship to everyone.

  ### Changes

  - `src/agent/tool_profiles.py` (new) — `TOOL_REGISTRY`, `Profile` dataclass, `PROFILES`, `resolve_profile`, `get_profile`.
  - `src/agent/graph.py` — resolves a `Profile` and derives bound tools + prompt sections from it (replaces the static `tools` list and hardcoded prompt sections).
  - `src/agent/skills/loader.py` + `analyze.md` / `pull-data.md` — `requires` frontmatter parsed into `SkillMeta`.
  - `src/api/routers/chat.py` — pass `help_test_features` through to the agent (was previously dropped).
  - `tests/unit/agent/test_tool_profiles.py` (new) — gating, prompt↔tool consistency, and skill-dependency invariants.

  ### Behavior change

  None today — both profiles currently bind the same core tools (`show_imagery` lands separately), so the `default` prompt renders **byte-identical** to before. This PR is
  the wiring that keeps tools, prompt, and skills consistent once profiles diverge.

  ### Testing

  - `ruff`, `ruff-format`, `mypy` pass (pre-commit).
  - 31 unit tests pass (`test_tool_profiles.py`, `test_skills.py`, `test_cli.py`).
  - Have ran this locally and works fine