### PR TITLE
add a concept of scopes for machine users to have granular scopes

### DIFF
--- a/db/alembic/versions/e0e882fba200_add_scopes_to_machine_user_keys.py
+++ b/db/alembic/versions/e0e882fba200_add_scopes_to_machine_user_keys.py
@@ -1,0 +1,39 @@
+"""add scopes to machine_user_keys
+
+Revision ID: e0e882fba200
+Revises: 8391583bd224
+Create Date: 2026-06-22 00:00:00.000000
+
+Per-key authorization scopes for machine API keys (e.g. ``traces:read``). A key
+carrying a scope grants access to the matching endpoints without an elevated
+user_type, decoupling authentication (the key) from authorization (the scope).
+Existing keys default to no scopes.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "e0e882fba200"
+down_revision: Union[str, None] = "8391583bd224"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "machine_user_keys",
+        sa.Column(
+            "scopes",
+            postgresql.ARRAY(sa.String()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("machine_user_keys", "scopes")

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -43,8 +43,76 @@ kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' 
 - This command changes their user type from regular user to admin
 - Admin users have higher prompt quotas
 
+### Machine users & API keys (scopes)
+
+Machine users are accounts for programmatic (machine-to-machine) access. They
+authenticate with an API key passed as a bearer token:
+`Authorization: Bearer zeno-key:<prefix>:<secret>`.
+
+Authorization is granted per-key via **scopes** (independent of `user_type`). An
+endpoint that requires a scope is accessible to a superuser human, or to a machine
+key that carries that scope. Currently defined scopes:
+
+- `traces:read` — read access to the traces API (`/api/traces/*`).
+
+**Create a machine user with a scoped key:**
+```bash
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py create-machine-user \
+  --name "Traces Reader" --email "traces-reader@example.com" \
+  --create-key --key-name "traces" --scope traces:read
+```
+
+**Add a key (with one or more scopes) to an existing machine user:**
+```bash
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py create-api-key \
+  --user-id "machine_xxx" --key-name "traces" --scope traces:read
+```
+
+**Parameters:**
+- `--scope` (repeatable): authorization scope(s) to grant the key. Unknown scopes
+  are rejected. Defaults to none (a key with no scopes cannot reach scoped
+  endpoints).
+
+The token is printed once at creation — save it then; it is not recoverable.
+`list-api-keys --user-id <id>` shows each key's scopes. Rotate/revoke with
+`rotate-key` / `revoke-key`.
+
+### ingest-langfuse-traces
+
+Ingests Langfuse traces into Postgres (`langfuse_traces`) with an idempotent
+upsert, recording a watermark per run so subsequent runs resume incrementally.
+
+**Usage:**
+```bash
+# Default: resume from the last watermark (or last 24h on first run)
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py ingest-langfuse-traces
+
+# Historical backfill over an explicit window
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py ingest-langfuse-traces --backfill --since 2025-12-22T00:00:00Z
+```
+
+**Parameters:**
+- `--since` (ISO datetime): start of the window; overrides the watermark. Required with `--backfill`.
+- `--until` (ISO datetime): end of the window (default: now).
+- `--backfill`: historical backfill from `--since`.
+- `--environment` (repeatable): filter to specific environment(s) (default: all).
+- `--overlap-hours` (default 12): re-scan overlap before the watermark to catch delayed traces.
+- `--chunk-hours` (default 24): window chunk size.
+- `--batch-size` (default 300): fetch page / upsert batch size.
+- `--dry-run`: fetch + parse but do not write (connectivity/parse smoke test).
+
+**Notes:**
+- Requires `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `DATABASE_URL` in the pod environment.
+- Each run prints a summary line: `fetched=… upserted=… chunks=… failed=… status=… watermark=…`.
+- The watermark only advances on fully-completed chunks, so an interrupted run is safe to re-run.
+
 ## Error Handling
 
 The command includes error handling:
 
 - **make-user-admin**: Returns an error if the user with the specified email doesn't exist
+- **create-api-key / create-machine-user**: Returns an error if an unknown `--scope` is supplied

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.17.3"
+version = "2026.6.22"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -40,7 +40,7 @@ async def fetch_user_from_rw_api(
     token = authorization.credentials
 
     if token and token.startswith(f"{MACHINE_USER_PREFIX}:"):
-        return await validate_machine_user_token(token, session)
+        return await validate_machine_user_token(token, session, request)
 
     if token and token in _user_info_cache:
         return _user_info_cache[token]
@@ -160,6 +160,28 @@ async def require_superuser(
             detail="Superuser privileges required",
         )
     return user
+
+
+def require_scope(scope: str):
+    """Dependency factory: allow a superuser, or a machine key whose scopes
+    include ``scope``. The key's scopes are read from ``request.state``, set
+    during token validation (see ``validate_machine_user_token``)."""
+
+    async def _dep(
+        request: Request,
+        user: UserModel = Depends(require_auth),
+    ) -> UserModel:
+        if user.user_type == UserType.SUPERUSER:
+            return user
+        scopes = getattr(request.state, "token_scopes", []) or []
+        if scope in scopes:
+            return user
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Missing required scope: {scope}",
+        )
+
+    return _dep
 
 
 async def fetch_user(

--- a/src/api/auth/machine_user.py
+++ b/src/api/auth/machine_user.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import bcrypt
 import structlog
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -16,9 +16,11 @@ MACHINE_USER_PREFIX = "zeno-key"
 
 
 async def validate_machine_user_token(
-    token: str, session: AsyncSession
+    token: str, session: AsyncSession, request: Request
 ) -> UserModel:
-    """Validate machine user API key and return associated user."""
+    """Validate machine user API key and return associated user. The key's
+    authorization scopes are stashed on ``request.state.token_scopes`` for
+    downstream scope checks (see ``require_scope``)."""
     # Parse token format: zeno-key:prefix:secret
     parts = token.split(":")
     if len(parts) != 3 or parts[0] != MACHINE_USER_PREFIX:
@@ -62,6 +64,9 @@ async def validate_machine_user_token(
         raise HTTPException(
             status_code=401, detail="Machine user key has expired"
         )
+
+    # Expose the key's scopes for downstream authorization (require_scope).
+    request.state.token_scopes = list(key_record.scopes or [])
 
     # Update last_used_at timestamp
     key_record.last_used_at = datetime.now()

--- a/src/api/auth/scopes.py
+++ b/src/api/auth/scopes.py
@@ -1,0 +1,13 @@
+"""Authorization scopes for machine API keys.
+
+A scope is a fine-grained permission carried by an individual machine key (see
+``MachineUserKeyOrm.scopes``). Endpoints gate on a scope via ``require_scope`` so
+machine-to-machine access is decoupled from ``user_type`` (a superuser human
+always passes; a machine key passes iff it carries the scope).
+"""
+
+# Read access to the ingested Langfuse traces API (/api/traces/*).
+TRACES_READ = "traces:read"
+
+# All scopes the CLI is allowed to mint.
+KNOWN_SCOPES = frozenset({TRACES_READ})

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from src.api.auth.machine_user import MACHINE_USER_PREFIX
+from src.api.auth.scopes import KNOWN_SCOPES
 from src.api.data_models import (
     MachineUserKeyOrm,
     UserOrm,
@@ -55,6 +56,17 @@ class DatabaseManager:
     async def close(self):
         """Close database connection"""
         await self.engine.dispose()
+
+
+def _validate_scopes(scopes: tuple) -> list[str]:
+    """Reject unknown scopes so a typo never silently mints a dead key."""
+    unknown = sorted(set(scopes) - KNOWN_SCOPES)
+    if unknown:
+        raise click.BadParameter(
+            f"Unknown scope(s): {', '.join(unknown)}. "
+            f"Known: {', '.join(sorted(KNOWN_SCOPES))}"
+        )
+    return list(scopes)
 
 
 def generate_api_key() -> tuple[str, str, str]:
@@ -117,6 +129,7 @@ async def create_api_key(
     user_id: str,
     key_name: str,
     expires_at: Optional[datetime] = None,
+    scopes: Optional[list[str]] = None,
 ) -> tuple[str, MachineUserKeyOrm]:
     """Create a new API key for a machine user"""
 
@@ -138,6 +151,7 @@ async def create_api_key(
         key_hash=secret_hash,
         key_prefix=prefix,
         expires_at=expires_at,
+        scopes=scopes or [],
         created_at=datetime.now(),
         is_active=True,
     )
@@ -301,14 +315,23 @@ def cli():
     default="default",
     help='Name for the initial API key (default: "default")',
 )
+@click.option(
+    "--scope",
+    "scopes",
+    multiple=True,
+    help="Authorization scope for the initial key; repeatable.",
+)
 def create_machine_user_command(
     name: str,
     email: str,
     description: Optional[str],
     create_key: bool,
     key_name: str,
+    scopes: tuple,
 ):
     """Create a new machine user"""
+
+    scope_list = _validate_scopes(scopes)
 
     async def _create():
         db = DatabaseManager()
@@ -328,13 +351,16 @@ def create_machine_user_command(
                 if create_key:
                     click.echo("\n🔑 Creating initial API key...")
                     full_token, api_key = await create_api_key(
-                        session, user.id, key_name
+                        session, user.id, key_name, scopes=scope_list
                     )
                     click.echo("✅ Created API key:")
                     click.echo(f"   Key ID: {api_key.id}")
                     click.echo(f"   Name: {api_key.key_name}")
                     click.echo(f"   Token: {full_token}")
                     click.echo(f"   Prefix: {api_key.key_prefix}")
+                    click.echo(
+                        f"   Scopes: {', '.join(api_key.scopes) or '(none)'}"
+                    )
                     click.echo(f"   Created: {api_key.created_at}")
                     click.echo(
                         "\n⚠️  IMPORTANT: Save this token now - it won't be shown again!"
@@ -351,10 +377,18 @@ def create_machine_user_command(
 @click.option(
     "--expires-days", type=int, help="Number of days until key expires"
 )
+@click.option(
+    "--scope",
+    "scopes",
+    multiple=True,
+    help="Authorization scope for the key; repeatable.",
+)
 def create_api_key_command(
-    user_id: str, key_name: str, expires_days: Optional[int]
+    user_id: str, key_name: str, expires_days: Optional[int], scopes: tuple
 ):
     """Create a new API key for a machine user"""
+
+    scope_list = _validate_scopes(scopes)
 
     async def _create():
         db = DatabaseManager()
@@ -367,7 +401,7 @@ def create_api_key_command(
                     expires_at = datetime.now() + timedelta(days=expires_days)
 
                 full_token, api_key = await create_api_key(
-                    session, user_id, key_name, expires_at
+                    session, user_id, key_name, expires_at, scopes=scope_list
                 )
 
                 click.echo("✅ Created API key:")
@@ -375,6 +409,9 @@ def create_api_key_command(
                 click.echo(f"   Name: {api_key.key_name}")
                 click.echo(f"   Token: {full_token}")
                 click.echo(f"   Prefix: {api_key.key_prefix}")
+                click.echo(
+                    f"   Scopes: {', '.join(api_key.scopes) or '(none)'}"
+                )
                 if api_key.expires_at:
                     click.echo(f"   Expires: {api_key.expires_at}")
                 click.echo(f"   Created: {api_key.created_at}")
@@ -443,6 +480,9 @@ def list_api_keys_command(user_id: str):
                     click.echo(f"🔑 {key.key_name} - {status}")
                     click.echo(f"   Key ID: {key.id}")
                     click.echo(f"   Prefix: {key.key_prefix}")
+                    click.echo(
+                        f"   Scopes: {', '.join(key.scopes) or '(none)'}"
+                    )
                     if key.expires_at:
                         click.echo(f"   Expires: {key.expires_at}")
                     if key.last_used_at:

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -181,6 +181,7 @@ class MachineUserKeyOrm(Base):
     last_used_at = Column(DateTime, nullable=True)
     expires_at = Column(DateTime, nullable=True)
     is_active = Column(Boolean, default=True)
+    scopes = Column(ARRAY(String), nullable=False, server_default="{}")
 
     user = relationship("UserOrm", back_populates="machine_user_keys")
 

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -1,4 +1,7 @@
-"""Superuser-only endpoints for exploring ingested Langfuse traces.
+"""Endpoints for exploring ingested Langfuse traces.
+
+Gated on the ``traces:read`` scope: a superuser human or a machine key carrying
+that scope (see ``require_scope``).
 
 Read path over ``langfuse_traces`` (see src/api/services/langfuse for ingestion).
 List/detail here; analytics + conversation views live alongside. All derived
@@ -17,7 +20,8 @@ from pydantic import BaseModel
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.api.auth.dependencies import require_superuser
+from src.api.auth.dependencies import require_scope
+from src.api.auth.scopes import TRACES_READ
 from src.api.data_models import LangfuseTraceOrm
 from src.api.schemas import UserModel
 from src.api.services.langfuse.fetch import LangfuseClient
@@ -159,7 +163,7 @@ async def list_traces(
     prompt_contains: Optional[str] = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
-    _superuser: UserModel = Depends(require_superuser),
+    _reader: UserModel = Depends(require_scope(TRACES_READ)),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceListResponse:
     """List/filter traces (derived columns only — never raw/output)."""
@@ -274,7 +278,7 @@ async def trace_analytics(
     user_id: Optional[str] = Query(None),
     start: Optional[datetime] = Query(None),
     end: Optional[datetime] = Query(None),
-    _superuser: UserModel = Depends(require_superuser),
+    _reader: UserModel = Depends(require_scope(TRACES_READ)),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceAnalytics:
     """Server-side aggregates over the filtered trace set. All metrics are
