### PR TITLE
Persist Sentinel-2 mosaics to S3, serve via external titiler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,14 @@ CODING_MODEL=gemini-3.1-pro-preview # Full Google model IDs required (used by ge
 CODING_FALLBACK_MODELS=gemini-2.5-pro,gemini-3-flash-preview # Full Google model IDs required
 EOAPI_BASE_URL=https://eoapi.staging.globalnaturewatch.org
 
+# Sentinel-2 mosaic storage. Built MosaicJSON files are written to this private
+# S3 bucket; an external titiler reads them via s3:// using IAM credentials.
+# AWS credentials come from the standard boto3 chain (IAM role / env / profile).
+MOSAIC_S3_BUCKET=<mosaic-bucket-name>
+MOSAIC_S3_PREFIX=mosaics
+MOSAIC_S3_REGION=us-west-2
+MOSAIC_TILER_URL=https://titiler.example
+
 # Logging Configuration
 LOG_LEVEL=INFO              # DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_FORMAT=text             # text (colored) or json (structured)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -5,8 +5,6 @@ from typing import Optional
 import structlog
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
-from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
 from src.agent.graph import close_checkpointer_pool, get_checkpointer_pool
 from src.api.routers import (
@@ -55,20 +53,6 @@ app.add_middleware(
     allow_headers=["*"],
     expose_headers=["Content-Disposition", "X-Next-Cursor"],
 )
-
-
-@app.middleware("http")
-async def mosaic_cache_headers(request: Request, call_next) -> Response:
-    """Mosaic tiles are immutable per token; let browsers cache them."""
-    response = await call_next(request)
-    if (
-        request.method == "GET"
-        and request.url.path.startswith("/mosaic/")
-        and response.status_code == 200
-    ):
-        # private: responses require auth, so only browsers should cache.
-        response.headers["Cache-Control"] = "private, max-age=86400"
-    return response
 
 
 @app.middleware("http")
@@ -130,10 +114,3 @@ app.include_router(metadata.router)
 app.include_router(admin.router)
 app.include_router(traces.router)
 app.include_router(mosaic.router, prefix="/mosaic", tags=["Map Tiles"])
-
-# Map titiler/cogeo-mosaic errors to proper status codes (e.g. tile requests
-# outside the mosaic bounds -> 404, unknown mosaic id -> 404). The catch-all
-# Exception entry is dropped to leave non-tiler error handling unchanged.
-_tiler_status_codes = {**DEFAULT_STATUS_CODES, **MOSAIC_STATUS_CODES}
-_tiler_status_codes.pop(Exception, None)
-add_exception_handlers(app, _tiler_status_codes)

--- a/src/api/routers/mosaic.py
+++ b/src/api/routers/mosaic.py
@@ -1,9 +1,10 @@
-"""Sentinel-2 mosaic tile service over AOI geometries.
+"""Sentinel-2 mosaic creation over AOI geometries.
 
-All endpoints — including the titiler tile/tilejson routes — require the
-same bearer auth as the rest of the API; map clients must attach the
-Authorization header to tile requests. Mosaic ids are recipe tokens (see
-src/api/services/mosaic.py).
+The create endpoint builds a MosaicJSON, persists it to S3 (see
+src/api/services/mosaic.py) and returns a recipe-token mosaic id. Tiles are
+served by an external titiler that reads the MosaicJSON from S3; this repo no
+longer serves tiles. Creation requires the same bearer auth as the rest of
+the API.
 """
 
 from datetime import date
@@ -11,31 +12,22 @@ from typing import Optional
 
 from cogeo_mosaic.errors import MosaicNotFoundError
 from fastapi import APIRouter, Depends, HTTPException, Query
-from titiler.mosaic.factory import MosaicTilerFactory
 
 from src.api.auth.dependencies import require_auth
 from src.api.models import MosaicCreateResponse
 from src.api.schemas import UserModel
 from src.api.services.mosaic import (
     AoiTooLargeError,
-    InMemoryBackend,
     MosaicRecipe,
     NoScenesFoundError,
     StacSearchError,
     create_sentinel2_mosaic,
-    ensure_mosaic,
 )
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-_mosaic_tiler = MosaicTilerFactory(backend=InMemoryBackend)
-
 router = APIRouter()
-router.include_router(
-    _mosaic_tiler.router,
-    dependencies=[Depends(require_auth), Depends(ensure_mosaic)],
-)
 
 
 @router.post("/create/{source}/{src_id}", response_model=MosaicCreateResponse)
@@ -50,11 +42,11 @@ async def create_mosaic(
 ):
     """
     Search Sentinel-2 L2A scenes covering an AOI around target_date
-    (within ±window_days) and cache a MosaicJSON.
+    (within ±window_days) and persist a MosaicJSON to S3.
 
-    Returns a mosaic_id to pass as ?url= to the titiler mosaic endpoints:
-      GET /mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}[.{format}]?url={mosaic_id}
-      GET /mosaic/WebMercatorQuad/tilejson.json?url={mosaic_id}
+    Returns a mosaic_id (recipe token). Tiles are served by the external
+    titiler, which reads the MosaicJSON from S3; the tile/tilejson URLs are
+    available on the MosaicResult (tile_url / tilejson_url).
     """
     recipe = MosaicRecipe(
         aois=((source, src_id),),

--- a/src/api/services/mosaic.py
+++ b/src/api/services/mosaic.py
@@ -4,59 +4,41 @@ Searches the earth-search STAC API for Sentinel-2 L2A scenes (COGs hosted in
 the public sentinel-cogs AWS bucket) around a target date and builds a
 MosaicJSON.
 
-Mosaics are not persisted: the mosaic id handed to clients is a token
-encoding the build recipe (AOI references, target date, search parameters).
-The in-memory store is only a per-process cache — on a cache miss the
-ensure_mosaic route dependency rebuilds the mosaic from its token, so any
-previously issued mosaic URL keeps working across restarts, workers and
-replicas. The tile endpoints require the same bearer auth as the rest of
-the API, so the token needs no signature: crafting one grants nothing the
-authenticated create endpoint would not.
+The built MosaicJSON is written to a private S3 bucket under a key derived
+from a deterministic, self-describing recipe token (AOI references, target
+date, search parameters). Tiles are served by an external, vanilla titiler
+deployment that reads the MosaicJSON from S3 via ``s3://`` using IAM
+credentials — this repo no longer serves tiles itself.
+
+Before building, we look up the recipe token in S3: if a mosaic already
+exists we skip the (expensive) STAC search, build and upload, and return the
+metadata recorded in a small sidecar object written alongside the mosaic.
 """
 
