### PR TITLE
PZB-961: Halt agent when pick_dataset returns only suggested datasets

### DIFF
--- a/src/agent/skills/skills_md/analyze.md
+++ b/src/agent/skills/skills_md/analyze.md
@@ -7,7 +7,7 @@ when_to_use: User wants end-to-end analysis with a chart or insight (e.g. "analy
 # Workflow
 
 1. `pick_aoi` — pass the user's request describing the place; the geocoder extracts, translates and resolves the AOI (and any subregion) on its own.
-2. `pick_dataset` — choose dataset and date range. Its tool description covers re-picking when the user changes topic or context layer. If it returns no dataset, stop and relay its explanation to the user — do not proceed to `pull_data`.
+2. `pick_dataset` — choose dataset and date range. Its tool description covers re-picking when the user changes topic or context layer. If it returns no dataset, **or only suggested/alternative datasets**, stop and relay its explanation and the alternatives to the user — do not proceed to `pull_data`, and do not pick one of the suggestions yourself. Wait for the user to choose.
 3. `pull_data` — fetch data for AOI + dataset + dates. You need AOI, dataset, and a date range before this step.
 4. `generate_insights` — after a successful pull, always run this to produce one chart insight.
 

--- a/src/agent/skills/skills_md/pull-data.md
+++ b/src/agent/skills/skills_md/pull-data.md
@@ -9,7 +9,7 @@ when_to_use: User asks to pull, fetch, or get data (with place and/or topic). No
 When the user wants data retrieved but does **not** ask for analysis, a chart, or insights (e.g. "pull dist alerts in Bern for last 2 weeks", "fetch tree cover loss for Para"):
 
 1. `pick_aoi` — pass the user's request describing the place; the geocoder extracts, translates and resolves the AOI (and any subregion) on its own.
-2. `pick_dataset` — choose dataset and date range. Dataset-only/re-pick rules are in its tool description. If it returns no dataset, stop and relay its explanation to the user — do not proceed to `pull_data`.
+2. `pick_dataset` — choose dataset and date range. Dataset-only/re-pick rules are in its tool description. If it returns no dataset, **or only suggested/alternative datasets**, stop and relay its explanation and the alternatives to the user — do not proceed to `pull_data`, and do not pick one of the suggestions yourself. Wait for the user to choose.
 3. `pull_data` — fetch data for AOI + dataset + dates.
 4. **Stop.** Confirm what was pulled. Do **not** call `generate_insights`.
 

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -228,7 +228,12 @@ class DatasetSelector:
                         ],
                         "messages": [
                             ToolMessage(
-                                tool_message, tool_call_id=tool_call_id
+                                tool_message,
+                                tool_call_id=tool_call_id,
+                                status="success",
+                                response_metadata={
+                                    "msg_type": "human_feedback"
+                                },
                             )
                         ],
                     }


### PR DESCRIPTION
## Problem

`pick_dataset` has three outcomes (see `pick_dataset/prompts.py`):

- **Case A** — a clear match (`selected_dataset` set)
- **Case B** — no single match, but related datasets exist (`suggested_datasets` set) — meant to **halt and let the user choose**
- **Case C** — no match at all (both null)

The `analyze` and `pull-data` skills only instructed the agent to stop on the "no dataset" outcome (Case C). Case B produces a different message ("No single dataset directly matches… here are the closest available options"), which the agent — operating under those skills — treated as actionable and proceeded to `pull_data`, or picked a suggestion itself, instead of waiting for user feedback.

The top-level orchestrator prompt does handle Case B, but once a skill is read its body becomes the in-focus spec, and the more-specific (incomplete) instruction wins.

### Example

In this thread, it did analysis, and then presented the chose dataset option on the frontend. So here it did not stop

https://staging.globalnaturewatch.org/app/threads/4c457302-382a-45c8-ad49-b68e577c3f4b

## Changes

- **`analyze.md` / `pull-data.md`**: extend the stop instruction to explicitly cover the suggested/alternative datasets case — relay the alternatives and wait for the user to choose; do not proceed or pick one.
- **`pick_dataset/tool.py`**: tag the `suggested_datasets` `ToolMessage` with `status="success"` and `response_metadata={"msg_type": "human_feedback"}`, matching the other human-feedback halt points (`pull_data`, `pick_aoi`, `analyst`).

Closes : [PZB-961](https://gfw.atlassian.net/browse/PZB-961)

## Keep in mind

`msg_type: "human_feedback"` is **not consumed anywhere in `src/`** — it's a frontend streaming hint, not a graph-level halt. Fix 2 aligns the UX signal, but the *actual* halting still rests entirely on prompt/skill adherence (fix 1). A hard guarantee would require enforcement in the graph/streaming layer rather than the prompt — a larger change, flagged separately rather than folded in here.


[PZB-961]: https://gfw.atlassian.net/browse/PZB-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