### PR TITLE
Mirror unzipped WRI Insights snapshot to S3 for runtime init container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.17.1"
+version = "2026.6.17.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/scripts/wri_insights_snapshot.py
+++ b/scripts/wri_insights_snapshot.py
@@ -9,6 +9,12 @@ The snapshot lives at ``$WRI_INSIGHTS_S3_URI`` (e.g. ``s3://bucket/prefix/``):
 The tarball bundles ``wri_insights/`` and ``wri_insights_index/`` so it extracts
 straight into ``data/``. Gzip is used so Python's stdlib ``tarfile`` can unpack
 it with no extra tooling in the app image.
+
+``push`` ALSO mirrors the two payload dirs, unzipped, at the bucket root
+(``s3://bucket/wri_insights/`` and ``.../wri_insights_index/``). The image build
+consumes the tarball; the runtime pods' init container runs
+``aws s3 sync s3://bucket /app/data`` and so needs the dirs laid out plainly,
+not tarred. The mirror is upload/overwrite only -- it never deletes from S3.
 """
 
 from __future__ import annotations
@@ -68,6 +74,21 @@ def pull() -> int:
     return 0
 
 
+def _sync_dir_to_s3(client, bucket: str, local_dir) -> None:
+    """Upload every file under ``local_dir`` to ``s3://<bucket>/<dirname>/``,
+    overwriting in place. Upload-only: nothing is ever deleted from S3. Lands at
+    the bucket root regardless of the tarball prefix, because the runtime init
+    container syncs the whole bucket into ``data/``."""
+    root_key = local_dir.name
+    count = 0
+    for path in sorted(local_dir.rglob("*")):
+        if path.is_file():
+            key = f"{root_key}/{path.relative_to(local_dir).as_posix()}"
+            client.upload_file(str(path), bucket, key)
+            count += 1
+    print(f"Uploaded {count} files to s3://{bucket}/{root_key}/")
+
+
 def push() -> int:
     uri = os.environ.get(_ENV_VAR, "").strip()
     if not uri:
@@ -95,6 +116,11 @@ def push() -> int:
     for key in (date_key, latest_key):
         client.put_object(Bucket=bucket, Key=key, Body=data)
         print(f"Uploaded s3://{bucket}/{key} ({len(data) / 1e6:.1f} MB)")
+
+    # Mirror the unzipped payload dirs at the bucket root for the runtime init
+    # container's `aws s3 sync` (the tarball above is for the image build).
+    for path in _PAYLOAD_DIRS:
+        _sync_dir_to_s3(client, bucket, path)
     return 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.17"
+version = "2026.6.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Problem

Blog search fails in production with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/app/data/wri_insights_index/embeddings.npy'
```

Root cause is a mismatch between how the WRI Insights data is **published** to S3 and how it's **delivered** to runtime pods:

- This script publishes the corpus + sgrep index as a single gzipped **tarball** under \`s3://zeno-static-data/wri-insights/\` (consumed by the Docker image build).
- The deploy repo's pod init container runs \`aws s3 sync s3://zeno-static-data /app/data\`. That delivers the dataset/docs indexes (plain files at the bucket root) fine, but only copies the WRI Insights snapshot as an **unextracted tarball** — so \`data/wri_insights_index/embeddings.npy\` never exists at runtime.

The image bakes the extracted data in, but the init container's \`emptyDir\` at \`/app/data\` shadows it, so updating the image tag can't fix it on its own.

## Fix

`push()` now **also** mirrors the two payload dirs, unzipped, at the S3 bucket root (`wri_insights/` and `wri_insights_index/`) so the existing init container lays them straight into `/app/data`. The tarball is still published for the image build — both representations are now kept in sync on every push, so a content refresh reaches runtime pods.

Implementation notes:
- **Upload/overwrite only** via boto3 `upload_file` — nothing is ever deleted from S3.
- **No AWS CLI dependency** — reuses the boto3 client already in `push()`.