### PR TITLE
Fixes for feedback on integrated alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.2"
+version = "2026.7.2.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -47,18 +47,22 @@ prompt_instructions: 'Use this dataset to show recent vegetation changes across 
 
   '
 selection_hints: >-
-  Use this dataset ONLY when the user needs a disturbance-alert breakdown that Integrated Alerts cannot provide — a
-  context layer of driver (likely cause / LDACS), land_cover, natural_lands, or grasslands. For any near-real-time
-  disturbance, clearing, deforestation, or conversion alert query that does NOT require one of those breakdowns, prefer
-  Integrated Alerts instead. DIST-ALERT is being deprecated in favor of Integrated Alerts, which already includes
-  DIST-ALERT alongside GLAD-L, GLAD-S2 and RADD. Covers all ecosystems (not just forests), Dec 2023 to present at 30m,
-  measured in hectares, with low and high confidence alerts. Apply context layers when the query targets a specific
-  breakdown: grasslands for natural grasslands/shrublands/savannas, natural_lands for natural land classes, driver for
-  likely causes of disturbance, land_cover for specific land cover classes. Driver (LDACS) is updated quarterly, covers
+  Use this dataset ONLY when the user needs disturbance alerts RESTRICTED TO or BROKEN DOWN BY a specific ecosystem or
+  class that Integrated Alerts cannot filter — via a context layer: natural_lands (forests, natural forests, natural
+  lands / natural areas, natural ecosystems), grasslands (natural grasslands/shrublands/savannas), land_cover (a
+  specific land-cover class such as tree cover, wetlands, or cropland), or driver (likely cause / LDACS). For any
+  near-real-time disturbance, clearing, deforestation, or conversion alert query over a whole area that does NOT require
+  such a filter or breakdown, prefer Integrated Alerts instead. DIST-ALERT is being deprecated in favor of Integrated
+  Alerts, which already includes DIST-ALERT alongside GLAD-L, GLAD-S2 and RADD. Covers all ecosystems, Dec 2023 to
+  present at 30m, measured in hectares, with low and high confidence alerts. Apply context layers when the query targets
+  a specific breakdown: natural_lands for forests / natural land classes, grasslands for natural
+  grasslands/shrublands/savannas, driver for likely causes of disturbance, land_cover for specific land cover classes. Driver (LDACS) is updated quarterly, covers
   the most recent 12 months, and has no classification for the last 90 days. For historical or long-term tree cover
   change prefer Tree Cover Loss; for driver attribution of tree cover loss specifically prefer Tree Cover Loss by
   Dominant Driver.
-code_instructions: "CHART TYPES: - Recent trends over time → line chart (x=alert month, y=area in hectares) - Distribution\
+code_instructions: "CHART TYPES — generate EXACTLY ONE chart; choose the single best type for what the user\
+  \ asked and never emit more than one chart (all charts share one data table, so a second chart of a different shape\
+  \ breaks the output). Pick from: - Recent trends over time → line chart (x=alert month, y=area in hectares) - Distribution\
   \ by driver → pie chart (one slice per driver class) - Distribution by land cover class or natural land type → pie chart\
   \ - Seasonal patterns by driver → grouped bar chart (x=month, y=area_ha, group=class name) DATA RULES: - All areas in hectares\
   \ (ha) - Show classified alerts by driver (LDACS) by default when driver context layer is active - If one driver accounts\

--- a/src/agent/datasets/catalog/integrated_alerts.yml
+++ b/src/agent/datasets/catalog/integrated_alerts.yml
@@ -3,7 +3,7 @@ dataset_name: Integrated alerts
 context_layers: null
 parameters: null
 variables: null
-tile_url: https://tiles.globalforestwatch.org/gfw_integrated_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color
+tile_url: https://tiles.globalforestwatch.org/gfw_integrated_dist_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color
 license: CC by 4.0
 geographic_coverage: Global
 resolution: 10 x 10 meters
@@ -33,13 +33,15 @@ prompt_instructions: >-
   do NOT use grouped bar charts for the confidence breakdown. Always interpret alerts as indicators of potential
   disturbance, not definitive deforestation outcomes.
 selection_hints: >-
