### PR TITLE
Searchable AOIs: unified GET /api/aois endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.1"
+version = "2026.7.1.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/subagents/pick_aoi/tool.py
+++ b/src/agent/subagents/pick_aoi/tool.py
@@ -26,7 +26,8 @@ from src.agent.subagents.progress import emit_progress
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.shared.database import get_connection_from_pool
 from src.shared.geocoding_helpers import (
-    CUSTOM_AREA_TABLE,
+    BBOX_SQL,
+    CUSTOM_BBOX_SQL,
     GADM_STANDARD_ID_RE,
     GADM_TABLE,
     KBA_TABLE,
@@ -34,6 +35,7 @@ from src.shared.geocoding_helpers import (
     SOURCE_ID_MAPPING,
     SUBREGION_TO_SUBTYPE_MAPPING,
     WDPA_TABLE,
+    search_aois,
 )
 from src.shared.logging_config import get_logger
 
@@ -58,60 +60,6 @@ aoi_to_table = {
 
 load_dotenv()
 logger = get_logger(__name__)
-
-
-def _antimeridian_bbox_sql(geom_expr: str) -> str:
-    """
-    Returns [west, south, east, north] JSON array.
-    For antimeridian-crossing geometries (span > 180°), clips to each
-    half-plane to get the bbox of the eastern and western parts separately —
-    no ST_Dump, no vertex iteration. Falls back to naive bbox if either
-    clip returns nothing (geometry doesn't truly cross the antimeridian).
-    """
-    east_half = "ST_MakeEnvelope(0, -90, 180, 90, 4326)"
-    west_half = "ST_MakeEnvelope(-180, -90, 0, 90, 4326)"
-    return f"""
-    CASE
-        WHEN ST_XMax({geom_expr}) - ST_XMin({geom_expr}) > 180
-        THEN (
-            SELECT COALESCE(
-                CASE
-                    WHEN west IS NOT NULL AND east IS NOT NULL
-                    THEN json_build_array(west, ST_YMin({geom_expr}), east, ST_YMax({geom_expr}))
-                END,
-                json_build_array(ST_XMin({geom_expr}), ST_YMin({geom_expr}), ST_XMax({geom_expr}), ST_YMax({geom_expr}))
-            )
-            FROM (
-                SELECT
-                    ST_XMin(ST_Envelope(ST_ClipByBox2D({geom_expr}, {east_half}))) AS west,
-                    ST_XMax(ST_Envelope(ST_ClipByBox2D({geom_expr}, {west_half}))) AS east
-            ) AS parts
-        )
-        ELSE json_build_array(
-            ST_XMin({geom_expr}),
-            ST_YMin({geom_expr}),
-            ST_XMax({geom_expr}),
-            ST_YMax({geom_expr})
-        )
-    END
-    """
-
-
-BBOX_SQL = f"({_antimeridian_bbox_sql('geometry')}) AS bbox"
-
-# The custom geometries table stores geometries as an list of geojsons,
-# requiring a funky SQL to pull out the overall bounds
-CUSTOM_BBOX_SQL = f"""
-(
-    SELECT {_antimeridian_bbox_sql("bounds.geometry")}
-    FROM (
-        SELECT ST_Envelope(
-            ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON(geom_json), 4326))
-        ) AS geometry
-        FROM jsonb_array_elements_text(geometries) AS geom(geom_json)
-    ) AS bounds
-) AS bbox
-"""
 
 
 async def fetch_aoi_bbox(source: str, src_id: str) -> list[float]:
@@ -168,181 +116,15 @@ async def query_aoi_database(
     Returns:
         DataFrame containing location information
     """
-    async with get_connection_from_pool() as conn:
-        # Enable pg_trgm extension for similarity function
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
-        await conn.execute(text("SET pg_trgm.similarity_threshold = 0.2;"))
-        await conn.commit()
-
-        user_id = structlog.contextvars.get_contextvars().get("user_id")
-
-        # Check which tables exist first
-        existing_tables = []
-
-        # Check GADM table
-        try:
-            await conn.execute(text(f"SELECT 1 FROM {GADM_TABLE} LIMIT 1"))
-            existing_tables.append("gadm")
-        except Exception:
-            logger.warning(f"Table {GADM_TABLE} does not exist")
-            await conn.rollback()
-
-        # Check KBA table
-        try:
-            await conn.execute(text(f"SELECT 1 FROM {KBA_TABLE} LIMIT 1"))
-            existing_tables.append("kba")
-        except Exception:
-            logger.warning(f"Table {KBA_TABLE} does not exist")
-            await conn.rollback()
-
-        # Check Landmark table
-        try:
-            await conn.execute(text(f"SELECT 1 FROM {LANDMARK_TABLE} LIMIT 1"))
-            existing_tables.append("landmark")
-        except Exception:
-            logger.warning(f"Table {LANDMARK_TABLE} does not exist")
-            await conn.rollback()
-
-        # Check WDPA table
-        try:
-            await conn.execute(text(f"SELECT 1 FROM {WDPA_TABLE} LIMIT 1"))
-            existing_tables.append("wdpa")
-        except Exception:
-            logger.warning(f"Table {WDPA_TABLE} does not exist")
-            await conn.rollback()
-
-        # Check Custom Areas table
-        try:
-            await conn.execute(
-                text(f"SELECT 1 FROM {CUSTOM_AREA_TABLE} LIMIT 1")
-            )
-            existing_tables.append("custom")
-        except Exception:
-            logger.warning(f"Table {CUSTOM_AREA_TABLE} does not exist")
-            await conn.rollback()
-
-        # Build the query based on existing tables
-        union_parts = []
-
-        if aoi_type is not None:
-            aoi_table = aoi_to_table[aoi_type]
-            if aoi_table in existing_tables:
-                existing_tables = [aoi_table]
-            else:
-                # This cannot happen in production, unless the AOI tables are
-                # misconfigured. This is to catch the case where not all tables have
-                # been created locally.
-                raise ValueError(
-                    f"Required geometry table {aoi_table} does not exist in the database"
-                )
-
-        if "gadm" in existing_tables:
-            union_parts.append(
-                f"""
-                SELECT gadm_id AS src_id,
-                    name, subtype, 'gadm' as source, {BBOX_SQL}
-                FROM {GADM_TABLE}
-                WHERE name IS NOT NULL AND name % :place_name
-                AND gadm_id ~ '{GADM_STANDARD_ID_RE}'
-            """
-            )
-
-        if "kba" in existing_tables:
-            src_id = SOURCE_ID_MAPPING["kba"]["id_column"]
-            union_parts.append(
-                f"""
-                SELECT CAST({src_id} as TEXT) as src_id,
-                       name,
-                       subtype,
-                       'kba' as source,
-                       {BBOX_SQL}
-                FROM {KBA_TABLE}
-                WHERE name IS NOT NULL AND name % :place_name
-            """
-            )
-
-        if "landmark" in existing_tables:
-            src_id = SOURCE_ID_MAPPING["landmark"]["id_column"]
-            union_parts.append(
-                f"""
-                SELECT CAST({src_id} as TEXT) as src_id,
-                       name,
-                       subtype,
-                       'landmark' as source,
-                       {BBOX_SQL}
-                FROM {LANDMARK_TABLE}
-                WHERE name IS NOT NULL AND name % :place_name
-            """
-            )
-
-        if "wdpa" in existing_tables:
-            src_id = SOURCE_ID_MAPPING["wdpa"]["id_column"]
-            union_parts.append(
-                f"""
-                SELECT CAST({src_id} as TEXT) as src_id,
-                       name,
-                       subtype,
-                       'wdpa' as source,
-                       {BBOX_SQL}
-                FROM {WDPA_TABLE}
-                WHERE name IS NOT NULL AND name % :place_name
-            """
-            )
-        if "custom" in existing_tables:
-            src_id = SOURCE_ID_MAPPING["custom"]["id_column"]
-            if not user_id:
-                raise ValueError("user_id required for custom areas")
-
-            union_parts.append(
-                f"""
-                SELECT CAST({src_id} as TEXT) as src_id,
-                        name,
-                        'custom-area' as subtype,
-                        'custom' as source,
-                        {CUSTOM_BBOX_SQL}
-                FROM {CUSTOM_AREA_TABLE}
-                WHERE user_id = :user_id
-                AND name IS NOT NULL AND name % :place_name
-            """
-            )
-
-        if not union_parts:
-            logger.error("No geometry tables exist in the database")
-            return pd.DataFrame()
-
-        # Create the combined search query
-        combined_query = " UNION ALL ".join(union_parts)
-
-        sql_query = f"""
-            WITH combined_search AS (
-                {combined_query}
-            )
-            SELECT *,
-                   similarity(LOWER(name), LOWER(:place_name)) AS similarity_score
-            FROM combined_search
-            WHERE name IS NOT NULL
-            AND name % :place_name
-            ORDER BY similarity_score DESC
-            LIMIT :limit_val
-        """
-
-        logger.debug(f"Executing AOI query: {sql_query}")
-
-        def _read(sync_conn):
-            return pd.read_sql(
-                text(sql_query),
-                sync_conn,
-                params={
-                    "place_name": place_name,
-                    "limit_val": result_limit,
-                    "user_id": user_id,
-                },
-            )
-
-        query_results = await conn.run_sync(_read)
-
-    logger.debug(f"AOI query results: {query_results}")
-    return query_results
+    sources = [aoi_to_table[aoi_type]] if aoi_type is not None else None
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    return await search_aois(
+        name=place_name,
+        sources=sources,
+        user_id=user_id,
+        limit=result_limit,
+        offset=0,
+    )
 
 
 async def query_subregion_database(

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -11,6 +11,7 @@ from src.agent.utils.sgrep import data_status
 from src.api.routers import (
     admin,
     analyze,
+    aois,
     chat,
     custom_areas,
     geometry,
@@ -139,6 +140,7 @@ app.include_router(chat.router)
 app.include_router(threads.router)
 app.include_router(users.router)
 app.include_router(custom_areas.router)
+app.include_router(aois.router)
 app.include_router(geometry.router)
 app.include_router(thumbnails.router)
 app.include_router(insights.router)

--- a/src/api/routers/aois.py
+++ b/src/api/routers/aois.py
@@ -1,0 +1,72 @@
+"""Unified AOI search endpoint.
+
+Searches Areas of Interest across all sources (gadm / kba / wdpa / landmark /
+custom) by name and/or source type, reusing the same pg_trgm search core as the
+agent's ``pick_aoi`` geocoder.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from src.api.auth.dependencies import require_auth
+from src.api.schemas import AOISearchResult, UserModel
+from src.shared.geocoding_helpers import normalize_aoi_source, search_aois
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/api/aois", response_model=list[AOISearchResult])
+async def search_aois_endpoint(
+    response: Response,
+    name: Optional[str] = Query(
+        default=None, description="Fuzzy name to search for. Omit to browse."
+    ),
+    source: List[str] = Query(
+        default=[],
+        description=(
+            "Source(s) to filter by: gadm, kba, wdpa (protectedareas), "
+            "landmark, custom. Repeatable; omit to search all sources."
+        ),
+    ),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    user: UserModel = Depends(require_auth),
+):
+    """Search/browse AOIs by name and source type.
+
+    - Provide ``name`` for fuzzy, similarity-ranked search.
+    - Omit ``name`` to browse AOIs alphabetically within the selected source(s).
+    - ``source`` may be repeated to search several sources at once; omitting it
+      searches all available sources. Custom areas are scoped to the caller.
+
+    When more results are available, the next page offset is returned in the
+    ``X-Next-Offset`` response header.
+    """
+    try:
+        sources = [normalize_aoi_source(s) for s in source] if source else None
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    try:
+        # Fetch one extra row to determine whether more pages exist.
+        df = await search_aois(
+            name=name,
+            sources=sources,
+            user_id=user.id,
+            limit=limit + 1,
+            offset=offset,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    rows = df.to_dict(orient="records")
+    has_more = len(rows) > limit
+    if has_more:
+        rows = rows[:limit]
+        response.headers["X-Next-Offset"] = str(offset + limit)
+
+    return [AOISearchResult(**row) for row in rows]

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -294,6 +294,22 @@ class GeometryResponse(BaseModel):
     geometry: dict = Field(..., description="GeoJSON geometry")
 
 
+class AOISearchResult(BaseModel):
+    """A single AOI returned by the ``GET /api/aois`` search endpoint."""
+
+    source: str = Field(
+        ...,
+        description="Source of the AOI (gadm, kba, wdpa, landmark, custom)",
+    )
+    src_id: str = Field(..., description="Source-specific ID of the AOI")
+    name: str = Field(..., description="Name of the AOI")
+    subtype: str = Field(..., description="Subtype of the AOI")
+    bbox: List[float] = Field(
+        default=[-180.0, -90.0, 180.0, 90.0],
+        description="Bounding box as [minx, miny, maxx, maxy]",
+    )
+
+
 class DailyUsageModel(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: str

--- a/src/shared/geocoding_helpers.py
+++ b/src/shared/geocoding_helpers.py
@@ -2,11 +2,18 @@ import json
 from typing import Any, Dict, Optional, Union
 from uuid import UUID
 
+import pandas as pd
 import structlog
 from sqlalchemy import select, text
 
 from src.api.data_models import CustomAreaOrm
-from src.shared.database import get_session_from_pool
+from src.shared.database import (
+    get_connection_from_pool,
+    get_session_from_pool,
+)
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 GADM_TABLE = "geometries_gadm"
 KBA_TABLE = "geometries_kba"
@@ -53,6 +60,216 @@ GADM_SUBTYPE_MAP = {val["col_name"]: key for key, val in GADM_LEVELS.items()}
 # Matches standard GADM IDs (3-letter ISO prefix): "USA", "BRA.16_1", "IND.12.26_1", etc.
 # Excludes disputed-territory codes like "Z01", "Z02" which downstream APIs reject.
 GADM_STANDARD_ID_RE = r"^[A-Z]{3}"
+
+
+# Friendly source aliases accepted from callers (e.g. the search API) and
+# mapped onto the canonical source keys used in SOURCE_ID_MAPPING.
+SOURCE_ALIASES = {
+    "protectedareas": "wdpa",
+    "protected_areas": "wdpa",
+    "protected-areas": "wdpa",
+}
+
+VALID_AOI_SOURCES = set(SOURCE_ID_MAPPING.keys())
+
+
+def normalize_aoi_source(source: str) -> str:
+    """Map a (possibly aliased) source name onto a canonical source key."""
+    key = SOURCE_ALIASES.get(source.lower(), source.lower())
+    if key not in VALID_AOI_SOURCES:
+        raise ValueError(
+            f"Invalid source: {source}. Must be one of: "
+            f"{', '.join(sorted(VALID_AOI_SOURCES))}"
+        )
+    return key
+
+
+def _antimeridian_bbox_sql(geom_expr: str) -> str:
+    """
+    Returns [west, south, east, north] JSON array.
+    For antimeridian-crossing geometries (span > 180°), clips to each
+    half-plane to get the bbox of the eastern and western parts separately —
+    no ST_Dump, no vertex iteration. Falls back to naive bbox if either
+    clip returns nothing (geometry doesn't truly cross the antimeridian).
+    """
+    east_half = "ST_MakeEnvelope(0, -90, 180, 90, 4326)"
+    west_half = "ST_MakeEnvelope(-180, -90, 0, 90, 4326)"
+    return f"""
+    CASE
+        WHEN ST_XMax({geom_expr}) - ST_XMin({geom_expr}) > 180
+        THEN (
+            SELECT COALESCE(
+                CASE
+                    WHEN west IS NOT NULL AND east IS NOT NULL
+                    THEN json_build_array(west, ST_YMin({geom_expr}), east, ST_YMax({geom_expr}))
+                END,
+                json_build_array(ST_XMin({geom_expr}), ST_YMin({geom_expr}), ST_XMax({geom_expr}), ST_YMax({geom_expr}))
+            )
+            FROM (
+                SELECT
+                    ST_XMin(ST_Envelope(ST_ClipByBox2D({geom_expr}, {east_half}))) AS west,
+                    ST_XMax(ST_Envelope(ST_ClipByBox2D({geom_expr}, {west_half}))) AS east
+            ) AS parts
+        )
+        ELSE json_build_array(
+            ST_XMin({geom_expr}),
+            ST_YMin({geom_expr}),
+            ST_XMax({geom_expr}),
+            ST_YMax({geom_expr})
+        )
+    END
+    """
+
+
+BBOX_SQL = f"({_antimeridian_bbox_sql('geometry')}) AS bbox"
+
+# The custom geometries table stores geometries as an list of geojsons,
+# requiring a funky SQL to pull out the overall bounds
+CUSTOM_BBOX_SQL = f"""
+(
+    SELECT {_antimeridian_bbox_sql("bounds.geometry")}
+    FROM (
+        SELECT ST_Envelope(
+            ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON(geom_json), 4326))
+        ) AS geometry
+        FROM jsonb_array_elements_text(geometries) AS geom(geom_json)
+    ) AS bounds
+) AS bbox
+"""
+
+
+async def search_aois(
+    name: Optional[str],
+    sources: Optional[list[str]],
+    user_id: Optional[str],
+    limit: int = 50,
+    offset: int = 0,
+) -> pd.DataFrame:
+    """Search AOIs across sources by name and/or source type.
+
+    This is the shared search core reused by both the agent's ``pick_aoi``
+    geocoder (via :func:`query_aoi_database`) and the ``GET /api/aois``
+    endpoint.
+
+    Args:
+        name: Fuzzy name to search for. When empty/None the query runs in
+            *browse* mode: no name filter, ordered alphabetically.
+        sources: Subset of canonical source keys (gadm/kba/wdpa/landmark/custom)
+            to search; ``None`` searches all available sources. Aliases such as
+            ``protectedareas`` are accepted and normalized.
+        user_id: Owner used to scope custom areas. Required when ``custom`` is
+            among the searched sources.
+        limit: Maximum number of rows to return.
+        offset: Number of rows to skip (offset pagination).
+
+    Returns:
+        DataFrame with columns ``src_id, name, subtype, source, bbox`` (plus
+        ``similarity_score`` when searching by name).
+    """
+    if sources:
+        requested = {normalize_aoi_source(s) for s in sources}
+    else:
+        requested = set(SOURCE_ID_MAPPING.keys())
+
+    has_name = bool(name and name.strip())
+
+    async with get_connection_from_pool() as conn:
+        # Enable pg_trgm extension for the similarity function
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
+        await conn.execute(text("SET pg_trgm.similarity_threshold = 0.2;"))
+        await conn.commit()
+
+        # Probe which of the requested tables actually exist
+        existing_tables = []
+        for source in ("gadm", "kba", "landmark", "wdpa", "custom"):
+            if source not in requested:
+                continue
+            table = SOURCE_ID_MAPPING[source]["table"]
+            try:
+                await conn.execute(text(f"SELECT 1 FROM {table} LIMIT 1"))
+                existing_tables.append(source)
+            except Exception:
+                logger.warning(f"Table {table} does not exist")
+                await conn.rollback()
+
+        name_filter = "AND name % :name" if has_name else ""
+        union_parts = []
+
+        if "gadm" in existing_tables:
+            union_parts.append(
+                f"""
+                SELECT gadm_id AS src_id, name, subtype, 'gadm' as source, {BBOX_SQL}
+                FROM {GADM_TABLE}
+                WHERE name IS NOT NULL AND gadm_id ~ '{GADM_STANDARD_ID_RE}' {name_filter}
+            """
+            )
+
+        for source in ("kba", "landmark", "wdpa"):
+            if source in existing_tables:
+                id_column = SOURCE_ID_MAPPING[source]["id_column"]
+                table = SOURCE_ID_MAPPING[source]["table"]
+                union_parts.append(
+                    f"""
+                    SELECT CAST({id_column} AS TEXT) as src_id,
+                           name, subtype, '{source}' as source, {BBOX_SQL}
+                    FROM {table}
+                    WHERE name IS NOT NULL {name_filter}
+                """
+                )
+
+        if "custom" in existing_tables:
+            if not user_id:
+                raise ValueError("user_id required for custom areas")
+            id_column = SOURCE_ID_MAPPING["custom"]["id_column"]
+            union_parts.append(
+                f"""
+                SELECT CAST({id_column} AS TEXT) as src_id,
+                       name, 'custom-area' as subtype, 'custom' as source, {CUSTOM_BBOX_SQL}
+                FROM {CUSTOM_AREA_TABLE}
+                WHERE user_id = :user_id AND name IS NOT NULL {name_filter}
+            """
+            )
+
+        if not union_parts:
+            logger.warning("No matching geometry tables exist for the request")
+            return pd.DataFrame()
+
+        combined_query = " UNION ALL ".join(union_parts)
+
+        if has_name:
+            sql_query = f"""
+                WITH combined_search AS (
+                    {combined_query}
+                )
+                SELECT *,
+                       similarity(LOWER(name), LOWER(:name)) AS similarity_score
+                FROM combined_search
+                WHERE name IS NOT NULL AND name % :name
+                ORDER BY similarity_score DESC, name, source, src_id
+                LIMIT :limit OFFSET :offset
+            """
+        else:
+            sql_query = f"""
+                WITH combined_search AS (
+                    {combined_query}
+                )
+                SELECT *
+                FROM combined_search
+                WHERE name IS NOT NULL
+                ORDER BY name, source, src_id
+                LIMIT :limit OFFSET :offset
+            """
+
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if has_name:
+            params["name"] = name
+        if "custom" in existing_tables:
+            params["user_id"] = user_id
+
+        def _read(sync_conn):
+            return pd.read_sql(text(sql_query), sync_conn, params=params)
+
+        return await conn.run_sync(_read)
 
 
 def format_id(idx):

--- a/tests/api/test_aois.py
+++ b/tests/api/test_aois.py
@@ -1,0 +1,124 @@
+"""Tests for the unified AOI search endpoint (GET /api/aois).
+
+The test database only contains the ORM tables (custom_areas), so the reference
+sources (gadm/kba/wdpa/landmark) are skipped by search_aois and these tests
+exercise the custom-area path, source filtering, pagination and validation.
+"""
+
+import pytest
+
+_POLYGON = {
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [29.2263174, -1.641965],
+            [29.2263174, -1.665582],
+            [29.2301511, -1.665582],
+            [29.2301511, -1.641965],
+            [29.2263174, -1.641965],
+        ]
+    ],
+}
+
+AUTH = {"Authorization": "Bearer abc123"}
+
+
+async def _create_area(client, name):
+    res = await client.post(
+        "/api/custom_areas",
+        json={"name": name, "geometries": [_POLYGON]},
+        headers=AUTH,
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_search_by_name(auth_override, client):
+    auth_override("test-user-wri")
+    await _create_area(client, "Amazon")
+    await _create_area(client, "Amazonia")
+    await _create_area(client, "Sahara")
+
+    res = await client.get("/api/aois?name=amazon", headers=AUTH)
+    assert res.status_code == 200, res.text
+    results = res.json()
+    names = [r["name"] for r in results]
+    assert "Amazon" in names
+    assert "Amazonia" in names
+    assert "Sahara" not in names
+    # The exact-match custom area is returned with the expected shape.
+    amazon = next(r for r in results if r["name"] == "Amazon")
+    assert amazon["source"] == "custom"
+    assert amazon["subtype"] == "custom-area"
+    assert len(amazon["bbox"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_browse_custom_without_name(auth_override, client):
+    auth_override("test-user-wri")
+    await _create_area(client, "Area B")
+    await _create_area(client, "Area A")
+    await _create_area(client, "Area C")
+
+    res = await client.get("/api/aois?source=custom", headers=AUTH)
+    assert res.status_code == 200, res.text
+    names = [r["name"] for r in res.json()]
+    # Browse mode is ordered alphabetically by name.
+    assert names == ["Area A", "Area B", "Area C"]
+
+
+@pytest.mark.asyncio
+async def test_results_scoped_to_owner(auth_override, client, user_ds):
+    auth_override("test-user-wri")
+    await _create_area(client, "Owned Area")
+
+    # A different user must not see another user's custom areas.
+    # (user_ds is pre-created so auth resolves it by id without an email clash.)
+    auth_override("test-user-ds")
+    res = await client.get("/api/aois?source=custom", headers=AUTH)
+    assert res.status_code == 200, res.text
+    assert res.json() == []
+
+
+@pytest.mark.asyncio
+async def test_pagination(auth_override, client):
+    auth_override("test-user-wri")
+    for name in ["Area A", "Area B", "Area C"]:
+        await _create_area(client, name)
+
+    first = await client.get("/api/aois?source=custom&limit=2", headers=AUTH)
+    assert first.status_code == 200, first.text
+    assert [r["name"] for r in first.json()] == ["Area A", "Area B"]
+    assert first.headers["x-next-offset"] == "2"
+
+    offset = first.headers["x-next-offset"]
+    second = await client.get(
+        f"/api/aois?source=custom&limit=2&offset={offset}", headers=AUTH
+    )
+    assert second.status_code == 200, second.text
+    assert [r["name"] for r in second.json()] == ["Area C"]
+    assert "x-next-offset" not in second.headers
+
+
+@pytest.mark.asyncio
+async def test_invalid_source_returns_422(auth_override, client):
+    auth_override("test-user-wri")
+    res = await client.get("/api/aois?source=bogus", headers=AUTH)
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_protectedareas_alias_accepted(auth_override, client):
+    auth_override("test-user-wri")
+    # The "protectedareas" alias resolves to the wdpa source.
+    res = await client.get("/api/aois?source=protectedareas", headers=AUTH)
+    assert res.status_code == 200, res.text
+    # Environment-independent: any rows returned must be wdpa.
+    assert all(r["source"] == "wdpa" for r in res.json())
+
+
+@pytest.mark.asyncio
+async def test_requires_auth(client):
+    res = await client.get("/api/aois?source=custom")
+    assert res.status_code == 401

--- a/tests/unit/agent/tools/pick_aoi/test_tool.py
+++ b/tests/unit/agent/tools/pick_aoi/test_tool.py
@@ -8,9 +8,9 @@ from src.agent.subagents.pick_aoi import Geocoder, pick_aoi
 from src.agent.subagents.pick_aoi.tool import (
     AOIIndex,
     PlaceQuery,
-    _antimeridian_bbox_sql,
     fetch_aoi_bbox,
 )
+from src.shared.geocoding_helpers import _antimeridian_bbox_sql
 
 
 def test_sql_contains_crossing_condition():


### PR DESCRIPTION
## What

Adds a unified, authenticated **`GET /api/aois`** endpoint to search Areas of Interest across all sources (`gadm` / `kba` / `wdpa` / `landmark` / `custom`), with multi-select source filtering and fuzzy name search. Reuses the agent's existing `pick_aoi` pg_trgm search core.

## Why

This is in preparation for dashboards, where we will start single-area-dashboards from selecting an aoi. This allows the user to search for aois outside of the map explorer.

There was no way to search AOIs across sources from the API — custom areas could only be listed unfiltered (`GET /api/custom_areas`) and reference AOIs fetched one at a time (`GET /api/geometry/{source}/{src_id}`). Users want to search by name and filter by source type.

## Endpoint

`GET /api/aois`

| Param | Notes |
|---|---|
| `name` | Fuzzy, similarity-ranked search. Omit to **browse** alphabetically. |
| `source` | Repeatable multi-select: `gadm`, `kba`, `wdpa` (alias `protectedareas`), `landmark`, `custom`. Omit = all sources. |
| `limit` | 1–100, default 50. |
| `offset` | Offset pagination; next page returned via the `X-Next-Offset` response header. |

Custom areas are scoped to the authenticated caller.

```
GET /api/aois?name=amazon
GET /api/aois?source=gadm&source=custom
GET /api/aois?source=custom                 # browse my custom areas
GET /api/aois?source=protectedareas&name=yellowstone
```

## How (reuse)

- **`src/shared/geocoding_helpers.py`** — new `search_aois(name, sources, user_id, limit, offset)` generalizes the old union builder: optional name (fuzzy vs browse mode), a *list* of sources incl. `custom`, an explicit `user_id`, and offset pagination. Relocated the bbox SQL helpers here, plus `normalize_aoi_source` (handles the `protectedareas`→`wdpa` alias + validation).
- **`src/agent/subagents/pick_aoi/tool.py`** — `query_aoi_database` now delegates to `search_aois`; the geocoder's behavior is unchanged.
- **`src/api/routers/aois.py`** (new) + registered in `app.py`; **`AOISearchResult`** schema in `schemas.py`.

No DB migration required — the `custom` source is implicit.

## Testing

- New `tests/api/test_aois.py`: fuzzy search, browse-by-source, owner scoping, offset pagination + `X-Next-Offset`, invalid-source `422`, `protectedareas` alias, auth required.
- Existing `pick_aoi` / `custom_area` suites pass (incl. the replay-based geocoder test), confirming the delegation refactor is regression-free.

## Notes

- Browse-with-no-name over the large reference tables uses `OFFSET` pagination — fine for `limit<=100`; keyset is a future optimization if browse-all gets heavy.