### PR TITLE
Move blog search into default profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.1"
+version = "2026.7.1.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -41,6 +41,7 @@ CORE_SPECS = (
     pull_data_spec,
     generate_insights_spec,
     read_skill_spec,
+    search_blogs_spec,
 )
 
 # Experimental, opt-in tools layered on top of the core set.
@@ -49,7 +50,6 @@ EXPERIMENTAL_SPECS = (
     *CORE_SPECS,
     inspect_view_context_spec,
     show_imagery_spec,
-    search_blogs_spec,
 )
 
 


### PR DESCRIPTION
This moves the blog post into main profile. Evals ran against this are as follows:

```
==================================================
EVALUATION SUMMARY
==================================================
Environment:           localhost
API Base URL:          http://localhost:8000
Run timestamp:         2026-07-01 10:08:36 UTC
GNW code version:      2026.7.1
GNW prompts version:   unknown
GNW agent LLM:         primary gemini-flash (ChatGoogleGenerativeAI), small gemini-flash (ChatGoogleGenerativeAI)
Eval judge LLM:        Anthropic / claude-haiku-4-5
Test latency (s):      avg=68.9, std=27.9, min=17.0, max=178.2 (n=62)

Tests Run (after filters): 62

Agent Answer:              40 /  49 (0.82)

AOI ID Match:              43 /  46 (0.93)
Dataset ID Match:          45 /  50 (0.90)
Dataset Parameter Match:    0 /   0
Context Layer Match:        3 /   3 (1.00)
Data Pull Exists:          45 /  49 (0.92)
Date Match:                24 /  29 (0.83)
Charts Answer:             36 /  45 (0.80)
Expected Text Match:        8 /   8 (1.00)
Clarification Requested:    4 /   9 (0.44)
Suggested Datasets:         5 /   5 (1.00)

(warning: overall_score is experimental and untested)
Tests with overall score ≥0.7:   50 /  62 (80.6%)
```