### PR TITLE
PZB-1026: Initial draft implementation for insights handling [not merge]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.2"
+version = "2026.7.2.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -29,7 +29,11 @@ from src.agent.tools.inspect_view_context import (
     SPEC as inspect_view_context_spec,
 )
 from src.agent.tools.pull_data import SPEC as pull_data_spec
+from src.agent.tools.search_insights import SPEC as search_insights_spec
 from src.agent.tools.show_imagery import SPEC as show_imagery_spec
+from src.agent.tools.update_insight_display import (
+    SPEC as update_insight_display_spec,
+)
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -50,6 +54,8 @@ EXPERIMENTAL_SPECS = (
     inspect_view_context_spec,
     show_imagery_spec,
     search_blogs_spec,
+    update_insight_display_spec,
+    search_insights_spec,
 )
 
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -64,6 +64,7 @@ Match the request to exactly one row; do not escalate a dataset / AOI / pull req
 - AOI-only (e.g. "zoom to Pará"): call pick_aoi, then stop unless asked for more.
 - Pull-only (e.g. "pull dist alerts in Bern for last 2 weeks"): read `pull-data`, run pick_aoi → pick_dataset → pull_data, then stop. Do not call generate_insights unless the user asked for a chart or analysis.
 - Full analysis (place + topic → chart/insight): read `analyze` and follow that pipeline.
+- Recall a past insight (e.g. "show that tree-cover insight again", "pull up the fires analysis from before"): call search_insights and then STOP. search_insights is terminal — the insight already exists and is put on screen, so it is NEVER followed by pick_aoi, pick_dataset, pull_data or generate_insights. "Show/recall/pull up an earlier insight" is a recall request, never a request for new analysis. After it returns, reply with a one-line summary only.
 - Imagery (e.g. "show satellite imagery of Bern in June"): read `show-imagery`, run pick_aoi → show_imagery, then stop. No dataset, pull or insights unless asked.
 - Capabilities (what you can do, what data exists): read `capabilities`, then answer in your own words — no analysis tools.
 

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -76,6 +76,17 @@ class InsightChart(BaseModel):
                 )
         return self
 
+    def available_columns(self) -> List[str]:
+        """Column names present across all data rows, in first-seen order.
+
+        Rows may be heterogeneous (a column can appear only in later rows),
+        so this unions keys over every row rather than trusting the first.
+        """
+        columns: dict = {}
+        for row in self.chart_data:
+            columns.update(dict.fromkeys(row))
+        return list(columns)
+
     # --- adapters -----------------------------------------------------------
 
     def to_orm_kwargs(self) -> dict:

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -123,6 +123,26 @@ class InsightChart(BaseModel):
             chart_data=chart_data,
         )
 
+    @classmethod
+    def from_orm_row(cls, row) -> "InsightChart":
+        """Rebuild the seam model from a persisted `InsightChartOrm` row.
+
+        The inverse of `to_orm_kwargs()`: used when an existing insight is
+        loaded back from the DB to be restyled (no new data is pulled).
+        """
+        return cls(
+            position=row.position,
+            title=row.title,
+            chart_type=row.chart_type,
+            x_axis=row.x_axis,
+            y_axis=row.y_axis,
+            color_field=row.color_field,
+            stack_field=row.stack_field,
+            group_field=row.group_field,
+            series_fields=row.series_fields or [],
+            chart_data=row.chart_data or [],
+        )
+
 
 class Insight(BaseModel):
     """Resolved charts plus the narrative from the text stage."""

--- a/src/agent/subagents/analyst/code_executors/base.py
+++ b/src/agent/subagents/analyst/code_executors/base.py
@@ -3,10 +3,23 @@
 from base64 import b64encode
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional, get_args
 
 from pydantic import BaseModel, Field, model_validator
 
+# The chart types the frontend can render. `ChartType` is the validating
+# annotation; `CHART_TYPES` the same names as plain strings for prompts.
+ChartType = Literal[
+    "line",
+    "bar",
+    "stacked-bar",
+    "grouped-bar",
+    "pie",
+    "area",
+    "scatter",
+    "table",
+]
+CHART_TYPES: tuple[str, ...] = get_args(ChartType)
 CHART_TYPES_WITHOUT_AXIS = {"pie", "table"}
 
 
@@ -17,7 +30,7 @@ class ChartInsight(BaseModel):
 
     title: str = Field(description="Clear, descriptive title for the chart")
     chart_type: str = Field(
-        description="Chart type: 'line', 'bar', 'stacked-bar', 'grouped-bar', 'pie', 'area', 'scatter', or 'table'"
+        description="Chart type: " + ", ".join(f"'{t}'" for t in CHART_TYPES)
     )
     x_axis: str = Field(
         description="Name of the field to use for X-axis (for applicable chart types)"

--- a/src/agent/subagents/analyst/display_reviser.py
+++ b/src/agent/subagents/analyst/display_reviser.py
@@ -19,22 +19,14 @@ from pydantic import BaseModel, Field
 
 from src.agent.llms import SMALL_MODEL
 from src.agent.subagents.analyst.charts.model import Insight
+from src.agent.subagents.analyst.code_executors.base import (
+    CHART_TYPES,
+    ChartType,
+)
 from src.agent.subagents.analyst.prompts import WORDING_GUIDE
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-# The chart types the frontend can render (mirrors ChartInsight's description).
-ALLOWED_CHART_TYPES = [
-    "line",
-    "bar",
-    "stacked-bar",
-    "grouped-bar",
-    "pie",
-    "area",
-    "scatter",
-    "table",
-]
 
 
 class RevisedChart(BaseModel):
@@ -45,8 +37,8 @@ class RevisedChart(BaseModel):
         "position of an existing chart so the data can be re-attached."
     )
     title: str = Field(description="Clear, descriptive chart title")
