### PR TITLE
Use tiles.globalforestwatch.org TiTiler endpoint to render mosaics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.17.2"
+version = "2026.6.17.3"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"
@@ -57,7 +57,7 @@ dependencies = [
     "trafilatura>=2.0.0",
     "deepagents[quickjs]>=0.4.12",
     "model2vec>=0.8.2",
-    "titiler-mosaic==0.25.0",
+    "cogeo-mosaic==8.2.0",
 ]
 
 [dependency-groups]

--- a/src/agent/tools/show_imagery.py
+++ b/src/agent/tools/show_imagery.py
@@ -14,6 +14,7 @@ from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.services.mosaic import (
     AoiTooLargeError,
     MosaicRecipe,
+    MosaicResult,
     NoScenesFoundError,
     StacSearchError,
     create_sentinel2_mosaic,
@@ -96,7 +97,7 @@ async def show_imagery(
     )
 
     try:
-        result = await create_sentinel2_mosaic(recipe)
+        result: MosaicResult = await create_sentinel2_mosaic(recipe)
     except MosaicNotFoundError:
         return _feedback(
             "Could not load the geometry of the selected AOI.", tool_call_id

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -5,8 +5,6 @@ from typing import Optional
 import structlog
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
-from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
 from src.agent.graph import close_checkpointer_pool, get_checkpointer_pool
 from src.agent.utils.sgrep import data_status
@@ -148,10 +146,3 @@ app.include_router(metadata.router)
 app.include_router(admin.router)
 app.include_router(traces.router)
 app.include_router(mosaic.router, prefix="/mosaic", tags=["Map Tiles"])
-
-# Map titiler/cogeo-mosaic errors to proper status codes (e.g. tile requests
-# outside the mosaic bounds -> 404, unknown mosaic id -> 404). The catch-all
-# Exception entry is dropped to leave non-tiler error handling unchanged.
-_tiler_status_codes = {**DEFAULT_STATUS_CODES, **MOSAIC_STATUS_CODES}
-_tiler_status_codes.pop(Exception, None)
-add_exception_handlers(app, _tiler_status_codes)

--- a/src/api/routers/mosaic.py
+++ b/src/api/routers/mosaic.py
@@ -1,17 +1,8 @@
-"""Sentinel-2 mosaic creation and tile serving over AOI geometries.
+"""Sentinel-2 mosaic creation endpoint.
 
-The create endpoint builds a MosaicJSON, persists it to S3 (see
-src/api/services/mosaic.py) and returns a recipe-token mosaic id.
-
-Tiles are served by the titiler MosaicTilerFactory mounted here, wired to
-S3MosaicBackend so it reads the persisted MosaicJSON from S3 via the
-``s3://`` uri in the tile URL's ``?url=`` param. When MOSAIC_TILER_URL is
-set, MosaicResult instead emits absolute URLs to that external titiler and
-these in-repo tile routes go unused.
-
-All endpoints — including the titiler tile/tilejson routes — require the
-same bearer auth as the rest of the API; map clients must attach the
-Authorization header to tile requests.
+Searches Sentinel-2 L2A scenes for an AOI and builds a MosaicJSON persisted
+to S3. Tiles are served externally by the GFW tiles service at
+https://tiles.globalforestwatch.org using the s3:// URI returned here.
 """
 
 from datetime import date
@@ -19,7 +10,6 @@ from typing import Optional
 
 from cogeo_mosaic.errors import MosaicNotFoundError
 from fastapi import APIRouter, Depends, HTTPException, Query
-from titiler.mosaic.factory import MosaicTilerFactory
 
 from src.api.auth.dependencies import require_auth
 from src.api.models import MosaicCreateResponse
@@ -28,7 +18,6 @@ from src.api.services.mosaic import (
     AoiTooLargeError,
     MosaicRecipe,
     NoScenesFoundError,
-    S3MosaicBackend,
     StacSearchError,
     create_sentinel2_mosaic,
 )
@@ -36,13 +25,7 @@ from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-_mosaic_tiler = MosaicTilerFactory(backend=S3MosaicBackend)
-
 router = APIRouter()
-router.include_router(
-    _mosaic_tiler.router,
-    dependencies=[Depends(require_auth)],
-)
 
 
 @router.post("/create/{source}/{src_id}", response_model=MosaicCreateResponse)
@@ -59,9 +42,8 @@ async def create_mosaic(
     Search Sentinel-2 L2A scenes covering an AOI around target_date
     (within ±window_days) and persist a MosaicJSON to S3.
 
-    Returns a mosaic_id (recipe token). The tile/tilejson URLs that read the
-    persisted MosaicJSON from S3 are available on the MosaicResult
-    (tile_url / tilejson_url).
+    Returns a mosaic_id (recipe token). Tile and TileJSON URLs pointing to
+    the GFW tiles service are available on the result (tile_url / tilejson_url).
     """
     recipe = MosaicRecipe(
         aois=((source, src_id),),

--- a/src/api/services/mosaic.py
+++ b/src/api/services/mosaic.py
@@ -99,6 +99,9 @@ def _mosaic_exists(token: str) -> bool:
         code = e.response["Error"]["Code"]
         if code in ("NoSuchKey", "404", "NotFound"):
             return False
+        # AccessDenied / NoSuchBucket / wrong region etc. — a real
+        # config/permission problem, not a cache miss, so surface it instead
+        # of failing the create opaquely.
         logger.error(
             "Mosaic existence check failed",
             bucket=SharedSettings.mosaic_s3_bucket,
@@ -137,7 +140,12 @@ def _write_mosaic(token: str, mosaic: MosaicJSON) -> None:
 
 @dataclass(frozen=True)
 class MosaicRecipe:
-    """Everything needed to (re)build a mosaic deterministically."""
+    """Everything needed to (re)build a mosaic deterministically.
+
+    target_date is always a resolved date, never an implicit "today", so a
+    token rebuilt later yields the same imagery. user_id is only set when a
+    custom area is referenced (its geometry lookup is scoped to the owner).
+    """
 
     aois: tuple[tuple[str, str], ...]  # (source, src_id) pairs
     target_date: date
@@ -245,6 +253,9 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
 
     token = encode_recipe(recipe)
 
+    # S3-based lookup: if the mosaic already exists, serve it without
+    # rebuilding. The scene count and date range are not persisted, so a
+    # cache hit returns without them.
     if await run_in_threadpool(_mosaic_exists, token):
         return MosaicResult(mosaic_id=token)
 
@@ -269,6 +280,7 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
 
     search_start = time.perf_counter()
     try:
+        # pystac_client is synchronous; keep it off the event loop.
         items = await run_in_threadpool(_search)
     except Exception as e:
         logger.error(
@@ -293,6 +305,9 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
             "No Sentinel-2 scenes found for this AOI and date range"
         )
 
+    # The mosaic renders the first valid scene per tile, so order items by
+    # proximity to the target date (cloud cover as tiebreak) to keep the
+    # displayed imagery as close to the requested date as possible.
     items.sort(
         key=lambda item: (
             abs((item.datetime.date() - recipe.target_date).days),
@@ -306,6 +321,8 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
         minzoom=8,
         maxzoom=14,
         accessor=lambda f: f["assets"][VISUAL_ASSET]["href"],
+        # Bound the sequential first-match reads per tile; items are sorted
+        # by date proximity, so the nearest scenes are kept.
         maximum_items_per_tile=12,
     )
 

--- a/src/api/services/mosaic.py
+++ b/src/api/services/mosaic.py
@@ -1,4 +1,4 @@
-"""Sentinel-2 mosaic creation shared by the API router and the agent tool.
+"""Sentinel-2 mosaic creation over AOI geometries.
 
 Searches the earth-search STAC API for Sentinel-2 L2A scenes (COGs hosted in
 the public sentinel-cogs AWS bucket) around a target date and builds a
@@ -6,16 +6,8 @@ MosaicJSON.
 
 The built MosaicJSON is written to a private S3 bucket under a key derived
 from a deterministic, self-describing recipe token (AOI references, target
-date, search parameters).
-
-Tiles can be served two ways, depending on the MOSAIC_TILER_URL setting:
-  * unset (default) — this app serves tiles itself via the titiler
-    MosaicTilerFactory wired to S3MosaicBackend, which reads the MosaicJSON
-    from S3 via the ``s3://`` uri carried in the tile URL's ``?url=`` param.
-    The tile URLs are then based on API_BASE_URL (this app's own host), or
-    host-relative if that is also unset;
-  * set — tiles are served by an external, vanilla titiler deployment that
-    reads the same MosaicJSON from S3 via ``s3://`` using IAM credentials.
+date, search parameters). Tiles are served by the GFW tiles service at
+https://tiles.globalforestwatch.org, which reads the MosaicJSON from S3.
 
 Before building, we check S3 for the mosaic object: if it already exists we
 skip the (expensive) STAC search, build and upload. The scene count and
@@ -26,19 +18,15 @@ cache hit returns without them.
 import base64
 import functools
 import json
-import os
 import time
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Optional
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
-import attr
 import boto3
 import pystac_client
 from botocore.exceptions import ClientError
-from cachetools import TTLCache
-from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.errors import MosaicNotFoundError
 from cogeo_mosaic.mosaic import MosaicJSON
 from fastapi.concurrency import run_in_threadpool
@@ -52,28 +40,10 @@ from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# GDAL tuning for reading remote COGs (read by rasterio at open time, so
-# deployment env vars take precedence). Only relevant when this app serves
-# tiles itself. Without GDAL_DISABLE_READDIR_ON_OPEN every COG open issues
-# extra (404ing) sidecar-file requests against S3.
-_GDAL_ENV_DEFAULTS = {
-    "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-    "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES": "YES",
-    "GDAL_HTTP_MULTIPLEX": "YES",
-    "GDAL_HTTP_VERSION": "2",
-    "GDAL_CACHEMAX": "200",
-    "VSI_CACHE": "TRUE",
-    "VSI_CACHE_SIZE": "5000000",
-    "CPL_VSIL_CURL_CACHE_SIZE": "200000000",
-    # Sentinel-2 COG headers are larger than GDAL's 16KB default read.
-    "GDAL_INGESTED_BYTES_AT_OPEN": "32768",
-}
-for _key, _value in _GDAL_ENV_DEFAULTS.items():
-    os.environ.setdefault(_key, _value)
-
 STAC_URL = "https://earth-search.aws.element84.com/v1"
 SENTINEL2_COLLECTION = "sentinel-2-l2a"
 VISUAL_ASSET = "visual"
+GFW_TILES_BASE = "https://tiles.globalforestwatch.org"
 
 # Mosaics are meant for regional AOIs; mid-size countries exceed this.
 MAX_AOI_AREA_KM2 = 50_000
@@ -119,23 +89,8 @@ def _s3_uri(token: str) -> str:
     return f"s3://{SharedSettings.mosaic_s3_bucket}/{_s3_key(token)}"
 
 
-def _tiler_base() -> str:
-    """Base URL for tile/tilejson links, without a trailing slash.
-
-    Prefers the external titiler (MOSAIC_TILER_URL); falls back to this app's
-    own host (API_BASE_URL) so the in-repo titiler routes get absolute URLs.
-    If neither is set, returns "" so URLs are host-relative.
-    """
-    base = SharedSettings.mosaic_tiler_url or SharedSettings.api_base_url
-    return base.rstrip("/")
-
-
 def _mosaic_exists(token: str) -> bool:
-    """Return True if the mosaic object for this recipe is already in S3.
-
-    S3 puts are atomic, so a present object is always a complete mosaic and
-    can be served without rebuilding.
-    """
+    """Return True if the mosaic object for this recipe is already in S3."""
     try:
         _s3_client().head_object(
             Bucket=SharedSettings.mosaic_s3_bucket, Key=_s3_key(token)
@@ -144,9 +99,6 @@ def _mosaic_exists(token: str) -> bool:
         code = e.response["Error"]["Code"]
         if code in ("NoSuchKey", "404", "NotFound"):
             return False
-        # AccessDenied / NoSuchBucket / wrong region etc. — a real
-        # config/permission problem, not a cache miss, so surface it instead
-        # of failing the create opaquely.
         logger.error(
             "Mosaic existence check failed",
             bucket=SharedSettings.mosaic_s3_bucket,
@@ -157,60 +109,6 @@ def _mosaic_exists(token: str) -> bool:
         )
         raise
     return True
-
-
-# uri -> MosaicJSON. Per-process cache so repeated tile requests for the same
-# mosaic don't re-fetch the (immutable) MosaicJSON document from S3.
-_mosaic_store: TTLCache = TTLCache(maxsize=256, ttl=12 * 3600)
-
-
-def _read_mosaic_from_uri(uri: str) -> MosaicJSON:
-    """Load a MosaicJSON from its ``s3://bucket/key`` uri.
-
-    Raises MosaicNotFoundError if the object does not exist.
-    """
-    parsed = urlparse(uri)
-    if parsed.scheme != "s3":
-        raise MosaicNotFoundError(f"Unsupported mosaic uri: {uri}")
-    try:
-        resp = _s3_client().get_object(
-            Bucket=parsed.netloc, Key=parsed.path.lstrip("/")
-        )
-    except ClientError as e:
-        if e.response["Error"]["Code"] in ("NoSuchKey", "404", "NotFound"):
-            raise MosaicNotFoundError(f"Mosaic not found: {uri}")
-        raise
-    return MosaicJSON.model_validate_json(resp["Body"].read())
-
-
-@attr.s
-class S3MosaicBackend(BaseBackend):
-    """Resolve a mosaic by its ``s3://`` uri, reading the MosaicJSON from S3.
-
-    titiler hands the tile URL's ``?url=`` value (an ``s3://bucket/key`` uri)
-    to this backend; the MosaicJSON is fetched from S3 once and cached in
-    _mosaic_store for the per-process TTL.
-    """
-
-    _backend_name = "ZenoS3"
-
-    def _read(self) -> MosaicJSON:
-        mosaic = _mosaic_store.get(self.input)
-        if mosaic is None:
-            mosaic = _read_mosaic_from_uri(self.input)
-            _mosaic_store[self.input] = mosaic
-        return mosaic
-
-    def tile(self, *args, **kwargs):
-        # Read scenes sequentially with lazy early exit: with the default
-        # "first" pixel selection, reading stops as soon as the tile is
-        # covered. The factory default (threads=70) would instead fetch
-        # every candidate scene from S3 concurrently and discard most.
-        kwargs["threads"] = 0
-        return super().tile(*args, **kwargs)
-
-    def write(self, overwrite: bool = False) -> None:
-        pass
 
 
 def _write_mosaic(token: str, mosaic: MosaicJSON) -> None:
@@ -239,12 +137,7 @@ def _write_mosaic(token: str, mosaic: MosaicJSON) -> None:
 
 @dataclass(frozen=True)
 class MosaicRecipe:
-    """Everything needed to (re)build a mosaic deterministically.
-
-    target_date is always a resolved date, never an implicit "today", so a
-    token rebuilt later yields the same imagery. user_id is only set when a
-    custom area is referenced (its geometry lookup is scoped to the owner).
-    """
+    """Everything needed to (re)build a mosaic deterministically."""
 
     aois: tuple[tuple[str, str], ...]  # (source, src_id) pairs
     target_date: date
@@ -265,18 +158,19 @@ class MosaicResult:
 
     @property
     def tile_url(self) -> str:
-        base = _tiler_base()
         url = quote(_s3_uri(self.mosaic_id), safe="")
         return (
-            f"{base}/mosaic/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png"
-            f"?url={url}"
+            f"{GFW_TILES_BASE}/cog/mosaic/tiles/WebMercatorQuad"
+            f"/{{z}}/{{x}}/{{y}}.png?url={url}"
         )
 
     @property
     def tilejson_url(self) -> str:
-        base = _tiler_base()
         url = quote(_s3_uri(self.mosaic_id), safe="")
-        return f"{base}/mosaic/WebMercatorQuad/tilejson.json?url={url}"
+        return (
+            f"{GFW_TILES_BASE}/cog/mosaic/WebMercatorQuad"
+            f"/tilejson.json?url={url}"
+        )
 
 
 def encode_recipe(recipe: MosaicRecipe) -> str:
@@ -294,11 +188,7 @@ def encode_recipe(recipe: MosaicRecipe) -> str:
 
 
 def decode_recipe(token: str) -> MosaicRecipe:
-    """Decode a mosaic token; raise MosaicNotFoundError if malformed.
-
-    Parameters are clamped to the same bounds the create endpoint
-    enforces, since tokens are plain encodings anyone could construct.
-    """
+    """Decode a mosaic token; raise MosaicNotFoundError if malformed."""
     try:
         raw = base64.urlsafe_b64decode(token + "=" * (-len(token) % 4))
         payload = json.loads(raw)
@@ -355,9 +245,6 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
 
     token = encode_recipe(recipe)
 
-    # S3-based lookup: if the mosaic already exists, serve it without
-    # rebuilding. The scene count and date range are not persisted, so a
-    # cache hit returns without them.
     if await run_in_threadpool(_mosaic_exists, token):
         return MosaicResult(mosaic_id=token)
 
@@ -382,7 +269,6 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
 
     search_start = time.perf_counter()
     try:
-        # pystac_client is synchronous; keep it off the event loop.
         items = await run_in_threadpool(_search)
     except Exception as e:
         logger.error(
@@ -407,9 +293,6 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
             "No Sentinel-2 scenes found for this AOI and date range"
         )
 
-    # The mosaic renders the first valid scene per tile, so order items by
-    # proximity to the target date (cloud cover as tiebreak) to keep the
-    # displayed imagery as close to the requested date as possible.
     items.sort(
         key=lambda item: (
             abs((item.datetime.date() - recipe.target_date).days),
@@ -423,8 +306,6 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
         minzoom=8,
         maxzoom=14,
         accessor=lambda f: f["assets"][VISUAL_ASSET]["href"],
-        # Bound the sequential first-match reads per tile; items are sorted
-        # by date proximity, so the nearest scenes are kept.
         maximum_items_per_tile=12,
     )
 

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -24,9 +24,6 @@ class _SharedSettings(BaseSettings):
         alias="EOAPI_BASE_URL",
     )
 
-    # This API's own public base URL. Used as the tiler base for Sentinel-2
-    # mosaics when MOSAIC_TILER_URL is unset, so tile URLs resolve to this
-    # app's in-repo titiler routes rather than being host-relative.
     api_base_url: str = Field(default="", alias="API_BASE_URL")
 
     # Dataset embeddings database
@@ -44,14 +41,13 @@ class _SharedSettings(BaseSettings):
     )
 
     # Sentinel-2 mosaic storage. Built MosaicJSON files are written to this
-    # (private) S3 bucket and served by an external titiler that reads them
-    # via s3:// using IAM credentials.
+    # S3 bucket and served by the GFW tiles service at
+    # https://tiles.globalforestwatch.org.
     mosaic_s3_bucket: str = Field(default="", alias="MOSAIC_S3_BUCKET")
     mosaic_s3_prefix: str = Field(default="mosaics", alias="MOSAIC_S3_PREFIX")
     mosaic_s3_region: Optional[str] = Field(
         default=None, alias="MOSAIC_S3_REGION"
     )
-    mosaic_tiler_url: str = Field(default="", alias="MOSAIC_TILER_URL")
 
     model_config = {
         "env_file": ".env",

--- a/tests/api/test_mosaic.py
+++ b/tests/api/test_mosaic.py
@@ -70,9 +70,6 @@ def fake_s3(monkeypatch):
     monkeypatch.setattr(mosaic_service, "_s3_client", lambda: client)
     monkeypatch.setattr(SharedSettings, "mosaic_s3_bucket", "test-bucket")
     monkeypatch.setattr(SharedSettings, "mosaic_s3_prefix", "mosaics")
-    monkeypatch.setattr(
-        SharedSettings, "mosaic_tiler_url", "https://titiler.example"
-    )
     return client
 
 
@@ -256,82 +253,16 @@ def test_mosaic_result_urls():
         date_end=date(2025, 1, 2),
     )
     assert result.tile_url == (
-        "https://titiler.example/mosaic/tiles/WebMercatorQuad/"
-        "{z}/{x}/{y}.png"
+        "https://tiles.globalforestwatch.org/cog/mosaic/tiles/WebMercatorQuad"
+        "/{z}/{x}/{y}.png"
         "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
     )
     assert result.tilejson_url == (
-        "https://titiler.example/mosaic/WebMercatorQuad/tilejson.json"
+        "https://tiles.globalforestwatch.org/cog/mosaic/WebMercatorQuad"
+        "/tilejson.json"
         "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
     )
-    # The url query value is the URL-encoded s3:// uri the titiler resolves.
     assert _s3_uri("abc123") == "s3://test-bucket/mosaics/abc123.json"
-
-
-def test_mosaic_result_urls_fall_back_to_api_base_url(monkeypatch):
-    """With MOSAIC_TILER_URL unset, tile URLs use this app's own host."""
-    monkeypatch.setattr(SharedSettings, "mosaic_tiler_url", "")
-    monkeypatch.setattr(SharedSettings, "api_base_url", "https://api.example/")
-    result = MosaicResult(
-        mosaic_id="abc123",
-        item_count=1,
-        date_start=date(2025, 1, 1),
-        date_end=date(2025, 1, 2),
-    )
-    assert result.tile_url == (
-        "https://api.example/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}.png"
-        "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
-    )
-    assert result.tilejson_url == (
-        "https://api.example/mosaic/WebMercatorQuad/tilejson.json"
-        "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
-    )
-
-
-def test_mosaic_result_urls_relative_when_nothing_set(monkeypatch):
-    """With both MOSAIC_TILER_URL and API_BASE_URL unset, URLs are relative."""
-    monkeypatch.setattr(SharedSettings, "mosaic_tiler_url", "")
-    monkeypatch.setattr(SharedSettings, "api_base_url", "")
-    result = MosaicResult(
-        mosaic_id="abc123",
-        item_count=1,
-        date_start=date(2025, 1, 1),
-        date_end=date(2025, 1, 2),
-    )
-    assert result.tile_url == (
-        "/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}.png"
-        "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
-    )
-    assert result.tilejson_url == (
-        "/mosaic/WebMercatorQuad/tilejson.json"
-        "?url=s3%3A%2F%2Ftest-bucket%2Fmosaics%2Fabc123.json"
-    )
-
-
-def test_s3_mosaic_backend_reads_from_s3(fake_s3):
-    """The in-repo backend resolves an s3:// uri to its MosaicJSON via S3."""
-    mosaic_service._mosaic_store.clear()
-    mosaic = MosaicJSON(
-        mosaicjson="0.0.3",
-        minzoom=8,
-        maxzoom=14,
-        bounds=[8.0, 46.8, 9.0, 47.5],
-        tiles={"0231": ["https://example.com/a.tif"]},
-    )
-    fake_s3.store[_s3_key("abc123")] = mosaic.model_dump_json(
-        exclude_none=True
-    ).encode("utf-8")
-
-    with mosaic_service.S3MosaicBackend(_s3_uri("abc123")) as backend:
-        assert backend.mosaic_def.tiles == mosaic.tiles
-    # The fetched document is cached for subsequent tile requests.
-    assert _s3_uri("abc123") in mosaic_service._mosaic_store
-
-
-def test_s3_mosaic_backend_missing_raises_not_found(fake_s3):
-    mosaic_service._mosaic_store.clear()
-    with pytest.raises(MosaicNotFoundError):
-        mosaic_service.S3MosaicBackend(_s3_uri("does-not-exist"))
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -3039,6 +3039,7 @@ dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
     { name = "click" },
+    { name = "cogeo-mosaic" },
     { name = "deepagents" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fiona" },
@@ -3078,7 +3079,6 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "structlog" },
     { name = "tabulate" },
-    { name = "titiler-mosaic" },
     { name = "trafilatura" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "watchdog" },
@@ -3112,6 +3112,7 @@ requires-dist = [
     { name = "boto3", specifier = "==1.38.27" },
     { name = "cachetools", specifier = "==5.5.2" },
     { name = "click", specifier = "==8.1.8" },
+    { name = "cogeo-mosaic", specifier = "==8.2.0" },
     { name = "deepagents", extras = ["quickjs"], specifier = ">=0.4.12" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.136.1" },
     { name = "fiona", specifier = "==1.10.1" },
@@ -3151,7 +3152,6 @@ requires-dist = [
     { name = "sqlalchemy", specifier = "==2.0.41" },
     { name = "structlog", specifier = "==25.4.0" },
     { name = "tabulate", specifier = "==0.9.0" },
-    { name = "titiler-mosaic", specifier = "==0.25.0" },
     { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.35.0" },
     { name = "watchdog", specifier = "==6.0.0" },
@@ -4120,26 +4120,6 @@ wheels = [
 ]
 
 [[package]]
-name = "simplejson"
-version = "4.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/25/e90998fe8e480eb43b966c09e835379887d427567ebd496563d3b1e16b19/simplejson-4.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:19040a17154dc03d289bab68d73ce0a6a0be01de30c584bbdd93490bead14b22", size = 112414, upload-time = "2026-04-24T19:23:06.084Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/a0/abd4785f36c3400f1fbb21f517be39295a750a714f04b7ee175adf6ef580/simplejson-4.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a94ebaecdbaa80d9551a3ec6bf0c9302fc8b53ab6c1b2bfd498a1df4cb28158d", size = 91120, upload-time = "2026-04-24T19:23:07.877Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/78/fc060d2e3b13c6ec59288574b8efac64075e316b2afba4396a56b2422f78/simplejson-4.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:67341c95c0a168ab4a6d1e807e50463f1c8da932c3286d81e201266c427061fa", size = 91055, upload-time = "2026-04-24T19:23:09.264Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b6/156a8de1e1b47694f0e7de6675866936608d45dc68388fd017d36f8693be/simplejson-4.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45ec18e337fec538b7e902d489505c450b2454653d1290f3f50385e6fd8aa607", size = 190297, upload-time = "2026-04-24T19:23:11.226Z" },
-    { url = "https://files.pythonhosted.org/packages/86/1c/e4d0eab695be3eb21d0f46bce820752031f03e7113f9c80a9b3c73ee7157/simplejson-4.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:820c69a4710400e9b248d5670647d60be58824369282d3925e516b3ff1a7cd82", size = 187002, upload-time = "2026-04-24T19:23:12.982Z" },
-    { url = "https://files.pythonhosted.org/packages/76/0e/7f5a59d29426b062d5928fb88b403c3f797129d53be7102f955dbe51aa44/simplejson-4.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e708d373a10e4378ef2d59f8361850c7150fd907ed49efe49bc5492160476d1", size = 195146, upload-time = "2026-04-24T19:23:14.517Z" },
-    { url = "https://files.pythonhosted.org/packages/78/18/9943db224dd4d5fa3c090c3e56a94c37b254338c83995ec5680285111c40/simplejson-4.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:980fc33353f81fd12d8c49d44f8c2760d1dc8192285e627c5180d141035b228a", size = 183931, upload-time = "2026-04-24T19:23:16.742Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/08/9a690da9a766161c06c627d805362cf159f1abe480969372b2897649b955/simplejson-4.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:de2ed102fff88dacf543699f53ee3a533cc11539a39baa176b7e09dd783069d6", size = 192228, upload-time = "2026-04-24T19:23:18.33Z" },
-    { url = "https://files.pythonhosted.org/packages/05/88/bd8aad36b451ffb0e0a3f721d695a88befa6d1ac7d1e02ae788ca7ff4029/simplejson-4.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2785ff8edc0e28bf773a32543a6bbed46351453c997b3f6709c744e3c2f7eabb", size = 187808, upload-time = "2026-04-24T19:23:21.165Z" },
-    { url = "https://files.pythonhosted.org/packages/04/ee/14f91db0d1f481533b651dafbf8cd0da088d9817f7af30c68f7f19f9c847/simplejson-4.1.1-cp312-cp312-win32.whl", hash = "sha256:2e0d5ead6d14610467ec356ec1f6b5d8a56aa216abaad8d41c8b873b16cf313f", size = 88512, upload-time = "2026-04-24T19:23:22.764Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c4/90de06b2d8737c68c05ff9274113f854dbf6a5f28b7a955212111672cb57/simplejson-4.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:63a5451f557d6be48a231bae932458655c620902b868170b2f1c8afed496f6b4", size = 90748, upload-time = "2026-04-24T19:23:24.494Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
-]
-
-[[package]]
 name = "simsimd"
 version = "6.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4340,40 +4320,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
-]
-
-[[package]]
-name = "titiler-core"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastapi" },
-    { name = "geojson-pydantic" },
-    { name = "jinja2" },
-    { name = "morecantile" },
-    { name = "numpy" },
-    { name = "pydantic" },
-    { name = "rasterio" },
-    { name = "rio-tiler" },
-    { name = "simplejson" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/6d/f4a00eff755081466eba4dfe406bdca084e9bb6c62616f67e77146edae05/titiler_core-0.25.0.tar.gz", hash = "sha256:a03a169e77d0c4804a0d3c7e8259d6640386f19c8ef60232dfb07069ae10aecb", size = 69584, upload-time = "2025-11-07T16:14:23.916Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9e/fcc8da9e7879facb2b53c33c741422523d37d0fcf090c5851fb455f26c43/titiler_core-0.25.0-py3-none-any.whl", hash = "sha256:134179c2a5599cd583edc7295e549422fc3ea16e3d84b82249c75f99e95b3849", size = 88057, upload-time = "2025-11-07T16:14:22.464Z" },
-]
-
-[[package]]
-name = "titiler-mosaic"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cogeo-mosaic" },
-    { name = "titiler-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/48/9c64494ecee5bd912c51a53c4d623406f40dc3f87d08892cab68e05aa889/titiler_mosaic-0.25.0.tar.gz", hash = "sha256:e9d5b34722af08d50b7988a4e48ea3c0777209a70bc23153c32d5a68266337df", size = 10463, upload-time = "2025-11-07T16:14:28.417Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/43/9cda8a1965e2b0d3c472b5bdec53258e2f8fc7b52cfa694628567487fb1a/titiler_mosaic-0.25.0-py3-none-any.whl", hash = "sha256:a6be59a69d24da35c881f7d4688f1a0e14c3133a234899da05421fa89d428cb7", size = 11858, upload-time = "2025-11-07T16:14:27.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Instead of running a local TiTiler instance, which be very CPU intensive to generate tiles, let's use our existing TiTiler service on tiles.globalforestwatch.org to render the MosaicJSONs. Tested locally this renders just as well. Remove all the TiTiler infra from the repo since it's no longer needed.