-import asyncio
 import base64
+import functools
 import json
-import os
 import time
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Optional
+from urllib.parse import quote
 
-import attr
+import boto3
 import pystac_client
-from cachetools import TTLCache
-from cogeo_mosaic.backends.base import BaseBackend
+from botocore.exceptions import ClientError
 from cogeo_mosaic.errors import MosaicNotFoundError
 from cogeo_mosaic.mosaic import MosaicJSON
-from fastapi import HTTPException, Query
 from fastapi.concurrency import run_in_threadpool
 from pyproj import Geod
 from shapely import union_all
 from shapely.geometry import mapping, shape
 
+from src.shared.config import SharedSettings
 from src.shared.geocoding_helpers import get_geometry_data
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-# GDAL tuning for reading remote COGs (read by rasterio at open time, so
-# deployment env vars take precedence). Without GDAL_DISABLE_READDIR_ON_OPEN
-# every COG open issues extra (404ing) sidecar-file requests against S3.
-_GDAL_ENV_DEFAULTS = {
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES": "YES",
-    "GDAL_HTTP_MULTIPLEX": "YES",
-    "GDAL_HTTP_VERSION": "2",
-    "GDAL_CACHEMAX": "200",
-    "VSI_CACHE": "TRUE",
-    "VSI_CACHE_SIZE": "5000000",
-    "CPL_VSIL_CURL_CACHE_SIZE": "200000000",
-    # Sentinel-2 COG headers are larger than GDAL's 16KB default read.
-    "GDAL_INGESTED_BYTES_AT_OPEN": "32768",
-}
-for _key, _value in _GDAL_ENV_DEFAULTS.items():
-    os.environ.setdefault(_key, _value)
 
 STAC_URL = "https://earth-search.aws.element84.com/v1"
 SENTINEL2_COLLECTION = "sentinel-2-l2a"
