### PR TITLE
PZB-1026: Add inspect tool for UI context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.6.22"
+version = "2026.6.24"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -25,6 +25,9 @@ from src.agent.subagents.pick_aoi.tool import SPEC as pick_aoi_spec
 from src.agent.subagents.pick_dataset.tool import SPEC as pick_dataset_spec
 from src.agent.subagents.search.blog import SPEC as search_blogs_spec
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.inspect_view_context import (
+    SPEC as inspect_view_context_spec,
+)
 from src.agent.tools.pull_data import SPEC as pull_data_spec
 from src.agent.tools.show_imagery import SPEC as show_imagery_spec
 from src.shared.logging_config import get_logger
@@ -42,6 +45,7 @@ CORE_SPECS = (
     pick_dataset_spec,
     pull_data_spec,
     generate_insights_spec,
+    inspect_view_context_spec,
     read_skill_spec,
 )
 

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -35,22 +35,22 @@ from src.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 DEFAULT_PROFILE = "default"
-
-# Feature flag exposing experimental, opt-in tools (Sentinel-2 imagery and
-# WRI Insights blog search).
-EXPERIMENTAL_PROFILE = "experimental"
-
 CORE_SPECS = (
     pick_aoi_spec,
     pick_dataset_spec,
     pull_data_spec,
     generate_insights_spec,
-    inspect_view_context_spec,
     read_skill_spec,
 )
 
 # Experimental, opt-in tools layered on top of the core set.
-EXPERIMENTAL_SPECS = (*CORE_SPECS, show_imagery_spec, search_blogs_spec)
+EXPERIMENTAL_PROFILE = "experimental"
+EXPERIMENTAL_SPECS = (
+    *CORE_SPECS,
+    inspect_view_context_spec,
+    show_imagery_spec,
+    search_blogs_spec,
+)
 
 
 @dataclass(frozen=True)

--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -10,6 +10,7 @@ Examples:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 import sys
@@ -563,6 +564,7 @@ async def _run_query(
     message_history: list[BaseMessage],
     printer: _CliPrinter,
     show_header: bool,
+    view_context: Optional[dict] = None,
 ) -> None:
     if show_header:
         printer.print_turn_header(query)
