### PR TITLE
PZB-979: insights tool uses a stand-alone narrative generator llm call

### DIFF
--- a/src/agent/subagents/analyst/charts/__init__.py
+++ b/src/agent/subagents/analyst/charts/__init__.py
@@ -1,12 +1,12 @@
-"""Chart layer for the analyst: the canonical `InsightChart`/`InsightBundle`
+"""Chart layer for the analyst: the canonical `InsightChart`/`Insight`
 seam model shared by both insight paths."""
 
 from src.agent.subagents.analyst.charts.model import (
-    InsightBundle,
+    Insight,
     InsightChart,
 )
 
 __all__ = [
-    "InsightBundle",
+    "Insight",
     "InsightChart",
 ]

--- a/src/agent/subagents/analyst/charts/__init__.py
+++ b/src/agent/subagents/analyst/charts/__init__.py
@@ -1,0 +1,12 @@
+"""Chart layer for the analyst: the canonical `InsightChart`/`InsightBundle`
+seam model shared by both insight paths."""
+
+from src.agent.subagents.analyst.charts.model import (
+    InsightBundle,
+    InsightChart,
+)
+
+__all__ = [
+    "InsightBundle",
+    "InsightChart",
+]

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -6,8 +6,7 @@ object passed between stages and into persistence, and it exposes adapters for
 the two wire shapes:
 
 - snake_case for the DB (`InsightChartOrm`) via `to_orm_kwargs()`
-- camelCase for the frontend `charts_data` via `to_frontend_dict()` /
-  `from_frontend_dict()`
+- camelCase for the frontend `charts_data` via `to_frontend_dict()`
 
 `InsightBundle` groups the resolved charts with the narrative produced by the
 text stage.
@@ -78,29 +77,6 @@ class InsightChart(BaseModel):
             "groupField": self.group_field,
             "seriesFields": self.series_fields,
         }
-
-    @classmethod
-    def from_frontend_dict(
-        cls, data: dict, position: int = 0
-    ) -> "InsightChart":
-        """Inverse of `to_frontend_dict()` — rehydrate a chart already in state.
-
-        `id` is derived from `position` on the way out, so it is not read back
-        here; the caller supplies `position` (defaulting to the list index).
-        """
-        return cls(
-            position=position,
-            title=data.get("title", ""),
-            chart_type=data.get("type", "bar"),
-            x_axis=data.get("xAxis", ""),
-            y_axis=data.get("yAxis", ""),
-            color_field=data.get("colorField", ""),
-            stack_field=data.get("stackField", ""),
-            group_field=data.get("groupField", ""),
-            series_fields=data.get("seriesFields", []),
-            chart_data=data.get("data", []),
-            insight=data.get("insight", ""),
-        )
 
     @classmethod
     def from_chart_insight(

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -12,14 +12,32 @@ the two wire shapes:
 text stage.
 """
 
+import math
 from typing import List
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src.agent.subagents.analyst.code_executors.base import (
     CHART_TYPES_WITHOUT_AXIS,
     ChartInsight,
 )
+
+
+def _json_safe(value):
+    """Recursively replace NaN/Inf floats with None.
+
+    `chart_data` rows come from `pandas.DataFrame.to_dict()`, which emits
+    `float('nan')` for missing cells. `NaN`/`Infinity` are not valid JSON tokens
+    under Postgres' strict `JSONB` parser, so they must be scrubbed before the
+    row reaches `to_orm_kwargs()` (DB) or `to_frontend_dict()` (frontend).
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
 
 
 class InsightChart(BaseModel):
@@ -40,6 +58,12 @@ class InsightChart(BaseModel):
     series_fields: List[str] = Field(default_factory=list)
     chart_data: List[dict] = Field(default_factory=list)
     insight: str = ""
+
+    @field_validator("chart_data")
+    @classmethod
+    def sanitize_chart_data(cls, rows: List[dict]) -> List[dict]:
+        """Scrub non-finite floats (NaN/Inf) so rows are valid JSONB."""
+        return [_json_safe(row) for row in rows]
 
     @model_validator(mode="after")
     def validate_axis_config(self) -> "InsightChart":

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -1,0 +1,139 @@
+"""Canonical in-code chart model — the seam between the chart stage and the
+text stage of insight generation.
+
+`InsightChart` carries the chart spec *and* its row data. It is the single typed
+object passed between stages and into persistence, and it exposes adapters for
+the two wire shapes:
+
+- snake_case for the DB (`InsightChartOrm`) via `to_orm_kwargs()`
+- camelCase for the frontend `charts_data` via `to_frontend_dict()` /
+  `from_frontend_dict()`
+
+`InsightBundle` groups the resolved charts with the narrative produced by the
+text stage.
+"""
+
+from typing import List
+
+from pydantic import BaseModel, Field, model_validator
+
+from src.agent.subagents.analyst.code_executors.base import (
+    CHART_TYPES_WITHOUT_AXIS,
+    ChartInsight,
+)
+
+
+class InsightChart(BaseModel):
+    """A single chart: spec + the rows it renders.
+
+    Mirrors `InsightChartOrm` (snake_case) plus the embedded `chart_data`. The
+    optional `insight` field holds the per-chart narrative from the text stage.
+    """
+
+    position: int = 0
+    title: str
+    chart_type: str
+    x_axis: str = ""
+    y_axis: str = ""
+    color_field: str = ""
+    stack_field: str = ""
+    group_field: str = ""
+    series_fields: List[str] = Field(default_factory=list)
+    chart_data: List[dict] = Field(default_factory=list)
+    insight: str = ""
+
+    @model_validator(mode="after")
+    def validate_axis_config(self) -> "InsightChart":
+        if self.chart_type not in CHART_TYPES_WITHOUT_AXIS:
+            if not self.y_axis and not self.series_fields:
+                raise ValueError(
+                    f"Chart '{self.title}' (type '{self.chart_type}') is missing axis "
+                    "configuration: set 'y_axis' for single-series charts or "
+                    "'series_fields' for multi-series charts"
+                )
+        return self
+
+    # --- adapters -----------------------------------------------------------
+
+    def to_orm_kwargs(self) -> dict:
+        """Kwargs for `InsightChartOrm(**...)` (snake_case).
+
+        `insight` is excluded: per-chart narrative is not a chart-row column; it
+        lives on the parent `InsightOrm.insight_text`.
+        """
+        return self.model_dump(exclude={"insight"})
+
+    def to_frontend_dict(self) -> dict:
+        """The camelCase shape consumed by the frontend `charts_data`."""
+        return {
+            "id": f"chart_{self.position}",
+            "title": self.title,
+            "type": self.chart_type,
+            "insight": self.insight,
+            "data": self.chart_data,
+            "xAxis": self.x_axis,
+            "yAxis": self.y_axis,
+            "colorField": self.color_field,
+            "stackField": self.stack_field,
+            "groupField": self.group_field,
+            "seriesFields": self.series_fields,
+        }
+
+    @classmethod
+    def from_frontend_dict(
+        cls, data: dict, position: int = 0
+    ) -> "InsightChart":
+        """Inverse of `to_frontend_dict()` — rehydrate a chart already in state.
+
+        `id` is derived from `position` on the way out, so it is not read back
+        here; the caller supplies `position` (defaulting to the list index).
+        """
+        return cls(
+            position=position,
+            title=data.get("title", ""),
+            chart_type=data.get("type", "bar"),
+            x_axis=data.get("xAxis", ""),
+            y_axis=data.get("yAxis", ""),
+            color_field=data.get("colorField", ""),
+            stack_field=data.get("stackField", ""),
+            group_field=data.get("groupField", ""),
+            series_fields=data.get("seriesFields", []),
+            chart_data=data.get("data", []),
+            insight=data.get("insight", ""),
+        )
+
+    @classmethod
+    def from_chart_insight(
+        cls,
+        chart: ChartInsight,
+        chart_data: List[dict],
+        position: int = 0,
+    ) -> "InsightChart":
+        """Adapt an LLM-produced `ChartInsight` + its rows into the seam model."""
+        return cls(
+            position=position,
+            title=chart.title,
+            chart_type=chart.chart_type,
+            x_axis=chart.x_axis,
+            y_axis=chart.y_axis,
+            color_field=chart.color_field,
+            stack_field=chart.stack_field,
+            group_field=chart.group_field,
+            series_fields=chart.series_fields,
+            chart_data=chart_data,
+        )
+
+
+class InsightBundle(BaseModel):
+    """Resolved charts plus the narrative from the text stage."""
+
+    charts: List[InsightChart]
+    primary_insight: str = ""
+    follow_up_suggestions: List[str] = Field(default_factory=list)
+
+    def stamp_insight(self) -> "InsightBundle":
+        """Copy `primary_insight` onto each chart's `insight` field, so the
+        frontend `charts_data` carries the narrative per chart."""
+        for chart in self.charts:
+            chart.insight = self.primary_insight
+        return self

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -8,7 +8,7 @@ the two wire shapes:
 - snake_case for the DB (`InsightChartOrm`) via `to_orm_kwargs()`
 - camelCase for the frontend `charts_data` via `to_frontend_dict()`
 
-`InsightBundle` groups the resolved charts with the narrative produced by the
+`Insight` groups the resolved charts with the narrative produced by the
 text stage.
 """
 
@@ -100,14 +100,14 @@ class InsightChart(BaseModel):
         )
 
 
-class InsightBundle(BaseModel):
+class Insight(BaseModel):
     """Resolved charts plus the narrative from the text stage."""
 
     charts: List[InsightChart]
     primary_insight: str = ""
     follow_up_suggestions: List[str] = Field(default_factory=list)
 
-    def stamp_insight(self) -> "InsightBundle":
+    def stamp_insight(self) -> "Insight":
         """Copy `primary_insight` onto each chart's `insight` field, so the
         frontend `charts_data` carries the narrative per chart."""
         for chart in self.charts:

--- a/src/agent/subagents/analyst/code_executors/base.py
+++ b/src/agent/subagents/analyst/code_executors/base.py
@@ -57,20 +57,18 @@ class ChartInsight(BaseModel):
 
 class MultiChartInsight(BaseModel):
     """
-    Represents multiple chart-based insights from a single analysis.
-    Used when the data supports multiple visualizations (e.g., tree cover loss AND emissions).
+    The chart spec(s) the code executor produces from a single analysis. Used
+    when the data supports multiple visualizations (e.g., tree cover loss AND
+    emissions).
+
+    Charts only — the narrative (insight text + follow-ups) is produced by a
+    separate text stage (`InsightTextGenerator`), not the executor.
     """
 
     charts: List[ChartInsight] = Field(
         min_length=1,
         max_length=2,
         description="List of 1-2 charts to display, each with title, type, and field mappings",
-    )
-    primary_insight: str = Field(
-        description="Overall insight that ties all charts together (2-3 sentences)"
-    )
-    follow_up_suggestions: List[str] = Field(
-        description="List of 1-2 follow-up suggestions based on available data and capability"
     )
 
 

