### PR TITLE
Persist dataset_id and aoi_ids on statistics

### DIFF
--- a/db/alembic/versions/a1b2c3d4e5f6_add_dataset_and_aoi_ids_to_statistics.py
+++ b/db/alembic/versions/a1b2c3d4e5f6_add_dataset_and_aoi_ids_to_statistics.py
@@ -1,0 +1,85 @@
+"""add dataset_id and aoi_ids/aoi_sources to statistics
+
+Revision ID: a1b2c3d4e5f6
+Revises: e0e882fba200
+Create Date: 2026-06-30 00:00:00.000000
+
+Persist the catalog dataset id and the src_ids (with their sources) of the
+analysed AOIs alongside the existing human-readable names, so the insights
+listing endpoint can filter by stable ids instead of names. src_id is only
+unique per source, so aoi_sources is stored parallel to aoi_ids. All columns
+are nullable / defaulted so existing rows stay valid without backfill.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "e0e882fba200"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "statistics",
+        sa.Column("dataset_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "statistics",
+        sa.Column(
+            "aoi_ids",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+    op.add_column(
+        "statistics",
+        sa.Column(
+            "aoi_sources",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+    # Backfill dataset_id for existing rows from their dataset_name. The mapping
+    # is a self-contained snapshot of the dataset catalog
+    # (src/agent/datasets/catalog/*.yml) at migration time -- deliberately NOT
+    # imported from app code so the migration stays offline and stable. Rows
+    # whose dataset_name predates a catalog rename simply stay NULL. aoi_ids /
+    # aoi_sources are intentionally left at their [] default: src_id and source
+    # were never persisted for historical rows and cannot be reliably recovered.
+    op.execute(
+        """
+        UPDATE statistics AS s
+        SET dataset_id = m.dataset_id
+        FROM (VALUES
+            ('Global all ecosystem disturbance alerts (DIST-ALERT)', 0),
+            ('Global land cover', 1),
+            ('Global natural/semi-natural grassland extent', 2),
+            ('SBTN Natural Lands Map', 3),
+            ('Tree cover loss', 4),
+            ('Tree cover gain', 5),
+            ('Forest greenhouse gas net flux', 6),
+            ('Tree cover', 7),
+            ('Tree cover loss by dominant driver', 8),
+            ('Deforestation (sLUC) Emission Factors by Agricultural Crop', 9),
+            ('Tree cover loss due to fires', 10),
+            ('Integrated alerts', 11)
+        ) AS m(dataset_name, dataset_id)
+        WHERE s.dataset_name = m.dataset_name
+          AND s.dataset_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("statistics", "aoi_sources")
+    op.drop_column("statistics", "aoi_ids")
+    op.drop_column("statistics", "dataset_id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.1.1"
+version = "2026.7.1.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -29,6 +29,7 @@ class StatisticsParameter(TypedDict):
 class Statistics(TypedDict):
     id: NotRequired[str]
     dataset_name: str
+    dataset_id: NotRequired[int | None]
     start_date: str
     end_date: str
     source_url: NotRequired[str]
@@ -38,6 +39,10 @@ class Statistics(TypedDict):
     # re-applied after URL fetch so chart labels stay readable.
     aoi_id_to_name: NotRequired[dict]
     aoi_names: list[str]
+    # src_ids of the analysed AOIs, parallel to aoi_names; aoi_sources carries
+    # the matching source per id since src_id is only unique per source.
+    aoi_ids: NotRequired[list[str]]
+    aoi_sources: NotRequired[list[str]]
     parameters: list[StatisticsParameter] | None
     context_layer: str | None
 

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -155,15 +155,20 @@ async def pull_data(
     raw = result.data if isinstance(result.data, dict) else {}
     aoi_id_to_name = dict(zip(raw.get("aoi_id", []), raw.get("name", [])))
 
+    aois = state["aoi_selection"]["aois"]
     statistics = {
         "dataset_name": dataset["dataset_name"],
+        "dataset_id": dataset.get("dataset_id"),
         "start_date": effective_start,
         "end_date": effective_end,
         "source_url": result.analytics_api_url,
         # ID-backed statistics keep state light; fetch data from source_url when needed.
         "data": {},
         "aoi_id_to_name": aoi_id_to_name,
-        "aoi_names": [aoi["name"] for aoi in state["aoi_selection"]["aois"]],
+        "aoi_names": [aoi["name"] for aoi in aois],
+        # src_id is only unique per source, so sources are kept parallel to ids.
+        "aoi_ids": [aoi["src_id"] for aoi in aois],
+        "aoi_sources": [aoi["source"] for aoi in aois],
         "parameters": dataset.get("parameters"),
         "context_layer": dataset.get("context_layer"),
     }
@@ -174,10 +179,13 @@ async def pull_data(
             user_id=ctx.get("user_id"),
             thread_id=ctx.get("thread_id"),
             dataset_name=statistics["dataset_name"],
+            dataset_id=statistics["dataset_id"],
             start_date=statistics["start_date"],
             end_date=statistics["end_date"],
             source_url=statistics["source_url"],
             aoi_names=statistics["aoi_names"],
+            aoi_ids=statistics["aoi_ids"],
+            aoi_sources=statistics["aoi_sources"],
             parameters=statistics["parameters"],
             context_layer=statistics["context_layer"],
         )

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -197,10 +197,17 @@ class StatisticsOrm(Base):
     user_id = Column(String, ForeignKey("users.id"), nullable=True)
     thread_id = Column(String, nullable=True)
     dataset_name = Column(String, nullable=False)
+    # Catalog id of the dataset (parallel to dataset_name). Nullable so existing
+    # rows stay valid without backfill.
+    dataset_id = Column(Integer, nullable=True)
     start_date = Column(String, nullable=False)
     end_date = Column(String, nullable=False)
     source_url = Column(String, nullable=True)
     aoi_names = Column(JSONB, nullable=False, server_default="[]")
+    # src_ids of the analysed AOIs, parallel to aoi_names. src_id is only unique
+    # per source, so aoi_sources carries the matching source for each entry.
+    aoi_ids = Column(JSONB, nullable=False, server_default="[]")
+    aoi_sources = Column(JSONB, nullable=False, server_default="[]")
     parameters = Column(JSONB, nullable=True)
     context_layer = Column(String, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.now)

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -136,6 +136,7 @@ TEST_AOIS = [
     {
         "name": "Brazil",
         "subtype": "country",
+        "source": "gadm",
         "src_id": "BRA",
         "gadm_id": "BRA",
         "aoi_type": "country",
@@ -144,6 +145,7 @@ TEST_AOIS = [
     {
         "name": "Berne, Bern, Bern, Switzerland",
         "subtype": "municipality",
+        "source": "gadm",
         "src_id": "CHE.6.3_1",
         "gadm_id": "CHE.6.3_1",
         "aoi_type": "municipality",
@@ -152,6 +154,7 @@ TEST_AOIS = [
     {
         "name": "Marungu highlands, Marungu highlands, COD",
         "subtype": "key-biodiversity-area",
+        "source": "kba",
         "src_id": "6072",
         "gadm_id": None,
         "aoi_type": "key-biodiversity-area",
@@ -160,6 +163,7 @@ TEST_AOIS = [
     {
         "name": "Protected area",
         "subtype": "protected-area",
+        "source": "wdpa",
         "src_id": "148322",
         "gadm_id": None,
         "aoi_type": "protected-area",
@@ -168,6 +172,7 @@ TEST_AOIS = [
     {
         "name": "Indigenous land",
         "subtype": "indigenous-and-community-land",
+        "source": "landmark",
         "src_id": "MEX9713",
         "gadm_id": None,
         "aoi_type": "indigenous-and-community-land",
@@ -310,9 +315,12 @@ async def test_pull_data_persists_statistics(monkeypatch):
         statistics_row = result.scalar_one()
 
     assert statistics_row.dataset_name == "Tree cover loss"
+    assert statistics_row.dataset_id == 4
     assert statistics_row.start_date == "2020-01-01"
     assert statistics_row.end_date == "2020-12-31"
     assert statistics_row.aoi_names == ["Brazil"]
+    assert statistics_row.aoi_ids == ["BRA"]
+    assert statistics_row.aoi_sources == ["gadm"]
     assert statistics_row.parameters == [
         {"name": "canopy_cover", "values": [75]}
     ]


### PR DESCRIPTION
## Motivation

This adds ids for AOI and Datasets to the statistics ORM.

This is in preparation of making insights filterable by AOI and dataset for discovery on dashboards.


## What

Persist stable ids on `StatisticsOrm` so the insights listing filter can match by id instead of by human-readable name:

- **`dataset_id`** (`Integer`, nullable) — the catalog id, alongside the existing `dataset_name`.
- **`aoi_ids`** / **`aoi_sources`** (`JSONB`, parallel to `aoi_names`) — the AOI `src_id`s and their sources. `src_id` is only unique per source (gadm/kba/wdpa/landmark/custom), so the source is stored alongside each id.

`pull_data` now writes all three; the `Statistics` TypedDict in `state.py` is kept in sync.

## Migration

`a1b2c3d4e5f6` adds the three columns (down_revision `e0e882fba200`) and **backfills `dataset_id` for existing rows** from `dataset_name`, using a frozen `VALUES` snapshot of the 12-dataset catalog. The backfill is failsafe: it's an inner join, so any row whose name isn't in the snapshot is left untouched (stays `NULL`) — never errored, never mis-attributed. Names are unique, so a match can't pick the wrong id. It's idempotent (`AND dataset_id IS NULL`).

`aoi_ids` / `aoi_sources` are **not** backfilled — `src_id`/`source` were never persisted for historical rows and can't be reliably recovered (only ambiguous `aoi_names` was stored). Historical rows keep the `[]` default; id-based AOI filtering applies to new rows only.

## Scope

This PR only persists + backfills the columns. The listing-endpoint filter that consumes them (`dataset_name == dataset` → `dataset_id == dataset`, `aoi_names.has_key` → `aoi_ids.has_any`) lives in the sibling branch `feat/filter-insights`.

## Test plan

- [x] `tests/tools/test_pull_data.py` extended to assert `dataset_id`, `aoi_ids`, `aoi_sources` persist; passing.
- [x] Migration `VALUES` snapshot cross-checked against the live `DATASETS` catalog (12/12 exact match).
- [x] `alembic heads` → single head; migration parses.
- [x] Apply on a DB copy: `cd db && uv run alembic upgrade head`, then `SELECT dataset_name, dataset_id, count(*) FROM statistics GROUP BY 1,2;`

## Next steps

Add filters to the list insights endpoint
https://github.com/wri/project-zeno/blob/be54688d145df2eb1b54f82a2d67e389a1e380b4/src/api/routers/insights.py#L63