@@ -66,13 +48,6 @@ VISUAL_ASSET = "visual"
 MAX_AOI_AREA_KM2 = 50_000
 
 _geod = Geod(ellps="WGS84")
-
-# token → MosaicJSON. Pure per-process cache; misses are rebuilt from the
-# token by ensure_mosaic.
-_mosaic_store: TTLCache = TTLCache(maxsize=256, ttl=12 * 3600)
-
-# token → lock, so concurrent tile requests trigger at most one rebuild.
-_rebuild_locks: dict[str, asyncio.Lock] = {}
 
 
 class AoiTooLargeError(Exception):
@@ -93,28 +68,79 @@ class NoScenesFoundError(Exception):
     pass
 
 
-@attr.s
-class InMemoryBackend(BaseBackend):
-    """Resolve a mosaic by token from the module-level _mosaic_store."""
+# ---------------------------------------------------------------------------
+# S3 persistence
+# ---------------------------------------------------------------------------
 
-    _backend_name = "InMemory"
 
-    def _read(self) -> MosaicJSON:
-        mosaic = _mosaic_store.get(self.input)
-        if mosaic is None:
-            raise MosaicNotFoundError("Mosaic not found")
-        return mosaic
+@functools.lru_cache(maxsize=1)
+def _s3_client():
+    return boto3.client(
+        "s3", region_name=SharedSettings.mosaic_s3_region or None
+    )
 
-    def tile(self, *args, **kwargs):
-        # Read scenes sequentially with lazy early exit: with the default
-        # "first" pixel selection, reading stops as soon as the tile is
-        # covered. The factory default (threads=70) would instead fetch
-        # every candidate scene from S3 concurrently and discard most.
-        kwargs["threads"] = 0
-        return super().tile(*args, **kwargs)
 
-    def write(self, overwrite: bool = False) -> None:
-        pass
+def _s3_key(token: str) -> str:
+    return f"{SharedSettings.mosaic_s3_prefix.strip('/')}/{token}.json"
+
+
+def _meta_key(token: str) -> str:
+    return f"{SharedSettings.mosaic_s3_prefix.strip('/')}/{token}.meta.json"
+
+
+def _s3_uri(token: str) -> str:
+    return f"s3://{SharedSettings.mosaic_s3_bucket}/{_s3_key(token)}"
+
+
+def _read_meta(token: str) -> Optional[dict]:
+    """Return the mosaic's metadata sidecar, or None if it does not exist.
+
+    The sidecar is written last, so its presence implies the mosaic object
+    itself is fully written.
+    """
+    try:
+        resp = _s3_client().get_object(
+            Bucket=SharedSettings.mosaic_s3_bucket, Key=_meta_key(token)
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] in ("NoSuchKey", "404", "NotFound"):
+            return None
+        raise
+    return json.loads(resp["Body"].read())
+
+
+def _write_mosaic(
+    token: str,
+    mosaic: MosaicJSON,
+    item_count: int,
+    date_start: date,
+    date_end: date,
+) -> None:
+    """Upload the MosaicJSON and its metadata sidecar to S3.
+
+    The mosaic object is written first, then the sidecar, so a present
+    sidecar always implies a complete mosaic.
+    """
+    client = _s3_client()
+    bucket = SharedSettings.mosaic_s3_bucket
+    client.put_object(
+        Bucket=bucket,
+        Key=_s3_key(token),
+        Body=mosaic.model_dump_json(exclude_none=True).encode("utf-8"),
+        ContentType="application/json",
+    )
+    client.put_object(
+        Bucket=bucket,
+        Key=_meta_key(token),
+        Body=json.dumps(
+            {
+                "item_count": item_count,
+                "date_start": date_start.isoformat(),
+                "date_end": date_end.isoformat(),
+            }
+        ).encode("utf-8"),
+        ContentType="application/json",
+    )
 
 
 @dataclass(frozen=True)
@@ -143,14 +169,18 @@ class MosaicResult:
 
     @property
     def tile_url(self) -> str:
