### PR TITLE
fix db ingestion error when getting a nul byte character from langfuse

### DIFF
--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -61,6 +61,18 @@ def _parse_dt(raw: Any) -> Optional[datetime]:
         return None
 
 
+def _strip_nul(value: Any) -> Any:
+    """Recursively drop NUL (U+0000) from strings. Postgres text and jsonb
+    reject 0x00, so an unsanitized trace text would abort the whole batch."""
+    if isinstance(value, str):
+        return value.replace("\x00", "") if "\x00" in value else value
+    if isinstance(value, dict):
+        return {_strip_nul(k): _strip_nul(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_nul(v) for v in value]
+    return value
+
+
 # --------------------------------------------------------------------------- #
 # Row building
 # --------------------------------------------------------------------------- #
@@ -94,7 +106,7 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         row["parse_error"] = str(e)[:500]
         row["parser_version"] = P.PARSER_VERSION
         row["recognized_contract"] = None
-    return row
+    return _strip_nul(row)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_langfuse_ingest.py
+++ b/tests/unit/test_langfuse_ingest.py
@@ -1,0 +1,43 @@
+"""Unit tests for the Langfuse ingestion row builder
+(src/api/services/langfuse/ingest.py).
+
+Synthetic fixtures only (no real user text). Focus: NUL-byte sanitization, since
+Postgres text/jsonb reject 0x00 and an unsanitized trace once aborted a batch.
+"""
+
+from src.api.services.langfuse.ingest import _strip_nul, build_row
+
+
+def test_strip_nul_scrubs_nested_strings():
+    payload = {
+        "a": "clean",
+        "b": "with\x00nul",
+        "c": ["ok", "bad\x00", {"d": "deep\x00nul"}],
+        "e": 42,
+        "f": None,
+    }
+    out = _strip_nul(payload)
+    assert out["b"] == "withnul"
+    assert out["c"] == ["ok", "bad", {"d": "deepnul"}]
+    # non-string scalars pass through untouched
+    assert out["e"] == 42
+    assert out["f"] is None
+
+
+def test_strip_nul_scrubs_dict_keys():
+    assert _strip_nul({"k\x00ey": "v"}) == {"key": "v"}
+
+
+def test_strip_nul_leaves_clean_strings_identical():
+    s = "no nul here"
+    assert _strip_nul(s) is s
+
+
+def test_build_row_strips_nul_from_identity_fields():
+    # A NUL in a trace identity field must be scrubbed regardless of parse path.
+    row = build_row(
+        {"id": "t1", "userId": "user\x00id", "environment": "production"}
+    )
+    assert "\x00" not in row["user_id"]
+    assert row["user_id"] == "userid"
+    assert row["id"] == "t1"


### PR DESCRIPTION
Got some errors when running the langfuse ingest script on staging like:

```
asyncpg.exceptions.CharacterNotInRepertoireError: invalid byte sequence for encoding "UTF8": 0x00
```

Most of the ingests were happening fine, but the ingest crashed out with this when processing a trace from a few months ago. Currently unsure of why this trace returns a `nul` character, that then causes the db insert to fail. But this should fix it by stripping out all nul chars before we ingest into the db. If we see this happening a lot, we can separately investigate what's happening in Langfuse, but I think this is likely some edge-case that's not worth worrying about, and just stripping out the offending characters before ingesting should be fine.

cc @yellowcap 