--- a/src/agent/subagents/analyst/prompts.py
+++ b/src/agent/subagents/analyst/prompts.py
@@ -1,9 +1,9 @@
 """Prompts for the analyst subagent behind `generate_insights`.
 
 EXECUTOR_WORKFLOW is the step-by-step workflow the code executor follows to
-turn pulled data into chart + insight JSON. WORDING_GUIDE is the neutral,
-measurement-first language guide for user-facing text. Both are assembled
-into the executor prompt by `build_analysis_prompt`.
+turn pulled data into chart JSON. WORDING_GUIDE is the neutral,
+measurement-first language guide for user-facing text, used by the separate
+text stage (`InsightTextGenerator`).
 """
 
 EXECUTOR_WORKFLOW = """### STEP-BY-STEP WORKFLOW (follow in order)
@@ -20,11 +20,12 @@ IMPORTANT: Write one code block for each step, so that you can use the actual da
 - Print your key findings clearly
 - Do **NOT** create any plots or charts yet
 
-**STEP 2: SUMMARIZE INSIGHTS**
-- Summarize the data relevant to the user query
-- Identify the most important patterns, trends, or comparisons
-- Print a clear summary of what the data shows
-- Include contextual layers or parameters used for analysis on the datasets
+**STEP 2: IDENTIFY WHAT TO CHART**
+- Identify the patterns, trends, or comparisons in the data worth visualizing
+  for the user query, and which fields and contextual layers/parameters the
+  chart(s) should use.
+- Do NOT write a narrative summary of the findings — a separate stage produces
+  the insight text. Your job is to select and shape the chart(s).
 
 **STEP 3: GENERATE CHART DATA**
 Now prepare the data for visualization in Recharts.js:
@@ -59,12 +60,11 @@ Now prepare the data for visualization in Recharts.js:
 
    c) **SAVE THE DATA**: Save as `chart_data.csv` — pipeline only reads this file. Final step must call `to_csv('chart_data.csv', index=False)`.
 
-   d) **SAVE THE INSIGHT**: Save as `insight.json` — pipeline only reads this file.
+   d) **SAVE THE CHART SPEC**: Save the chart spec(s) as `insight.json` — the
+      pipeline only reads this file. A separate stage generates the narrative,
+      so do not write any insight text here.
 
    e) **PRINT CHART TYPE**: State the recommended chart type in the output
-
-**STEP 4: FINAL DATA-DRIVEN INSIGHT**
-- Concise 2–3 sentence insight grounded in the numbers found
 """
 
 WORDING_GUIDE = """# Wording

--- a/src/agent/subagents/analyst/prompts.py
+++ b/src/agent/subagents/analyst/prompts.py
@@ -20,12 +20,11 @@ IMPORTANT: Write one code block for each step, so that you can use the actual da
 - Print your key findings clearly
 - Do **NOT** create any plots or charts yet
 
-**STEP 2: IDENTIFY WHAT TO CHART**
-- Identify the patterns, trends, or comparisons in the data worth visualizing
-  for the user query, and which fields and contextual layers/parameters the
-  chart(s) should use.
-- Do NOT write a narrative summary of the findings — a separate stage produces
-  the insight text. Your job is to select and shape the chart(s).
+**STEP 2: SUMMARIZE INSIGHTS**
+- Summarize the data relevant to the user query
+- Identify the most important patterns, trends, or comparisons
+- Include contextual layers or parameters used for analysis on the datasets
+- Use this summary to ground the chart(s) you generate in the next step
 
 **STEP 3: GENERATE CHART DATA**
 Now prepare the data for visualization in Recharts.js:

--- a/src/agent/subagents/analyst/text_generator.py
+++ b/src/agent/subagents/analyst/text_generator.py
@@ -1,0 +1,98 @@
+"""Independent insight-text generator.
+
+Takes resolved charts (spec + data) and produces the narrative
+(`primary_insight`) plus follow-up suggestions, decoupled from how the charts
+were built. Grounding is chart data + dataset cautions/presentation only —
+never conversation state.
+
+It is a LangChain runnable, so when invoked inside the `generate_insights` tool
+it nests as a span in the active Langfuse trace via the ambient
+`RunnableConfig`. Callers outside a traced context may pass an explicit `config`.
+"""
+
+from typing import List, Optional
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, Field
+
+from src.agent.llms import GEMINI_FLASH
+from src.agent.subagents.analyst.charts.model import InsightChart
+from src.agent.subagents.analyst.prompts import WORDING_GUIDE
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class InsightText(BaseModel):
+    """Structured output of the text stage."""
+
+    primary_insight: str = Field(
+        description="Overall insight that ties the chart(s) together (2-3 sentences)"
+    )
+    follow_up_suggestions: List[str] = Field(
+        description="1-2 follow-up suggestions based on the available data"
+    )
+
+
+_SYSTEM = """You write the narrative insight for one or two charts that have \
+already been produced from geospatial data. Describe what the data shows — do \
+not invent numbers, and do not redescribe the chart mechanics.
+
+Write a 2-3 sentence `primary_insight` grounded in the numbers, and 1-2 \
+`follow_up_suggestions`.
+
+{wording_guide}"""
+
+_USER = """## User query
+{query}
+
+## Dataset cautions
+{cautions}
+
+## How to describe this dataset
+{presentation_instructions}
+
+## Charts (spec + data)
+{charts}"""
+
+_PROMPT = ChatPromptTemplate.from_messages(
+    [("system", _SYSTEM), ("user", _USER)]
+)
+
+
+class InsightTextGenerator:
+    """Generates insight text from resolved charts."""
+
+    def __init__(self, model=GEMINI_FLASH):
+        self._chain = (
+            _PROMPT | model.with_structured_output(InsightText)
+        ).with_config(run_name="generate_insight_text")
+
+    async def generate(
+        self,
+        charts: List[InsightChart],
+        dataset: dict,
+        query: str = "",
+        config: Optional[RunnableConfig] = None,
+    ) -> InsightText:
+        charts_block = "\n".join(
+            c.model_dump_json(exclude={"insight"}) for c in charts
+        )
+        inputs = {
+            "wording_guide": WORDING_GUIDE,
+            "query": query or "(none provided)",
+            "cautions": dataset.get(
+                "cautions", "No specific dataset cautions provided."
+            ),
+            "presentation_instructions": dataset.get(
+                "presentation_instructions", "(none)"
+            ),
+            "charts": charts_block,
+        }
+        result: InsightText = await self._chain.ainvoke(inputs, config=config)
+        logger.info(
+            f"Generated insight text ({len(result.primary_insight)} chars, "
+            f"{len(result.follow_up_suggestions)} follow-ups)"
+        )
+        return result

--- a/src/agent/subagents/analyst/text_generator.py
+++ b/src/agent/subagents/analyst/text_generator.py
@@ -16,7 +16,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
-from src.agent.llms import GEMINI_FLASH
+from src.agent.llms import SMALL_MODEL
 from src.agent.subagents.analyst.charts.model import InsightChart
 from src.agent.subagents.analyst.prompts import WORDING_GUIDE
 from src.shared.logging_config import get_logger
@@ -64,7 +64,7 @@ _PROMPT = ChatPromptTemplate.from_messages(
 class InsightTextGenerator:
     """Generates insight text from resolved charts."""
 
-    def __init__(self, model=GEMINI_FLASH):
+    def __init__(self, model=SMALL_MODEL):
         self._chain = (
             _PROMPT | model.with_structured_output(InsightText)
         ).with_config(run_name="generate_insight_text")

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+from base64 import b64encode
 from typing import Annotated, Dict, List, Optional
 
 import pandas as pd
@@ -10,20 +11,21 @@ from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
+from src.agent.subagents.analyst.charts import (
+    InsightBundle,
+    InsightChart,
+)
 from src.agent.subagents.analyst.code_executors import GeminiCodeExecutor
 from src.agent.subagents.analyst.code_executors.base import (
     ChartInsight,
     MultiChartInsight,
     PartType,
 )
-from src.agent.subagents.analyst.prompts import (
-    EXECUTOR_WORKFLOW,
-    WORDING_GUIDE,
-)
+from src.agent.subagents.analyst.prompts import EXECUTOR_WORKFLOW
+from src.agent.subagents.analyst.text_generator import InsightTextGenerator
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.agent.tools.pull_data import fetch_statistics_from_url
-from src.api.data_models import InsightChartOrm, InsightOrm
-from src.shared.database import get_session_from_pool
+from src.api.repositories.insight_writer import persist_insight
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -173,8 +175,8 @@ def build_analysis_prompt(
     file_references: str,
     dataset_guidelines: str = "",
     dataset_cautions: str = "",
-    code_instructions: str | None = None,
-    context_layer: str | None = None,
+    code_instructions: Optional[str] = None,
+    context_layer: Optional[str] = None,
 ) -> str:
     """
     Build the analysis prompt for the code executor.