+        base = SharedSettings.mosaic_tiler_url.rstrip("/")
+        url = quote(_s3_uri(self.mosaic_id), safe="")
         return (
-            "/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}.png"
-            f"?url={self.mosaic_id}"
+            f"{base}/mosaic/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png"
+            f"?url={url}"
         )
 
     @property
     def tilejson_url(self) -> str:
-        return f"/mosaic/WebMercatorQuad/tilejson.json?url={self.mosaic_id}"
+        base = SharedSettings.mosaic_tiler_url.rstrip("/")
+        url = quote(_s3_uri(self.mosaic_id), safe="")
+        return f"{base}/mosaic/WebMercatorQuad/tilejson.json?url={url}"
 
 
 def encode_recipe(recipe: MosaicRecipe) -> str:
@@ -212,11 +242,26 @@ async def _load_geometry(recipe: MosaicRecipe) -> dict:
 
 
 async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
-    """Build the mosaic for a recipe and cache it under its token.
+    """Build the mosaic for a recipe and persist it to S3.
+
+    If a mosaic for this recipe already exists in S3, the STAC search, build
+    and upload are skipped and the recorded metadata is returned.
 
     Raises MosaicNotFoundError (AOI geometry gone), AoiTooLargeError,
     StacSearchError or NoScenesFoundError.
     """
+    token = encode_recipe(recipe)
+
+    # S3-based lookup: if the mosaic already exists, return without rebuilding.
+    meta = await run_in_threadpool(_read_meta, token)
+    if meta is not None:
+        return MosaicResult(
+            mosaic_id=token,
+            item_count=meta["item_count"],
+            date_start=date.fromisoformat(meta["date_start"]),
+            date_end=date.fromisoformat(meta["date_end"]),
+        )
+
     geometry = await _load_geometry(recipe)
     check_aoi_area(geometry)
 
@@ -284,53 +329,22 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
         maximum_items_per_tile=12,
     )
 
-    token = encode_recipe(recipe)
-    _mosaic_store[token] = mosaic
+    item_dates = [item.datetime.date() for item in items]
+    date_start = min(item_dates)
+    date_end = max(item_dates)
+
+    await run_in_threadpool(
+        _write_mosaic, token, mosaic, len(items), date_start, date_end
+    )
     logger.info(
         "Mosaic created",
         item_count=len(items),
         build_ms=round((time.perf_counter() - build_start) * 1000),
     )
 
-    item_dates = [item.datetime.date() for item in items]
     return MosaicResult(
         mosaic_id=token,
         item_count=len(items),
-        date_start=min(item_dates),
-        date_end=max(item_dates),
+        date_start=date_start,
+        date_end=date_end,
     )
-
-
-async def ensure_mosaic(url: str = Query(...)) -> None:
-    """Route dependency: rebuild the mosaic from its token if not cached.
-
-    Runs before the (synchronous) titiler endpoints so the rebuild can use
-    the async DB pool for geometry lookups.
-    """
-    if url in _mosaic_store:
-        return
-
-    lock = _rebuild_locks.setdefault(url, asyncio.Lock())
-    try:
-        async with lock:
-            if url in _mosaic_store:
-                return
-            recipe = decode_recipe(url)
-            logger.info("Rebuilding mosaic from token")
-            try:
-                result = await create_sentinel2_mosaic(recipe)
-                # If decoding clamped any parameter, the rebuilt mosaic is
-                # stored under the canonical token; alias the requested one
-                # so this URL does not rebuild on every request.
-                if result.mosaic_id != url:
-                    _mosaic_store[url] = _mosaic_store[result.mosaic_id]
-            except AoiTooLargeError as e:
-                raise HTTPException(status_code=422, detail=str(e))
-            except NoScenesFoundError as e:
-                raise HTTPException(status_code=404, detail=str(e))
-            except StacSearchError:
-                raise HTTPException(
-                    status_code=502, detail="STAC search failed"
-                )
-    finally:
-        _rebuild_locks.pop(url, None)

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings
@@ -35,6 +37,16 @@ class _SharedSettings(BaseSettings):
         default="RETRIEVAL_QUERY",
         alias="DATASET_EMBEDDINGS_TASK_TYPE",
     )
+
+    # Sentinel-2 mosaic storage. Built MosaicJSON files are written to this
+    # (private) S3 bucket and served by an external titiler that reads them
+    # via s3:// using IAM credentials.
+    mosaic_s3_bucket: str = Field(default="", alias="MOSAIC_S3_BUCKET")
+    mosaic_s3_prefix: str = Field(default="mosaics", alias="MOSAIC_S3_PREFIX")
+    mosaic_s3_region: Optional[str] = Field(
+        default=None, alias="MOSAIC_S3_REGION"
+    )
+    mosaic_tiler_url: str = Field(default="", alias="MOSAIC_TILER_URL")
 
     model_config = {
         "env_file": ".env",

--- a/tests/agent/test_show_imagery.py
+++ b/tests/agent/test_show_imagery.py
@@ -64,7 +64,9 @@ async def test_show_imagery_success():
 
     imagery = command.update["imagery"]
     assert imagery["mosaic_id"] == "abc123"
-    assert imagery["tile_url"].endswith("?url=abc123")
+    # The tool passes the MosaicResult's external titiler URLs through.
+    assert imagery["tile_url"] == result.tile_url
+    assert imagery["tilejson_url"] == result.tilejson_url
     assert imagery["target_date"] == "2025-06-01"
     assert imagery["window_days"] == 7
     assert imagery["max_cloud_cover"] == 20

--- a/tests/api/test_mosaic.py
+++ b/tests/api/test_mosaic.py
@@ -1,25 +1,31 @@
 """Tests for the Sentinel-2 mosaic service and endpoints."""
 
 import base64
+import io
 import json
 from datetime import date, datetime, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 from cogeo_mosaic.errors import MosaicNotFoundError
+from cogeo_mosaic.mosaic import MosaicJSON
 
+import src.api.services.mosaic as mosaic_service
 from src.api.services.mosaic import (
     AoiTooLargeError,
-    InMemoryBackend,
     MosaicRecipe,
     MosaicResult,
     NoScenesFoundError,
-    _mosaic_store,
+    _meta_key,
+    _s3_key,
+    _s3_uri,
     check_aoi_area,
     create_sentinel2_mosaic,
     decode_recipe,
     encode_recipe,
 )
+from src.shared.config import SharedSettings
 
 REGIONAL_POLYGON = {
     "type": "Polygon",
@@ -36,6 +42,39 @@ CONTINENTAL_POLYGON = {
 RECIPE = MosaicRecipe(
     aois=(("gadm", "CHE.26_1"),), target_date=date(2025, 6, 15)
 )
+
+
+class FakeS3Client:
+    """Minimal in-memory stand-in for the boto3 S3 client."""
+
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def put_object(self, Bucket, Key, Body, ContentType=None):
+        self.store[Key] = Body
+
+    def get_object(self, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": io.BytesIO(self.store[Key])}
+
+    def head_object(self, Bucket, Key):
+        if Key not in self.store:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        return {}
+
+
+@pytest.fixture(autouse=True)
+def fake_s3(monkeypatch):
+    """Replace the S3 client with an in-memory fake and set mosaic settings."""
+    client = FakeS3Client()
+    monkeypatch.setattr(mosaic_service, "_s3_client", lambda: client)
+    monkeypatch.setattr(SharedSettings, "mosaic_s3_bucket", "test-bucket")
+    monkeypatch.setattr(SharedSettings, "mosaic_s3_prefix", "mosaics")
+    monkeypatch.setattr(
+        SharedSettings, "mosaic_tiler_url", "https://titiler.example"
+    )
+    return client
 
 
 class FakeItem:
@@ -80,6 +119,10 @@ def _patch_geometry(geometry=REGIONAL_POLYGON):
         new_callable=AsyncMock,
         return_value={"geometry": geometry} if geometry else None,
     )
+
+
+def _load_mosaic_from_s3(s3, token) -> MosaicJSON:
+    return MosaicJSON.model_validate_json(s3.store[_s3_key(token)])
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +202,7 @@ async def test_create_mosaic_no_scenes():
 
 
 @pytest.mark.asyncio
-async def test_create_mosaic_orders_scenes_by_date_proximity():
+async def test_create_mosaic_orders_scenes_by_date_proximity(fake_s3):
     far = FakeItem(date(2025, 5, 1), 5.0, "https://example.com/far.tif")
     near = FakeItem(date(2025, 6, 14), 10.0, "https://example.com/near.tif")
 
@@ -171,16 +214,37 @@ async def test_create_mosaic_orders_scenes_by_date_proximity():
     assert result.date_start == date(2025, 5, 1)
     assert result.date_end == date(2025, 6, 14)
 
+    # The mosaic and its metadata sidecar are persisted to S3.
+    assert _s3_key(result.mosaic_id) in fake_s3.store
+    assert _meta_key(result.mosaic_id) in fake_s3.store
+
     # The scene closest to the target date must be first per quadkey, since
     # the mosaic renders the first valid scene.
-    mosaic = _mosaic_store[result.mosaic_id]
+    mosaic = _load_mosaic_from_s3(fake_s3, result.mosaic_id)
     for assets in mosaic.tiles.values():
         assert assets[0] == "https://example.com/near.tif"
 
 
-def test_backend_unknown_mosaic_raises_not_found():
-    with pytest.raises(MosaicNotFoundError):
-        InMemoryBackend("does-not-exist")
+@pytest.mark.asyncio
+async def test_create_mosaic_skips_when_exists(fake_s3):
+    """A second build for the same recipe reads S3 and skips search/upload."""
+    item = FakeItem(date(2025, 6, 1), 3.0, "https://example.com/a.tif")
+    with _patch_geometry(), _patch_search([item]):
+        first = await create_sentinel2_mosaic(RECIPE)
+
+    # Drop the mosaic body but keep the sidecar to prove the upload is skipped
+    # (the sidecar alone drives the cache-hit response).
+    fake_s3.store.pop(_s3_key(first.mosaic_id))
+
+    with _patch_geometry() as geo, _patch_search([item]) as search:
+        second = await create_sentinel2_mosaic(RECIPE)
+
+    assert second == first
+    # On a hit we return from the sidecar without loading geometry, searching
+    # STAC, or re-uploading the mosaic body.
+    geo.assert_not_called()
+    search.assert_not_called()
+    assert _s3_key(first.mosaic_id) not in fake_s3.store
 
 
 def test_mosaic_result_urls():
@@ -191,11 +255,16 @@ def test_mosaic_result_urls():
         date_end=date(2025, 1, 2),
     )
     assert result.tile_url == (
-        "/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=abc123"
+        "https://titiler.example/mosaic/tiles/WebMercatorQuad/"
+        "{z}/{x}/{y}.png"
+        "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
     )
     assert result.tilejson_url == (
-        "/mosaic/WebMercatorQuad/tilejson.json?url=abc123"
+        "https://titiler.example/mosaic/WebMercatorQuad/tilejson.json"
+        "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
     )
+    # The url query value is the URL-encoded s3:// uri the titiler resolves.
+    assert _s3_uri("abc123") == "s3://test-bucket/mosaics/abc123.json"
 
 
 # ---------------------------------------------------------------------------
@@ -238,8 +307,8 @@ async def test_create_mosaic_aoi_too_large(client, auth_override):
 
 
 @pytest.mark.asyncio
-async def test_create_mosaic_success_and_rebuild_on_cold_cache(
-    client, auth_override
+async def test_create_mosaic_success_and_idempotent(
+    client, auth_override, fake_s3
 ):
     auth_override("test-user-1")
     item = FakeItem(date(2025, 6, 1), 3.0, "https://example.com/a.tif")
@@ -250,43 +319,22 @@ async def test_create_mosaic_success_and_rebuild_on_cold_cache(
             headers={"Authorization": "Bearer test-token"},
         )
 
-        assert response.status_code == 200
-        body = response.json()
-        assert body["item_count"] == 1
-        assert body["date_start"] == "2025-06-01"
+    assert response.status_code == 200
+    body = response.json()
+    assert body["item_count"] == 1
+    assert body["date_start"] == "2025-06-01"
 
-        # The cached mosaic is served through the titiler endpoints.
-        tilejson = await client.get(
-            f"/mosaic/WebMercatorQuad/tilejson.json?url={body['mosaic_id']}",
+    # The mosaic is persisted to S3 and served by the external titiler.
+    assert _s3_key(body["mosaic_id"]) in fake_s3.store
+
+    # A second identical create hits S3 and skips the STAC search entirely.
+    with _patch_geometry() as geo, _patch_search([item]) as search:
+        response = await client.post(
+            "/mosaic/create/gadm/CHE.1_1?target_date=2025-06-15",
             headers={"Authorization": "Bearer test-token"},
         )
-        assert tilejson.status_code == 200
-        assert tilejson.json()["minzoom"] == 8
 
-        # A cold cache (restart, other worker) rebuilds from the token.
-        _mosaic_store.clear()
-        tilejson = await client.get(
-            f"/mosaic/WebMercatorQuad/tilejson.json?url={body['mosaic_id']}",
-            headers={"Authorization": "Bearer test-token"},
-        )
-        assert tilejson.status_code == 200
-        assert body["mosaic_id"] in _mosaic_store
-
-
-@pytest.mark.asyncio
-async def test_tilejson_requires_auth(client):
-    token = encode_recipe(RECIPE)
-    response = await client.get(
-        f"/mosaic/WebMercatorQuad/tilejson.json?url={token}"
-    )
-    assert response.status_code == 401
-
-
-@pytest.mark.asyncio
-async def test_tilejson_invalid_token_returns_404(client, auth_override):
-    auth_override("test-user-1")
-    response = await client.get(
-        "/mosaic/WebMercatorQuad/tilejson.json?url=unknown",
-        headers={"Authorization": "Bearer test-token"},
-    )
-    assert response.status_code == 404
+    assert response.status_code == 200
+    assert response.json() == body
+    geo.assert_not_called()
+    search.assert_not_called()


### PR DESCRIPTION
## What

Moves Sentinel-2 MosaicJSON storage out of the per-process in-memory cache and into S3, and hands tile serving to an **external vanilla titiler** that reads the MosaicJSON directly from S3.

## Why

The mosaic was held in a per-process `TTLCache` and served by an in-repo `MosaicTilerFactory` + custom `InMemoryBackend`, with an `ensure_mosaic` dependency rebuilding from the token on every cold cache. Persisting to S3 makes mosaics durable and shareable across workers/replicas, and lets a standard titiler do all tiling.

## How

- **S3 persistence**: `create_sentinel2_mosaic` builds the `MosaicJSON` and uploads it to a private bucket at `{prefix}/{token}.json`, plus a tiny `{token}.meta.json` sidecar (item count + date range).
- **S3-based lookup**: before building, it reads the sidecar; on a hit it returns immediately, skipping the STAC search, build and upload.
- **External titiler**: `MosaicResult.tile_url` / `tilejson_url` now emit absolute external titiler URLs with the URL-encoded `s3://` URI as `?url=`. The mosaic id stays the self-describing recipe token.
- **Removed** (tiles no longer served here): `MosaicTilerFactory`, `InMemoryBackend`, `ensure_mosaic`, `_mosaic_store`/`_rebuild_locks`, the `/mosaic/` cache-header middleware, and the titiler error handlers in `app.py`.
- **Config**: `MOSAIC_S3_BUCKET`, `MOSAIC_S3_PREFIX`, `MOSAIC_S3_REGION`, `MOSAIC_TILER_URL` added to `_SharedSettings` + `.env.example`. AWS creds via the standard boto3 chain.

## Deployment (outside this repo)

- Grant the external titiler IAM read on the mosaic bucket.
- Set **`MOSAIC_CONCURRENCY=1`** on it to reproduce the sequential first-pixel lazy-read efficiency the old `InMemoryBackend` got via `threads=0` (first-pixel selection + early-exit are vanilla rio-tiler).

## Tests

`tests/api/test_mosaic.py` reworked around an in-memory fake S3 (no new deps): persistence + ordering, cache-hit skip, idempotent create endpoint, and unchanged token/area/auth tests. `tests/agent/test_show_imagery.py` updated to assert the passed-through external URLs. All green.