### PR TITLE
Fix WRI insights data snapshot fetch CI failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.1.4"
+version = "2026.7.1.5"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -1,7 +1,7 @@
-from .pull_data import pull_data
-from .show_imagery import show_imagery
+"""Agent tools package.
 
-__all__ = [
-    "pull_data",
-    "show_imagery",
-]
+Submodules are imported directly (e.g. ``src.agent.tools.pull_data``) so data
+ingestion scripts can load lightweight stores without initializing DB settings.
+"""
+
+__all__: list[str] = []

--- a/tests/tools/test_wri_insights_store.py
+++ b/tests/tools/test_wri_insights_store.py
@@ -1,3 +1,7 @@
+import os
+import subprocess
+import sys
+
 import src.agent.tools.wri_insights_store as store
 from src.agent.tools.wri_insights_store import (
     _parse_meta,
@@ -16,6 +20,22 @@ SAMPLE = """\
 
 [§2 | Section: "Background"] Second paragraph.
 """
+
+
+def test_wri_insights_store_imports_without_database_url() -> None:
+    env = {k: v for k, v in os.environ.items() if k != "DATABASE_URL"}
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from src.agent.tools.wri_insights_store import sync_articles",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
 
 
 def test_linkify_citations_makes_paragraph_tags_clickable() -> None:


### PR DESCRIPTION
## Summary
- Stop eagerly importing DB-backed agent tools from `src.agent.tools` so ingestion scripts can load `wri_insights_store` without `DATABASE_URL`.
- Add a regression test that imports the store module in a subprocess with `DATABASE_URL` unset.

## Why
The scheduled **WRI Insights Data Snapshot** workflow has failed on every run so far at the fetch step because `scripts/fetch_wri_insights.py` triggers an import chain through `src/agent/tools/__init__.py` → `pull_data` → database settings, which requires `DATABASE_URL` (not set in that job).

Failed runs:
- https://github.com/wri/project-zeno/actions/runs/28353280040 (2026-06-29)
- https://github.com/wri/project-zeno/actions/runs/27934825233 (2026-06-22)

Error excerpt:
```
pydantic_core.ValidationError: 1 validation error for _SharedSettings
database_url
  Field required
```

## Test plan
- [x] `uv run pytest tests/tools/test_wri_insights_store.py -q`
- [x] `uv run ruff check src/agent/tools/__init__.py tests/tools/test_wri_insights_store.py`
- [x] Re-run **WRI Insights Data Snapshot** workflow after merge