@@ -206,7 +208,6 @@ def build_analysis_prompt(
 ---
 """
 
-    # Build dataset-specific rules section when tiered code_instructions are available
     dataset_rules_section = ""
     if code_instructions:
         header = "### DATASET-SPECIFIC RULES (follow these strictly):\n"
@@ -219,10 +220,7 @@ def build_analysis_prompt(
 ---
 """
 
-    executor_workflow = EXECUTOR_WORKFLOW
-    wording = WORDING_GUIDE
-
-    prompt = f"""### User Query:
+    return f"""### User Query:
 {query}
 
 
@@ -237,28 +235,152 @@ For example: "I will begin by loading and examining" -> "Load and examine"
 {dataset_rules_section}
 {cautions_section}
 
-{executor_workflow}
+{EXECUTOR_WORKFLOW}
 
    Here is the JSON schema for the insight:
    {MultiChartInsight.model_json_schema()}
 
    Here is the JSON schema for the chart data:
    {ChartInsight.model_json_schema()}
-
-{wording}
 """
 
-    return prompt
+
+def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=message,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+            ]
+        }
+    )
+
+
+def _encode_parts(parts: list) -> list[dict]:
+    return [
+        {
+            "type": part.type.value,
+            "content": b64encode(part.content.encode("utf-8")).decode("utf-8"),
+        }
+        for part in parts
+    ]
+
+
+def _build_tool_message(bundle: InsightBundle, dataset_cautions: str) -> str:
+    """Human-feedback message summarizing the generated charts + insight."""
+    tool_message = f"Generated {len(bundle.charts)} chart(s)\n"
+    tool_message += f"Key Finding: {bundle.primary_insight}\n\n"
+    for idx, chart in enumerate(bundle.charts, 1):
+        tool_message += f"Chart {idx}: {chart.title}\n"
+
+    if bundle.charts:
+        chart_data_df = pd.DataFrame(bundle.charts[0].chart_data)
+        formatted_df = chart_data_df.apply(
+            lambda col: (
+                col.map(lambda x: f"{x:.4f}".rstrip("0").rstrip("."))
+                if pd.api.types.is_float_dtype(col)
+                else col
+            )
+        )
+        csv_str = formatted_df.to_csv(index=False)
+        if len(csv_str) < 4000:
+            tool_message += f"\nChart data CSV:\n{csv_str}"
+
+    if dataset_cautions:
+        tool_message += f"\n\nDataset cautions:\n{dataset_cautions}"
+
+    tool_message += "\n\nFollow-up suggestions:"
+    for i, suggestion in enumerate(bundle.follow_up_suggestions, 1):
+        tool_message += f"\n{i}. {suggestion}"
+    return tool_message
 
 
 class Analyst:
     """Insight subagent: turns pulled data into a chart artifact.
 
-    Used as a tool by the orchestrator via `generate_insights`. Given the
-    pulled `statistics` and the active `dataset`, it builds dataframes, runs
-    the code executor (driven by EXECUTOR_WORKFLOW + WORDING_GUIDE), persists
-    the resulting insight and charts, and updates state.
+    Used as a tool by the orchestrator via `generate_insights`. The pipeline has
+    two independent stages: (1) build charts from the pulled data via the LLM
+    code executor, and (2) generate the narrative insight text from those
+    charts. It then persists the insight + charts and updates state.
     """
+
+    async def _resolve_charts(
+        self,
+        query: str,
+        statistics: list[dict],
+        dataset: dict,
+    ) -> tuple[Optional[list[InsightChart]], list[dict], Optional[str]]:
+        """Build charts via the LLM code executor.
+
+        Returns (charts, encoded_codeact_parts, error_message). On success
+        `charts` is non-empty and error is None. On failure `charts` is None and
+        a user-facing error message is returned.
+        """
+        dataframes, source_urls = await prepare_dataframes(statistics)
+        logger.info(f"Prepared {len(dataframes)} dataframes for analysis")
+
+        # When a dataset provides code_instructions, use those and drop
+        # prompt_instructions to avoid sending overlapping guidance.
+        code_instructions = dataset.get("code_instructions")
+        dataset_guidelines = (
+            "" if code_instructions else dataset.get("prompt_instructions", "")
+        )
+        dataset_cautions = dataset.get(
+            "cautions", "No specific dataset cautions provided."
+        )
+
+        executor = GeminiCodeExecutor()
+        analysis_prompt = build_analysis_prompt(
+            query,
+            executor.build_file_references(dataframes),
+            dataset_guidelines=dataset_guidelines,
+            dataset_cautions=dataset_cautions,
+            code_instructions=code_instructions,
+            context_layer=dataset.get("context_layer"),
+        )
+        logger.debug(f"Analysis prompt:\n{analysis_prompt}")
+
+        file_refs = await executor.prepare_dataframes(dataframes)
+        result = await executor.execute(analysis_prompt, file_refs)
+
+        text_output = " ".join(
+            part.content
+            for part in result.parts
+            if part.type == PartType.TEXT_OUTPUT
+        )
+        if result.error:
+            logger.error(f"Code execution error: {result.error}")
+            return None, [], f"Analysis failed: {result.error}"
+        if not result.chart_data:
+            logger.error("No chart data generated")
+            return (
+                None,
+                [],
+                f"Failed to generate chart data. Feedback:{text_output}",
+            )
+        if result.insight is None or not result.insight.charts:
+            logger.error("No chart insight generated")
+            return (
+                None,
+                [],
+                f"Failed to generate chart insight. Feedback:{text_output}",
+            )
+
+        # Make code blocks runnable anywhere by swapping CSV paths for URLs.
+        for part in result.parts:
+            if part.type == PartType.CODE_BLOCK:
+                part.content = replace_csv_paths_with_urls(
+                    part.content, source_urls
+                )
+
+        charts = [
+            InsightChart.from_chart_insight(chart, result.chart_data, idx)
+            for idx, chart in enumerate(result.insight.charts)
+        ]
+        return charts, _encode_parts(result.parts), None
 
     async def analyze(
         self,
@@ -271,212 +393,55 @@ class Analyst:
         logger.info("ANALYST: generating insight")
         logger.debug(f"Generating insights for query: {query}")
         dataset = dataset or {}
-
-        # 1. PREPARE DATAFRAMES: Fetch data from source URLs and build DataFrames
-        dataframes, source_urls = await prepare_dataframes(statistics)
-        logger.info(f"Prepared {len(dataframes)} dataframes for analysis")
-
-        # 2. EXTRACT DATASET GUIDELINES: Get dataset-specific instructions early
-        # For tiered datasets, code_instructions replaces the code-relevant parts of
-        # prompt_instructions — skip the legacy blob to avoid redundancy.
-        code_instructions = dataset.get("code_instructions")
-        dataset_guidelines = (
-            "" if code_instructions else dataset.get("prompt_instructions", "")
-        )
         dataset_cautions = dataset.get(
             "cautions", "No specific dataset cautions provided."
         )
-        # 3. INITIALIZE EXECUTOR: Create Gemini code executor
-        executor = GeminiCodeExecutor()
 
-        # 4. BUILD PROMPT: Create analysis prompt with executor-specific file references
-        file_references = executor.build_file_references(dataframes)
-        analysis_prompt = build_analysis_prompt(
+        # STAGE 1: build charts from the pulled data.
+        charts, codeact_parts, error = await self._resolve_charts(
             query,
-            file_references,
-            dataset_guidelines=dataset_guidelines,
-            dataset_cautions=dataset_cautions,
-            code_instructions=code_instructions,
-            context_layer=dataset.get("context_layer"),
+            statistics,
+            dataset,
         )
-        logger.debug(f"Analysis prompt:\n{analysis_prompt}")
-
-        # 4. PREPARE DATA: Convert DataFrames to inline data format
-        file_refs = await executor.prepare_dataframes(dataframes)
-        logger.info(f"Prepared {len(file_refs)} inline data parts for Gemini")
-
-        # 5. EXECUTE CODE: Run analysis with Gemini
-        result = await executor.execute(analysis_prompt, file_refs)
-
-        # Check for errors
-        if result.error:
-            logger.error(f"Code execution error: {result.error}")
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Analysis failed: {result.error}",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ]
-                }
+        if error or not charts:
+            return _error_command(
+                error or "Failed to generate charts.", tool_call_id
             )
 
-        text_output = " ".join(
-            [
-                part.content
-                for part in result.parts
-                if part.type == PartType.TEXT_OUTPUT
-            ]
-        )
+        # STAGE 2: generate insight text from the resolved charts.
+        text = await InsightTextGenerator().generate(charts, dataset, query)
+        bundle = InsightBundle(
+            charts=charts,
+            primary_insight=text.primary_insight,
+            follow_up_suggestions=text.follow_up_suggestions,
+        ).stamp_insight()
 
-        # Check for chart data
-        if not result.chart_data:
-            logger.error("No chart data generated")
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Failed to generate chart data. Feedback:{text_output}",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ]
-                }
-            )
-
-        if result.insight is None:
-            logger.error("No chart insight generated")
-            return Command(
-                update={
-                    "messages": [
-                        ToolMessage(
-                            content=f"Failed to generate chart insight. Feedback:{text_output}",
-                            tool_call_id=tool_call_id,
-                            status="error",
-                        )
-                    ]
-                }
-            )
-
-        logger.info(f"Generated chart data with {len(result.chart_data)} rows")
-
-        # 5.5. REPLACE CSV PATHS: Replace CSV file paths with URL-based loading
-        # This makes the code blocks runnable in any environment.
-        for part in result.parts:
-            if part.type == PartType.CODE_BLOCK:
-                part.content = replace_csv_paths_with_urls(
-                    part.content, source_urls
-                )
-
-        # 6. GENERATE CHART SCHEMA: Use LLM to create structured chart metadata
-        chart_data_df = pd.DataFrame(result.chart_data)
-
-        # 7. BUILD RESPONSE - Support multiple charts
-        tool_message = f"Generated {len(result.insight.charts)} chart(s)\n"
-        tool_message += f"Key Finding: {result.insight.primary_insight}\n\n"
-
-        for idx, chart in enumerate(result.insight.charts, 1):
-            tool_message += f"Chart {idx}: {chart.title}\n"
-
-        MAX_CHART_DATA_CHARS_FOR_TOOL_MESSAGE = 4000
-        formatted_df = chart_data_df.apply(
-            lambda col: col.map(lambda x: f"{x:.4f}".rstrip("0").rstrip("."))
-            if pd.api.types.is_float_dtype(col)
-            else col
-        )
-        csv_str = formatted_df.to_csv(index=False)
-        if len(csv_str) < MAX_CHART_DATA_CHARS_FOR_TOOL_MESSAGE:
-            tool_message += f"\nChart data CSV:\n{csv_str}"
-
-        tool_message += "\n\nFollow-up suggestions:"
-
-        if dataset_cautions:
-            tool_message += f"\n\nDataset cautions:\n{dataset_cautions}"
-
-        for i, suggestion in enumerate(
-            result.insight.follow_up_suggestions, 1
-        ):
-            tool_message += f"\n{i}. {suggestion}"
-
-        # 8. BUILD INLINE STATE (kept for backwards compatibility during migration)
-        encoded_parts = result.get_encoded_parts()
-        charts_data = []
-        for idx, chart in enumerate(result.insight.charts):
-            charts_data.append(
-                {
-                    "id": f"chart_{idx}",
-                    "title": chart.title,
-                    "type": chart.chart_type,
-                    "insight": result.insight.primary_insight,
-                    "data": result.chart_data,
-                    "xAxis": chart.x_axis,
-                    "yAxis": chart.y_axis,
-                    "colorField": chart.color_field,
-                    "stackField": chart.stack_field,
-                    "groupField": chart.group_field,
-                    "seriesFields": chart.series_fields,
-                }
-            )
-
-        # 9. PERSIST INSIGHT(S) TO DB
+        # PERSIST + STATE.
         ctx = structlog.contextvars.get_contextvars()
-        statistics_ids = _extract_statistics_ids(statistics)
-        insight_ids: list[str] = []
-        async with get_session_from_pool() as session:
-            insight_row = InsightOrm(
-                user_id=ctx.get("user_id"),
-                thread_id=ctx.get("thread_id", ""),
-                insight_text=result.insight.primary_insight,
-                follow_up_suggestions=result.insight.follow_up_suggestions,
-                statistics_ids=statistics_ids,
-                codeact_types=[p["type"] for p in encoded_parts],
-                codeact_contents=[p["content"] for p in encoded_parts],
-            )
-            session.add(insight_row)
-            await session.flush()
-
-            for idx, chart in enumerate(result.insight.charts):
-                session.add(
-                    InsightChartOrm(
-                        insight_id=insight_row.id,
-                        position=idx,
-                        title=chart.title,
-                        chart_type=chart.chart_type,
-                        x_axis=chart.x_axis,
-                        y_axis=chart.y_axis,
-                        color_field=chart.color_field,
-                        stack_field=chart.stack_field,
-                        group_field=chart.group_field,
-                        series_fields=chart.series_fields,
-                        chart_data=result.chart_data,
-                    )
-                )
-
-            await session.commit()
-            await session.refresh(insight_row)
-            insight_ids.append(str(insight_row.id))
-
-        insight_id = insight_ids[0] if insight_ids else ""
+        insight_id = await persist_insight(
+            bundle,
+            user_id=ctx.get("user_id"),
+            thread_id=ctx.get("thread_id", ""),
+            statistics_ids=_extract_statistics_ids(statistics),
+            codeact_parts=codeact_parts,
+        )
         logger.info(f"Persisted insight to DB: {insight_id}")
 
         updated_state = {
             "insight_id": insight_id,
-            "insight": result.insight.primary_insight,
-            "follow_up_suggestions": result.insight.follow_up_suggestions,
-            "codeact_parts": encoded_parts,
-            "charts_data": charts_data,
+            "insight": bundle.primary_insight,
+            "follow_up_suggestions": bundle.follow_up_suggestions,
+            "codeact_parts": codeact_parts,
+            "charts_data": [c.to_frontend_dict() for c in bundle.charts],
             "messages": [
                 ToolMessage(
-                    content=tool_message,
+                    content=_build_tool_message(bundle, dataset_cautions),
                     tool_call_id=tool_call_id,
                     status="success",
                     response_metadata={"msg_type": "human_feedback"},
                 )
             ],
         }
-
         return Command(update=updated_state)
 
 
@@ -490,17 +455,7 @@ async def generate_insights(
     if not state or "statistics" not in state:
         error_msg = "No statistics available yet. Please pull data first."
         logger.error(error_msg)
-        return Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content=error_msg,
-                        tool_call_id=tool_call_id,
-                        status="error",
-                    )
-                ]
-            }
-        )
+        return _error_command(error_msg, tool_call_id)
     return await Analyst().analyze(
         query,
         statistics=state["statistics"],

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -12,7 +12,7 @@ from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
 from src.agent.subagents.analyst.charts import (
-    InsightBundle,
+    Insight,
     InsightChart,
 )
 from src.agent.subagents.analyst.code_executors import GeminiCodeExecutor
@@ -269,15 +269,15 @@ def _encode_parts(parts: list) -> list[dict]:
     ]
 
 
-def _build_tool_message(bundle: InsightBundle, dataset_cautions: str) -> str:
+def _build_tool_message(insight: Insight, dataset_cautions: str) -> str:
     """Human-feedback message summarizing the generated charts + insight."""
-    tool_message = f"Generated {len(bundle.charts)} chart(s)\n"
-    tool_message += f"Key Finding: {bundle.primary_insight}\n\n"
-    for idx, chart in enumerate(bundle.charts, 1):
+    tool_message = f"Generated {len(insight.charts)} chart(s)\n"
+    tool_message += f"Key Finding: {insight.primary_insight}\n\n"
+    for idx, chart in enumerate(insight.charts, 1):
         tool_message += f"Chart {idx}: {chart.title}\n"
 
-    if bundle.charts:
-        chart_data_df = pd.DataFrame(bundle.charts[0].chart_data)
+    if insight.charts:
+        chart_data_df = pd.DataFrame(insight.charts[0].chart_data)
         formatted_df = chart_data_df.apply(
             lambda col: (
                 col.map(lambda x: f"{x:.4f}".rstrip("0").rstrip("."))
@@ -293,7 +293,7 @@ def _build_tool_message(bundle: InsightBundle, dataset_cautions: str) -> str:
         tool_message += f"\n\nDataset cautions:\n{dataset_cautions}"
 
     tool_message += "\n\nFollow-up suggestions:"
-    for i, suggestion in enumerate(bundle.follow_up_suggestions, 1):
+    for i, suggestion in enumerate(insight.follow_up_suggestions, 1):
         tool_message += f"\n{i}. {suggestion}"
     return tool_message
 
@@ -410,7 +410,7 @@ class Analyst:
 
         # STAGE 2: generate insight text from the resolved charts.
         text = await InsightTextGenerator().generate(charts, dataset, query)
-        bundle = InsightBundle(
+        insight = Insight(
             charts=charts,
             primary_insight=text.primary_insight,
             follow_up_suggestions=text.follow_up_suggestions,
@@ -419,7 +419,7 @@ class Analyst:
         # PERSIST + STATE.
         ctx = structlog.contextvars.get_contextvars()
         insight_id = await persist_insight(
-            bundle,
+            insight,
             user_id=ctx.get("user_id"),
             thread_id=ctx.get("thread_id", ""),
             statistics_ids=_extract_statistics_ids(statistics),
@@ -429,13 +429,13 @@ class Analyst:
 
         updated_state = {
             "insight_id": insight_id,
-            "insight": bundle.primary_insight,
-            "follow_up_suggestions": bundle.follow_up_suggestions,
+            "insight": insight.primary_insight,
+            "follow_up_suggestions": insight.follow_up_suggestions,
             "codeact_parts": codeact_parts,
-            "charts_data": [c.to_frontend_dict() for c in bundle.charts],
+            "charts_data": [c.to_frontend_dict() for c in insight.charts],
             "messages": [
                 ToolMessage(
-                    content=_build_tool_message(bundle, dataset_cautions),
+                    content=_build_tool_message(insight, dataset_cautions),
                     tool_call_id=tool_call_id,
                     status="success",
                     response_metadata={"msg_type": "human_feedback"},

--- a/src/api/repositories/insight_writer.py
+++ b/src/api/repositories/insight_writer.py
@@ -2,12 +2,12 @@
 
 Both the agent/chat path (`Analyst.analyze`) and the deterministic
 `/api/analyze` job write the same `InsightOrm` + `InsightChartOrm` rows. This is
-the single place that mapping lives, driven by the canonical `InsightBundle`.
+the single place that mapping lives, driven by the canonical `Insight`.
 """
 
 from typing import Optional
 
-from src.agent.subagents.analyst.charts.model import InsightBundle
+from src.agent.subagents.analyst.charts.model import Insight
 from src.api.data_models import InsightChartOrm, InsightOrm
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 
 
 async def persist_insight(
-    bundle: InsightBundle,
+    insight: Insight,
     *,
     user_id: Optional[str],
     thread_id: str,
@@ -35,8 +35,8 @@ async def persist_insight(
         insight = InsightOrm(
             user_id=user_id,
             thread_id=thread_id,
-            insight_text=bundle.primary_insight,
-            follow_up_suggestions=bundle.follow_up_suggestions,
+            insight_text=insight.primary_insight,
+            follow_up_suggestions=insight.follow_up_suggestions,
             statistics_ids=statistics_ids,
             codeact_types=[p["type"] for p in codeact_parts],
             codeact_contents=[p["content"] for p in codeact_parts],
@@ -46,7 +46,7 @@ async def persist_insight(
 
         session.add_all(
             InsightChartOrm(insight_id=insight.id, **chart.to_orm_kwargs())
-            for chart in bundle.charts
+            for chart in insight.charts
         )
 
         await session.commit()
@@ -57,6 +57,6 @@ async def persist_insight(
         "insight_persisted",
         insight_id=insight_id,
         thread_id=thread_id,
-        charts_count=len(bundle.charts),
+        charts_count=len(insight.charts),
     )
     return insight_id

--- a/src/api/repositories/insight_writer.py
+++ b/src/api/repositories/insight_writer.py
@@ -32,7 +32,7 @@ async def persist_insight(
     codeact_parts = codeact_parts or []
 
     async with get_session_from_pool() as session:
-        insight = InsightOrm(
+        insight_orm = InsightOrm(
             user_id=user_id,
             thread_id=thread_id,
             insight_text=insight.primary_insight,
@@ -41,17 +41,17 @@ async def persist_insight(
             codeact_types=[p["type"] for p in codeact_parts],
             codeact_contents=[p["content"] for p in codeact_parts],
         )
-        session.add(insight)
+        session.add(insight_orm)
         await session.flush()
 
         session.add_all(
-            InsightChartOrm(insight_id=insight.id, **chart.to_orm_kwargs())
+            InsightChartOrm(insight_id=insight_orm.id, **chart.to_orm_kwargs())
             for chart in insight.charts
         )
 
         await session.commit()
-        await session.refresh(insight)
-        insight_id = str(insight.id)
+        await session.refresh(insight_orm)
+        insight_id = str(insight_orm.id)
 
     logger.info(
         "insight_persisted",

--- a/src/api/repositories/insight_writer.py
+++ b/src/api/repositories/insight_writer.py
@@ -1,0 +1,62 @@
+"""Centralized insight persistence shared by both insight paths.
+
+Both the agent/chat path (`Analyst.analyze`) and the deterministic
+`/api/analyze` job write the same `InsightOrm` + `InsightChartOrm` rows. This is
+the single place that mapping lives, driven by the canonical `InsightBundle`.
+"""
+
+from typing import Optional
+
+from src.agent.subagents.analyst.charts.model import InsightBundle
+from src.api.data_models import InsightChartOrm, InsightOrm
+from src.shared.database import get_session_from_pool
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+async def persist_insight(
+    bundle: InsightBundle,
+    *,
+    user_id: Optional[str],
+    thread_id: str,
+    statistics_ids: Optional[list[str]] = None,
+    codeact_parts: Optional[list[dict]] = None,
+) -> str:
+    """Persist an insight and its charts; return the new insight id (str).
+
+    `codeact_parts` are the base64-encoded code/output blocks (as produced by
+    `ExecutionResult.get_encoded_parts`); empty for deterministic charts.
+    """
+    statistics_ids = statistics_ids or []
+    codeact_parts = codeact_parts or []
+
+    async with get_session_from_pool() as session:
+        insight = InsightOrm(
+            user_id=user_id,
+            thread_id=thread_id,
+            insight_text=bundle.primary_insight,
+            follow_up_suggestions=bundle.follow_up_suggestions,
+            statistics_ids=statistics_ids,
+            codeact_types=[p["type"] for p in codeact_parts],
+            codeact_contents=[p["content"] for p in codeact_parts],
+        )
+        session.add(insight)
+        await session.flush()
+
+        session.add_all(
+            InsightChartOrm(insight_id=insight.id, **chart.to_orm_kwargs())
+            for chart in bundle.charts
+        )
+
+        await session.commit()
+        await session.refresh(insight)
+        insight_id = str(insight.id)
+
+    logger.info(
+        "insight_persisted",
+        insight_id=insight_id,
+        thread_id=thread_id,
+        charts_count=len(bundle.charts),
+    )
+    return insight_id

--- a/src/api/repositories/job_repository.py
+++ b/src/api/repositories/job_repository.py
@@ -4,12 +4,12 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from src.agent.subagents.analyst.charts import InsightBundle
 from src.api.data_models import (
-    InsightChartOrm,
-    InsightOrm,
     JobOrm,
     JobResourceOrm,
 )
+from src.api.repositories.insight_writer import persist_insight
 from src.api.services.job import (
     JobData,
     JobRepository,
@@ -53,52 +53,29 @@ class DBJobRepository(JobRepository):
         job_id: UUID,
         user_id: str,
         thread_id: Optional[str],
-        charts: list[dict],
-    ) -> None:
+        bundle: InsightBundle,
+    ) -> str:
+        insight_id = await persist_insight(
+            bundle,
+            user_id=user_id,
+            thread_id=thread_id or "",
+        )
         async with get_session_from_pool() as session:
-            insight = InsightOrm(
-                user_id=user_id,
-                thread_id=thread_id,
-                insight_text="",
-                follow_up_suggestions=[],
-                statistics_ids=[],
-                codeact_types=[],
-                codeact_contents=[],
-            )
-            session.add(insight)
-            await session.flush()
-
-            session.add_all(
-                InsightChartOrm(
-                    insight_id=insight.id,
-                    position=idx,
-                    title=chart.get("title", ""),
-                    chart_type=chart.get("type", "bar"),
-                    x_axis=chart.get("xAxis", ""),
-                    y_axis=chart.get("yAxis", ""),
-                    color_field=chart.get("colorField", ""),
-                    stack_field=chart.get("stackField", ""),
-                    group_field=chart.get("groupField", ""),
-                    series_fields=chart.get("seriesFields", []),
-                    chart_data=chart.get("data", []),
-                )
-                for idx, chart in enumerate(charts)
-            )
-
             session.add(
                 JobResourceOrm(
                     job_id=job_id,
-                    resource_url=f"/api/insights/{insight.id}",
+                    resource_url=f"/api/insights/{insight_id}",
                     status=ResourceStatus.COMPLETED.value,
                 )
             )
             await session.commit()
-            logger.info(
-                "insight_resource_created",
-                job_id=str(job_id),
-                insight_id=str(insight.id),
-                charts_count=len(charts),
-            )
+        logger.info(
+            "insight_resource_created",
+            job_id=str(job_id),
+            insight_id=insight_id,
+            charts_count=len(bundle.charts),
+        )
+        return insight_id
 
     async def get_job(self, job_id: UUID) -> Optional[JobData]:
         async with get_session_from_pool() as session:

--- a/src/api/repositories/job_repository.py
+++ b/src/api/repositories/job_repository.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from src.agent.subagents.analyst.charts import InsightBundle
+from src.agent.subagents.analyst.charts import Insight
 from src.api.data_models import (
     JobOrm,
     JobResourceOrm,
@@ -53,10 +53,10 @@ class DBJobRepository(JobRepository):
         job_id: UUID,
         user_id: str,
         thread_id: Optional[str],
-        bundle: InsightBundle,
+        insight: Insight,
     ) -> str:
         insight_id = await persist_insight(
-            bundle,
+            insight,
             user_id=user_id,
             thread_id=thread_id or "",
         )
@@ -73,7 +73,7 @@ class DBJobRepository(JobRepository):
             "insight_resource_created",
             job_id=str(job_id),
             insight_id=insight_id,
-            charts_count=len(bundle.charts),
+            charts_count=len(insight.charts),
         )
         return insight_id
 

--- a/src/api/routers/analyze.py
+++ b/src/api/routers/analyze.py
@@ -5,29 +5,25 @@ from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends
 
-from src.agent.datasets.handlers.analytics_handler import (
-    TREE_COVER_LOSS_ID,
-    AnalyticsHandler,
-)
+from src.agent.datasets.handlers.analytics_handler import AnalyticsHandler
 from src.api.auth.dependencies import require_auth
 from src.api.repositories.job_repository import get_job_repository
 from src.api.schemas import AnalyzeRequest, JobResponse, UserModel
 from src.api.services.analysis_job import AnalysisJobRunner
 from src.api.services.analyze import AnalyzeService
-from src.api.services.charts import TCLChartGenerator
+from src.api.services.charts import DETERMINISTIC_GENERATORS
 from src.api.services.job import JobRepository, JobType
 
 router = APIRouter()
 
 handler = AnalyticsHandler()
-generators = [TCLChartGenerator(TREE_COVER_LOSS_ID)]
 
 
 def get_analysis_runner(
     repo: JobRepository = Depends(get_job_repository),
 ) -> AnalysisJobRunner:
     return AnalysisJobRunner(
-        service=AnalyzeService(handler, generators),
+        service=AnalyzeService(handler, DETERMINISTIC_GENERATORS),
         repo=repo,
     )
 

--- a/src/api/services/analysis_job.py
+++ b/src/api/services/analysis_job.py
@@ -2,7 +2,7 @@ import time
 from typing import Optional
 from uuid import UUID
 
-from src.agent.subagents.analyst.charts import InsightBundle
+from src.agent.subagents.analyst.charts import Insight
 from src.api.services.analyze import AnalyzeService
 from src.api.services.job import JobRepository, JobStatus
 from src.shared.logging_config import get_logger
@@ -59,13 +59,13 @@ class AnalysisJobRunner:
 
             # Charts only, no narrative: this job doesn't run the LLM text
             # generation step.
-            bundle = InsightBundle(charts=result.charts)
+            insight = Insight(charts=result.charts)
 
             await self._repo.create_insight_resource(
                 job_id=job_id,
                 user_id=user_id,
                 thread_id=thread_id,
-                bundle=bundle,
+                insight=insight,
             )
 
             await self._repo.update_job_status(job_id, JobStatus.COMPLETED)

--- a/src/api/services/analysis_job.py
+++ b/src/api/services/analysis_job.py
@@ -2,6 +2,7 @@ import time
 from typing import Optional
 from uuid import UUID
 
+from src.agent.subagents.analyst.charts import InsightBundle
 from src.api.services.analyze import AnalyzeService
 from src.api.services.job import JobRepository, JobStatus
 from src.shared.logging_config import get_logger
@@ -35,36 +36,57 @@ class AnalysisJobRunner:
         )
 
         started_at = time.perf_counter()
-        result = await self._service.analyze(
-            aois=aois,
-            dataset_id=dataset_id,
-            start_date=start_date,
-            end_date=end_date,
-        )
-        duration_ms = round((time.perf_counter() - started_at) * 1000)
+        try:
+            result = await self._service.analyze(
+                aois=aois,
+                dataset_id=dataset_id,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            duration_ms = round((time.perf_counter() - started_at) * 1000)
 
-        if not result.data.success:
-            await self._repo.update_job_status(job_id, JobStatus.FAILED)
-            logger.error(
-                "analysis_job_failed",
-                severity="high",
+            if not result.data.success:
+                await self._repo.update_job_status(job_id, JobStatus.FAILED)
+                logger.error(
+                    "analysis_job_failed",
+                    severity="high",
+                    job_id=str(job_id),
+                    user_id=user_id,
+                    duration_ms=duration_ms,
+                    error_details=result.data.message,
+                )
+                return
+
+            # The /api/analyze path persists the resolved charts only. Narrative
+            # text (primary insight + follow-ups) is an LLM call that belongs on
+            # the chat request path; generating it here would make this
+            # background job depend on a Gemini call.
+            bundle = InsightBundle(charts=result.charts)
+
+            await self._repo.create_insight_resource(
+                job_id=job_id,
+                user_id=user_id,
+                thread_id=thread_id,
+                bundle=bundle,
+            )
+
+            await self._repo.update_job_status(job_id, JobStatus.COMPLETED)
+            logger.info(
+                "analysis_job_completed",
                 job_id=str(job_id),
                 user_id=user_id,
                 duration_ms=duration_ms,
-                error_details=result.data.message,
             )
-            return
-
-        await self._repo.create_insight_resource(
-            job_id=job_id,
-            user_id=user_id,
-            thread_id=thread_id,
-            charts=result.charts or [],
-        )
-        await self._repo.update_job_status(job_id, JobStatus.COMPLETED)
-        logger.info(
-            "analysis_job_completed",
-            job_id=str(job_id),
-            user_id=user_id,
-            duration_ms=duration_ms,
-        )
+        except Exception:
+            # This runs as a fire-and-forget BackgroundTask, so an unhandled
+            # exception would silently leave the job stuck in RUNNING with no
+            # terminal state for the polling client. Mark it FAILED instead.
+            # (A persistence failure here can still orphan an InsightOrm row
+            # without a JobResource — that is unreferenced data, not a wedge.)
+            await self._repo.update_job_status(job_id, JobStatus.FAILED)
+            logger.exception(
+                "analysis_job_errored",
+                severity="high",
+                job_id=str(job_id),
+                user_id=user_id,
+            )

--- a/src/api/services/analysis_job.py
+++ b/src/api/services/analysis_job.py
@@ -57,10 +57,8 @@ class AnalysisJobRunner:
                 )
                 return
 
-            # The /api/analyze path persists the resolved charts only. Narrative
-            # text (primary insight + follow-ups) is an LLM call that belongs on
-            # the chat request path; generating it here would make this
-            # background job depend on a Gemini call.
+            # Charts only, no narrative: this job doesn't run the LLM text
+            # generation step.
             bundle = InsightBundle(charts=result.charts)
 
             await self._repo.create_insight_resource(
@@ -78,11 +76,10 @@ class AnalysisJobRunner:
                 duration_ms=duration_ms,
             )
         except Exception:
-            # This runs as a fire-and-forget BackgroundTask, so an unhandled
-            # exception would silently leave the job stuck in RUNNING with no
-            # terminal state for the polling client. Mark it FAILED instead.
-            # (A persistence failure here can still orphan an InsightOrm row
-            # without a JobResource — that is unreferenced data, not a wedge.)
+            # Fire-and-forget BackgroundTask: an unhandled exception would leave
+            # the job stuck in RUNNING, so mark it FAILED instead. (May leave an
+            # InsightOrm row with no JobResource pointing at it — harmless dead
+            # data, not something that blocks the job or future requests.)
             await self._repo.update_job_status(job_id, JobStatus.FAILED)
             logger.exception(
                 "analysis_job_errored",

--- a/src/api/services/analyze.py
+++ b/src/api/services/analyze.py
@@ -1,14 +1,15 @@
-from dataclasses import dataclass
-from typing import Any, Optional, Sequence
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
 
 from src.agent.datasets.handlers.base import DataPullResult, DataSourceHandler
-from src.api.services.charts import ChartGenerator
+from src.agent.subagents.analyst.charts import InsightChart
+from src.api.services.charts import ChartGenerator, column_to_rows
 
 
 @dataclass
 class AnalyzeResult:
     data: DataPullResult
-    charts: Optional[Any] = None
+    charts: list[InsightChart] = field(default_factory=list)
     source_urls: Optional[list[str]] = None
 
 
@@ -36,15 +37,20 @@ class AnalyzeService:
             change_over_time_query=False,
             aois=aois,
         )
-        charts = None
+
+        charts: list[InsightChart] = []
         if result.success and result.data:
+            rows = column_to_rows(result.data)
             for gen in self._generators:
                 if gen.can_handle(dataset_id):
-                    charts = gen.generate(result)
+                    charts = gen.generate(rows)
                     break
+
         source_urls = (
             [result.analytics_api_url] if result.analytics_api_url else None
         )
         return AnalyzeResult(
-            data=result, charts=charts, source_urls=source_urls
+            data=result,
+            charts=charts,
+            source_urls=source_urls,
         )

--- a/src/api/services/charts.py
+++ b/src/api/services/charts.py
@@ -1,51 +1,65 @@
+"""Deterministic chart generators — rule/config-driven builders that turn
+pulled data into `InsightChart`s without calling an LLM.
+
+`AnalyzeService` is injected with a sequence of these and picks the first whose
+`can_handle(dataset_id)` matches; datasets with no matching generator yield no
+charts.
+"""
+
 from abc import ABC, abstractmethod
+from typing import List
 
-from src.agent.datasets.handlers.base import DataPullResult
-
-
-class ChartGenerator(ABC):
-    @abstractmethod
-    def can_handle(self, dataset_id: int) -> bool:
-        pass
-
-    @abstractmethod
-    def generate(self, result: DataPullResult) -> list[dict]:
-        pass
+from src.agent.datasets.handlers.analytics_handler import TREE_COVER_LOSS_ID
+from src.agent.subagents.analyst.charts import InsightChart
 
 
-def _column_to_rows(data: dict) -> list[dict]:
+def column_to_rows(data: dict) -> List[dict]:
+    """Convert column-oriented data ({col: [..]}) to a list of row dicts."""
     keys = list(data.keys())
     return [dict(zip(keys, values)) for values in zip(*data.values())]
 
 
+class ChartGenerator(ABC):
+    """A deterministic chart builder for one (or more) dataset(s)."""
+
+    @abstractmethod
+    def can_handle(self, dataset_id: int) -> bool: ...
+
+    @abstractmethod
+    def generate(self, rows: List[dict]) -> List[InsightChart]: ...
+
+
 class TCLChartGenerator(ChartGenerator):
-    def __init__(self, dataset_id: int):
+    """Tree Cover Loss: annual loss area + annual GHG emissions, as two bars."""
+
+    def __init__(self, dataset_id: int = TREE_COVER_LOSS_ID):
         self.dataset_id = dataset_id
 
     def can_handle(self, dataset_id: int) -> bool:
         return dataset_id == self.dataset_id
 
-    def generate(self, result: DataPullResult) -> list[dict]:
-        rows = [
-            r for r in _column_to_rows(result.data) if r.get("area_ha") != 0
-        ]
+    def generate(self, rows: List[dict]) -> List[InsightChart]:
+        rows = [r for r in rows if r.get("area_ha") != 0]
         return [
-            {
-                "id": "chart_0",
-                "title": "Annual Tree Cover Loss",
-                "type": "bar",
-                "insight": "",
-                "data": rows,
-                "xAxis": "tree_cover_loss_year",
-                "yAxis": "area_ha",
-            },
-            {
-                "id": "chart_1",
-                "title": "Annual GHG Emissions from Tree Cover Loss",
-                "type": "bar",
-                "insight": "",
-                "data": rows,
-                "xAxis": "tree_cover_loss_year",
-                "yAxis": "carbon_emissions_MgCO2e",
-            },
+            InsightChart(
+                position=0,
+                title="Annual Tree Cover Loss",
+                chart_type="bar",
+                x_axis="tree_cover_loss_year",
+                y_axis="area_ha",
+                chart_data=rows,
+            ),
+            InsightChart(
+                position=1,
+                title="Annual GHG Emissions from Tree Cover Loss",
+                chart_type="bar",
+                x_axis="tree_cover_loss_year",
+                y_axis="carbon_emissions_MgCO2e",
+                chart_data=rows,
+            ),
         ]
+
+
+DETERMINISTIC_GENERATORS: List[ChartGenerator] = [
+    TCLChartGenerator(),
+]

--- a/src/api/services/job.py
+++ b/src/api/services/job.py
@@ -2,8 +2,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from uuid import UUID
+
+if TYPE_CHECKING:
+    from src.agent.subagents.analyst.charts import InsightBundle
 
 
 class JobStatus(str, Enum):
@@ -60,8 +63,8 @@ class JobRepository(ABC):
         job_id: UUID,
         user_id: str,
         thread_id: Optional[str],
-        charts: list[dict],
-    ) -> None: ...
+        bundle: "InsightBundle",
+    ) -> str: ...
 
     @abstractmethod
     async def get_job(self, job_id: UUID) -> Optional[JobData]: ...

--- a/src/api/services/job.py
+++ b/src/api/services/job.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Optional
 from uuid import UUID
 
-from src.agent.subagents.analyst.charts import InsightBundle
+from src.agent.subagents.analyst.charts import Insight
 
 
 class JobStatus(str, Enum):
@@ -62,7 +62,7 @@ class JobRepository(ABC):
         job_id: UUID,
         user_id: str,
         thread_id: Optional[str],
-        bundle: InsightBundle,
+        insight: Insight,
     ) -> str: ...
 
     @abstractmethod

--- a/src/api/services/job.py
+++ b/src/api/services/job.py
@@ -2,11 +2,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 from uuid import UUID
 
-if TYPE_CHECKING:
-    from src.agent.subagents.analyst.charts import InsightBundle
+from src.agent.subagents.analyst.charts import InsightBundle
 
 
 class JobStatus(str, Enum):
@@ -63,7 +62,7 @@ class JobRepository(ABC):
         job_id: UUID,
         user_id: str,
         thread_id: Optional[str],
-        bundle: "InsightBundle",
+        bundle: InsightBundle,
     ) -> str: ...
 
     @abstractmethod

--- a/tests/agent/test_graph.py
+++ b/tests/agent/test_graph.py
@@ -64,7 +64,7 @@ def mock_insight_db():
         yield mock_session
 
     with patch(
-        "src.agent.subagents.analyst.tool.get_session_from_pool",
+        "src.api.repositories.insight_writer.get_session_from_pool",
         fake_pool,
     ):
         yield mock_session

--- a/tests/evals/conftest.py
+++ b/tests/evals/conftest.py
@@ -120,7 +120,7 @@ def mock_eval_db():
 
     with (
         patch(
-            "src.agent.subagents.analyst.tool.get_session_from_pool",
+            "src.api.repositories.insight_writer.get_session_from_pool",
             fake_pool,
         ),
         patch("src.shared.database.get_session_from_pool", fake_pool),

--- a/tests/tools/test_generate_insights.py
+++ b/tests/tools/test_generate_insights.py
@@ -62,10 +62,29 @@ def mock_insight_db():
         yield mock_session
 
     with patch(
-        "src.agent.subagents.analyst.tool.get_session_from_pool",
+        "src.api.repositories.insight_writer.get_session_from_pool",
         fake_pool,
     ):
         yield mock_session
+
+
+@pytest.fixture(autouse=True)
+def mock_insight_text():
+    """Stub the text stage so these chart-focused tests don't require a
+    second live LLM call. The chart stage (Gemini code exec) still runs."""
+
+    class _Text:
+        primary_insight = "Synthetic insight text for tests."
+        follow_up_suggestions = ["Follow-up one."]
+
+    async def fake_generate(self, charts, dataset, query="", config=None):
+        return _Text()
+
+    with patch(
+        "src.agent.subagents.analyst.tool.InsightTextGenerator.generate",
+        new=fake_generate,
+    ):
+        yield
 
 
 async def test_generate_insights_comparison():

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -20,9 +20,11 @@ import pytest
 
 from src.agent.datasets.config import DATASETS
 from src.agent.state import Statistics
-from src.agent.subagents.analyst.tool import (
+from src.agent.subagents.analyst.code_executors.base import (
     ChartInsight,
     MultiChartInsight,
+)
+from src.agent.subagents.analyst.tool import (
     _extract_statistics_ids,
     generate_insights,
     prepare_dataframes,
@@ -95,7 +97,7 @@ def mock_insight_db():
         yield mock_session
 
     with patch(
-        "src.agent.subagents.analyst.tool.get_session_from_pool",
+        "src.api.repositories.insight_writer.get_session_from_pool",
         fake_pool,
     ):
         yield mock_session
@@ -490,8 +492,6 @@ async def test_generate_insights_persists_statistics_provenance(monkeypatch):
                 y_axis="value",
             )
         ],
-        primary_insight="Brazil has one unit.",
-        follow_up_suggestions=["Compare another area."],
     )
 
     class FakeExecutionResult:
@@ -520,6 +520,19 @@ async def test_generate_insights_persists_statistics_provenance(monkeypatch):
 
     monkeypatch.setattr(
         generate_insights_module, "GeminiCodeExecutor", FakeExecutor
+    )
+
+    class _Text:
+        primary_insight = "Brazil has one unit."
+        follow_up_suggestions = ["Compare another area."]
+
+    async def fake_generate(self, charts, dataset, query="", config=None):
+        return _Text()
+
+    monkeypatch.setattr(
+        generate_insights_module.InsightTextGenerator,
+        "generate",
+        fake_generate,
     )
 
     await invoke_generate_insights(

--- a/tests/unit/agent/tools/test_insight_chart_model.py
+++ b/tests/unit/agent/tools/test_insight_chart_model.py
@@ -1,0 +1,103 @@
+"""Unit tests for the canonical InsightChart/InsightBundle seam model."""
+
+import pytest
+
+from src.agent.subagents.analyst.charts.model import (
+    InsightBundle,
+    InsightChart,
+)
+from src.agent.subagents.analyst.code_executors.base import ChartInsight
+
+# The exact camelCase keys the frontend `charts_data` consumes today.
+FRONTEND_KEYS = {
+    "id",
+    "title",
+    "type",
+    "insight",
+    "data",
+    "xAxis",
+    "yAxis",
+    "colorField",
+    "stackField",
+    "groupField",
+    "seriesFields",
+}
+
+
+def _sample_chart() -> InsightChart:
+    return InsightChart(
+        position=1,
+        title="Annual Loss",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="area_ha",
+        chart_data=[{"year": 2020, "area_ha": 5.0}],
+    )
+
+
+def test_to_frontend_dict_has_exact_legacy_keys():
+    fe = _sample_chart().to_frontend_dict()
+    assert set(fe.keys()) == FRONTEND_KEYS
+    assert fe["id"] == "chart_1"
+    assert fe["type"] == "bar"
+    assert fe["xAxis"] == "year"
+    assert fe["data"] == [{"year": 2020, "area_ha": 5.0}]
+
+
+def test_frontend_round_trip_is_stable():
+    fe = _sample_chart().to_frontend_dict()
+    back = InsightChart.from_frontend_dict(fe, position=1)
+    assert back.to_frontend_dict() == fe
+
+
+def test_to_orm_kwargs_is_snake_case_and_complete():
+    kwargs = _sample_chart().to_orm_kwargs()
+    assert set(kwargs.keys()) == {
+        "position",
+        "title",
+        "chart_type",
+        "x_axis",
+        "y_axis",
+        "color_field",
+        "stack_field",
+        "group_field",
+        "series_fields",
+        "chart_data",
+    }
+    assert kwargs["chart_type"] == "bar"
+    assert kwargs["y_axis"] == "area_ha"
+
+
+def test_from_chart_insight_carries_spec_and_data():
+    ci = ChartInsight(
+        title="Multi",
+        chart_type="stacked-bar",
+        x_axis="year",
+        series_fields=["a", "b"],
+    )
+    rows = [{"year": 2020, "a": 1, "b": 2}]
+    chart = InsightChart.from_chart_insight(ci, rows, position=3)
+    assert chart.position == 3
+    assert chart.chart_type == "stacked-bar"
+    assert chart.series_fields == ["a", "b"]
+    assert chart.chart_data == rows
+
+
+def test_axis_validator_rejects_missing_axis():
+    with pytest.raises(ValueError):
+        InsightChart(title="bad", chart_type="bar", x_axis="year")
+
+
+def test_axis_validator_allows_pie_without_axis():
+    chart = InsightChart(title="ok", chart_type="pie", x_axis="name")
+    assert chart.chart_type == "pie"
+
+
+def test_bundle_stamp_insight_copies_text_to_each_chart():
+    bundle = InsightBundle(
+        charts=[_sample_chart(), _sample_chart()],
+        primary_insight="Loss increased.",
+        follow_up_suggestions=["Compare regions."],
+    ).stamp_insight()
+    assert all(c.insight == "Loss increased." for c in bundle.charts)
+    assert bundle.charts[0].to_frontend_dict()["insight"] == "Loss increased."

--- a/tests/unit/agent/tools/test_insight_chart_model.py
+++ b/tests/unit/agent/tools/test_insight_chart_model.py
@@ -44,12 +44,6 @@ def test_to_frontend_dict_has_exact_legacy_keys():
     assert fe["data"] == [{"year": 2020, "area_ha": 5.0}]
 
 
-def test_frontend_round_trip_is_stable():
-    fe = _sample_chart().to_frontend_dict()
-    back = InsightChart.from_frontend_dict(fe, position=1)
-    assert back.to_frontend_dict() == fe
-
-
 def test_to_orm_kwargs_is_snake_case_and_complete():
     kwargs = _sample_chart().to_orm_kwargs()
     assert set(kwargs.keys()) == {

--- a/tests/unit/agent/tools/test_insight_chart_model.py
+++ b/tests/unit/agent/tools/test_insight_chart_model.py
@@ -1,9 +1,9 @@
-"""Unit tests for the canonical InsightChart/InsightBundle seam model."""
+"""Unit tests for the canonical InsightChart/Insight seam model."""
 
 import pytest
 
 from src.agent.subagents.analyst.charts.model import (
-    InsightBundle,
+    Insight,
     InsightChart,
 )
 from src.agent.subagents.analyst.code_executors.base import ChartInsight
@@ -87,11 +87,11 @@ def test_axis_validator_allows_pie_without_axis():
     assert chart.chart_type == "pie"
 
 
-def test_bundle_stamp_insight_copies_text_to_each_chart():
-    bundle = InsightBundle(
+def test_stamp_insight_copies_text_to_each_chart():
+    insight = Insight(
         charts=[_sample_chart(), _sample_chart()],
         primary_insight="Loss increased.",
         follow_up_suggestions=["Compare regions."],
     ).stamp_insight()
-    assert all(c.insight == "Loss increased." for c in bundle.charts)
-    assert bundle.charts[0].to_frontend_dict()["insight"] == "Loss increased."
+    assert all(c.insight == "Loss increased." for c in insight.charts)
+    assert insight.charts[0].to_frontend_dict()["insight"] == "Loss increased."

--- a/tests/unit/agent/tools/test_insight_chart_model.py
+++ b/tests/unit/agent/tools/test_insight_chart_model.py
@@ -1,5 +1,8 @@
 """Unit tests for the canonical InsightChart/Insight seam model."""
 
+import json
+import math
+
 import pytest
 
 from src.agent.subagents.analyst.charts.model import (
@@ -75,6 +78,35 @@ def test_from_chart_insight_carries_spec_and_data():
     assert chart.chart_type == "stacked-bar"
     assert chart.series_fields == ["a", "b"]
     assert chart.chart_data == rows
+
+
+def test_chart_data_nan_is_sanitized_to_none():
+    # pandas to_dict() emits float('nan') for missing cells; these are not valid
+    # JSONB tokens and must be scrubbed before persistence. The failing payload
+    # had NaN in both value and key positions.
+    chart = InsightChart(
+        title="Disturbance",
+        chart_type="pie",
+        x_axis="name",
+        chart_data=[
+            {"name": "forest", "value": 540.0},
+            {"name": float("nan"), "value": float("nan")},
+            {"name": "infra", "value": float("inf")},
+        ],
+    )
+    assert chart.chart_data == [
+        {"name": "forest", "value": 540.0},
+        {"name": None, "value": None},
+        {"name": "infra", "value": None},
+    ]
+    # The sanitized rows must survive a strict (NaN-rejecting) JSON dump,
+    # which is what the Postgres JSONB parser does.
+    json.dumps(chart.to_orm_kwargs()["chart_data"], allow_nan=False)
+    assert not any(
+        isinstance(v, float) and not math.isfinite(v)
+        for row in chart.chart_data
+        for v in row.values()
+    )
 
 
 def test_axis_validator_rejects_missing_axis():

--- a/tests/unit/agent/tools/test_insight_text_generator.py
+++ b/tests/unit/agent/tools/test_insight_text_generator.py
@@ -1,0 +1,96 @@
+"""Unit tests for InsightTextGenerator.
+
+The LLM chain is replaced with a fake runnable so these are hermetic; they
+assert the prompt is grounded in chart data + dataset cautions/presentation and
+honors the wording guide.
+"""
+
+import pytest
+
+from src.agent.subagents.analyst.charts.model import InsightChart
+from src.agent.subagents.analyst.text_generator import (
+    InsightText,
+    InsightTextGenerator,
+)
+
+
+class _FakeChain:
+    """Captures inputs passed to ainvoke; returns a fixed InsightText."""
+
+    def __init__(self):
+        self.last_inputs = None
+        self.last_config = None
+
+    def with_config(self, **kwargs):
+        return self
+
+    async def ainvoke(self, inputs, config=None):
+        self.last_inputs = inputs
+        self.last_config = config
+        return InsightText(
+            primary_insight="Loss increased.",
+            follow_up_suggestions=["Compare regions."],
+        )
+
+
+@pytest.fixture
+def generator(monkeypatch):
+    gen = InsightTextGenerator.__new__(InsightTextGenerator)
+    fake = _FakeChain()
+    gen._chain = fake
+    return gen, fake
+
+
+CHARTS = [
+    InsightChart(
+        position=0,
+        title="Annual Loss",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="area_ha",
+        chart_data=[{"year": 2020, "area_ha": 1234.5}],
+    )
+]
+DATASET = {
+    "cautions": "Tree cover loss is not deforestation.",
+    "presentation_instructions": "Use neutral wording.",
+}
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_structured_text(generator):
+    gen, _ = generator
+    result = await gen.generate(CHARTS, DATASET, query="Loss in Brazil?")
+    assert result.primary_insight == "Loss increased."
+    assert result.follow_up_suggestions == ["Compare regions."]
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_cautions_and_presentation(generator):
+    gen, fake = generator
+    await gen.generate(CHARTS, DATASET, query="Loss in Brazil?")
+    inputs = fake.last_inputs
+    assert inputs["cautions"] == "Tree cover loss is not deforestation."
+    assert inputs["presentation_instructions"] == "Use neutral wording."
+    assert "Wording" in inputs["wording_guide"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_serializes_chart_data(generator):
+    gen, fake = generator
+    await gen.generate(CHARTS, DATASET, query="Loss in Brazil?")
+    charts_block = fake.last_inputs["charts"]
+    assert "Annual Loss" in charts_block
+    assert "year" in charts_block and "area_ha" in charts_block
+    assert "1234.5" in charts_block
+    # serialized as JSON, and the per-chart narrative field is excluded
+    assert "chart_type" in charts_block
+    assert "insight" not in charts_block
+
+
+@pytest.mark.asyncio
+async def test_config_is_forwarded_to_chain(generator):
+    gen, fake = generator
+    cfg = {"callbacks": ["x"]}
+    await gen.generate(CHARTS, DATASET, query="q", config=cfg)
+    assert fake.last_config == cfg

--- a/tests/unit/api/services/test_analysis_job_runner.py
+++ b/tests/unit/api/services/test_analysis_job_runner.py
@@ -3,59 +3,43 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from src.agent.datasets.handlers.base import DataPullResult, DataSourceHandler
+from src.agent.subagents.analyst.charts import InsightBundle, InsightChart
 from src.api.services.analysis_job import AnalysisJobRunner
-from src.api.services.analyze import AnalyzeService
-from src.api.services.charts import ChartGenerator
+from src.api.services.analyze import AnalyzeResult
 from src.api.services.job import JobRepository, JobStatus
 
 JOB_ID = uuid4()
 USER_ID = "user123"
 AOI = {"source": "gadm", "src_id": "BRA", "subtype": "country"}
 
-SUCCESS_RESULT = DataPullResult(
-    success=True,
-    data={
-        "tree_cover_loss_year": [2020],
-        "area_ha": [1000.0],
-        "carbon_emissions_MgCO2e": [500.0],
-        "aoi_id": ["BRA"],
-        "aoi_type": ["admin"],
-    },
-    message="ok",
-    data_points_count=1,
-    analytics_api_url="https://analytics.example.com/abc",
-)
-FAILURE_RESULT = DataPullResult(
-    success=False, data=None, message="upstream error", data_points_count=0
-)
+CHARTS = [
+    InsightChart(
+        position=0,
+        title="Annual Tree Cover Loss",
+        chart_type="bar",
+        x_axis="tree_cover_loss_year",
+        y_axis="area_ha",
+        chart_data=[{"tree_cover_loss_year": 2020, "area_ha": 1000.0}],
+    )
+]
 
 
-class FakeHandler(DataSourceHandler):
-    def __init__(self, result: DataPullResult):
-        self._result = result
-
-    def can_handle(self, dataset) -> bool:
-        return True
-
-    async def pull_data(
-        self,
-        query,
-        dataset,
-        start_date,
-        end_date,
-        change_over_time_query,
-        aois,
-    ):
-        return self._result
+class _Result:
+    def __init__(self, success, message=""):
+        self.success = success
+        self.message = message
 
 
-class FakeChartGenerator(ChartGenerator):
-    def can_handle(self, dataset_id: int) -> bool:
-        return True
+class FakeService:
+    def __init__(self, *, success: bool, charts):
+        self._success = success
+        self._charts = charts
 
-    def generate(self, result: DataPullResult) -> list[dict]:
-        return [{"id": "chart_0", "type": "bar", "title": "Test"}]
+    async def analyze(self, aois, dataset_id, start_date, end_date):
+        return AnalyzeResult(
+            data=_Result(self._success, "upstream error"),
+            charts=self._charts if self._success else [],
+        )
 
 
 class FakeJobRepository(JobRepository):
@@ -74,29 +58,30 @@ class FakeJobRepository(JobRepository):
         job_id: UUID,
         user_id: str,
         thread_id: Optional[str],
-        charts: list[dict],
-    ) -> None:
+        bundle: InsightBundle,
+    ) -> str:
         self.insight_resources.append(
             {
                 "job_id": job_id,
                 "user_id": user_id,
                 "thread_id": thread_id,
-                "charts": charts,
+                "bundle": bundle,
             }
         )
+        return "insight-123"
 
     async def get_job(self, job_id: UUID):
         return None
 
 
-def make_service(result: DataPullResult) -> AnalyzeService:
-    return AnalyzeService(FakeHandler(result), [FakeChartGenerator()])
+def make_runner(repo, *, success=True, charts=CHARTS):
+    return AnalysisJobRunner(FakeService(success=success, charts=charts), repo)
 
 
 @pytest.mark.asyncio
 async def test_run_sets_job_to_running_then_completed():
     repo = FakeJobRepository()
-    runner = AnalysisJobRunner(make_service(SUCCESS_RESULT), repo)
+    runner = make_runner(repo)
 
     await runner.run(JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31")
 
@@ -105,49 +90,36 @@ async def test_run_sets_job_to_running_then_completed():
 
 
 @pytest.mark.asyncio
-async def test_run_creates_insight_resource_on_success():
+async def test_run_creates_insight_resource_with_charts_only():
     repo = FakeJobRepository()
-    runner = AnalysisJobRunner(make_service(SUCCESS_RESULT), repo)
+    runner = make_runner(repo)
 
     await runner.run(JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31")
 
     assert len(repo.insight_resources) == 1
-    assert repo.insight_resources[0]["job_id"] == JOB_ID
-    assert repo.insight_resources[0]["user_id"] == USER_ID
-
-
-@pytest.mark.asyncio
-async def test_run_passes_charts_to_insight_resource():
-    repo = FakeJobRepository()
-    runner = AnalysisJobRunner(make_service(SUCCESS_RESULT), repo)
-
-    await runner.run(JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31")
-
-    assert len(repo.insight_resources[0]["charts"]) > 0
+    bundle = repo.insight_resources[0]["bundle"]
+    assert len(bundle.charts) == 1
+    # The /api/analyze path persists charts only; no LLM-generated narrative.
+    assert bundle.primary_insight == ""
+    assert bundle.follow_up_suggestions == []
 
 
 @pytest.mark.asyncio
 async def test_run_passes_thread_id_to_insight_resource():
     repo = FakeJobRepository()
-    runner = AnalysisJobRunner(make_service(SUCCESS_RESULT), repo)
+    runner = make_runner(repo)
 
     await runner.run(
-        JOB_ID,
-        USER_ID,
-        [AOI],
-        4,
-        "2020-01-01",
-        "2022-12-31",
-        thread_id="t-123",
+        JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31", thread_id="t-1"
     )
 
-    assert repo.insight_resources[0]["thread_id"] == "t-123"
+    assert repo.insight_resources[0]["thread_id"] == "t-1"
 
 
 @pytest.mark.asyncio
 async def test_run_on_failure_sets_job_to_failed():
     repo = FakeJobRepository()
-    runner = AnalysisJobRunner(make_service(FAILURE_RESULT), repo)
+    runner = make_runner(repo, success=False)
 
     await runner.run(JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31")
 
@@ -157,8 +129,25 @@ async def test_run_on_failure_sets_job_to_failed():
 @pytest.mark.asyncio
 async def test_run_on_failure_does_not_create_insight_resource():
     repo = FakeJobRepository()
-    runner = AnalysisJobRunner(make_service(FAILURE_RESULT), repo)
+    runner = make_runner(repo, success=False)
 
     await runner.run(JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31")
 
     assert len(repo.insight_resources) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_marks_job_failed_when_persistence_raises():
+    repo = FakeJobRepository()
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    repo.create_insight_resource = boom
+    runner = make_runner(repo)
+
+    # Must not propagate out of the background task...
+    await runner.run(JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31")
+
+    # ...and the job must reach a terminal FAILED state, not stay RUNNING.
+    assert repo.job_statuses[-1] == (JOB_ID, JobStatus.FAILED)

--- a/tests/unit/api/services/test_analysis_job_runner.py
+++ b/tests/unit/api/services/test_analysis_job_runner.py
@@ -3,7 +3,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from src.agent.subagents.analyst.charts import InsightBundle, InsightChart
+from src.agent.subagents.analyst.charts import Insight, InsightChart
 from src.api.services.analysis_job import AnalysisJobRunner
 from src.api.services.analyze import AnalyzeResult
 from src.api.services.job import JobRepository, JobStatus
@@ -58,14 +58,14 @@ class FakeJobRepository(JobRepository):
         job_id: UUID,
         user_id: str,
         thread_id: Optional[str],
-        bundle: InsightBundle,
+        insight: Insight,
     ) -> str:
         self.insight_resources.append(
             {
                 "job_id": job_id,
                 "user_id": user_id,
                 "thread_id": thread_id,
-                "bundle": bundle,
+                "insight": insight,
             }
         )
         return "insight-123"
@@ -97,11 +97,11 @@ async def test_run_creates_insight_resource_with_charts_only():
     await runner.run(JOB_ID, USER_ID, [AOI], 4, "2020-01-01", "2022-12-31")
 
     assert len(repo.insight_resources) == 1
-    bundle = repo.insight_resources[0]["bundle"]
-    assert len(bundle.charts) == 1
+    insight = repo.insight_resources[0]["insight"]
+    assert len(insight.charts) == 1
     # The /api/analyze path persists charts only; no LLM-generated narrative.
-    assert bundle.primary_insight == ""
-    assert bundle.follow_up_suggestions == []
+    assert insight.primary_insight == ""
+    assert insight.follow_up_suggestions == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/services/test_analyze_service.py
+++ b/tests/unit/api/services/test_analyze_service.py
@@ -1,13 +1,22 @@
 import pytest
 
 from src.agent.datasets.handlers.base import DataPullResult, DataSourceHandler
+from src.agent.subagents.analyst.charts import InsightChart
 from src.api.services.analyze import AnalyzeService
-from src.api.services.charts import ChartGenerator
 
 UNHANDLED_DATASET_ID = 1
 HANDLED_DATASET_ID = 99
 
-FAKE_CHARTS = [{"id": "chart_0", "title": "Fake", "type": "bar"}]
+FAKE_CHARTS = [
+    InsightChart(
+        position=0,
+        title="Fake",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="value",
+        chart_data=[],
+    )
+]
 
 
 class FakeHandler(DataSourceHandler):
@@ -38,18 +47,18 @@ class FakeHandler(DataSourceHandler):
         return self._result
 
 
-class FakeChartGenerator(ChartGenerator):
+class FakeChartGenerator:
     def can_handle(self, dataset_id: int) -> bool:
         return dataset_id == HANDLED_DATASET_ID
 
-    def generate(self, result: DataPullResult) -> list[dict]:
+    def generate(self, rows):
         return FAKE_CHARTS
 
 
 AOI = {"source": "gadm", "src_id": "BRA", "subtype": "country"}
 SUCCESS_RESULT = DataPullResult(
     success=True,
-    data={"rows": []},
+    data={"year": [2020], "area_ha": [5]},
     message="ok",
     data_points_count=5,
     analytics_api_url="https://analytics.example.com/result/abc123",
@@ -59,19 +68,23 @@ FAILURE_RESULT = DataPullResult(
 )
 
 
+def make_service(handler):
+    return AnalyzeService(handler, [FakeChartGenerator()])
+
+
 @pytest.mark.asyncio
 async def test_analyze_passes_correct_args_to_handler():
     handler = FakeHandler(SUCCESS_RESULT)
-    service = AnalyzeService(handler, [])
+    service = make_service(handler)
 
     await service.analyze(
         aois=[AOI],
-        dataset_id=4,
+        dataset_id=HANDLED_DATASET_ID,
         start_date="2020-01-01",
         end_date="2020-12-31",
     )
 
-    assert handler.last_call["dataset"] == {"dataset_id": 4}
+    assert handler.last_call["dataset"] == {"dataset_id": HANDLED_DATASET_ID}
     assert handler.last_call["aois"] == [AOI]
     assert handler.last_call["start_date"] == "2020-01-01"
     assert handler.last_call["end_date"] == "2020-12-31"
@@ -80,11 +93,11 @@ async def test_analyze_passes_correct_args_to_handler():
 @pytest.mark.asyncio
 async def test_analyze_always_passes_change_over_time_false():
     handler = FakeHandler(SUCCESS_RESULT)
-    service = AnalyzeService(handler, [])
+    service = make_service(handler)
 
     await service.analyze(
         aois=[AOI],
-        dataset_id=1,
+        dataset_id=HANDLED_DATASET_ID,
         start_date="2020-01-01",
         end_date="2020-12-31",
     )
@@ -95,11 +108,11 @@ async def test_analyze_always_passes_change_over_time_false():
 @pytest.mark.asyncio
 async def test_analyze_returns_data_on_success():
     handler = FakeHandler(SUCCESS_RESULT)
-    service = AnalyzeService(handler, [])
+    service = make_service(handler)
 
     result = await service.analyze(
         aois=[AOI],
-        dataset_id=4,
+        dataset_id=HANDLED_DATASET_ID,
         start_date="2020-01-01",
         end_date="2020-12-31",
     )
@@ -111,23 +124,24 @@ async def test_analyze_returns_data_on_success():
 @pytest.mark.asyncio
 async def test_analyze_propagates_failed_pull():
     handler = FakeHandler(FAILURE_RESULT)
-    service = AnalyzeService(handler, [])
+    service = make_service(handler)
 
     result = await service.analyze(
         aois=[AOI],
-        dataset_id=4,
+        dataset_id=HANDLED_DATASET_ID,
         start_date="2020-01-01",
         end_date="2020-12-31",
     )
 
     assert result.data.success is False
     assert result.data.message == "upstream error"
+    assert result.charts == []
 
 
 @pytest.mark.asyncio
-async def test_uses_matching_generator():
+async def test_uses_deterministic_source_when_one_matches():
     handler = FakeHandler(SUCCESS_RESULT)
-    service = AnalyzeService(handler, [FakeChartGenerator()])
+    service = make_service(handler)
 
     result = await service.analyze(
         aois=[AOI],
@@ -140,9 +154,9 @@ async def test_uses_matching_generator():
 
 
 @pytest.mark.asyncio
-async def test_returns_none_charts_when_no_generator_matches():
+async def test_no_charts_when_no_deterministic_source():
     handler = FakeHandler(SUCCESS_RESULT)
-    service = AnalyzeService(handler, [FakeChartGenerator()])
+    service = make_service(handler)
 
     result = await service.analyze(
         aois=[AOI],
@@ -151,4 +165,4 @@ async def test_returns_none_charts_when_no_generator_matches():
         end_date="2020-12-31",
     )
 
-    assert result.charts is None
+    assert result.charts == []

--- a/tests/unit/api/services/test_chart_generators.py
+++ b/tests/unit/api/services/test_chart_generators.py
@@ -1,6 +1,9 @@
 from src.agent.datasets.handlers.analytics_handler import TREE_COVER_LOSS_ID
-from src.agent.datasets.handlers.base import DataPullResult
-from src.api.services.charts import TCLChartGenerator
+from src.api.services.charts import (
+    DETERMINISTIC_GENERATORS,
+    TCLChartGenerator,
+    column_to_rows,
+)
 
 TCL_DATA = {
     "tree_cover_loss_year": [2020, 2021, 2022],
@@ -9,13 +12,7 @@ TCL_DATA = {
     "aoi_id": ["BRA"] * 3,
     "aoi_type": ["admin"] * 3,
 }
-TCL_RESULT = DataPullResult(
-    success=True,
-    message="ok",
-    data_points_count=3,
-    analytics_api_url="https://analytics.example.com/result/abc123",
-    data=TCL_DATA,
-)
+TCL_ROWS = column_to_rows(TCL_DATA)
 
 
 def test_can_handle_tcl_dataset():
@@ -26,27 +23,38 @@ def test_cannot_handle_other_dataset():
     assert not TCLChartGenerator(TREE_COVER_LOSS_ID).can_handle(1)
 
 
+def test_tcl_generator_registered():
+    assert any(
+        isinstance(gen, TCLChartGenerator) for gen in DETERMINISTIC_GENERATORS
+    )
+
+
 def test_generates_two_charts():
-    charts = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_RESULT)
+    charts = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_ROWS)
     assert len(charts) == 2
 
 
 def test_loss_chart_is_bar_with_correct_axes():
-    chart = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_RESULT)[0]
-    assert chart["type"] == "bar"
-    assert chart["xAxis"] == "tree_cover_loss_year"
-    assert chart["yAxis"] == "area_ha"
+    chart = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_ROWS)[0]
+    fe = chart.to_frontend_dict()
+    assert fe["type"] == "bar"
+    assert fe["xAxis"] == "tree_cover_loss_year"
+    assert fe["yAxis"] == "area_ha"
+    # snake_case persistence parity
+    assert chart.to_orm_kwargs()["chart_type"] == "bar"
+    assert chart.to_orm_kwargs()["y_axis"] == "area_ha"
 
 
 def test_emissions_chart_is_separate_bar_with_correct_axes():
-    chart = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_RESULT)[1]
-    assert chart["type"] == "bar"
-    assert chart["xAxis"] == "tree_cover_loss_year"
-    assert chart["yAxis"] == "carbon_emissions_MgCO2e"
+    chart = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_ROWS)[1]
+    fe = chart.to_frontend_dict()
+    assert fe["type"] == "bar"
+    assert fe["xAxis"] == "tree_cover_loss_year"
+    assert fe["yAxis"] == "carbon_emissions_MgCO2e"
 
 
 def test_drops_rows_where_area_ha_is_zero():
-    charts = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_RESULT)
+    charts = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(TCL_ROWS)
     for chart in charts:
-        for row in chart["data"]:
+        for row in chart.chart_data:
             assert row["area_ha"] != 0


### PR DESCRIPTION
This splits the analyst tool into two steps: the code executor handles chart generation, and a second LLM narrates the insight from the chart data. It also introduces a seam model for insights to improve interoperability between the chat and analysis chart-generation paths. Also this adds insight persistence with both the chat and /api/analyze paths now writing InsightOrm/InsightChartOrm through one place.

This is primarily groundwork: it makes deterministic chart generators easy to add and decouples the narrative stage from how the charts were built, so it can be reused across paths. This decoupled insight narrative generator can easily be a separate tool that we surface to the orchestrator as well.