@@ -390,7 +394,7 @@ async def list_sessions(
     end: Optional[datetime] = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
-    _superuser: UserModel = Depends(require_superuser),
+    _reader: UserModel = Depends(require_scope(TRACES_READ)),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> SessionListResponse:
     """Conversation browser: one row per session (thread), newest first, with the
@@ -447,7 +451,7 @@ async def list_sessions(
 @router.get("/{trace_id}", response_model=TraceDetail)
 async def get_trace(
     trace_id: str,
-    _superuser: UserModel = Depends(require_superuser),
+    _reader: UserModel = Depends(require_scope(TRACES_READ)),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceDetail:
     """Full detail for one trace: our derived columns from Postgres, plus the

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -3,11 +3,46 @@
 from datetime import datetime, timezone
 
 import pytest
+from fastapi import Request
 
+from src.api.app import app
+from src.api.auth.dependencies import fetch_user_from_rw_api
+from src.api.auth.scopes import TRACES_READ
 from src.api.data_models import LangfuseTraceOrm
+from src.api.schemas import UserModel
 from tests.conftest import async_session_maker
 
 H = {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture
+def machine_auth_override():
+    """Override auth with a machine identity carrying the given scopes (set on
+    request.state, as validate_machine_user_token does for a real key)."""
+    original = app.dependency_overrides.get(fetch_user_from_rw_api)
+
+    def _set(scopes, user_id="machine-traces"):
+        async def _dep(request: Request):
+            request.state.token_scopes = list(scopes)
+            return UserModel.model_validate(
+                {
+                    "id": user_id,
+                    "name": user_id,
+                    "email": f"{user_id}@example.com",
+                    "user_type": "machine",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                    "updatedAt": "2024-01-01T00:00:00Z",
+                }
+            )
+
+        app.dependency_overrides[fetch_user_from_rw_api] = _dep
+
+    yield _set
+
+    if original is not None:
+        app.dependency_overrides[fetch_user_from_rw_api] = original
+    else:
+        app.dependency_overrides.pop(fetch_user_from_rw_api, None)
 
 
 async def _seed_trace(trace_id: str, **kw) -> None:
@@ -41,6 +76,20 @@ async def test_list_requires_superuser_not_regular(
     client, auth_override, user
 ):
     auth_override(user.id)
+    assert (await client.get("/api/traces", headers=H)).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_machine_key_with_scope_allowed(client, machine_auth_override):
+    machine_auth_override([TRACES_READ])
+    assert (await client.get("/api/traces", headers=H)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_machine_key_without_scope_forbidden(
+    client, machine_auth_override
+):
+    machine_auth_override([])
     assert (await client.get("/api/traces", headers=H)).status_code == 403
 
 

--- a/tests/unit/test_auth_scopes.py
+++ b/tests/unit/test_auth_scopes.py
@@ -1,0 +1,63 @@
+"""Unit tests for scope-based authorization (src/api/auth/dependencies.py
+require_scope). A superuser always passes; a machine key passes iff its scopes
+(read from request.state) include the required scope; anyone else is forbidden."""
+
+import types
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.auth.dependencies import require_scope
+from src.api.auth.scopes import TRACES_READ
+from src.api.schemas import UserModel
+
+
+def _user(user_type: str) -> UserModel:
+    return UserModel.model_validate(
+        {
+            "id": "u",
+            "name": "u",
+            "email": "u@example.com",
+            "user_type": user_type,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:00:00Z",
+        }
+    )
+
+
+def _request(token_scopes=None) -> object:
+    state = types.SimpleNamespace()
+    if token_scopes is not None:
+        state.token_scopes = token_scopes
+    return types.SimpleNamespace(state=state)
+
+
+@pytest.mark.asyncio
+async def test_superuser_always_allowed_even_without_scopes():
+    dep = require_scope(TRACES_READ)
+    user = _user("superuser")
+    assert await dep(_request(), user=user) is user
+
+
+@pytest.mark.asyncio
+async def test_machine_with_scope_allowed():
+    dep = require_scope(TRACES_READ)
+    user = _user("machine")
+    assert await dep(_request([TRACES_READ]), user=user) is user
+
+
+@pytest.mark.asyncio
+async def test_machine_without_scope_forbidden():
+    dep = require_scope(TRACES_READ)
+    with pytest.raises(HTTPException) as exc:
+        await dep(_request([]), user=_user("machine"))
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_regular_user_with_no_scope_state_forbidden():
+    dep = require_scope(TRACES_READ)
+    # No token_scopes on request.state at all (e.g. an RW-token user).
+    with pytest.raises(HTTPException) as exc:
+        await dep(_request(), user=_user("regular"))
+    assert exc.value.status_code == 403

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.17.2"
+version = "2026.6.22"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This landed up being a bit of a side-quest for the Traces API stuff.

### The Problem

With the new Traces API, we want access to be restricted to superusers, but also enable machine-to-machine use-cases, for example from the `tracey` app that @01painadam was working on. We currently have a concept of a "machine_user" type, but no ability to specify more granular permissions per machine user / token. This means we'd have to allow _all_ machine user tokens to access the Traces API, which would have been non-ideal.

### What this PR does

This PR introduces a new `scopes` field for machine users, with the `scopes` then being baked into the token generated. In this PR, we creates a `traces:read` scope and then check on the traces endpoint if the user is a `superuser` OR a machine user with that scope.

This adds the `scopes` field to the schema and db, so we can expand this to include granular scopes assigned to machine tokens for specific tasks. I think this will likely be useful long-term to ensure we are giving fine-grained access to tokens.

@sunu - I think we've spoken about this in the past - if you have a moment, it would be good to get your 👀 on this and any quick feedback or thoughts.

cc @yellowcap 