-  DEFAULT dataset for near-real-time vegetation and forest disturbance, clearing, and deforestation alerts globally at
-  10m resolution, measured in hectares. Integrates DIST-ALERT, GLAD-L, GLAD-S2 and RADD into one layer, detecting
-  disturbance faster than any single system. Provides low, high, and highest confidence alerts (highest = confirmed by
-  multiple systems). PREFER this for any recent disturbance/clearing/deforestation-alert query. It has NO context layers
-  / intersections — ONLY when the user needs a breakdown by driver, land cover, natural lands, or grasslands should
-  DIST-ALERT be used instead. For historical or long-term tree cover change, prefer Tree Cover Loss; for driver
-  attribution of tree cover loss, prefer Tree Cover Loss by Dominant Driver.
+  DEFAULT dataset for near-real-time disturbance, clearing, and deforestation alerts globally at 10m resolution,
+  measured in hectares. Integrates DIST-ALERT, GLAD-L, GLAD-S2 and RADD into one layer, detecting disturbance faster
+  than any single system. Provides low, high, and highest confidence alerts (highest = confirmed by multiple systems).
+  Reports TOTAL disturbed area across ALL vegetation — it is NOT filtered to forests or any ecosystem, and has NO
+  context layers / intersections. PREFER this for a plain recent-disturbance/clearing/deforestation-alert query over a
+  whole area. Use DIST-ALERT instead whenever the user wants alerts RESTRICTED TO or BROKEN DOWN BY a specific ecosystem
+  or class — forests, natural forests, natural lands / natural areas, grasslands, a land-cover class, or a driver/cause
+  (DIST-ALERT's natural_lands / grasslands / land_cover / driver context layers). For historical or long-term tree cover
+  change, prefer Tree Cover Loss; for driver attribution of tree cover loss, prefer Tree Cover Loss by Dominant Driver.
 code_instructions: |-
   CHART TYPES — generate EXACTLY ONE chart for Integrated alerts, chosen by the query; never emit both a pie and a line:
   - Totals / breakdown by confidence → PIE chart, one slice per confidence tier (low, high, highest), value = total area_ha summed over the period
@@ -49,6 +51,7 @@ code_instructions: |-
   DATA RULES:
   - Result columns are: aoi_id, alert_date, alert_confidence, area_ha, aoi_type
   - All areas are in hectares (ha) in the area_ha column
+  - ALWAYS label the unit hectares (ha) in the output: on the chart's y-axis/legend and title, and on every table column header and total that shows area — never present a bare area number without "ha"
   - alert_confidence values are low, high, and highest; 'highest' means detected by two or more alert systems (it may be absent when only one system covered the area/time)
   - There are NO driver, land-cover, or natural-lands intersections — do NOT create class/driver breakdowns
   DO/DON'T:
@@ -57,7 +60,8 @@ code_instructions: |-
   - Do not use alerts for area estimates or long-term trend assessment; recommend annual tree cover loss instead
 presentation_instructions: >-
   Describe results as integrated disturbance alerts (potential vegetation and forest disturbance), not confirmed
-  deforestation. Always reference the confidence tiers shown and the selected time range. Include a caution that explains
+  deforestation. Always state the unit hectares (ha) with every area figure in the narrative. Always reference the
+  confidence tiers shown and the selected time range. Include a caution that explains
   (a) the alert systems contributing to the integrated count — DIST-ALERT, GLAD-L, GLAD-S2 and RADD — and (b) what each
   confidence level means: low = detected once; high = detected multiple times by a single system (two or more for
   GLAD-L/GLAD-S2/RADD, four or more for DIST-ALERT); highest = detected by two or more systems, which effectively


### PR DESCRIPTION
This includes a few fixes:
- Use the correct tile service for int dist alerts
- Always report in hectares
- Tweak prompt to use integrated alerts only for general alert queries, and still use DIST alerts for any contextual filer like forests, grasslands, natural areas, etc.
- Also only use one chart for DIST alerts output to avoid same bug with messed up multiple charts