@@ -571,11 +573,18 @@ async def _run_query(
         # The checkpointer restores prior messages and graph state for the
         # thread, so only the new message is sent.
         config = {"configurable": {"thread_id": thread_id}}
-        input_state = {"messages": [HumanMessage(content=query)]}
+        input_state: dict[str, Any] = {
+            "messages": [HumanMessage(content=query)]
+        }
     else:
         config = {}
         message_history.append(HumanMessage(content=query))
         input_state = {"messages": message_history}
+
+    # Mirror the chat service: attach the ambient view-state snapshot to the
+    # turn so inspect_view_context (and the session breadcrumb) can see it.
+    if view_context:
+        input_state["view_context"] = view_context
 
     new_messages = await _stream_turn(
         agent, input_state, config, printer=printer
@@ -632,6 +641,7 @@ async def _interactive_loop(
     checkpoint_kind: str,
     using_custom_prompt: bool,
     printer: _CliPrinter,
+    view_context: Optional[dict] = None,
 ) -> None:
     click.echo(
         click.style("Zeno agent CLI", bold=True)
@@ -667,6 +677,7 @@ async def _interactive_loop(
             message_history=message_history,
             printer=printer,
             show_header=True,
+            view_context=view_context,
         )
 
 
@@ -680,6 +691,7 @@ async def _async_main(
     user_email: str,
     verbose: bool,
     ff: Optional[str] = None,
+    view_context: Optional[dict] = None,
 ) -> None:
     structlog.contextvars.clear_contextvars()
     bind_request_logging_context(user_id=user_id, thread_id=thread_id)
@@ -718,6 +730,7 @@ async def _async_main(
                     using_custom_prompt=system_prompt is not None
                     or ff is not None,
                     printer=printer,
+                    view_context=view_context,
                 )
             elif query:
                 await _run_query(
@@ -728,6 +741,7 @@ async def _async_main(
                     message_history=[],
                     printer=printer,
                     show_header=True,
+                    view_context=view_context,
                 )
         finally:
             await close_global_pool()
@@ -792,6 +806,17 @@ async def _async_main(
     help="Email for the CLI user row (default: <user-id>@cli.local).",
 )
 @click.option(
+    "--view-context",
+    "view_context_arg",
+    default=None,
+    help=(
+        "Frontend view state to attach to every turn, as inline JSON or a "
+        "path to a .json file. Exercises inspect_view_context and the session "
+        "breadcrumb. Keys: page, viewport, visible_layers, visible_aois, "
+        "visible_insights (insight ids — must exist in the DB to load)."
+    ),
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -808,6 +833,7 @@ def main(
     checkpoint: bool,
     user_id: str,
     user_email: str,
+    view_context_arg: Optional[str],
     verbose: bool,
 ) -> None:
     """Run the Zeno geospatial agent locally."""
@@ -823,6 +849,7 @@ def main(
         )
 
     system_prompt = _resolve_system_prompt(prompt, prompt_file)
+    view_context = _resolve_view_context(view_context_arg)
     resolved_thread_id = thread_id or str(uuid.uuid4())
     resolved_user_email = user_email or f"{user_id}@cli.local"
 
@@ -838,6 +865,7 @@ def main(
                 user_email=resolved_user_email,
                 verbose=verbose,
                 ff=ff,
+                view_context=view_context,
             )
         )
     except KeyboardInterrupt:
@@ -854,6 +882,22 @@ def _resolve_system_prompt(
     if prompt is not None:
         return prompt.strip()
     return None
+
+
+def _resolve_view_context(value: Optional[str]) -> Optional[dict]:
+    """Parse --view-context: inline JSON object or a path to a .json file."""
+    if not value:
+        return None
+    path = Path(value)
+    if path.exists():
+        value = path.read_text(encoding="utf-8")
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise click.UsageError(f"--view-context is not valid JSON: {exc}")
+    if not isinstance(parsed, dict):
+        raise click.UsageError("--view-context must be a JSON object.")
+    return parsed
 
 
 if __name__ == "__main__":

--- a/src/agent/middleware.py
+++ b/src/agent/middleware.py
@@ -98,6 +98,9 @@ def _view_breadcrumb(view: dict | None) -> str:
     aois = view.get("visible_aois") or []
     if aois:
         parts.append(f"{len(aois)} AOI(s) visible")
+    insights = view.get("visible_insights") or []
+    if insights:
+        parts.append(f"{len(insights)} insight(s) on screen")
 
     summary = " · ".join(parts) if parts else "active"
     return f"View: {summary} (call inspect_view_context for details)"

--- a/src/agent/middleware.py
+++ b/src/agent/middleware.py
@@ -74,7 +74,33 @@ def format_session_block(state: dict) -> str:
         else "Active insight: none"
     )
 
+    lines.append(_view_breadcrumb(state.get("view_context")))
+
     return "\n".join(lines)
+
+
+def _view_breadcrumb(view: dict | None) -> str:
+    """One-line hint that frontend view state exists, with details on demand.
+
+    Keeps the bulky snapshot (exact viewport, full layer list) out of the
+    prompt — the agent calls inspect_view_context when it actually needs it.
+    """
+    if not view:
+        return "View: none"
+
+    parts = []
+    page = view.get("page")
+    if page:
+        parts.append(f"{page} page")
+    layers = view.get("visible_layers") or []
+    if layers:
+        parts.append(f"{len(layers)} layer(s)")
+    aois = view.get("visible_aois") or []
+    if aois:
+        parts.append(f"{len(aois)} AOI(s) visible")
+
+    summary = " · ".join(parts) if parts else "active"
+    return f"View: {summary} (call inspect_view_context for details)"
 
 
 class SessionContextMiddleware(AgentMiddleware):

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -51,6 +51,12 @@ class AgentState(TypedDict):
     messages: Annotated[Sequence[BaseMessage], add_messages]
     user_persona: str
 
+    # Ambient frontend view state (what the user is currently looking at):
+    # page, map viewport, visible layers/AOIs. Last-write-wins each turn —
+    # no reducer; we only ever want the latest snapshot. Read on demand via
+    # the inspect_view_context tool, not eagerly injected into the prompt.
+    view_context: dict
+
     # pick-aoi tool
     aoi_selection: AOISelection
 

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -1,0 +1,122 @@
+"""inspect_view_context — surface the user's current frontend view state.
+
+The frontend sends an ambient "view state" snapshot (which page the user is
+on, the map viewport, which layers and AOIs are visible) with each chat
+request. It is stored on AgentState (``view_context``) but deliberately kept
+out of the prompt — only a one-line breadcrumb appears in the session block.
+This tool returns the full snapshot when the agent actually needs it to answer
+a query that refers to what the user is looking at.
+"""
+
+import json
+from typing import Annotated, Dict, Optional
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _label(item: object, *keys: str) -> str:
+    """Best human-readable label for a layer/AOI entry, always a string."""
+    if isinstance(item, dict):
+        for key in keys:
+            value = item.get(key)
+            if value:
+                return str(value)
+        return "?"
+    return str(item)
+
+
+def format_view_context(view: dict) -> str:
+    """Render the full frontend view-state snapshot as readable text.
+
+    The snapshot is free-form (the frontend owns its shape); we surface the
+    well-known keys explicitly and fall back to a JSON dump for the rest so
+    nothing the frontend sends is silently dropped.
+    """
+    if not view:
+        return (
+            "No frontend view context is available — the app did not report "
+            "what the user is currently looking at."
+        )
+
+    lines = ["Current frontend view:"]
+
+    page = view.get("page")
+    if page:
+        lines.append(f"- Page: {page}")
+
+    viewport = view.get("viewport")
+    if viewport:
+        bbox = viewport.get("bbox") if isinstance(viewport, dict) else None
+        zoom = viewport.get("zoom") if isinstance(viewport, dict) else None
+        parts = []
+        if bbox:
+            parts.append(f"bbox {bbox}")
+        if zoom is not None:
+            parts.append(f"zoom {zoom}")
+        lines.append(f"- Viewport: {', '.join(parts) if parts else viewport}")
+
+    layers = view.get("visible_layers")
+    if layers:
+        names = [_label(layer, "name", "id") for layer in layers]
+        lines.append(f"- Visible layers ({len(names)}): {', '.join(names)}")
+
+    aois = view.get("visible_aois")
+    if aois:
+        names = [_label(aoi, "name", "src_id") for aoi in aois]
+        lines.append(f"- Visible AOIs ({len(names)}): {', '.join(names)}")
+
+    # Surface any other keys the frontend sent so nothing is lost.
+    known = {"page", "viewport", "visible_layers", "visible_aois"}
+    extra = {k: v for k, v in view.items() if k not in known}
+    if extra:
+        lines.append(f"- Other: {json.dumps(extra, default=str)}")
+
+    return "\n".join(lines)
+
+
+@tool("inspect_view_context")
+async def inspect_view_context(
+    state: Annotated[Dict, InjectedState],
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Return what the user is currently looking at in the app.
+
+    Reports the current page (map vs report), the map viewport, and the
+    layers and AOIs visible on screen. Call this when the user refers to
+    "this", "here", the current view, or what's on their screen, and you need
+    those details to answer.
+    """
+    logger.info("inspect_view_context tool called")
+    view = (state or {}).get("view_context") or {}
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    format_view_context(view),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                )
+            ],
+        },
+    )
+
+
+SPEC = ToolSpec(
+    tool=inspect_view_context,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- inspect_view_context(): returns what the user is currently looking "
+        "at in the app (page, map viewport, visible layers, visible AOIs). "
+        "Call this when the user refers to 'this', 'here', the current view, "
+        "or what's on their screen."
+    ),
+)

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -1,26 +1,49 @@
 """inspect_view_context — surface the user's current frontend view state.
 
 The frontend sends an ambient "view state" snapshot (which page the user is
-on, the map viewport, which layers and AOIs are visible) with each chat
+on, the map viewport, which layers/AOIs/insights are visible) with each chat
 request. It is stored on AgentState (``view_context``) but deliberately kept
 out of the prompt — only a one-line breadcrumb appears in the session block.
 This tool returns the full snapshot when the agent actually needs it to answer
 a query that refers to what the user is looking at.
+
+Insights are the exception to "just echo what the frontend sent": they carry a
+lot of content that lives in the database, not the snapshot. When the frontend
+reports visible insight ids (typically on the report page), the tool loads each
+insight and prints its most important content — summary, chart titles and the
+variables behind each chart — so the agent can reason about what's on screen
+even when that detail isn't already in the conversation history.
 """
 
 import json
 from typing import Annotated, Dict, Optional
+from uuid import UUID
 
+import structlog
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.data_models import InsightOrm
+from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+# view_context keys the tool understands explicitly; everything else is dumped
+# verbatim under "Other" so nothing the frontend sends is silently lost.
+_KNOWN_KEYS = {
+    "page",
+    "viewport",
+    "visible_layers",
+    "visible_aois",
+    "visible_insights",
+}
 
 
 def _label(item: object, *keys: str) -> str:
@@ -35,11 +58,11 @@ def _label(item: object, *keys: str) -> str:
 
 
 def format_view_context(view: dict) -> str:
-    """Render the full frontend view-state snapshot as readable text.
+    """Render the well-known parts of the view-state snapshot as readable text.
 
     The snapshot is free-form (the frontend owns its shape); we surface the
-    well-known keys explicitly and fall back to a JSON dump for the rest so
-    nothing the frontend sends is silently dropped.
+    well-known keys explicitly and fall back to a JSON dump for the rest.
+    Insights are handled separately (they are loaded from the database).
     """
     if not view:
         return (
@@ -74,12 +97,108 @@ def format_view_context(view: dict) -> str:
         names = [_label(aoi, "name", "src_id") for aoi in aois]
         lines.append(f"- Visible AOIs ({len(names)}): {', '.join(names)}")
 
+    insights = view.get("visible_insights")
+    if insights:
+        # Detail is loaded from the DB and appended by the tool; here we just
+        # note the count so the line shows even if a load later turns up empty.
+        lines.append(f"- Visible insights: {len(insights)} (detail below)")
+
     # Surface any other keys the frontend sent so nothing is lost.
-    known = {"page", "viewport", "visible_layers", "visible_aois"}
-    extra = {k: v for k, v in view.items() if k not in known}
+    extra = {k: v for k, v in view.items() if k not in _KNOWN_KEYS}
     if extra:
         lines.append(f"- Other: {json.dumps(extra, default=str)}")
 
+    return "\n".join(lines)
+
+
+def _extract_insight_ids(refs: object) -> list[UUID]:
+    """Parse insight ids out of view_context['visible_insights'].
+
+    Entries may be ``{"id": ...}`` dicts or bare id strings. Unparseable
+    values are skipped rather than failing the whole call.
+    """
+    if not isinstance(refs, list):
+        return []
+    ids: list[UUID] = []
+    for ref in refs:
+        raw = ref.get("id") if isinstance(ref, dict) else ref
+        if not raw:
+            continue
+        try:
+            ids.append(UUID(str(raw)))
+        except (ValueError, TypeError):
+            logger.warning("inspect_view_context: bad insight id %r", raw)
+    return ids
+
+
+async def _load_insights(insight_ids: list[UUID]) -> list[InsightOrm]:
+    """Load insights (with charts) the current user is allowed to see.
+
+    Ownership mirrors the /api/insights/{id} endpoint: a user's own insights
+    plus any public one. The user id comes from the request-scoped logging
+    context bound by the auth dependency.
+    """
+    if not insight_ids:
+        return []
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(InsightOrm.id.in_(insight_ids))
+        )
+        rows = result.scalars().all()
+    return [
+        row
+        for row in rows
+        if row.is_public or (user_id and row.user_id == user_id)
+    ]
+
+
+def _chart_variables(chart) -> str:
+    """Summarize the fields (variables) a chart is built from."""
+    parts = []
+    if chart.x_axis:
+        parts.append(f"x={chart.x_axis}")
+    if chart.y_axis:
+        parts.append(f"y={chart.y_axis}")
+    if chart.color_field:
+        parts.append(f"color={chart.color_field}")
+    if chart.stack_field:
+        parts.append(f"stack={chart.stack_field}")
+    if chart.group_field:
+        parts.append(f"group={chart.group_field}")
+    if chart.series_fields:
+        parts.append(f"series={', '.join(chart.series_fields)}")
+    return ", ".join(parts) if parts else "no variables"
+
+
+def format_insights(rows: list[InsightOrm]) -> str:
+    """Render the most important content of each on-screen insight.
+
+    Prints the summary, each chart's title + variables and the follow-up
+    suggestions. The raw chart data rows are deliberately omitted (only the
+    row count) to keep the message focused and cheap.
+    """
+    lines = ["Insights on screen:"]
+    for row in rows:
+        created = (
+            row.created_at.strftime("%Y-%m-%d") if row.created_at else "?"
+        )
+        lines.append(f"\nInsight {row.id} (created {created}):")
+        if row.insight_text:
+            lines.append(f"  Summary: {row.insight_text}")
+        for chart in row.charts or []:
+            title = chart.title or "(untitled)"
+            rows_n = len(chart.chart_data or [])
+            lines.append(
+                f'  Chart "{title}" ({chart.chart_type}): '
+                f"{_chart_variables(chart)} — {rows_n} data point(s)"
+            )
+        if row.follow_up_suggestions:
+            lines.append(
+                "  Follow-ups: " + "; ".join(row.follow_up_suggestions)
+            )
     return "\n".join(lines)
 
 
@@ -90,18 +209,34 @@ async def inspect_view_context(
 ) -> Command:
     """Return what the user is currently looking at in the app.
 
-    Reports the current page (map vs report), the map viewport, and the
-    layers and AOIs visible on screen. Call this when the user refers to
-    "this", "here", the current view, or what's on their screen, and you need
-    those details to answer.
+    Reports the current page (map vs report), the map viewport, the layers and
+    AOIs visible on screen, and — when the frontend reports visible insights
+    (e.g. on the report page) — the key content of each insight: its summary,
+    chart titles and the variables behind each chart. Call this when the user
+    refers to "this", "here", the current view, the report, or an insight on
+    screen, and you need those details to answer.
     """
     logger.info("inspect_view_context tool called")
     view = (state or {}).get("view_context") or {}
+
+    sections = [format_view_context(view)]
+
+    insight_ids = _extract_insight_ids(view.get("visible_insights"))
+    if insight_ids:
+        rows = await _load_insights(insight_ids)
+        if rows:
+            sections.append(format_insights(rows))
+        else:
+            sections.append(
+                "Insights on screen: referenced but none could be loaded "
+                "(not found or not accessible)."
+            )
+
     return Command(
         update={
             "messages": [
                 ToolMessage(
-                    format_view_context(view),
+                    "\n\n".join(sections),
                     tool_call_id=tool_call_id,
                     status="success",
                 )
@@ -115,8 +250,9 @@ SPEC = ToolSpec(
     category=ToolCategory.PRIMITIVE,
     prompt_fragment=(
         "- inspect_view_context(): returns what the user is currently looking "
-        "at in the app (page, map viewport, visible layers, visible AOIs). "
-        "Call this when the user refers to 'this', 'here', the current view, "
-        "or what's on their screen."
+        "at in the app (page, map viewport, visible layers, visible AOIs, and "
+        "the content of any insights on screen — summary, charts and "
+        "variables). Call this when the user refers to 'this', 'here', the "
+        "current view, the report, or an insight on screen."
     ),
 )

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -109,6 +109,7 @@ async def chat(
                     user_persona=chat_request.user_persona,
                     thread_id=thread_id,
                     ui_context=chat_request.ui_context,
+                    view_context=chat_request.view_context,
                     ui_action_only=chat_request.ui_action_only,
                     langfuse_metadata=langfuse_metadata,
                     user=user_dict,

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -334,6 +334,20 @@ class ChatRequest(BaseModel):
         None  # {"aoi_selected": {...}, "dataset_selected": {...}, "daterange_selected": {...}}
     )
 
+    # Ambient frontend view state — what the user is currently looking at.
+    # Unlike ui_context (deliberate actions), this is reference material the
+    # agent consults on demand via the inspect_view_context tool; it is NOT
+    # turned into a message or eagerly merged into the agent's selections.
+    # Free-form (the frontend owns the shape), e.g.:
+    #   {"page": "map" | "report",
+    #    "viewport": {"bbox": [minx, miny, maxx, maxy], "zoom": 5},
+    #    "visible_layers": [{"id": "...", "name": "..."}],
+    #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}]}
+    view_context: Optional[dict] = Field(
+        None,
+        description="Ambient frontend view state (page, viewport, visible layers/AOIs)",
+    )
+
     # Pure UI actions - no query
     ui_action_only: Optional[bool] = False
 

--- a/src/api/services/chat.py
+++ b/src/api/services/chat.py
@@ -119,6 +119,7 @@ async def stream_chat(
     query: str,
     user_persona: Optional[str] = None,
     ui_context: Optional[dict] = None,
+    view_context: Optional[dict] = None,
     ui_action_only: Optional[bool] = False,
     thread_id: Optional[str] = None,
     langfuse_metadata: Optional[Dict] = {},
@@ -163,6 +164,11 @@ async def stream_chat(
                 case _:
                     content = f"User performed action in UI: {action_type}\n\n"
             ui_action_message.append(content)
+
+    # Ambient view state is stored as-is for on-demand inspection — unlike
+    # ui_context above, it does not become a message or merge into selections.
+    if view_context:
+        state_updates["view_context"] = view_context
 
     ui_action_content = "\n".join(ui_action_message).strip()
     if ui_action_content:

--- a/src/api/services/langfuse/parse.py
+++ b/src/api/services/langfuse/parse.py
@@ -35,6 +35,7 @@ EXPECTED_STATE_KEYS = frozenset(
     {
         "messages",
         "user_persona",
+        "view_context",
         "aoi_selection",
         "dataset",
         "suggested_datasets",

--- a/tests/agent/test_inspect_view_context.py
+++ b/tests/agent/test_inspect_view_context.py
@@ -1,0 +1,64 @@
+"""Tests for the inspect_view_context agent tool and the view breadcrumb."""
+
+import pytest
+
+from src.agent.middleware import format_session_block
+from src.agent.tools.inspect_view_context import (
+    format_view_context,
+    inspect_view_context,
+)
+
+VIEW_STATE = {
+    "view_context": {
+        "page": "report",
+        "viewport": {"bbox": [-74, -34, -34, 5], "zoom": 5},
+        "visible_layers": [
+            {"id": "tree-cover", "name": "Tree cover"},
+            {"id": "fire-alerts", "name": "Fire alerts"},
+        ],
+        "visible_aois": [
+            {"source": "gadm", "src_id": "BRA.24_1", "name": "São Paulo"}
+        ],
+        "selected_basemap": "satellite",
+    }
+}
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_inspect_view_context_returns_snapshot():
+    command = await inspect_view_context.coroutine(
+        state=VIEW_STATE, tool_call_id="t1"
+    )
+    content = _content(command)
+    assert "Page: report" in content
+    assert "Tree cover" in content
+    assert "Fire alerts" in content
+    assert "São Paulo" in content
+    # Unknown keys are surfaced, not dropped.
+    assert "selected_basemap" in content
+
+
+@pytest.mark.asyncio
+async def test_inspect_view_context_handles_missing_state():
+    command = await inspect_view_context.coroutine(state={}, tool_call_id="t1")
+    assert "No frontend view context" in _content(command)
+
+
+def test_format_view_context_empty():
+    assert "No frontend view context" in format_view_context({})
+
+
+def test_breadcrumb_present_with_view_context():
+    block = format_session_block(VIEW_STATE)
+    assert "View: report page · 2 layer(s) · 1 AOI(s) visible" in block
+    assert "call inspect_view_context for details" in block
+    # The bulky detail (exact viewport, layer ids) stays out of the prompt.
+    assert "BRA.24_1" not in block
+
+
+def test_breadcrumb_none_without_view_context():
+    assert "View: none" in format_session_block({})

--- a/tests/agent/test_inspect_view_context.py
+++ b/tests/agent/test_inspect_view_context.py
@@ -1,9 +1,17 @@
 """Tests for the inspect_view_context agent tool and the view breadcrumb."""
 
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
 import pytest
 
 from src.agent.middleware import format_session_block
 from src.agent.tools.inspect_view_context import (
+    _chart_variables,
+    _extract_insight_ids,
+    format_insights,
     format_view_context,
     inspect_view_context,
 )
@@ -26,6 +34,33 @@ VIEW_STATE = {
 
 def _content(command):
     return command.update["messages"][0].content
+
+
+def _fake_insight(**kwargs):
+    """Build an object shaped like InsightOrm (+ charts) for formatting tests."""
+    defaults = dict(
+        id=uuid4(),
+        insight_text="Tree cover loss rose 12% over the period.",
+        follow_up_suggestions=["Compare to fires", "Break down by driver"],
+        is_public=False,
+        user_id="user-1",
+        created_at=datetime(2026, 6, 1),
+        charts=[
+            SimpleNamespace(
+                title="Annual tree cover loss",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss_ha",
+                color_field="",
+                stack_field="",
+                group_field="",
+                series_fields=[],
+                chart_data=[{"year": 2020}, {"year": 2021}],
+            )
+        ],
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
 
 
 @pytest.mark.asyncio
@@ -62,3 +97,75 @@ def test_breadcrumb_present_with_view_context():
 
 def test_breadcrumb_none_without_view_context():
     assert "View: none" in format_session_block({})
+
+
+def test_breadcrumb_includes_insight_count():
+    state = {"view_context": {"page": "report", "visible_insights": [{}, {}]}}
+    assert "2 insight(s) on screen" in format_session_block(state)
+
+
+def test_extract_insight_ids_parses_dicts_strings_and_skips_bad():
+    good = uuid4()
+    refs = [{"id": str(good)}, str(uuid4()), {"id": None}, "not-a-uuid"]
+    ids = _extract_insight_ids(refs)
+    assert good in ids
+    assert all(isinstance(i, UUID) for i in ids)
+    assert len(ids) == 2  # the None and the bad string are skipped
+
+
+def test_chart_variables_lists_only_populated_fields():
+    chart = SimpleNamespace(
+        x_axis="year",
+        y_axis="loss_ha",
+        color_field="driver",
+        stack_field="",
+        group_field="",
+        series_fields=[],
+    )
+    out = _chart_variables(chart)
+    assert "x=year" in out and "y=loss_ha" in out and "color=driver" in out
+    assert "stack=" not in out
+
+
+def test_format_insights_prints_key_content():
+    out = format_insights([_fake_insight()])
+    assert "Summary: Tree cover loss rose 12%" in out
+    assert 'Chart "Annual tree cover loss" (bar)' in out
+    assert "x=year, y=loss_ha" in out
+    assert "2 data point(s)" in out
+    assert "Follow-ups: Compare to fires; Break down by driver" in out
+
+
+@pytest.mark.asyncio
+async def test_inspect_view_context_loads_insights():
+    insight = _fake_insight()
+    view = {
+        "view_context": {
+            "page": "report",
+            "visible_insights": [{"id": str(insight.id)}],
+        }
+    }
+    with patch(
+        "src.agent.tools.inspect_view_context._load_insights",
+        new=AsyncMock(return_value=[insight]),
+    ):
+        command = await inspect_view_context.coroutine(
+            state=view, tool_call_id="t1"
+        )
+    content = _content(command)
+    assert "Visible insights: 1" in content
+    assert "Annual tree cover loss" in content
+    assert "Summary: Tree cover loss rose 12%" in content
+
+
+@pytest.mark.asyncio
+async def test_inspect_view_context_insight_load_empty():
+    view = {"view_context": {"visible_insights": [{"id": str(uuid4())}]}}
+    with patch(
+        "src.agent.tools.inspect_view_context._load_insights",
+        new=AsyncMock(return_value=[]),
+    ):
+        command = await inspect_view_context.coroutine(
+            state=view, tool_call_id="t1"
+        )
+    assert "none could be loaded" in _content(command)

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.22"
+version = "2026.6.24"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.6.24"
+version = "2026.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
### Overview

This PR introduces the ability for the agent to access the frontend's ambient view state (current page, map viewport, visible layers, AOIs, and insights) on demand. Instead of dumping bulky view state into the model context on every turn, the frontend now sends a snapshot with each request. The agent is made aware of this state via a lightweight breadcrumb and can use the new `inspect_view_context` tool to retrieve the details when the user references "this", "here", or the current view.

### Key Changes

**State Management & Agent Awareness**

* **`ChatRequest.view_context`:** Carries the state snapshot, stored as-is on `AgentState` using a last-write-wins approach.
* **Separation of Concerns:** Kept strictly separate from the `ui_context` action channel to prevent it from becoming a standard message or merging into agent selections.
* **Session Breadcrumbs:** Added a one-line breadcrumb to the session block so the agent knows the view state is available. This includes dynamic hints like "N insight(s) on screen."

**The `inspect_view_context` Tool**

* **Core Functionality:** A primitive tool that returns the formatted view snapshot when invoked.
* **Insight Loading:** The tool dynamically loads content for insights referenced in `view_context.visible_insights` (e.g., from a report page) directly from the database.
* Prints key content: summary, chart titles/variables, and follow-up suggestions.
* Omits raw chart rows to keep the context window focused.
* Enforces ownership filtering (user's own or public insights), mirroring the `GET /api/insights/{id}` endpoint.


* **Experimental Profile:** The tool has been moved from `CORE_SPECS` to `EXPERIMENTAL_SPECS`. It will only ship behind the experimental feature flag.

**CLI & Testing Updates**

* **`--view-context` Flag:** Added to `cli.py`. Accepts inline JSON or a `.json` file path to attach the snapshot to each turn, mirroring the chat service and allowing local testing of the tool and breadcrumb behavior.
* **Experimental Flag Requirement:** Local execution requires the `--ff experimental` CLI flag to access the tool.

## Example

Here is an example call with dummy UI view context data

```
project-zeno$ uv run python src/agent/cli.py -v --ff experimental    -q "What am I looking at right now?"     --view-context '{"page":"report","viewport":{"bbox":[-74,-34,-34,5],"zoom":5},"visible_layers":[{"id":"tree-cover-loss","name":"Tree cover loss"},{"id":"fire-alerts","name":"Fire alerts"}],"visible_aois":[{"source":"gadm","src_id":"BRA.24_1","name":"São Paulo"}]}'
NumExpr defaulting to 14 threads.
2026-06-24T13:19:32.393298Z [info     ] Global database pool initialized [src.shared.database] max_overflow=30 pool_size=5 thread_id=ac00e5ea-6fba-48ce-84fe-6307a737ac1b total_connections=35 user_id=zeno-default-user
2026-06-24T13:19:32.478403Z [info     ] Agent profile set            [src.agent.graph] profile=experimental thread_id=ac00e5ea-6fba-48ce-84fe-6307a737ac1b user_id=zeno-default-user

Zeno › What am I looking at right now?
────────────────────────────────────────

  │ [Session — 2026-06-24]  (2 messages)
  │ AOI: none
  │ Dataset: none
  │ Date range: none
  │ Pulled data: none
  │ Imagery: none
  │ Active insight: none
  │ View: report page · 2 layer(s) · 1 AOI(s) visible (call inspect_view_context for details)
[model]
tool call: inspect_view_context({})
2026-06-24T13:19:33.385398Z [info     ] inspect_view_context tool called [src.agent.tools.inspect_view_context] thread_id=ac00e5ea-6fba-48ce-84fe-6307a737ac1b user_id=zeno-default-user
[tools]
tool result: Current frontend view:
- Page: report
- Viewport: bbox [-74, -34, -34, 5], zoom 5
- Visible layers (2): Tree cover loss, Fire alerts
- Visible AOIs (1): São Paulo
[model]
assistant: I see you are looking at the report page for **São Paulo**.

The map is currently displaying two layers:
*   **Tree cover loss**
*   **Fire alerts**

Would you like me to analyze the data for these layers in São Paulo, or are you interested in looking at a different area or dataset?
2026-06-24T13:19:35.167845Z [info     ] Global database pool closed  [src.shared.database] thread_id=ac00e5ea-6fba-48ce-84fe-6307a737ac1b user_id=zeno-default-user
```