-    chart_type: str = Field(
-        description=f"One of: {', '.join(ALLOWED_CHART_TYPES)}"
+    chart_type: ChartType = Field(
+        description=f"One of: {', '.join(CHART_TYPES)}"
     )
     x_axis: str = Field(
         default="", description="Existing column for the X-axis"
@@ -143,12 +135,12 @@ class InsightDisplayReviser:
 
         columns = "\n".join(
             f"- {chart.position}: "
-            f"{', '.join(chart.chart_data[0].keys()) if chart.chart_data else '(no data)'}"
+            f"{', '.join(chart.available_columns()) or '(no data)'}"
             for chart in insight.charts
         )
 
         inputs = {
-            "chart_types": ", ".join(ALLOWED_CHART_TYPES),
+            "chart_types": ", ".join(CHART_TYPES),
             "wording_guide": WORDING_GUIDE,
             "instruction": instruction or "(none provided)",
             "current": current,

--- a/src/agent/subagents/analyst/display_reviser.py
+++ b/src/agent/subagents/analyst/display_reviser.py
@@ -1,0 +1,165 @@
+"""Generative insight display reviser.
+
+Rewrites the *presentation* of an existing insight — narrative text, follow-up
+suggestions, chart titles, chart types and field mappings — without pulling new
+data or running new code. The underlying ``chart_data`` rows are fixed; the
+reviser may only restyle the charts and re-map among the columns that already
+exist in each chart's data.
+
+Like `InsightTextGenerator`, this is a LangChain runnable, so it nests as a span
+in the active Langfuse trace via the ambient `RunnableConfig`.
+"""
+
+import json
+from typing import List, Optional
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, Field
+
+from src.agent.llms import SMALL_MODEL
+from src.agent.subagents.analyst.charts.model import Insight
+from src.agent.subagents.analyst.prompts import WORDING_GUIDE
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# The chart types the frontend can render (mirrors ChartInsight's description).
+ALLOWED_CHART_TYPES = [
+    "line",
+    "bar",
+    "stacked-bar",
+    "grouped-bar",
+    "pie",
+    "area",
+    "scatter",
+    "table",
+]
+
+
+class RevisedChart(BaseModel):
+    """The restyled spec for one existing chart (no data, just presentation)."""
+
+    position: int = Field(
+        description="Position of the chart being revised; must match the "
+        "position of an existing chart so the data can be re-attached."
+    )
+    title: str = Field(description="Clear, descriptive chart title")
+    chart_type: str = Field(
+        description=f"One of: {', '.join(ALLOWED_CHART_TYPES)}"
+    )
+    x_axis: str = Field(
+        default="", description="Existing column for the X-axis"
+    )
+    y_axis: str = Field(
+        default="",
+        description="Existing column for the Y-axis (single-series charts)",
+    )
+    color_field: str = Field(
+        default="", description="Existing column for color"
+    )
+    stack_field: str = Field(
+        default="", description="Existing column to stack"
+    )
+    group_field: str = Field(
+        default="", description="Existing column to group"
+    )
+    series_fields: List[str] = Field(
+        default_factory=list,
+        description="Existing columns for multi-series charts",
+    )
+
+
+class RevisedInsight(BaseModel):
+    """Structured output: the restyled narrative + chart specs."""
+
+    primary_insight: str = Field(
+        description="Revised overall insight (2-3 sentences)"
+    )
+    follow_up_suggestions: List[str] = Field(
+        description="Revised 1-2 follow-up suggestions"
+    )
+    charts: List[RevisedChart] = Field(
+        description="One entry per existing chart, keyed by position"
+    )
+
+
+_SYSTEM = """You restyle an existing data insight — its narrative text, \
+follow-up suggestions, chart titles, chart types and field mappings.
+
+You are NOT given new data and you MUST NOT invent any: the underlying chart \
+rows are fixed. You may only:
+- reword the `primary_insight` and `follow_up_suggestions`,
+- rename chart titles,
+- change a chart's type (one of: {chart_types}),
+- re-map a chart to DIFFERENT columns that ALREADY EXIST in its data.
+
+Hard rules:
+- Never reference a column that is not listed as available for that chart.
+- Return exactly one revised chart per existing chart, keeping its `position`. \
+Do not add or remove charts.
+- For chart types other than 'pie' and 'table', set either `y_axis` (single \
+series) or `series_fields` (multi series).
+- Apply only what the instruction asks for; leave everything else as it was.
+
+{wording_guide}"""
+
+_USER = """## Instruction (what to change)
+{instruction}
+
+## Current insight
+{current}
+
+## Available columns per chart (position -> columns)
+{columns}"""
+
+_PROMPT = ChatPromptTemplate.from_messages(
+    [("system", _SYSTEM), ("user", _USER)]
+)
+
+
+class InsightDisplayReviser:
+    """Generates a restyled insight spec from an existing one + an instruction."""
+
+    def __init__(self, model=SMALL_MODEL):
+        self._chain = (
+            _PROMPT | model.with_structured_output(RevisedInsight)
+        ).with_config(run_name="revise_insight_display")
+
+    async def revise(
+        self,
+        insight: Insight,
+        instruction: str,
+        config: Optional[RunnableConfig] = None,
+    ) -> RevisedInsight:
+        # Show the spec but not the rows — the data is fixed and only inflates
+        # the prompt; available columns are surfaced separately below.
+        current = json.dumps(
+            insight.model_dump(
+                exclude={"charts": {"__all__": {"chart_data", "insight"}}}
+            ),
+            default=str,
+        )
+
+        columns = "\n".join(
+            f"- {chart.position}: "
+            f"{', '.join(chart.chart_data[0].keys()) if chart.chart_data else '(no data)'}"
+            for chart in insight.charts
+        )
+
+        inputs = {
+            "chart_types": ", ".join(ALLOWED_CHART_TYPES),
+            "wording_guide": WORDING_GUIDE,
+            "instruction": instruction or "(none provided)",
+            "current": current,
+            "columns": columns,
+        }
+        result: RevisedInsight = await self._chain.ainvoke(
+            inputs, config=config
+        )
+        logger.info(
+            "revised insight display",
+            charts=len(result.charts),
+            follow_ups=len(result.follow_up_suggestions),
+        )
+        return result

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -216,14 +216,23 @@ async def inspect_view_context(
     refers to "this", "here", the current view, the report, or an insight on
     screen, and you need those details to answer.
     """
-    logger.info("inspect_view_context tool called")
     view = (state or {}).get("view_context") or {}
+    logger.info(
+        "inspect_view_context tool called",
+        page=view.get("page"),
+        has_view_context=bool(view),
+    )
 
     sections = [format_view_context(view)]
 
     insight_ids = _extract_insight_ids(view.get("visible_insights"))
     if insight_ids:
         rows = await _load_insights(insight_ids)
+        logger.info(
+            "inspect_view_context loaded insights",
+            requested=len(insight_ids),
+            loaded=len(rows),
+        )
         if rows:
             sections.append(format_insights(rows))
         else:

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -30,6 +30,7 @@ from sqlalchemy.orm import selectinload
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.data_models import InsightOrm
+from src.api.repositories.insight_access import is_visible_to_user
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
 
@@ -134,9 +135,8 @@ def _extract_insight_ids(refs: object) -> list[UUID]:
 async def _load_insights(insight_ids: list[UUID]) -> list[InsightOrm]:
     """Load insights (with charts) the current user is allowed to see.
 
-    Ownership mirrors the /api/insights/{id} endpoint: a user's own insights
-    plus any public one. The user id comes from the request-scoped logging
-    context bound by the auth dependency.
+    Visibility is the shared `insight_access` rule (own + public). The user id
+    comes from the request-scoped logging context bound by the auth dependency.
     """
     if not insight_ids:
         return []
@@ -148,11 +148,7 @@ async def _load_insights(insight_ids: list[UUID]) -> list[InsightOrm]:
             .where(InsightOrm.id.in_(insight_ids))
         )
         rows = result.scalars().all()
-    return [
-        row
-        for row in rows
-        if row.is_public or (user_id and row.user_id == user_id)
-    ]
+    return [row for row in rows if is_visible_to_user(row, user_id)]
 
 
 def _chart_variables(chart) -> str:

--- a/src/agent/tools/search_insights.py
+++ b/src/agent/tools/search_insights.py
@@ -1,20 +1,19 @@
 """search_insights — find a past insight by free-text and re-surface it.
 
-Demo tooling: shows the agent can dig up an insight produced earlier (this
-thread or any the user owns / a public one) and put it back on screen. It does
-not generate anything — it searches the persisted `InsightOrm` rows by their
-summary text, picks the best match, and pushes it into state in the same shape
-`generate_insights` uses, so the frontend renders it as a normal insight card.
+Digs up an insight produced earlier (this thread or any the user owns, or a
+public one) and puts it back on screen. It does not generate anything — it
+searches the persisted `InsightOrm` rows by their summary text, picks the best
+match, and pushes it into state in the same shape `generate_insights` uses, so
+the frontend renders it as a normal insight card.
 """
 
 import re
-from typing import Annotated, Dict, Optional
+from typing import Annotated, Optional
 
 import structlog
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
-from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 from sqlalchemy import Text, cast, or_, select
 from sqlalchemy.orm import selectinload
@@ -22,6 +21,7 @@ from sqlalchemy.orm import selectinload
 from src.agent.subagents.analyst.charts.model import Insight, InsightChart
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.data_models import InsightChartOrm, InsightOrm
+from src.api.repositories.insight_access import visible_insights_clause
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
 
@@ -29,8 +29,14 @@ logger = get_logger(__name__)
 
 
 def _terms(query: str) -> list[str]:
-    """Split a query into lowercased search terms (drops punctuation/stopgaps)."""
+    """Split a query into lowercased terms, dropping punctuation and tokens
+    shorter than 3 characters."""
     return [t for t in re.split(r"\W+", query.lower()) if len(t) > 2]
+
+
+def _escape_like(text: str) -> str:
+    """Escape ILIKE metacharacters so user text matches literally."""
+    return text.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
 
 
 def _haystack(row: InsightOrm) -> str:
@@ -60,25 +66,31 @@ async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
     """Fetch candidate insights the user may see whose summary matches `query`.
 
     Search spans ALL of the user's conversations — it is deliberately not scoped
-    to the current thread. Visibility mirrors the insights API: the user's own
-    insights (from any thread) plus public ones and owner-less rows (e.g. CLI
-    runs). Matching is an ILIKE (per term or full phrase) across the summary,
-    the chart titles, and the chart data text — so place names and datasets that
+    to the current thread. Visibility is the shared rule from `insight_access`
+    (own + public), applied in SQL so invisible rows never consume the limit.
+    Matching is an ILIKE (per term or full phrase) across the summary, the
+    chart titles, and the chart data text — so place names and datasets that
     only show up in a title or a data value are still found. Ranking is in Python.
     """
     terms = _terms(query)
     user_id = structlog.contextvars.get_contextvars().get("user_id")
 
-    patterns = [f"%{t}%" for t in terms] + [f"%{query.strip()}%"]
+    patterns = [f"%{_escape_like(t)}%" for t in terms]
+    if query.strip():
+        patterns.append(f"%{_escape_like(query.strip())}%")
     text_match = or_(
         *[
             cond
             for p in patterns
             for cond in (
-                InsightOrm.insight_text.ilike(p),
-                InsightOrm.charts.any(InsightChartOrm.title.ilike(p)),
+                InsightOrm.insight_text.ilike(p, escape="\\"),
                 InsightOrm.charts.any(
-                    cast(InsightChartOrm.chart_data, Text).ilike(p)
+                    InsightChartOrm.title.ilike(p, escape="\\")
+                ),
+                InsightOrm.charts.any(
+                    cast(InsightChartOrm.chart_data, Text).ilike(
+                        p, escape="\\"
+                    )
                 ),
             )
         ]
@@ -88,25 +100,16 @@ async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
         result = await session.execute(
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
-            .where(text_match)
+            .where(visible_insights_clause(user_id), text_match)
             .order_by(InsightOrm.created_at.desc())
             .limit(limit)
         )
-        rows = result.scalars().all()
-
-    return [
-        row
-        for row in rows
-        if row.is_public
-        or row.user_id is None
-        or (user_id and row.user_id == user_id)
-    ]
+        return list(result.scalars().all())
 
 
 @tool("search_insights")
 async def search_insights(
     query: str,
-    state: Annotated[Dict, InjectedState] | None = None,
     tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
     """Find a previously generated insight by description and put it back on screen.
@@ -118,6 +121,25 @@ async def search_insights(
     before" or "pull up the one about fires in the Amazon".
     """
     logger.info("search_insights tool called", query=query)
+
+    # Without at least one usable pattern the ILIKE degenerates to '%%' and
+    # "matches" every insight — refuse instead of recalling an arbitrary one.
+    if not _terms(query) and len(query.strip()) < 3:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            "Query too short to search past insights. Describe "
+                            "the insight to recall, e.g. a place, dataset or "
+                            "phrase from its summary."
+                        ),
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
+                ]
+            }
+        )
 
     rows = await _search_insights(query)
     if not rows:

--- a/src/agent/tools/search_insights.py
+++ b/src/agent/tools/search_insights.py
@@ -1,0 +1,196 @@
+"""search_insights — find a past insight by free-text and re-surface it.
+
+Demo tooling: shows the agent can dig up an insight produced earlier (this
+thread or any the user owns / a public one) and put it back on screen. It does
+not generate anything — it searches the persisted `InsightOrm` rows by their
+summary text, picks the best match, and pushes it into state in the same shape
+`generate_insights` uses, so the frontend renders it as a normal insight card.
+"""
+
+import re
+from typing import Annotated, Dict, Optional
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from sqlalchemy import Text, cast, or_, select
+from sqlalchemy.orm import selectinload
+
+from src.agent.subagents.analyst.charts.model import Insight, InsightChart
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.data_models import InsightChartOrm, InsightOrm
+from src.shared.database import get_session_from_pool
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _terms(query: str) -> list[str]:
+    """Split a query into lowercased search terms (drops punctuation/stopgaps)."""
+    return [t for t in re.split(r"\W+", query.lower()) if len(t) > 2]
+
+
+def _haystack(row: InsightOrm) -> str:
+    """All searchable text for a row: summary + chart titles + chart data.
+
+    Place names and dataset/metric names live in the chart titles and in the
+    chart_data values (e.g. {"country": "Brazil"}), not just the summary — so
+    they are all folded in here.
+    """
+    parts = [row.insight_text or ""]
+    for chart in row.charts or []:
+        parts.append(chart.title or "")
+        parts.append(str(chart.chart_data or ""))
+    return " ".join(parts).lower()
+
+
+def _score(row: InsightOrm, terms: list[str], phrase: str) -> int:
+    """Rough relevance: term hits across all searchable text, phrase bonus."""
+    haystack = _haystack(row)
+    score = sum(1 for t in terms if t in haystack)
+    if phrase and phrase.lower() in haystack:
+        score += len(terms) + 1  # full-phrase match outranks scattered terms
+    return score
+
+
+async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
+    """Fetch candidate insights the user may see whose summary matches `query`.
+
+    Search spans ALL of the user's conversations — it is deliberately not scoped
+    to the current thread. Visibility mirrors the insights API: the user's own
+    insights (from any thread) plus public ones and owner-less rows (e.g. CLI
+    runs). Matching is an ILIKE (per term or full phrase) across the summary,
+    the chart titles, and the chart data text — so place names and datasets that
+    only show up in a title or a data value are still found. Ranking is in Python.
+    """
+    terms = _terms(query)
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+
+    patterns = [f"%{t}%" for t in terms] + [f"%{query.strip()}%"]
+    text_match = or_(
+        *[
+            cond
+            for p in patterns
+            for cond in (
+                InsightOrm.insight_text.ilike(p),
+                InsightOrm.charts.any(InsightChartOrm.title.ilike(p)),
+                InsightOrm.charts.any(
+                    cast(InsightChartOrm.chart_data, Text).ilike(p)
+                ),
+            )
+        ]
+    )
+
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(text_match)
+            .order_by(InsightOrm.created_at.desc())
+            .limit(limit)
+        )
+        rows = result.scalars().all()
+
+    return [
+        row
+        for row in rows
+        if row.is_public
+        or row.user_id is None
+        or (user_id and row.user_id == user_id)
+    ]
+
+
+@tool("search_insights")
+async def search_insights(
+    query: str,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Find a previously generated insight by description and put it back on screen.
+
+    Searches past insights across ALL of the user's conversations (plus public
+    ones) by their summary text, picks the best match, and surfaces it so they see
+    the chart and summary again — without recomputing anything. Use this when the
+    user refers to an earlier finding, e.g. "show me that tree-cover insight from
+    before" or "pull up the one about fires in the Amazon".
+    """
+    logger.info("search_insights tool called", query=query)
+
+    rows = await _search_insights(query)
+    if not rows:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"No past insight matched '{query}'.",
+                        tool_call_id=tool_call_id,
+                        status="success",
+                    )
+                ]
+            }
+        )
+
+    terms = _terms(query)
+    best = max(rows, key=lambda r: (_score(r, terms, query), r.created_at))
+    logger.info(
+        "search_insights matched",
+        insight_id=str(best.id),
+        candidates=len(rows),
+    )
+
+    insight = Insight(
+        charts=[InsightChart.from_orm_row(c) for c in (best.charts or [])],
+        primary_insight=best.insight_text,
+        follow_up_suggestions=best.follow_up_suggestions or [],
+    ).stamp_insight()
+
+    chart_titles = ", ".join(c.title for c in insight.charts) or "(no charts)"
+    return Command(
+        update={
+            "insight_id": str(best.id),
+            "insight": insight.primary_insight,
+            "follow_up_suggestions": insight.follow_up_suggestions,
+            "charts_data": [c.to_frontend_dict() for c in insight.charts],
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Found a past insight ({best.id}) matching '{query}'.\n"
+                        f"Charts: {chart_titles}.\n\n"
+                        f"Summary: {insight.primary_insight}\n\n"
+                        "STOP HERE. This insight already exists and is now on "
+                        "screen. Do NOT call pull_data, generate_insights or any "
+                        "other tool. Reply to the user with a one-line summary "
+                        "of this recalled insight and nothing else."
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    # Same signal as update_insight_display: the insight already
+                    # exists, so the frontend re-fetches /api/insights/{id} and
+                    # shows it (replacing in place, or rendering it if not yet
+                    # mounted) rather than treating it as a brand-new analysis.
+                    response_metadata={
+                        "msg_type": "insight_updated",
+                        "insight_id": str(best.id),
+                    },
+                )
+            ],
+        },
+    )
+
+
+SPEC = ToolSpec(
+    tool=search_insights,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- search_insights(query): find a previously generated insight by "
+        "description and put it back on screen (chart + summary), without "
+        "recomputing. Use when the user refers to an earlier finding, e.g. "
+        "'show that insight about fires in the Amazon again'. This is a "
+        "TERMINAL action: after it returns, do NOT call pull_data, "
+        "generate_insights or any other tool — just give a one-line summary "
+        "of the recalled insight and stop."
+    ),
+)

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -31,6 +31,7 @@ from src.agent.subagents.analyst.display_reviser import (
 )
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.data_models import InsightOrm
+from src.api.repositories.insight_access import is_editable_by_user
 from src.api.repositories.insight_writer import update_insight
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
@@ -55,20 +56,23 @@ def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
 async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
     """Load an insight (with charts) the current user is allowed to edit.
 
-    Editable means the user owns it (or it has no owner, e.g. CLI runs). Public
-    insights owned by someone else are read-only and not returned.
+    Editable means the current user owns it (`insight_access` rule). Public or
+    owner-less insights are read-only; without an authenticated user nothing
+    is editable. Malformed ids are treated as not found.
     """
     user_id = structlog.contextvars.get_contextvars().get("user_id")
+    try:
+        target = UUID(insight_id)
+    except ValueError:
+        return None
     async with get_session_from_pool() as session:
         result = await session.execute(
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
-            .where(InsightOrm.id == UUID(insight_id))
+            .where(InsightOrm.id == target)
         )
         row = result.scalar_one_or_none()
-    if row is None:
-        return None
-    if row.user_id and user_id and row.user_id != user_id:
+    if row is None or not is_editable_by_user(row, user_id):
         return None
     return row
 
@@ -100,11 +104,7 @@ def _apply_revision(
     new_charts: list[InsightChart] = []
     for original in originals:
         rc = revised_by_pos.get(original.position)
-        available = (
-            set(original.chart_data[0].keys())
-            if original.chart_data
-            else set()
-        )
+        available = set(original.available_columns())
         if rc is None or not _referenced_columns(rc) <= available:
             if rc is not None:
                 logger.warning(

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -1,0 +1,235 @@
+"""update_insight_display — restyle an existing insight, no new data.
+
+Where `generate_insights` pulls data, runs code and builds an insight from
+scratch, this tool only touches the *display* layer of an insight that already
+exists: the narrative text, follow-up suggestions, chart titles, chart types and
+which existing columns each chart maps to. It never pulls data or runs code — the
+underlying chart rows are preserved untouched.
+
+The target is the current insight in state (the last one generated this thread)
+unless an explicit ``insight_id`` is given. The revised insight is persisted in
+place and pushed back onto state so the frontend re-renders it.
+"""
+
+from typing import Annotated, Dict, Optional
+from uuid import UUID
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from src.agent.subagents.analyst.charts.model import Insight, InsightChart
+from src.agent.subagents.analyst.display_reviser import (
+    InsightDisplayReviser,
+    RevisedChart,
+    RevisedInsight,
+)
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.data_models import InsightOrm
+from src.api.repositories.insight_writer import update_insight
+from src.shared.database import get_session_from_pool
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=message,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+            ]
+        }
+    )
+
+
+async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
+    """Load an insight (with charts) the current user is allowed to edit.
+
+    Editable means the user owns it (or it has no owner, e.g. CLI runs). Public
+    insights owned by someone else are read-only and not returned.
+    """
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(InsightOrm.id == UUID(insight_id))
+        )
+        row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    if row.user_id and user_id and row.user_id != user_id:
+        return None
+    return row
+
+
+def _referenced_columns(chart: RevisedChart) -> set[str]:
+    """Every non-empty column a revised chart points at."""
+    named = {
+        chart.x_axis,
+        chart.y_axis,
+        chart.color_field,
+        chart.stack_field,
+        chart.group_field,
+    }
+    named.update(chart.series_fields)
+    return {name for name in named if name}
+
+
+def _apply_revision(
+    originals: list[InsightChart], revised: RevisedInsight
+) -> Insight:
+    """Merge the revised display fields back onto the fixed chart data.
+
+    Charts are matched by `position`; the original `chart_data` is always kept.
+    A revision that references a column the data does not have is dropped (the
+    original chart is left as-is) so we never produce a chart that can't render.
+    """
+    revised_by_pos = {rc.position: rc for rc in revised.charts}
+
+    new_charts: list[InsightChart] = []
+    for original in originals:
+        rc = revised_by_pos.get(original.position)
+        available = (
+            set(original.chart_data[0].keys())
+            if original.chart_data
+            else set()
+        )
+        if rc is None or not _referenced_columns(rc) <= available:
+            if rc is not None:
+                logger.warning(
+                    "update_insight_display: revision references unknown "
+                    "columns, keeping original chart",
+                    position=original.position,
+                )
+            new_charts.append(original)
+            continue
+        new_charts.append(
+            InsightChart(
+                position=original.position,
+                title=rc.title,
+                chart_type=rc.chart_type,
+                x_axis=rc.x_axis,
+                y_axis=rc.y_axis,
+                color_field=rc.color_field,
+                stack_field=rc.stack_field,
+                group_field=rc.group_field,
+                series_fields=rc.series_fields,
+                chart_data=original.chart_data,
+            )
+        )
+
+    return Insight(
+        charts=new_charts,
+        primary_insight=revised.primary_insight,
+        follow_up_suggestions=revised.follow_up_suggestions,
+    ).stamp_insight()
+
+
+@tool("update_insight_display")
+async def update_insight_display(
+    instruction: str,
+    insight_id: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Restyle an existing insight without pulling new data or running code.
+
+    Use this for presentation-only changes the user asks for on an insight that
+    already exists: reword the summary or follow-up suggestions, rename a chart,
+    change a chart type (e.g. bar -> line), or re-map a chart to other columns it
+    already has. It cannot add data, compute new metrics or create charts — use
+    generate_insights for anything that needs new data or analysis.
+
+    By default it updates the most recent insight in this conversation; pass
+    `insight_id` to target a specific one (e.g. an insight visible on screen).
+    """
+    target_id = insight_id or (state or {}).get("insight_id")
+    if not target_id:
+        return _error_command(
+            "No insight to update. Generate an insight first, or pass an "
+            "insight_id.",
+            tool_call_id,
+        )
+
+    logger.info("update_insight_display tool called", insight_id=target_id)
+
+    row = await _load_editable_insight(str(target_id))
+    if row is None:
+        return _error_command(
+            f"Insight {target_id} not found or not editable.", tool_call_id
+        )
+
+    current = Insight(
+        charts=[InsightChart.from_orm_row(c) for c in (row.charts or [])],
+        primary_insight=row.insight_text,
+        follow_up_suggestions=row.follow_up_suggestions or [],
+    )
+
+    revised = await InsightDisplayReviser().revise(current, instruction)
+
+    try:
+        updated = _apply_revision(current.charts, revised)
+    except ValueError as exc:
+        logger.warning("update_insight_display: invalid revision: %s", exc)
+        return _error_command(
+            f"Could not apply that change: {exc}", tool_call_id
+        )
+
+    if not await update_insight(str(target_id), updated):
+        return _error_command(
+            f"Insight {target_id} disappeared before it could be updated.",
+            tool_call_id,
+        )
+
+    chart_titles = ", ".join(c.title for c in updated.charts)
+    return Command(
+        update={
+            "insight_id": str(target_id),
+            "insight": updated.primary_insight,
+            "follow_up_suggestions": updated.follow_up_suggestions,
+            "charts_data": [c.to_frontend_dict() for c in updated.charts],
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Updated insight {target_id}. "
+                        f"Charts: {chart_titles}.\n\n"
+                        f"Summary: {updated.primary_insight}"
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    # Distinct from "human_feedback" (a new insight) so the
+                    # frontend replaces the existing insight in place / re-fetches
+                    # /api/insights/{insight_id} rather than rendering a new card.
+                    response_metadata={
+                        "msg_type": "insight_updated",
+                        "insight_id": str(target_id),
+                    },
+                )
+            ],
+        }
+    )
+
+
+SPEC = ToolSpec(
+    tool=update_insight_display,
+    category=ToolCategory.SUBAGENT,
+    prompt_fragment=(
+        "- update_insight_display(instruction, insight_id?): restyle an "
+        "existing insight without new data — reword the summary or follow-ups, "
+        "rename charts, change a chart type, or re-map a chart to columns it "
+        "already has. Defaults to the most recent insight; pass insight_id to "
+        "target a specific one. Use generate_insights when new data or "
+        "analysis is needed."
+    ),
+)

--- a/src/api/repositories/insight_access.py
+++ b/src/api/repositories/insight_access.py
@@ -1,0 +1,42 @@
+"""Who may see or edit an insight — the single place that rule lives.
+
+Read rule: a user sees their own insights plus public ones.
+Edit rule: only the owner may edit. Owner-less rows (user_id NULL, e.g. old
+CLI runs) are neither visible nor editable through the agent tools.
+
+Both rules take the user id from the caller (the agent tools read it from the
+request-scoped structlog context bound by the auth dependency) and treat a
+missing user id as "not authenticated": nothing private is visible, nothing is
+editable.
+
+The API router (``src/api/routers/insights.py``) implements the same read rule
+with two extras that don't apply to agent tools — admin/superuser override and
+HTTP error semantics — so it stays separate.
+"""
+
+from typing import Optional
+
+from sqlalchemy import or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from src.api.data_models import InsightOrm
+
+
+def visible_insights_clause(user_id: Optional[str]) -> ColumnElement:
+    """SQL WHERE clause selecting the insights `user_id` may see."""
+    if user_id:
+        return or_(
+            InsightOrm.is_public.is_(True),
+            InsightOrm.user_id == user_id,
+        )
+    return InsightOrm.is_public.is_(True)
+
+
+def is_visible_to_user(row: InsightOrm, user_id: Optional[str]) -> bool:
+    """Python twin of `visible_insights_clause` for already-loaded rows."""
+    return bool(row.is_public or (user_id and row.user_id == user_id))
+
+
+def is_editable_by_user(row: InsightOrm, user_id: Optional[str]) -> bool:
+    """Only the owner may edit; unauthenticated callers edit nothing."""
+    return bool(user_id and row.user_id == user_id)

--- a/src/api/repositories/insight_writer.py
+++ b/src/api/repositories/insight_writer.py
@@ -75,13 +75,19 @@ async def update_insight(insight_id: str, insight: Insight) -> bool:
     the `codeact_*` provenance and `created_at` are deliberately left untouched:
     this path restyles an insight, it does not pull new data or re-run code.
 
-    Returns ``True`` on success, ``False`` if the insight no longer exists.
+    Returns ``True`` on success, ``False`` if the insight no longer exists
+    (or the id is malformed).
     """
+    try:
+        target = UUID(insight_id)
+    except ValueError:
+        return False
+
     async with get_session_from_pool() as session:
         result = await session.execute(
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
-            .where(InsightOrm.id == UUID(insight_id))
+            .where(InsightOrm.id == target)
         )
         insight_orm = result.scalar_one_or_none()
         if insight_orm is None:

--- a/src/api/repositories/insight_writer.py
+++ b/src/api/repositories/insight_writer.py
@@ -6,6 +6,10 @@ the single place that mapping lives, driven by the canonical `Insight`.
 """
 
 from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from src.agent.subagents.analyst.charts.model import Insight
 from src.api.data_models import InsightChartOrm, InsightOrm
@@ -60,3 +64,43 @@ async def persist_insight(
         charts_count=len(insight.charts),
     )
     return insight_id
+
+
+async def update_insight(insight_id: str, insight: Insight) -> bool:
+    """Rewrite an existing insight's display layer in place.
+
+    Only the generative/presentation fields are replaced — narrative text,
+    follow-up suggestions and the chart specs (titles, types, field mappings,
+    per-chart `chart_data`). Ownership (`user_id`/`thread_id`), `statistics_ids`,
+    the `codeact_*` provenance and `created_at` are deliberately left untouched:
+    this path restyles an insight, it does not pull new data or re-run code.
+
+    Returns ``True`` on success, ``False`` if the insight no longer exists.
+    """
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(InsightOrm.id == UUID(insight_id))
+        )
+        insight_orm = result.scalar_one_or_none()
+        if insight_orm is None:
+            return False
+
+        insight_orm.insight_text = insight.primary_insight
+        insight_orm.follow_up_suggestions = insight.follow_up_suggestions
+        # Reassigning the collection lets the delete-orphan cascade drop the old
+        # chart rows and insert the revised ones in their place.
+        insight_orm.charts = [
+            InsightChartOrm(**chart.to_orm_kwargs())
+            for chart in insight.charts
+        ]
+
+        await session.commit()
+
+    logger.info(
+        "insight_updated",
+        insight_id=insight_id,
+        charts_count=len(insight.charts),
+    )
+    return True

--- a/src/api/routers/insights.py
+++ b/src/api/routers/insights.py
@@ -89,6 +89,9 @@ async def get_insight(
     """
     Get a single insight. Public insights can be accessed by anyone.
     Private insights require authentication and ownership.
+
+    Same read rule as `src.api.repositories.insight_access` (used by the
+    agent tools), plus the admin/superuser override and HTTP error semantics.
     """
     result = await session.execute(
         select(InsightOrm)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -358,7 +358,8 @@ class ChatRequest(BaseModel):
     #   {"page": "map" | "report",
     #    "viewport": {"bbox": [minx, miny, maxx, maxy], "zoom": 5},
     #    "visible_layers": [{"id": "...", "name": "..."}],
-    #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}]}
+    #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}],
+    #    "visible_insights": ["<uuid>", "<uuid>"]}
     view_context: Optional[dict] = Field(
         None,
         description="Ambient frontend view state (page, viewport, visible layers/AOIs)",

--- a/tests/agent/test_insights_db.py
+++ b/tests/agent/test_insights_db.py
@@ -1,0 +1,196 @@
+"""DB-integration tests for insight recall and in-place update.
+
+These exercise the real SQL paths the tool unit tests mock out: the shared
+visibility clause in `_search_insights` (including its interaction with
+LIMIT), the ownership rule in `_load_editable_insight`, and the chart
+replacement + provenance preservation in `update_insight`.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+import structlog
+from sqlalchemy import func, select
+
+from src.agent.subagents.analyst.charts.model import Insight, InsightChart
+from src.agent.tools.search_insights import _search_insights
+from src.agent.tools.update_insight_display import _load_editable_insight
+from src.api.data_models import InsightChartOrm, InsightOrm
+from src.api.repositories.insight_writer import update_insight
+from tests.conftest import async_session_maker
+
+
+async def _insert_insight(
+    *,
+    user_id,
+    text,
+    is_public=False,
+    created_at=datetime(2026, 6, 1),
+    chart_title="Annual tree cover loss",
+    chart_data=None,
+):
+    async with async_session_maker() as session:
+        row = InsightOrm(
+            user_id=user_id,
+            thread_id="thread-1",
+            insight_text=text,
+            follow_up_suggestions=["old follow-up"],
+            statistics_ids=["stat-1"],
+            codeact_types=["code"],
+            codeact_contents=["cHJpbnQoKQ=="],
+            is_public=is_public,
+            created_at=created_at,
+        )
+        session.add(row)
+        await session.flush()
+        session.add(
+            InsightChartOrm(
+                insight_id=row.id,
+                position=0,
+                title=chart_title,
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss",
+                chart_data=chart_data or [{"year": 2020, "loss": 5}],
+            )
+        )
+        await session.commit()
+        return row.id
+
+
+def _revised_insight():
+    return Insight(
+        charts=[
+            InsightChart(
+                position=0,
+                title="New title",
+                chart_type="line",
+                x_axis="year",
+                y_axis="loss",
+                chart_data=[{"year": 2020, "loss": 5}],
+            )
+        ],
+        primary_insight="New summary.",
+        follow_up_suggestions=["new follow-up"],
+    ).stamp_insight()
+
+
+async def test_search_returns_own_and_public_only(user, user_ds):
+    own = await _insert_insight(
+        user_id=user.id, text="Tree cover loss in the Amazon rose."
+    )
+    theirs_public = await _insert_insight(
+        user_id=user_ds.id,
+        text="Amazon fires spiked in 2025.",
+        is_public=True,
+    )
+    await _insert_insight(  # other's private: must not appear
+        user_id=user_ds.id, text="Private Amazon deforestation note."
+    )
+    await _insert_insight(  # ownerless: must not appear
+        user_id=None, text="Ownerless Amazon CLI insight."
+    )
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        rows = await _search_insights("amazon")
+
+    assert {row.id for row in rows} == {own, theirs_public}
+
+
+async def test_invisible_rows_do_not_consume_the_limit(user, user_ds):
+    own = await _insert_insight(
+        user_id=user.id,
+        text="Tree cover loss in the Amazon rose.",
+        created_at=datetime(2026, 6, 1),
+    )
+    # Newer matching rows the user may not see: with the visibility filter
+    # applied after LIMIT these would crowd out the real match.
+    for day in range(2, 5):
+        await _insert_insight(
+            user_id=user_ds.id,
+            text="Private Amazon note.",
+            created_at=datetime(2026, 6, day),
+        )
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        rows = await _search_insights("amazon", limit=1)
+
+    assert [row.id for row in rows] == [own]
+
+
+async def test_search_matches_chart_title_and_data(user):
+    insight_id = await _insert_insight(
+        user_id=user.id,
+        text="Deforestation summary.",
+        chart_title="Fires in Para",
+        chart_data=[{"country": "Brazil", "fires": 120}],
+    )
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        by_title = await _search_insights("para fires")
+        by_data = await _search_insights("brazil")
+
+    assert insight_id in {row.id for row in by_title}
+    assert insight_id in {row.id for row in by_data}
+
+
+async def test_load_editable_insight_owner_only(user, user_ds):
+    own = await _insert_insight(user_id=user.id, text="Mine.")
+    theirs = await _insert_insight(
+        user_id=user_ds.id, text="Theirs.", is_public=True
+    )
+    ownerless = await _insert_insight(user_id=None, text="Ownerless.")
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        assert (await _load_editable_insight(str(own))).id == own
+        assert await _load_editable_insight(str(theirs)) is None
+        assert await _load_editable_insight(str(ownerless)) is None
+        assert await _load_editable_insight("not-a-uuid") is None
+
+    # Without an authenticated user nothing is editable.
+    assert await _load_editable_insight(str(own)) is None
+
+
+async def test_update_insight_replaces_charts_preserves_provenance(user):
+    insight_id = await _insert_insight(user_id=user.id, text="Old summary.")
+
+    assert await update_insight(str(insight_id), _revised_insight()) is True
+
+    async with async_session_maker() as session:
+        row = await session.get(InsightOrm, insight_id)
+        charts = (
+            (
+                await session.execute(
+                    select(InsightChartOrm).where(
+                        InsightChartOrm.insight_id == insight_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        orphans = await session.scalar(
+            select(func.count())
+            .select_from(InsightChartOrm)
+            .where(InsightChartOrm.insight_id != insight_id)
+        )
+
+    # Display layer replaced...
+    assert row.insight_text == "New summary."
+    assert row.follow_up_suggestions == ["new follow-up"]
+    assert len(charts) == 1
+    assert charts[0].title == "New title"
+    assert charts[0].chart_type == "line"
+    assert orphans == 0
+    # ...provenance untouched.
+    assert row.user_id == user.id
+    assert row.thread_id == "thread-1"
+    assert row.statistics_ids == ["stat-1"]
+    assert row.codeact_types == ["code"]
+    assert row.codeact_contents == ["cHJpbnQoKQ=="]
+    assert row.created_at == datetime(2026, 6, 1)
+
+
+async def test_update_insight_missing_or_malformed_id():
+    assert await update_insight(str(uuid4()), _revised_insight()) is False
+    assert await update_insight("not-a-uuid", _revised_insight()) is False

--- a/tests/agent/test_search_insights.py
+++ b/tests/agent/test_search_insights.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 
 from src.agent.tools.search_insights import (
+    _escape_like,
     _score,
     _terms,
     search_insights,
@@ -53,6 +54,10 @@ def test_terms_drops_short_tokens_and_lowercases():
         "the",
         "amazon",
     ]
+
+
+def test_escape_like_escapes_metacharacters():
+    assert _escape_like("100%_gain\\") == "100\\%\\_gain\\\\"
 
 
 def test_score_rewards_phrase_match():
@@ -108,6 +113,15 @@ async def test_search_insights_picks_highest_scoring():
             query="tree cover amazon", tool_call_id="t1"
         )
     assert command.update["insight_id"] == str(strong.id)
+
+
+@pytest.mark.asyncio
+async def test_search_insights_rejects_empty_query():
+    # No DB call: an empty query would ILIKE-match every insight.
+    command = await search_insights.coroutine(query="  ", tool_call_id="t1")
+    assert command.update["messages"][0].status == "error"
+    assert "too short" in _content(command)
+    assert "insight_id" not in command.update
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_search_insights.py
+++ b/tests/agent/test_search_insights.py
@@ -1,0 +1,123 @@
+"""Tests for the search_insights agent tool."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.agent.tools.search_insights import (
+    _score,
+    _terms,
+    search_insights,
+)
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _fake_insight(**kwargs):
+    """Object shaped like InsightOrm (+ chart rows)."""
+    defaults = dict(
+        id=uuid4(),
+        user_id="user-1",
+        is_public=False,
+        insight_text="Tree cover loss in the Amazon rose 12% over the period.",
+        follow_up_suggestions=["Compare to fires"],
+        created_at=datetime(2026, 6, 1),
+        charts=[
+            SimpleNamespace(
+                position=0,
+                title="Annual tree cover loss",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss_ha",
+                color_field="",
+                stack_field="",
+                group_field="",
+                series_fields=[],
+                chart_data=[{"year": 2020, "loss_ha": 5}],
+            )
+        ],
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_terms_drops_short_tokens_and_lowercases():
+    assert _terms("Tree cover IN the Amazon") == [
+        "tree",
+        "cover",
+        "the",
+        "amazon",
+    ]
+
+
+def test_score_rewards_phrase_match():
+    row = _fake_insight()
+    terms = _terms("amazon tree cover")
+    phrase_hit = _score(row, terms, "tree cover loss in the amazon")
+    scattered = _score(row, terms, "amazon tree cover")
+    assert phrase_hit > scattered > 0
+
+
+@pytest.mark.asyncio
+async def test_search_insights_surfaces_best_match():
+    insight = _fake_insight()
+    with patch(
+        "src.agent.tools.search_insights._search_insights",
+        new=AsyncMock(return_value=[insight]),
+    ):
+        command = await search_insights.coroutine(
+            query="tree cover in the amazon", tool_call_id="t1"
+        )
+
+    # Surfaced into state exactly like the generator would.
+    assert command.update["insight_id"] == str(insight.id)
+    assert "Tree cover loss" in command.update["insight"]
+    assert (
+        command.update["charts_data"][0]["title"] == "Annual tree cover loss"
+    )
+    assert command.update["charts_data"][0]["type"] == "bar"
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    # Frontend treats it as an update (re-fetch/replace by id), not a new card.
+    assert message.response_metadata["msg_type"] == "insight_updated"
+    assert message.response_metadata["insight_id"] == str(insight.id)
+    assert "Found a past insight" in message.content
+
+
+@pytest.mark.asyncio
+async def test_search_insights_picks_highest_scoring():
+    weak = _fake_insight(
+        insight_text="Fire alerts spiked in Indonesia.",
+        created_at=datetime(2026, 6, 10),  # newer, but weaker match
+        charts=[],
+    )
+    strong = _fake_insight(
+        insight_text="Tree cover loss in the Amazon rose sharply.",
+        created_at=datetime(2026, 6, 1),
+    )
+    with patch(
+        "src.agent.tools.search_insights._search_insights",
+        new=AsyncMock(return_value=[weak, strong]),
+    ):
+        command = await search_insights.coroutine(
+            query="tree cover amazon", tool_call_id="t1"
+        )
+    assert command.update["insight_id"] == str(strong.id)
+
+
+@pytest.mark.asyncio
+async def test_search_insights_no_match():
+    with patch(
+        "src.agent.tools.search_insights._search_insights",
+        new=AsyncMock(return_value=[]),
+    ):
+        command = await search_insights.coroutine(
+            query="penguins in antarctica", tool_call_id="t1"
+        )
+    assert "No past insight matched" in _content(command)
+    assert "insight_id" not in command.update

--- a/tests/agent/test_update_insight_display.py
+++ b/tests/agent/test_update_insight_display.py
@@ -1,0 +1,177 @@
+"""Tests for the update_insight_display tool and its merge logic."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.agent.subagents.analyst.charts.model import InsightChart
+from src.agent.subagents.analyst.display_reviser import (
+    RevisedChart,
+    RevisedInsight,
+)
+from src.agent.tools.update_insight_display import (
+    _apply_revision,
+    update_insight_display,
+)
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _original_chart():
+    return InsightChart(
+        position=0,
+        title="Old title",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="loss",
+        chart_data=[{"year": 2020, "loss": 5, "gain": 2}],
+    )
+
+
+def _fake_orm_row(**kwargs):
+    """Object shaped like InsightOrm (+ chart rows) for the load path."""
+    defaults = dict(
+        id=uuid4(),
+        user_id="user-1",
+        insight_text="Old summary.",
+        follow_up_suggestions=["old follow-up"],
+        charts=[
+            SimpleNamespace(
+                position=0,
+                title="Old title",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss",
+                color_field="",
+                stack_field="",
+                group_field="",
+                series_fields=[],
+                chart_data=[{"year": 2020, "loss": 5, "gain": 2}],
+            )
+        ],
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_apply_revision_restyles_and_keeps_data():
+    revised = RevisedInsight(
+        primary_insight="New summary",
+        follow_up_suggestions=["f1"],
+        charts=[
+            RevisedChart(
+                position=0,
+                title="New title",
+                chart_type="line",
+                x_axis="year",
+                y_axis="gain",  # different but existing column
+            )
+        ],
+    )
+    out = _apply_revision([_original_chart()], revised)
+    chart = out.charts[0]
+    assert out.primary_insight == "New summary"
+    assert out.follow_up_suggestions == ["f1"]
+    assert chart.title == "New title"
+    assert chart.chart_type == "line"
+    assert chart.y_axis == "gain"
+    # Underlying rows are untouched (no new data).
+    assert chart.chart_data == [{"year": 2020, "loss": 5, "gain": 2}]
+    # stamp_insight copies the primary onto each chart.
+    assert chart.insight == "New summary"
+
+
+def test_apply_revision_drops_unknown_columns():
+    revised = RevisedInsight(
+        primary_insight="x",
+        follow_up_suggestions=["f"],
+        charts=[
+            RevisedChart(
+                position=0,
+                title="Bad",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="does_not_exist",
+            )
+        ],
+    )
+    out = _apply_revision([_original_chart()], revised)
+    # Original chart is preserved untouched rather than producing a broken one.
+    assert out.charts[0].title == "Old title"
+    assert out.charts[0].y_axis == "loss"
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_no_target_errors():
+    command = await update_insight_display.coroutine(
+        instruction="make it a line chart", state={}, tool_call_id="t1"
+    )
+    assert command.update["messages"][0].status == "error"
+    assert "No insight to update" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_not_editable_errors():
+    with patch(
+        "src.agent.tools.update_insight_display._load_editable_insight",
+        new=AsyncMock(return_value=None),
+    ):
+        command = await update_insight_display.coroutine(
+            instruction="rename it",
+            insight_id=str(uuid4()),
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not editable" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_happy_path():
+    row = _fake_orm_row()
+    revised = RevisedInsight(
+        primary_insight="New summary",
+        follow_up_suggestions=["f1"],
+        charts=[
+            RevisedChart(
+                position=0, title="New title", chart_type="line", y_axis="gain"
+            )
+        ],
+    )
+    with (
+        patch(
+            "src.agent.tools.update_insight_display._load_editable_insight",
+            new=AsyncMock(return_value=row),
+        ),
+        patch(
+            "src.agent.tools.update_insight_display.InsightDisplayReviser.revise",
+            new=AsyncMock(return_value=revised),
+        ),
+        patch(
+            "src.agent.tools.update_insight_display.update_insight",
+            new=AsyncMock(return_value=True),
+        ) as mock_update,
+    ):
+        command = await update_insight_display.coroutine(
+            instruction="change to a line chart and reword",
+            state={"insight_id": str(row.id)},
+            tool_call_id="t1",
+        )
+
+    assert command.update["insight"] == "New summary"
+    assert command.update["follow_up_suggestions"] == ["f1"]
+    charts_data = command.update["charts_data"]
+    assert charts_data[0]["title"] == "New title"
+    assert charts_data[0]["type"] == "line"
+    # Persisted in place under the same id.
+    persisted_id, persisted_insight = mock_update.call_args.args
+    assert persisted_id == str(row.id)
+    assert persisted_insight.primary_insight == "New summary"
+    # Distinct signal so the frontend replaces the insight in place.
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata["msg_type"] == "insight_updated"
+    assert message.response_metadata["insight_id"] == str(row.id)

--- a/tests/agent/test_update_insight_display.py
+++ b/tests/agent/test_update_insight_display.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from src.agent.subagents.analyst.charts.model import InsightChart
 from src.agent.subagents.analyst.display_reviser import (
@@ -105,6 +106,42 @@ def test_apply_revision_drops_unknown_columns():
     assert out.charts[0].y_axis == "loss"
 
 
+def test_revised_chart_rejects_unknown_chart_type():
+    # chart_type is a Literal: an off-list value from the LLM fails structured
+    # output validation instead of being persisted for the frontend to choke on.
+    with pytest.raises(ValidationError):
+        RevisedChart(
+            position=0, title="Bad", chart_type="sankey", y_axis="loss"
+        )
+
+
+def test_apply_revision_finds_columns_in_later_rows():
+    # 'gain' only appears from the second data row on; the revision must not
+    # be dropped just because the first row lacks it.
+    original = InsightChart(
+        position=0,
+        title="Old title",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="loss",
+        chart_data=[
+            {"year": 2020, "loss": 5},
+            {"year": 2021, "loss": 3, "gain": 2},
+        ],
+    )
+    revised = RevisedInsight(
+        primary_insight="x",
+        follow_up_suggestions=["f"],
+        charts=[
+            RevisedChart(
+                position=0, title="Gain", chart_type="bar", y_axis="gain"
+            )
+        ],
+    )
+    out = _apply_revision([original], revised)
+    assert out.charts[0].y_axis == "gain"
+
+
 @pytest.mark.asyncio
 async def test_update_insight_display_no_target_errors():
     command = await update_insight_display.coroutine(
@@ -125,6 +162,16 @@ async def test_update_insight_display_not_editable_errors():
             insight_id=str(uuid4()),
             tool_call_id="t1",
         )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not editable" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_malformed_id_errors():
+    # UUID parsing fails before any DB access; same error as "not found".
+    command = await update_insight_display.coroutine(
+        instruction="rename it", insight_id="not-a-uuid", tool_call_id="t1"
+    )
     assert command.update["messages"][0].status == "error"
     assert "not found or not editable" in _content(command)
 

--- a/tests/unit/api/test_insight_access.py
+++ b/tests/unit/api/test_insight_access.py
@@ -1,0 +1,45 @@
+"""Tests for the shared insight visibility/edit rules."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.repositories.insight_access import (
+    is_editable_by_user,
+    is_visible_to_user,
+)
+
+
+def _row(user_id="owner", is_public=False):
+    return SimpleNamespace(user_id=user_id, is_public=is_public)
+
+
+@pytest.mark.parametrize(
+    ("row", "user_id", "visible"),
+    [
+        (_row(user_id="me"), "me", True),  # own private
+        (_row(user_id="someone-else"), "me", False),  # other's private
+        (_row(user_id="someone-else", is_public=True), "me", True),  # public
+        (_row(user_id=None), "me", False),  # ownerless private
+        (_row(user_id=None, is_public=True), "me", True),  # ownerless public
+        (_row(user_id="me"), None, False),  # unauthenticated, private
+        (_row(user_id="me", is_public=True), None, True),  # unauth, public
+    ],
+)
+def test_is_visible_to_user(row, user_id, visible):
+    assert is_visible_to_user(row, user_id) is visible
+
+
+@pytest.mark.parametrize(
+    ("row", "user_id", "editable"),
+    [
+        (_row(user_id="me"), "me", True),  # own
+        (_row(user_id="someone-else"), "me", False),  # other's
+        (_row(user_id="someone-else", is_public=True), "me", False),  # public
+        (_row(user_id=None), "me", False),  # ownerless
+        (_row(user_id="me"), None, False),  # unauthenticated
+        (_row(user_id=None), None, False),  # unauthenticated + ownerless
+    ],
+)
+def test_is_editable_by_user(row, user_id, editable):
+    assert is_editable_by_user(row, user_id) is editable

--- a/uv.lock
+++ b/uv.lock
@@ -31,11 +31,11 @@ wheels = [
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.6.2"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.115.0"
+version = "0.115.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -142,9 +142,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/52/b9022707a25fd263b8ff5e11f480dcc9cd6da0a380c486e5be053c01d995/anthropic-0.115.0.tar.gz", hash = "sha256:6bb25184441d51544f8bc9877a7efbddd9bc4a6207cce898536d84b233310f4a", size = 949136, upload-time = "2026-06-30T19:47:33.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/e2/e27b1e70b1ddcda72362d6a26c9c699a46173d48a6c7ba966e8cc97a6c4d/anthropic-0.115.1.tar.gz", hash = "sha256:040287319abb909acf1cc49d83c0405dc0b1121ef257034b02c2b54151cf2446", size = 949185, upload-time = "2026-07-01T21:54:19.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/89/cd08c2fb41f10fc902593579cb81717ce0ce5489fdf9dcb8e04ea9825fb2/anthropic-0.115.0-py3-none-any.whl", hash = "sha256:aa4bbea9272fa1cced6749728f18d0af9d7934b7268779e84d6f5a246f4b998d", size = 960664, upload-time = "2026-06-30T19:47:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/85/3c/501c58a8f8c68811079e218a25d8672fe4fb9a650a4655e499e24d9375e9/anthropic-0.115.1-py3-none-any.whl", hash = "sha256:685fa94964c1b9428f6a76e42d0dbae49aa2016f5ad386a96becac04c5e80ef9", size = 957006, upload-time = "2026-07-01T21:54:17.392Z" },
 ]
 
 [[package]]
@@ -970,7 +970,7 @@ standard = [
 
 [[package]]
 name = "fastapi-cloud-cli"
-version = "0.22.0"
+version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "detect-installer" },
@@ -983,9 +983,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/85/f1bba93afc0c3d6457e2e455fd627796f71035771e7e25c0fb255afb31e1/fastapi_cloud_cli-0.22.0.tar.gz", hash = "sha256:cde14470227fc9275075ff537977d2991e8ce1baf947055d7a4149726de27e08", size = 94373, upload-time = "2026-06-30T17:08:49.15Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/e5/bee77aa542ec66bcc55b458d606f3356a58f5bb9f2c59006f6ff53a3869b/fastapi_cloud_cli-0.22.1.tar.gz", hash = "sha256:50d80de6ce397a4959e6f3509574edac65d0a6998655215c95d077b18ec2f4b1", size = 94501, upload-time = "2026-07-01T22:09:03.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/1b/3575ec4052a3fe241ddaa24807a5200e3cc33211318d5786d8b792eedc19/fastapi_cloud_cli-0.22.0-py3-none-any.whl", hash = "sha256:799e263140d1b6e679390fc6e90da404556aee6730fd479d3b52475e850073bf", size = 77649, upload-time = "2026-06-30T17:08:48.134Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0c/9e3069ff571142e571d68156aa4c1ab1d51c0b87f21bbe0f44c10029b19b/fastapi_cloud_cli-0.22.1-py3-none-any.whl", hash = "sha256:4ba307b97b08282d1efb2daef5f1e88af23e02fe2286c25273c1794e399df509", size = 77739, upload-time = "2026-07-01T22:09:02.359Z" },
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.4"
+version = "0.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2239,9 +2239,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/a7/a78b4105d1c01ee8d404d122d9acc047b8b9f628f3733cb837a321b2f6c6/langsmith-0.9.4.tar.gz", hash = "sha256:36c15e5a692e7812ee927e43d777c6166c839eb02b1d482ba9a805b438b1d91c", size = 4576594, upload-time = "2026-06-30T10:20:43.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/dc/ca2ab3b74f3a5a2089aee1483e86b6aa7ae15fba96f73866a16e31356319/langsmith-0.9.6.tar.gz", hash = "sha256:1df590a40352b2f40a36229d90e2ef6af276a0bc9f1e44a87b829f879eed2130", size = 4714803, upload-time = "2026-07-02T11:14:30.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/15/79367a3d159141fe4fc138f41db4ef21eb4759cd64cf8f635f41d55ded67/langsmith-0.9.4-py3-none-any.whl", hash = "sha256:f10f07438c7c6f9f907e8c810d8f338268fe863a74c37ded3d8a90830bb25451", size = 603804, upload-time = "2026-06-30T10:20:41.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/8f/6e8f1f3e12be9848993c297c879f63f225361eb594f8343ff42c2b26c6fd/langsmith-0.9.6-py3-none-any.whl", hash = "sha256:c5e5f2425dcb8fe363b9e1fa87a9cb9cf5631389bf7e168aa4f325f580ca284c", size = 660131, upload-time = "2026-07-02T11:14:28.552Z" },
 ]
 
 [[package]]
@@ -4464,11 +4464,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
⚠️ Do not merge, this is just for visibility on these initial experiments ⚠️ 

These are musings / initial experimentation for tooling that can work on insights.

### Motivation

This is in the context of dashboards, where the user will probably expect the agent to find past insights, edit them, or create new ones.

### What is in the experiments

Two new generative tools for working with already-persisted insights, plus the plumbing they share:

- update_insight_display: restyles an existing insight (narrative text, follow-ups, chart titles/types, field remapping) without pulling new data or running code. InsightDisplayReviser only re-maps among existing columns; chart_data rows are preserved. Persisted in place via update_insight() and pushed onto state so the frontend re-renders.
- search_insights: finds a past insight across ALL of the user's conversations (own + public) by ILIKE over summary, chart titles and chart_data text, surfaces the best match into state like the generator.

Both emit response_metadata msg_type "insight_updated" + insight_id so the frontend replaces/re-fetches the insight by id rather than rendering a duplicate card. search is steered to be terminal (no follow-on analysis) via prompt + tool-message instructions and a routing rule.

Supporting changes:
- InsightChart.from_orm_row() to rebuild the seam model from a DB row.
- update_insight() in insight_writer for in-place display updates.
- inspect_view_context: extra info logging.
- schemas: document visible_insights (list of uuids) in view_context.
- Tests for both new tools.
