### PR TITLE
Dashboards MVP: insights, layers and map widgets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ SMALL_MODEL=gemini-flash
 FALLBACK_MODELS=gemini-flash,gemini-flash-lite
 CODING_MODEL=gemini-3.1-pro-preview # Full Google model IDs required (used by genai SDK directly, not LangChain)
 CODING_FALLBACK_MODELS=gemini-2.5-pro,gemini-3-flash-preview # Full Google model IDs required
-EOAPI_BASE_URL=https://eoapi.staging.globalnaturewatch.org
+EOAPI_BASE_URL=https://eoapi-cache.globalnaturewatch.org
 
 # Sentinel-2 mosaic storage. Built MosaicJSON files are written to this private
 # S3 bucket. AWS credentials come from the standard boto3 chain

--- a/db/alembic/versions/b7e4d9a2c1f8_add_dashboards_tables.py
+++ b/db/alembic/versions/b7e4d9a2c1f8_add_dashboards_tables.py
@@ -1,0 +1,109 @@
+"""add dashboards, dashboard_aois and dashboard_widgets tables
+
+Revision ID: b7e4d9a2c1f8
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-02 00:00:00.000000
+
+A dashboard is a persistent, curated collection of insights, layers and AOIs.
+Widgets only *reference* insights (FK with ON DELETE CASCADE so deleting an
+insight silently drops widgets pointing at it) plus presentation config;
+dashboard AOIs store the canonical (source, src_id, subtype) address plus a
+denormalized display name — never geometry. The AOI join table supports
+multiple areas from day one; the MVP single-area constraint lives in API
+validation, not the schema.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e4d9a2c1f8"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dashboards",
+        sa.Column(
+            "id",
+            postgresql.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column(
+            "is_public",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "dashboard_aois",
+        sa.Column(
+            "id",
+            postgresql.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("dashboard_id", postgresql.UUID(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("src_id", sa.String(), nullable=False),
+        sa.Column("subtype", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "position", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.ForeignKeyConstraint(["dashboard_id"], ["dashboards.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "dashboard_id",
+            "source",
+            "src_id",
+            name="uq_dashboard_aois_dashboard_source_src_id",
+        ),
+    )
+    op.create_table(
+        "dashboard_widgets",
+        sa.Column(
+            "id",
+            postgresql.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("dashboard_id", postgresql.UUID(), nullable=False),
+        sa.Column(
+            "position", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("widget_type", sa.String(), nullable=False),
+        sa.Column("insight_id", postgresql.UUID(), nullable=True),
+        sa.Column(
+            "config",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["dashboard_id"], ["dashboards.id"]),
+        sa.ForeignKeyConstraint(
+            ["insight_id"], ["insights.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dashboard_widgets")
+    op.drop_table("dashboard_aois")
+    op.drop_table("dashboards")

--- a/db/alembic/versions/b7e4d9a2c1f8_add_dashboards_tables.py
+++ b/db/alembic/versions/b7e4d9a2c1f8_add_dashboards_tables.py
@@ -101,6 +101,15 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
+    # An insight appears on a dashboard at most once, so retries cannot
+    # duplicate widgets. Partial: map/text widgets (insight_id NULL) exempt.
+    op.create_index(
+        "uq_dashboard_widgets_dashboard_insight",
+        "dashboard_widgets",
+        ["dashboard_id", "insight_id"],
+        unique=True,
+        postgresql_where=sa.text("widget_type = 'insight'"),
+    )
 
 
 def downgrade() -> None:

--- a/docs/dashboards-frontend-handoff.md
+++ b/docs/dashboards-frontend-handoff.md
@@ -130,12 +130,7 @@ expanded with its full insight payload:
       "position": 1,
       "widget_type": "map",
       "insight_id": null,
-      "config": {
-        "default_view": "map",
-        "dataset_id": 4,
-        "start_date": "2024-01-01",
-        "end_date": "2024-12-31"
-      },
+      "config": { "…": "see dashboards-map-widgets-handoff.md" },
       "created_at": "2026-07-03T14:12:00",
       "insight": null
     }
@@ -147,9 +142,10 @@ expanded with its full insight payload:
 `GET /api/insights/{id}` — reuse the existing insight-card component with no
 new data mapping. The widget adds only `config` (presentation) on top.
 
-`widget_type` is `"insight"` or `"map"`. Map widgets carry their layer spec
-entirely in `config` (`dataset_id`, `start_date`/`end_date`, optional
-`viewport`); resolve to tiles the same way the explorer does.
+`widget_type` is `"insight"` or `"map"`. Map widgets carry a self-contained
+layer snapshot in `config` — the full contract (dataset layers, Sentinel-2
+imagery, map focus, validation) lives in
+**`dashboards-map-widgets-handoff.md`**.
 
 An **insight widget with `"insight": null`** means the insight is not
 visible to this viewer (e.g. it was made private again after the dashboard
@@ -207,9 +203,9 @@ Removes the dashboard and its widgets; insights survive.
 
 ## Chat / agent integration
 
-The agent's dashboard tools (`create_dashboard`, `add_to_dashboard`) are in
-the **experimental profile** — send `"ff": "experimental"` in the chat
-request for dashboard-aware chat.
+The agent's dashboard tools (`create_dashboard`, `add_to_dashboard`,
+`add_map_widget`) are in the **experimental profile** — send
+`"ff": "experimental"` in the chat request for dashboard-aware chat.
 
 **Outbound — tell the agent where the user is.** While on the dashboard
 page, include in every chat request:
@@ -259,5 +255,5 @@ trip needed. Untoggling is `DELETE` on the widget.
 3. Chat wiring: `view_context` outbound, `dashboard_updated` refetch,
    sidebar "Add to dashboard" toggle.
 4. Publish/share flow with the cascade confirmation dialog.
-5. Map widgets (layer resolution from `config`) — last; insight widgets are
-   the MVP core.
+5. Map widgets — see `dashboards-map-widgets-handoff.md` (self-contained
+   configs, no layer resolution needed); insight widgets are the MVP core.

--- a/docs/dashboards-frontend-handoff.md
+++ b/docs/dashboards-frontend-handoff.md
@@ -1,0 +1,263 @@
+# Dashboards MVP — frontend handoff
+
+*Audience: the frontend build (separate repo, no access to this codebase).
+This document is the narrative contract; the machine-readable truth is the
+OpenAPI spec served by the backend at `/openapi.json` (interactive at
+`/docs`). Backend lives on branch `feat/dashboards-mvp` of
+`wri/project-zeno`. Design reference: the "Paraná, Brazil" dashboard mock
+(2026-07).*
+
+## What a dashboard is
+
+A persistent, curated collection of **insight widgets for one area** (a
+country, a state, a protected area) — a complement to the map explorer,
+toggled in the top bar. Widgets *reference* insights that already exist;
+nothing on a dashboard is recomputed when you view it. Dashboards are owned;
+they can be made public.
+
+**MVP scope cuts — do not build UI for these:** refresh / relative date
+windows, subscribe-to-alerts, PDF export, multi-area (portfolio) dashboards.
+The API enforces exactly one area per dashboard.
+
+## Auth model (same as insights)
+
+- All endpoints take the standard `Authorization: Bearer <token>`.
+- Read: **own + public**. Write: **owner only**.
+- `404` is returned for *both* "does not exist" and "exists but isn't
+  yours" — do not distinguish them in UI.
+- `401` on private resources when unauthenticated.
+
+## REST API
+
+Base path: `/api/dashboards`. Timestamps are ISO-8601 without timezone.
+
+### Create — `POST /api/dashboards` (auth) → `201`
+
+Exactly one AOI (2+ → `422`). `name` defaults to the AOI's name.
+
+```json
+// request
+{
+  "name": "Paraná",                       // optional
+  "description": "Forest monitoring",     // optional
+  "aois": [
+    {
+      "source": "gadm",                   // gadm | custom | wdpa | kba | landmark
+      "src_id": "BRA.16_1",
+      "subtype": "state-province",
+      "name": "Paraná"
+    }
+  ]
+}
+```
+
+```json
+// response (DashboardResponse — the shape every dashboard endpoint returns)
+{
+  "id": "5c9f7dd8-…",
+  "user_id": "user-abc",
+  "name": "Paraná",
+  "description": "Forest monitoring",
+  "is_public": false,
+  "created_at": "2026-07-03T14:05:22.123456",
+  "updated_at": "2026-07-03T14:05:22.123456",
+  "aois": [
+    {
+      "id": "a1b2…",
+      "source": "gadm",
+      "src_id": "BRA.16_1",
+      "subtype": "state-province",
+      "name": "Paraná",
+      "position": 0
+    }
+  ],
+  "widgets": []
+}
+```
+
+### List — `GET /api/dashboards` (auth) → `200`
+
+The caller's own dashboards, newest first: `[DashboardResponse, …]`.
+Widgets in the *list* response are **not expanded** (`"insight": null`) —
+use it for the dashboard switcher/overview, not for rendering widgets.
+
+### Get one — `GET /api/dashboards/{id}` (auth optional) → `200 | 401 | 404`
+
+The render endpoint. Public dashboards work without auth. Each widget is
+expanded with its full insight payload:
+
+```json
+{
+  "id": "5c9f7dd8-…",
+  "…": "…dashboard fields as above…",
+  "widgets": [
+    {
+      "id": "w-111…",
+      "position": 0,
+      "widget_type": "insight",
+      "insight_id": "ins-222…",
+      "config": { "default_view": "chart" },
+      "created_at": "2026-07-03T14:10:00",
+      "insight": {
+        "id": "ins-222…",
+        "user_id": "user-abc",
+        "thread_id": "thread-1",
+        "insight_text": "Tree cover loss in Paraná rose 12%…",
+        "follow_up_suggestions": ["Compare to fires"],
+        "statistics_ids": ["…"],
+        "charts": [
+          {
+            "id": "c-333…",
+            "position": 0,
+            "title": "Annual tree cover loss",
+            "chart_type": "bar",
+            "x_axis": "year",
+            "y_axis": "loss_ha",
+            "color_field": "",
+            "stack_field": "",
+            "group_field": "",
+            "series_fields": [],
+            "chart_data": [{ "year": 2020, "loss_ha": 5 }]
+          }
+        ],
+        "codeact_parts": [{ "type": "code", "content": "…base64…" }],
+        "is_public": true,
+        "created_at": "2026-07-01T09:00:00"
+      }
+    },
+    {
+      "id": "w-444…",
+      "position": 1,
+      "widget_type": "map",
+      "insight_id": null,
+      "config": {
+        "default_view": "map",
+        "dataset_id": 4,
+        "start_date": "2024-01-01",
+        "end_date": "2024-12-31"
+      },
+      "created_at": "2026-07-03T14:12:00",
+      "insight": null
+    }
+  ]
+}
+```
+
+**Key shortcut:** `widget.insight` is byte-for-byte the same shape as
+`GET /api/insights/{id}` — reuse the existing insight-card component with no
+new data mapping. The widget adds only `config` (presentation) on top.
+
+`widget_type` is `"insight"` or `"map"`. Map widgets carry their layer spec
+entirely in `config` (`dataset_id`, `start_date`/`end_date`, optional
+`viewport`); resolve to tiles the same way the explorer does.
+
+An **insight widget with `"insight": null`** means the insight is not
+visible to this viewer (e.g. it was made private again after the dashboard
+was published). Render a placeholder ("not available"), not an error.
+
+### Rename / description — `PATCH /api/dashboards/{id}` (owner) → `200`
+
+Body: `{ "name": "…", "description": "…" }` (both optional). Returns the
+dashboard.
+
+### Publish — `PATCH /api/dashboards/{id}/public` (owner) → `200`
+
+Body: `{ "is_public": true | false }`.
+
+```json
+// response = DashboardResponse plus:
+{ "…": "…", "publicized_insight_ids": ["ins-222…"] }
+```
+
+**UX-critical:** publishing a dashboard **cascades `is_public: true` to
+every insight its widgets reference** (otherwise a public dashboard renders
+empty for viewers). Show a confirmation dialog before publishing, and use
+`publicized_insight_ids` to tell the user which insights were made public.
+**Unpublishing does NOT make those insights private again** — say so in the
+unpublish confirmation.
+
+### Widgets
+
+- `POST /api/dashboards/{id}/widgets` (owner) → `201`. Body:
+  `{ "widget_type": "insight", "insight_id": "…", "config": {…}, "position": 0 }`
+  — `insight_id` required for insight widgets (`422` if missing; `404` if
+  the caller can't see that insight); `position` defaults to the end.
+  Returns the full dashboard **without** insight expansion — refetch
+  `GET /api/dashboards/{id}` to render.
+- `PATCH /api/dashboards/{id}/widgets/{widget_id}` (owner) → `200` —
+  `{ "position": 2 }` and/or `{ "config": {…} }` (config is replaced whole,
+  not merged). Reordering is per-widget; to reorder N widgets, send N
+  PATCHes.
+- `DELETE /api/dashboards/{id}/widgets/{widget_id}` (owner) → `204`. The
+  referenced insight is untouched.
+
+### Delete — `DELETE /api/dashboards/{id}` (owner) → `204`
+
+Removes the dashboard and its widgets; insights survive.
+
+### Two silent behaviors to design for
+
+- If an **insight** is ever deleted (wherever that gets exposed), any
+  widgets referencing it are silently deleted too, on every dashboard. No
+  event is emitted — refetch on navigation rather than caching dashboards
+  long-term.
+- `config.default_view` (`"map" | "chart" | "table"`) is the widget's
+  initial toggle state; `config.title` (optional) overrides the insight's
+  title in the widget header.
+
+## Chat / agent integration
+
+The agent's dashboard tools (`create_dashboard`, `add_to_dashboard`) are in
+the **experimental profile** — send `"ff": "experimental"` in the chat
+request for dashboard-aware chat.
+
+**Outbound — tell the agent where the user is.** While on the dashboard
+page, include in every chat request:
+
+```json
+{
+  "query": "add this to my dashboard",
+  "ff": "experimental",
+  "view_context": {
+    "page": "dashboard",
+    "dashboard_id": "5c9f7dd8-…",
+    "dashboard_name": "Paraná"
+  }
+}
+```
+
+This is what makes "add this to my dashboard" / "refine this dashboard"
+work without the user naming anything: the backend renders a scope hint
+from `page` + `dashboard_id` into the agent's context every turn, and
+`add_to_dashboard` defaults to the dashboard on screen. `dashboard_name` is
+optional but lets the agent name the dashboard without a DB read. On the
+explorer, keep sending the existing `{"page": "map", …viewport/layers…}`.
+
+**Inbound — react to agent writes.** Watch streamed tool messages for:
+
+```json
+{ "response_metadata": { "msg_type": "dashboard_updated", "dashboard_id": "5c9f7dd8-…" } }
+```
+
+On this signal, refetch `GET /api/dashboards/{dashboard_id}` — the agent
+created the dashboard or added a widget. Same pattern as the existing
+`insight_updated` handling (refetch-and-replace, not a new card).
+
+**"Add to dashboard" toggle in the chat sidebar** (per the mock): every
+analysis in chat has a persisted `insight_id` (already streamed in agent
+state / `insight_updated` metadata). The toggle is a plain
+`POST /api/dashboards/{id}/widgets` with that `insight_id` — no chat round
+trip needed. Untoggling is `DELETE` on the widget.
+
+## Suggested build order
+
+1. Dashboard page shell + top-bar toggle; `GET` list + single; render
+   widgets via the existing insight card (chart/table views come free,
+   `default_view` from config).
+2. Create flow (from the current explorer AOI) + rename + delete + widget
+   remove/reorder.
+3. Chat wiring: `view_context` outbound, `dashboard_updated` refetch,
+   sidebar "Add to dashboard" toggle.
+4. Publish/share flow with the cascade confirmation dialog.
+5. Map widgets (layer resolution from `config`) — last; insight widgets are
+   the MVP core.

--- a/docs/dashboards-map-widgets-handoff.md
+++ b/docs/dashboards-map-widgets-handoff.md
@@ -61,6 +61,15 @@ reuse that layer-rendering code.
 explorer renders when this dataset is selected in chat. `context_layer` names
 which entry of `context_layers` is active; render it like the explorer does.
 
+Storage note (backend-internal, no frontend action): tile URLs on the eoapi
+host are persisted as a relative `tile_path` and reassembled against the
+currently configured host on every read, so an eoapi host rotation is a
+config change rather than a breakage of existing widgets. API responses
+always carry the absolute `tile_url` shown above; a `tile_path` key may also
+appear in the config and can be ignored. Imagery mosaics live on the GFW
+tiles host and are stored verbatim (their `mosaic_id` allows re-derivation
+if that host ever moves).
+
 ### Imagery map widget
 
 ```json

--- a/docs/dashboards-map-widgets-handoff.md
+++ b/docs/dashboards-map-widgets-handoff.md
@@ -1,0 +1,136 @@
+# Dashboards — map widgets (frontend handoff, extension)
+
+*Audience: the frontend build (separate repo, no access to this codebase).
+This extends the dashboards MVP handoff (`dashboards-frontend-handoff.md`);
+everything there still holds — this doc only covers what map widgets add.
+Machine-readable truth: the OpenAPI spec at `/openapi.json`. Backend lives on
+branch `feat/dashboards-mvp` of `wri/project-zeno`.*
+
+## What changed
+
+Map widgets (`widget_type: "map"`) are now real. The agent can create them
+(new `add_map_widget` tool), and the API validates their config. The
+speculative config shape in the MVP handoff (flat `dataset_id` /
+`start_date` keys) is **replaced** by the contract below.
+
+There are two kinds of map widget, discriminated by exactly one of two keys
+in `config`:
+
+- **`config.dataset`** — a dataset rendered as a tile layer (e.g. tree
+  cover loss over Paraná).
+- **`config.imagery`** — a Sentinel-2 satellite mosaic the agent built.
+
+Both are **self-contained snapshots**: render `tile_url` directly. No layer
+resolution, no catalog lookup, no chat state needed. The sub-objects mirror
+the `dataset` / `imagery` agent-state updates the explorer already renders —
+reuse that layer-rendering code.
+
+## Config shapes
+
+### Dataset map widget
+
+```json
+{
+  "id": "w-444…",
+  "position": 1,
+  "widget_type": "map",
+  "insight_id": null,
+  "insight": null,
+  "config": {
+    "default_view": "map",
+    "title": "Tree cover loss",              // optional header override
+    "dataset": {
+      "dataset_id": 4,
+      "dataset_name": "Tree cover loss",
+      "tile_url": "https://tiles.globalforestwatch.org/…/{z}/{x}/{y}.png?…",
+      "context_layer": "driver",             // chosen context layer, or null
+      "context_layers": [                    // all available context layers
+        { "name": "driver", "tile_url": "https://…/{z}/{x}/{y}.png" }
+      ],
+      "parameters": [                        // dataset params, or null
+        { "name": "canopy_cover", "values": [30] }
+      ],
+      "start_date": "2024-01-01",            // nullable
+      "end_date": "2024-12-31"               // nullable
+    }
+  }
+}
+```
+
+`tile_url` is fully resolved (thresholds/params baked in) — the same URL the
+explorer renders when this dataset is selected in chat. `context_layer` names
+which entry of `context_layers` is active; render it like the explorer does.
+
+### Imagery map widget
+
+```json
+{
+  "widget_type": "map",
+  "insight_id": null,
+  "insight": null,
+  "config": {
+    "default_view": "map",
+    "title": "Sentinel-2, June 2024",        // optional
+    "imagery": {
+      "tile_url": "https://tiles.globalforestwatch.org/cog/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=…",
+      "tilejson_url": "https://tiles.globalforestwatch.org/cog/mosaic/WebMercatorQuad/tilejson.json?url=…",
+      "mosaic_id": "eyJhIjp…",
+      "item_count": 12,                       // null on mosaic-cache hit
+      "date_start": "2024-05-28",             // null on mosaic-cache hit
+      "date_end": "2024-06-04",               // null on mosaic-cache hit
+      "target_date": "2024-06-01",
+      "window_days": 7,
+      "max_cloud_cover": 20,
+      "aoi_names": ["Paraná"]
+    }
+  }
+}
+```
+
+Identical to the `imagery` state update from the chat `show_imagery` flow.
+The tile URLs are stable and content-addressed (the mosaic persists in S3);
+`mosaic_id` is the durable reference — ignore it for rendering, but keep it
+in any config you write back. Note the mosaic only has tiles where it was
+built (its own area); outside that, tiles are empty.
+
+## Map focus
+
+**Map widgets render fitted to the dashboard's area by default.** Get the
+geometry from the dashboard's `aois` via the existing
+`GET /api/geometry/{source}/{src_id}` and fit the viewport to it (same
+mechanism as the explorer AOI fit). `config.viewport` is a reserved manual
+override the backend never writes — if present, it wins; do not build UI to
+set it.
+
+## Creating map widgets over REST
+
+`POST /api/dashboards/{id}/widgets` (owner) with `widget_type: "map"` now
+validates `config`, returning `422` when:
+
+- `config` is missing, or
+- it contains **neither or both** of `dataset` / `imagery`, or
+- the present sub-object has no non-empty `tile_url`.
+
+Nothing else inside the sub-object is validated — extra keys are fine.
+Insight widgets are unchanged. `PATCH …/widgets/{widget_id}` still replaces
+`config` whole and is **not** re-validated (owner-only endpoint) — send back
+the full config when patching.
+
+## Chat / agent integration
+
+Nothing new to wire. The agent's new `add_map_widget` tool (experimental
+profile, like the other dashboard tools) emits the same signal you already
+handle:
+
+```json
+{ "response_metadata": { "msg_type": "dashboard_updated", "dashboard_id": "…" } }
+```
+
+→ refetch `GET /api/dashboards/{dashboard_id}` and re-render. Users can now
+say "add this layer to my dashboard" (after a dataset was picked in chat) or
+"add the imagery to my dashboard" (after satellite imagery was shown).
+
+## Scope cuts (unchanged from MVP)
+
+No refresh/relative date windows, no viewport-editing UI, no
+subscribe-to-alerts, no PDF export, single-area only.

--- a/docs/dashboards-mvp-plan.md
+++ b/docs/dashboards-mvp-plan.md
@@ -1,0 +1,249 @@
+# Dashboards MVP — implementation plan (backend)
+
+*Status: agreed design, ready to implement. Written 2026-07-02 after the insights
+hardening on `feat/insights-musings` (commit 6d8b677). This document is
+self-contained: a fresh session can implement from it without prior context.*
+
+## Context
+
+A **dashboard** is a persistent, curated collection of insights, layers and
+AOIs — a complement to the map/explorer view. The design mock ("Paraná,
+Brazil") shows: a dashboard titled by its area; widgets that each toggle
+between map/chart/table views with "show params" / "view how this was
+generated" / download; an "Add to dashboard" toggle on analyses in the chat
+sidebar; dashboard-level Share/Export/Subscribe actions; and an AI-assistant
+panel to "refine this dashboard".
+
+**MVP is a single-area dashboard** (a country, a state, a protected area), but
+the schema must extend to **multiple areas for portfolio monitoring** without
+migration. Scope here is backend only: models, repositories, API, agent tools.
+
+### Existing building blocks (do not rebuild these)
+
+- **Insights are standalone artifacts**: `InsightOrm` + `InsightChartOrm`
+  (`src/api/data_models.py`) persist charts, narrative and provenance
+  (`statistics_ids`). A dashboard widget only *references* an insight.
+- **AOIs have a canonical address**: `AreaOfInterest(source, src_id, subtype)`
+  (`src/api/schemas.py`), sources `gadm|custom|wdpa|kba|landmark`. Custom areas
+  are rows in `custom_areas` referenced as `source="custom"`. Dashboards store
+  these references, never geometry.
+- **Deterministic analysis**: `POST /api/analyze` (`src/api/routers/analyze.py`)
+  turns (AOIs + dataset_id + dates) into a new insight via a background job.
+  This is the future refresh/alerts mechanism — nothing to build now.
+- **Access rules**: `src/api/repositories/insight_access.py` centralizes
+  own+public read / owner-only edit. Dashboards get twin functions.
+- **Agent harness**: everything is a tool on one agent (`src/agent/graph.py`);
+  tools export `SPEC = ToolSpec(...)` (`src/agent/tool_spec.py`) and are added
+  to profiles in `src/agent/agent_config.py` (`EXPERIMENTAL_SPECS` for new
+  tools). Workflows live as markdown skills in
+  `src/agent/skills/skills_md/*.md` with `requires:` frontmatter.
+- **Frontend contract**: tools that change persisted artifacts attach
+  `response_metadata={"msg_type": ..., "<id-field>": ...}` to their ToolMessage
+  so the frontend refetches (see `search_insights.py` / `update_insight_display.py`
+  using `msg_type: "insight_updated"`).
+
+### Decisions already made (don't re-litigate)
+
+1. **Multi-AOI join table from day one**; the single-area constraint is API
+   validation (`max_length=1`), not schema.
+2. **Access**: own + public read, owner-only edit — same as insights.
+   **Publishing a dashboard cascades `is_public=True` to its referenced
+   insights** (otherwise a public dashboard renders empty for viewers).
+   Read-through access was considered and deferred.
+3. **Agent = primitive tools + a skill, no subagent.** `create_dashboard` and
+   `add_to_dashboard` are deterministic DB writes; orchestration ("build me a
+   dashboard for X") is a markdown skill. A "dashboard composer" subagent is
+   deferred until there is a real multi-stage LLM pipeline to hide (mirrors
+   the insights split: primitives + Analyst).
+4. Widgets don't store chart data, geometry, or tile URLs — only references
+   plus presentation config.
+
+## 1. Data model + migration
+
+Add to `src/api/data_models.py`, following `InsightOrm`/`InsightChartOrm`
+conventions (UUID PK via `gen_random_uuid()`, `String` user FK, JSONB with
+server defaults):
+
+**`dashboards`** (`DashboardOrm`)
+- `id` UUID PK
+- `user_id` String FK→users, **NOT NULL** (dashboards are always owned)
+- `name` String NOT NULL
+- `description` String nullable
+- `is_public` Boolean NOT NULL server_default false
+- `created_at` / `updated_at` DateTime (`onupdate=datetime.now`, like
+  `CustomAreaOrm`)
+- relationships: `aois` → DashboardAoiOrm, `widgets` → DashboardWidgetOrm,
+  both `cascade="all, delete-orphan"`, ordered by `position`
+
+**`dashboard_aois`** (`DashboardAoiOrm`)
+- `id` UUID PK, `dashboard_id` UUID FK→dashboards NOT NULL
+- `source` String NOT NULL, `src_id` String NOT NULL, `subtype` String NOT NULL
+- `name` String NOT NULL (display name, denormalized like
+  `StatisticsOrm.aoi_names`)
+- `position` Integer NOT NULL server_default 0
+- UniqueConstraint(`dashboard_id`, `source`, `src_id`)
+
+**`dashboard_widgets`** (`DashboardWidgetOrm`)
+- `id` UUID PK, `dashboard_id` UUID FK→dashboards NOT NULL
+- `position` Integer NOT NULL server_default 0
+- `widget_type` String NOT NULL — `"insight"` | `"map"` (plain String like
+  `JobOrm.type`; validate in Pydantic, not the DB)
+- `insight_id` UUID FK→insights **nullable**, `ondelete="CASCADE"` — deleting
+  an insight silently drops widgets that reference it
+- `config` JSONB NOT NULL server_default `'{}'` — presentation only:
+  `default_view` ("map"|"chart"|"table"), optional `title` override; for map
+  widgets: `dataset_id`, `start_date`/`end_date`, optional viewport. Leave room
+  for a future `refresh` key (relative date window) — do not implement it.
+- `created_at` DateTime
+
+Migration: new revision in `db/alembic/versions/` (alembic config at
+`db/alembic.ini`, run alembic from the `db/` directory). Follow the style of a
+recent revision file there.
+
+## 2. Access rules — `src/api/repositories/dashboard_access.py`
+
+Twin of `insight_access.py` (same docstring discipline, same semantics):
+`visible_dashboards_clause(user_id)`, `is_visible_to_user(row, user_id)`,
+`is_editable_by_user(row, user_id)`. Missing/unset user id ⇒ only public rows
+visible, nothing editable. Unit-test as pure functions (copy
+`tests/unit/api/test_insight_access.py`).
+
+## 3. Repository — `src/api/repositories/dashboard_writer.py`
+
+Follow `insight_writer.py` conventions (`get_session_from_pool`, structlog
+`logger.info` events, malformed UUIDs return None/False rather than raise):
+
+- `create_dashboard(*, user_id, name, description=None, aois: list[dict]) -> str`
+- `get_dashboard(dashboard_id) -> Optional[DashboardOrm]` (selectinload aois +
+  widgets; caller applies access check)
+- `add_widget(dashboard_id, *, widget_type, insight_id=None, config=None, position=None) -> Optional[str]`
+  (position defaults to max+1)
+- `update_widget(widget_id, *, position=None, config=None) -> bool`
+- `remove_widget(widget_id) -> bool`
+- `update_dashboard(dashboard_id, *, name=None, description=None) -> bool`
+- `delete_dashboard(dashboard_id) -> bool`
+- `set_dashboard_public(dashboard_id, is_public) -> bool` — when setting True,
+  also set `is_public=True` on all insights referenced by its widgets
+  (decision 2), in the same transaction.
+
+Ownership checks live in the callers (router/tools) via `dashboard_access`,
+same split as insights.
+
+## 4. API — `src/api/routers/dashboards.py`
+
+Mirror `src/api/routers/insights.py` (auth dependencies from
+`src/api/auth/dependencies.py`, `_row_to_response` mapping helpers, 404 for
+not-found *and* not-owned). Register the router wherever the others are
+included (`src/api/app.py`).
+
+- `POST /api/dashboards` — `require_auth`. Body: `name?` (defaults to the
+  first AOI's name), `description?`, `aois: List[DashboardAoi]` with
+  **`min_length=1, max_length=1`** (the MVP single-area constraint — lift
+  later by raising max_length). `DashboardAoi` = `AreaOfInterest` + `name`.
+- `GET /api/dashboards` — own dashboards, newest first.
+- `GET /api/dashboards/{id}` — `optional_auth`; own or public (mirror
+  `get_insight`, including admin/superuser override). Response expands widgets
+  with their insight payloads reusing the insights `_row_to_response` shape so
+  the frontend renders widgets like insights.
+- `PATCH /api/dashboards/{id}` — rename/description, owner only.
+- `PATCH /api/dashboards/{id}/public` — mirror
+  `PATCH /api/insights/{id}/public`; cascades to insights per decision 2.
+  Response should list the insight ids it publicized.
+- `POST /api/dashboards/{id}/widgets` — body: `widget_type`,
+  `insight_id?`, `config?`, `position?`. Validate: insight widgets need an
+  `insight_id` the user can see (`insight_access.is_visible_to_user`).
+- `PATCH /api/dashboards/{id}/widgets/{widget_id}` — reorder/config.
+- `DELETE /api/dashboards/{id}/widgets/{widget_id}` and
+  `DELETE /api/dashboards/{id}` — owner only.
+
+Schemas in `src/api/schemas.py` next to the insight response models.
+
+## 5. Agent integration (experimental profile only)
+
+**Tools** — copy the structure of `src/agent/tools/search_insights.py`
+(module docstring, private DB helpers, pure helpers separated, `Command` +
+ToolMessage return, `SPEC` at the bottom, user id from
+`structlog.contextvars.get_contextvars().get("user_id")`):
+
+- `src/agent/tools/create_dashboard.py` —
+  `create_dashboard(name?, tool_call_id)`: AOIs default from
+  `state["aoi_selection"]` (`AOISelection` in `src/agent/state.py`: `{name,
+  aois: list[dict]}`); error ToolMessage if no AOI in state. Returns success
+  ToolMessage with `response_metadata={"msg_type": "dashboard_updated",
+  "dashboard_id": ...}` and puts `dashboard_id` into state (add the key to
+  `AgentState`).
+- `src/agent/tools/add_to_dashboard.py` —
+  `add_to_dashboard(insight_id?, dashboard_id?, tool_call_id)`: insight
+  defaults to `state["insight_id"]`; dashboard defaults to
+  `state["dashboard_id"]` or `view_context["dashboard_id"]`. Owner-only via
+  `dashboard_access.is_editable_by_user`; referenced insight must be visible
+  via `insight_access.is_visible_to_user`. Same `dashboard_updated` metadata.
+
+Register both in `EXPERIMENTAL_SPECS` (`src/agent/agent_config.py`).
+
+**Skill** — `src/agent/skills/skills_md/dashboard.md` with frontmatter
+`requires: create_dashboard, add_to_dashboard` (skills are only advertised
+when their tools are in the profile — see `src/agent/skills/loader.py`).
+Content: when to create vs. reuse the dashboard in view/state; the compose
+loop (per topic: `pick_aoi` if needed → analyze pipeline → `generate_insights`
+→ `add_to_dashboard`); recall flow (`search_insights` → `add_to_dashboard`);
+stop conditions (don't keep adding widgets unprompted). Look at
+`skills_md/show-imagery.md` and `analyze.md` for tone/format.
+
+**view_context** — extend the comment on `ChatRequest.view_context`
+(`src/api/schemas.py`) with `"dashboard_id": "<uuid>"` and `page: "dashboard"`.
+Extend `src/agent/tools/inspect_view_context.py`: when `dashboard_id` is
+present, load the dashboard (visibility via `dashboard_access`), print name,
+area(s) and its widgets — reuse `format_insights` for the insight content.
+
+**Routing** — add one line to the routing table in the `graph.py` system
+prompt for "add this to my dashboard / build a dashboard for X" → read skill
+`dashboard`.
+
+## 6. Tests
+
+Follow the two established patterns:
+
+- **Pure/unit**: `tests/unit/api/test_dashboard_access.py` (copy
+  `test_insight_access.py` parametrization).
+- **Tool unit tests**: `tests/agent/test_create_dashboard.py`,
+  `test_add_to_dashboard.py` — SimpleNamespace fakes + `AsyncMock`-patch the
+  repository functions, invoke `tool.coroutine(...)`, assert ToolMessage
+  content/status/`response_metadata` and state updates (copy
+  `tests/agent/test_search_insights.py` style).
+- **DB integration**: `tests/agent/test_dashboards_db.py` — the autouse
+  `test_db_pool` fixture in `tests/conftest.py` points
+  `get_session_from_pool()` at the test DB; bind the user with
+  `structlog.contextvars.bound_contextvars(user_id=user.id)` (see
+  `tests/agent/test_insights_db.py` for the whole pattern, incl. `user` /
+  `user_ds` fixtures). Cover: create + single-area enforcement happens in API
+  (not repo); widget add/reorder/remove; owner-only edit; publish cascades
+  `is_public` to referenced insights; deleting an insight cascades widget
+  removal; deleting a dashboard leaves insights intact.
+- **API tests**: `tests/api/test_dashboards.py` using `client` +
+  `auth_override` fixtures (copy `tests/api/test_insights.py`): 401/404
+  semantics, public read, single-area validation (2 AOIs → 422), widget
+  endpoints.
+
+## 7. Verification
+
+1. `uv run pytest tests/unit tests/agent tests/api/test_dashboards.py tests/api/test_insights.py`
+   (test DB via docker compose service `test-db`, port 5434, env in `.env`).
+   Note: `tests/agent/test_graph.py::test_agent_for_disturbance_alerts_for_brazil`
+   is a known-flaky live-LLM test — rerun before blaming a change.
+2. Pre-commit hooks run ruff/ruff-format/mypy and bump the CalVer version in
+   `pyproject.toml` on commit; if the first commit attempt fails with
+   "files were modified", `git add` the hook changes and commit again.
+3. Manual smoke via the agent CLI (`src/agent/cli.py`) on the experimental
+   profile: run an analysis, then "create a dashboard for this area", then
+   "add this insight to the dashboard"; verify rows and
+   `GET /api/dashboards/{id}`.
+
+## Out of scope (deliberately)
+
+- Refresh / relative date windows (future `config.refresh` + re-run
+  `POST /api/analyze`, swap `insight_id`).
+- Subscribe-to-alerts, PDF export.
+- Portfolio UX (schema already supports multiple `dashboard_aois` rows).
+- Read-through access for private insights on public dashboards.
+- A dashboard-composer subagent.

--- a/docs/dashboards-mvp-plan.md
+++ b/docs/dashboards-mvp-plan.md
@@ -56,7 +56,9 @@ migration. Scope here is backend only: models, repositories, API, agent tools.
    deferred until there is a real multi-stage LLM pipeline to hide (mirrors
    the insights split: primitives + Analyst).
 4. Widgets don't store chart data, geometry, or tile URLs — only references
-   plus presentation config.
+   plus presentation config. *Superseded for map widgets (2026-07-03):
+   their config snapshots the resolved layer including tile URLs, mirroring
+   the `dataset`/`imagery` state updates the explorer already renders.*
 
 ## 1. Data model + migration
 

--- a/docs/view-context-pages.md
+++ b/docs/view-context-pages.md
@@ -1,0 +1,86 @@
+# View pages — how the agent knows which surface the user is on
+
+*Status: implemented 2026-07-03 on `feat/dashboards-mvp`, as a follow-up to
+`docs/dashboards-mvp-plan.md`. The app is growing a second surface (the
+dashboard page, toggled in the top bar, next to the map explorer); this
+records how page scope is communicated to the agent and where to add the
+next page.*
+
+## The problem
+
+The frontend sends an ambient view snapshot with every chat request
+(`ChatRequest.view_context`), including a `page` value. Before this change
+the backend treated `page` as an opaque string: the session block echoed
+"`map page`" and `inspect_view_context` dumped the snapshot, but nothing
+told the agent what a page *means* — what the user can do there, what
+"this" / "here" refer to, or which tools are the natural defaults. Each new
+surface (dashboard, and whatever comes next) would have made that gap wider.
+
+## The design: one registry, two renderings
+
+**`src/agent/view_pages.py`** is the single place page semantics live. Each
+registered page (`map`, `dashboard`) defines the same knowledge in two
+shapes, matching the two channels the agent already has:
+
+1. **Session line (every model call).** `SessionContextMiddleware` prepends
+   a `[Session — date]` block before each model call; its `View:` line is
+   now rendered by the page's `session_line`. This is the cheap, ambient
+   layer — the agent always knows where the user is without a tool call.
+
+   ```
+   View: dashboard 'Paraná' (5c9f…) — a persistent collection of insight
+   widgets for one area. 'This dashboard' = the one on screen;
+   add_to_dashboard targets it by default (call inspect_view_context for
+   its area and widgets).
+   ```
+
+2. **`# Current surface` prompt section (per request).** `stream_chat`
+   passes `view_context["page"]` to `fetch_zeno(page=...)` →
+   `get_prompt(config, page=...)`, which inserts the page's
+   `prompt_section` — the behavioral/routing hints ("'add this' means
+   add_to_dashboard", "new analyses default to the dashboard's area").
+   The agent is rebuilt per request, so switching pages mid-thread simply
+   produces the matching prompt on the next request.
+
+Deep content stays where it was: the full snapshot (viewport, layer lists,
+widget contents) is only returned by the `inspect_view_context` tool, which
+loads and formats dashboards and insights from the DB on demand.
+
+## The frontend contract
+
+`view_context` remains frontend-owned and free-form. The parts the backend
+assigns meaning to:
+
+- `page`: `"map"` | `"dashboard"` (`"report"` is sent today but has no
+  registered semantics yet). Unknown values degrade gracefully — generic
+  breadcrumb, no prompt section.
+- On the dashboard page: `dashboard_id` (used by `add_to_dashboard` as the
+  default target and by `inspect_view_context` to load the dashboard) and
+  optionally `dashboard_name` (lets the session line name the dashboard
+  without a DB read; omitted → the line falls back to the id).
+
+## Deliberately not done: eager scope hydration
+
+We do **not** pre-fill agent selections from the view (e.g. setting
+`aoi_selection` from the dashboard's area before the agent runs). The
+`ChatRequest.view_context` comment records this ADR: ambient view state is
+reference material, unlike `ui_context` (deliberate user actions), and is
+never turned into a message or merged into selections. Eager merging breaks
+down as soon as a user browses one dashboard while chatting about something
+else. Scope becomes *actionable* through tool defaulting on explicit intent
+instead: `add_to_dashboard` already defaults to `view_context["dashboard_id"]`;
+if "analyze deforestation" on a dashboard page proves to need it, `pick_aoi`
+could similarly learn to consult the dashboard's area — revisit then.
+
+## Adding the next page
+
+1. Register a `ViewPage` in `src/agent/view_pages.py`: a `session_line`
+   renderer (one line — what the surface is + what "this/here" means) and a
+   `prompt_section` (2–4 sentences of routing hints). Keep both terse; bulky
+   content belongs in `inspect_view_context`.
+2. If the page anchors on an entity (like `dashboard_id`), document the id
+   field in the `ChatRequest.view_context` comment, teach
+   `inspect_view_context` to load/format it, and let the relevant tools
+   default from it.
+3. Tests: `tests/unit/agent/test_view_pages.py` covers session lines, prompt
+   sections and the unknown-page fallback — extend the same file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.2.1"
+version = "2026.7.7"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.2"
+version = "2026.7.2.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -25,6 +25,8 @@ from src.agent.subagents.pick_aoi.tool import SPEC as pick_aoi_spec
 from src.agent.subagents.pick_dataset.tool import SPEC as pick_dataset_spec
 from src.agent.subagents.search.blog import SPEC as search_blogs_spec
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.add_to_dashboard import SPEC as add_to_dashboard_spec
+from src.agent.tools.create_dashboard import SPEC as create_dashboard_spec
 from src.agent.tools.inspect_view_context import (
     SPEC as inspect_view_context_spec,
 )
@@ -56,6 +58,8 @@ EXPERIMENTAL_SPECS = (
     search_blogs_spec,
     update_insight_display_spec,
     search_insights_spec,
+    create_dashboard_spec,
+    add_to_dashboard_spec,
 )
 
 

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -25,6 +25,7 @@ from src.agent.subagents.pick_aoi.tool import SPEC as pick_aoi_spec
 from src.agent.subagents.pick_dataset.tool import SPEC as pick_dataset_spec
 from src.agent.subagents.search.blog import SPEC as search_blogs_spec
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.add_map_widget import SPEC as add_map_widget_spec
 from src.agent.tools.add_to_dashboard import SPEC as add_to_dashboard_spec
 from src.agent.tools.create_dashboard import SPEC as create_dashboard_spec
 from src.agent.tools.inspect_view_context import (
@@ -60,6 +61,7 @@ EXPERIMENTAL_SPECS = (
     search_insights_spec,
     create_dashboard_spec,
     add_to_dashboard_spec,
+    add_map_widget_spec,
 )
 
 

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -29,7 +29,11 @@ from src.agent.tools.inspect_view_context import (
     SPEC as inspect_view_context_spec,
 )
 from src.agent.tools.pull_data import SPEC as pull_data_spec
+from src.agent.tools.search_insights import SPEC as search_insights_spec
 from src.agent.tools.show_imagery import SPEC as show_imagery_spec
+from src.agent.tools.update_insight_display import (
+    SPEC as update_insight_display_spec,
+)
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -50,6 +54,8 @@ EXPERIMENTAL_SPECS = (
     inspect_view_context_spec,
     show_imagery_spec,
     search_blogs_spec,
+    update_insight_display_spec,
+    search_insights_spec,
 )
 
 

--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -50,6 +50,7 @@ from src.shared.database import (
     initialize_global_pool,
 )
 from src.shared.logging_config import bind_request_logging_context
+from src.shared.request_context import set_current_user_id
 
 DEFAULT_CLI_USER_ID = "zeno-default-user"
 
@@ -695,6 +696,7 @@ async def _async_main(
 ) -> None:
     structlog.contextvars.clear_contextvars()
     bind_request_logging_context(user_id=user_id, thread_id=thread_id)
+    set_current_user_id(user_id)
 
     printer = _CliPrinter(verbose=verbose)
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -65,6 +65,7 @@ Match the request to exactly one row; do not escalate a dataset / AOI / pull req
 - Pull-only (e.g. "pull dist alerts in Bern for last 2 weeks"): read `pull-data`, run pick_aoi → pick_dataset → pull_data, then stop. Do not call generate_insights unless the user asked for a chart or analysis.
 - Full analysis (place + topic → chart/insight): read `analyze` and follow that pipeline.
 - Recall a past insight (e.g. "show that tree-cover insight again", "pull up the fires analysis from before"): call search_insights and then STOP. search_insights is terminal — the insight already exists and is put on screen, so it is NEVER followed by pick_aoi, pick_dataset, pull_data or generate_insights. "Show/recall/pull up an earlier insight" is a recall request, never a request for new analysis. After it returns, reply with a one-line summary only.
+- Dashboard (e.g. "add this to my dashboard", "build a dashboard for X"): read skill `dashboard` and follow it.
 - Imagery (e.g. "show satellite imagery of Bern in June"): read `show-imagery`, run pick_aoi → show_imagery, then stop. No dataset, pull or insights unless asked.
 - Capabilities (what you can do, what data exists): read `capabilities`, then answer in your own words — no analysis tools.
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -151,15 +151,42 @@ async def fetch_checkpointer() -> AsyncPostgresSaver:
     return checkpointer
 
 
+# Tool args whose values identify the artifact a failed call was targeting;
+# logged with the exception so an error can be tied to a specific record.
+_TARGET_ID_ARGS = ("dashboard_id", "insight_id", "widget_id")
+
+
 @wrap_tool_call
 async def handle_tool_errors(request, handler):
+    """Last-resort funnel for exceptions a tool did not anticipate.
+
+    The raw exception stays server-side only: the returned ToolMessage is
+    streamed to the model and on to the browser, so it must never carry
+    driver/ORM text (SQL fragments, table names) — just the tool and the
+    exception class.
+    """
     try:
         return await handler(request)
     except Exception as e:
-        logger.exception("Tool execution failed")
+        tool_call = request.tool_call
+        tool_name = tool_call.get("name") or "unknown"
+        args = tool_call.get("args") or {}
+        target_ids = {
+            key: str(args[key]) for key in _TARGET_ID_ARGS if args.get(key)
+        }
+        logger.exception(
+            "tool_execution_failed",
+            tool_name=tool_name,
+            tool_call_id=tool_call.get("id"),
+            **target_ids,
+        )
         return ToolMessage(
-            content=f"Tool error: {str(e)}",
-            tool_call_id=request.tool_call["id"],
+            content=(
+                f"Tool '{tool_name}' failed unexpectedly "
+                f"({type(e).__name__}). The error has been logged."
+            ),
+            tool_call_id=tool_call.get("id"),
+            status="error",
         )
 
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -76,7 +76,7 @@ Match the request to exactly one row; do not escalate a dataset / AOI / pull req
 - Pull-only (e.g. "pull dist alerts in Bern for last 2 weeks"): read `pull-data`, run pick_aoi → pick_dataset → pull_data, then stop. Do not call generate_insights unless the user asked for a chart or analysis.
 - Full analysis (place + topic → chart/insight): read `analyze` and follow that pipeline.
 - Recall a past insight (e.g. "show that tree-cover insight again", "pull up the fires analysis from before"): call search_insights and then STOP. search_insights is terminal — the insight already exists and is put on screen, so it is NEVER followed by pick_aoi, pick_dataset, pull_data or generate_insights. "Show/recall/pull up an earlier insight" is a recall request, never a request for new analysis. After it returns, reply with a one-line summary only.
-- Dashboard (e.g. "add this to my dashboard", "build a dashboard for X"): read skill `dashboard` and follow it.
+- Dashboard (e.g. "add this to my dashboard", "add this layer/imagery to my dashboard", "build a dashboard for X"): read skill `dashboard` and follow it.
 - Imagery (e.g. "show satellite imagery of Bern in June"): read `show-imagery`, run pick_aoi → show_imagery, then stop. No dataset, pull or insights unless asked.
 - Capabilities (what you can do, what data exists): read `capabilities`, then answer in your own words — no analysis tools.
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -23,14 +23,23 @@ from src.agent.agent_config import (
 from src.agent.llms import FALLBACK_MODELS, MODEL
 from src.agent.middleware import SessionContextMiddleware
 from src.agent.state import AgentState
+from src.agent.view_pages import prompt_section
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 
-def get_prompt(config: Optional[AgentConfig] = None) -> str:
-    """Generate the system prompt from the config's tools and skills."""
+def get_prompt(
+    config: Optional[AgentConfig] = None, page: Optional[str] = None
+) -> str:
+    """Generate the system prompt from the config's tools and skills.
+
+    ``page`` is the frontend surface the user is on (from
+    ``view_context["page"]``, known at request time); registered pages
+    (src/agent/view_pages.py) contribute a "# Current surface" section with
+    their scope and routing hints. Unknown/absent pages add nothing.
+    """
     if config is None:
         config = default_registry.resolve()
     skill_lines = [
@@ -39,13 +48,15 @@ def get_prompt(config: Optional[AgentConfig] = None) -> str:
     ]
     skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
     tool_descriptions = config.tool_descriptions()
+    surface = prompt_section(page)
+    surface_block = f"\n# Current surface\n\n{surface}\n" if surface else ""
     today = datetime.now().strftime("%Y-%m-%d")
     return f"""You are Global Nature Watch's Geospatial Agent. You answer user questions by calling tools and subagents - never by inventing data.
 
 Today: {today}
 
 A [Session — date] system message is prepended to every model call with the live AOI, dataset, date range, pulled data and active insight. Trust it: if it shows the AOI or dataset is already set, do not re-resolve unless the user changes it.
-
+{surface_block}
 Call tools one at a time, never in parallel.
 
 {tool_descriptions}
@@ -192,12 +203,18 @@ async def fetch_zeno(
     registry: AgentConfigRegistry = default_registry,
     checkpointer: Any = _CHECKPOINTER_UNSET,
     config: Optional[AgentConfig] = None,
+    page: Optional[str] = None,
 ) -> CompiledStateGraph:
     """Setup the Zeno agent for the given config and feature flag.
 
     The config is resolved from ``ff`` via ``registry``; unknown flags fall
     back to the registry's default. Pass a custom ``registry`` in tests to
     inject isolated configs without mutating global state.
+
+    ``page`` is the frontend surface for this request (from
+    ``view_context["page"]``); it conditions the "# Current surface" prompt
+    section. The agent is built per request, so a mid-thread page switch
+    simply produces the matching prompt on the next request.
 
     By default the Postgres checkpointer is used (API and durable CLI runs).
     Pass an explicit ``checkpointer`` (e.g. ``InMemorySaver()``) for local
@@ -212,7 +229,7 @@ async def fetch_zeno(
         model=MODEL,
         tools=config.tools(),
         state_schema=AgentState,
-        system_prompt=config.system_prompt or get_prompt(config),
+        system_prompt=config.system_prompt or get_prompt(config, page=page),
         middleware=_build_middleware(),
         checkpointer=checkpointer,
     )

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -64,6 +64,7 @@ Match the request to exactly one row; do not escalate a dataset / AOI / pull req
 - AOI-only (e.g. "zoom to Pará"): call pick_aoi, then stop unless asked for more.
 - Pull-only (e.g. "pull dist alerts in Bern for last 2 weeks"): read `pull-data`, run pick_aoi → pick_dataset → pull_data, then stop. Do not call generate_insights unless the user asked for a chart or analysis.
 - Full analysis (place + topic → chart/insight): read `analyze` and follow that pipeline.
+- Recall a past insight (e.g. "show that tree-cover insight again", "pull up the fires analysis from before"): call search_insights and then STOP. search_insights is terminal — the insight already exists and is put on screen, so it is NEVER followed by pick_aoi, pick_dataset, pull_data or generate_insights. "Show/recall/pull up an earlier insight" is a recall request, never a request for new analysis. After it returns, reply with a one-line summary only.
 - Imagery (e.g. "show satellite imagery of Bern in June"): read `show-imagery`, run pick_aoi → show_imagery, then stop. No dataset, pull or insights unless asked.
 - Capabilities (what you can do, what data exists): read `capabilities`, then answer in your own words — no analysis tools.
 

--- a/src/agent/middleware.py
+++ b/src/agent/middleware.py
@@ -13,6 +13,8 @@ from datetime import date
 from langchain.agents.middleware.types import AgentMiddleware, ModelRequest
 from langchain_core.messages import SystemMessage
 
+from src.agent.view_pages import get_page, on_screen_counts
+
 
 def format_session_block(state: dict) -> str:
     """Render a short text block summarizing the current session state.
@@ -80,27 +82,26 @@ def format_session_block(state: dict) -> str:
 
 
 def _view_breadcrumb(view: dict | None) -> str:
-    """One-line hint that frontend view state exists, with details on demand.
+    """One-line scope hint for the surface the user is on.
 
-    Keeps the bulky snapshot (exact viewport, full layer list) out of the
-    prompt — the agent calls inspect_view_context when it actually needs it.
+    Registered pages (src/agent/view_pages.py) render their own line with
+    the page's scope semantics ("this dashboard" = ..., etc.); unregistered
+    pages fall back to the generic count summary. Either way the bulky
+    snapshot (exact viewport, full layer list) stays out of the prompt —
+    the agent calls inspect_view_context when it actually needs it.
     """
     if not view:
         return "View: none"
+
+    page_meta = get_page(view)
+    if page_meta is not None:
+        return page_meta.session_line(view)
 
     parts = []
     page = view.get("page")
     if page:
         parts.append(f"{page} page")
-    layers = view.get("visible_layers") or []
-    if layers:
-        parts.append(f"{len(layers)} layer(s)")
-    aois = view.get("visible_aois") or []
-    if aois:
-        parts.append(f"{len(aois)} AOI(s) visible")
-    insights = view.get("visible_insights") or []
-    if insights:
-        parts.append(f"{len(insights)} insight(s) on screen")
+    parts.extend(on_screen_counts(view))
 
     summary = " · ".join(parts) if parts else "active"
     return f"View: {summary} (call inspect_view_context for details)"

--- a/src/agent/skills/skills_md/dashboard.md
+++ b/src/agent/skills/skills_md/dashboard.md
@@ -1,15 +1,16 @@
 ---
 name: dashboard
-description: Create a dashboard for an area and fill it with insights (new or recalled).
-when_to_use: User asks to build/create a dashboard for a place, or to add an insight/analysis to a dashboard. Not for one-off analysis without a dashboard — use `analyze`.
-requires: create_dashboard, add_to_dashboard
+description: Create a dashboard for an area and fill it with insights (new or recalled) and map widgets.
+when_to_use: User asks to build/create a dashboard for a place, to add an insight/analysis to a dashboard, or to add a map layer / satellite imagery to a dashboard. Not for one-off analysis without a dashboard — use `analyze`.
+requires: create_dashboard, add_to_dashboard, add_map_widget
 ---
 
 # Dashboards
 
-A dashboard is a persistent collection of insights for ONE area (a country, a
-state, a protected area). Widgets reference insights that already exist —
-adding to a dashboard never recomputes anything.
+A dashboard is a persistent collection of widgets for ONE area (a country, a
+state, a protected area). Widgets are insights or map layers. Widgets
+reference or snapshot work that already exists — adding to a dashboard never
+recomputes anything.
 
 # Which dashboard to use
 
@@ -29,7 +30,9 @@ adding to a dashboard never recomputes anything.
 2. Per topic, reuse existing work before computing: if the user refers to an
    earlier finding, `search_insights` → `add_to_dashboard`. Otherwise run the
    `analyze` pipeline (pick_dataset → pull_data → generate_insights) →
-   `add_to_dashboard`.
+   `add_to_dashboard`. If the user asks for a map/layer/imagery view of a
+   topic, add it with `add_map_widget` after the dataset is picked (or after
+   `show_imagery`) — a map widget does not need an insight.
 3. Give a short progress message per topic added.
 
 # Adding a single insight ("add this to my dashboard")
@@ -37,6 +40,14 @@ adding to a dashboard never recomputes anything.
 `add_to_dashboard` — it defaults to the current insight in state and the
 dashboard in state/on screen. Recall the insight first (`search_insights`)
 only if the user refers to a past finding that is not the current one.
+
+# Adding a map layer ("add this layer / the imagery to my dashboard")
+
+`add_map_widget(layer="dataset")` snapshots the currently selected dataset
+layer — run `pick_dataset` first if none is selected.
+`add_map_widget(layer="imagery")` snapshots the Sentinel-2 mosaic — run
+`show_imagery` first. Build the layer/imagery for the dashboard's area. Map
+widgets render focused on the dashboard's area automatically.
 
 # Stop conditions
 

--- a/src/agent/skills/skills_md/dashboard.md
+++ b/src/agent/skills/skills_md/dashboard.md
@@ -1,0 +1,47 @@
+---
+name: dashboard
+description: Create a dashboard for an area and fill it with insights (new or recalled).
+when_to_use: User asks to build/create a dashboard for a place, or to add an insight/analysis to a dashboard. Not for one-off analysis without a dashboard — use `analyze`.
+requires: create_dashboard, add_to_dashboard
+---
+
+# Dashboards
+
+A dashboard is a persistent collection of insights for ONE area (a country, a
+state, a protected area). Widgets reference insights that already exist —
+adding to a dashboard never recomputes anything.
+
+# Which dashboard to use
+
+- If the user is viewing a dashboard (view_context has a `dashboard_id`, page
+  `dashboard` — check with `inspect_view_context` if unsure) or one was
+  created/used earlier this conversation, **reuse it**: `add_to_dashboard`
+  defaults to it.
+- Only call `create_dashboard` when there is no dashboard yet, or the user
+  explicitly asks for a new one. It needs an AOI in state — run `pick_aoi`
+  first if none is selected. One area per dashboard; for "a dashboard for X
+  and Y", ask the user to pick one area (multi-area portfolios are not
+  supported yet).
+
+# Composing ("build me a dashboard for X about A, B, C")
+
+1. `pick_aoi` for X (skip if already selected), then `create_dashboard`.
+2. Per topic, reuse existing work before computing: if the user refers to an
+   earlier finding, `search_insights` → `add_to_dashboard`. Otherwise run the
+   `analyze` pipeline (pick_dataset → pull_data → generate_insights) →
+   `add_to_dashboard`.
+3. Give a short progress message per topic added.
+
+# Adding a single insight ("add this to my dashboard")
+
+`add_to_dashboard` — it defaults to the current insight in state and the
+dashboard in state/on screen. Recall the insight first (`search_insights`)
+only if the user refers to a past finding that is not the current one.
+
+# Stop conditions
+
+- Add only what the user asked for — never keep adding widgets unprompted.
+- After the requested widgets are added, confirm what the dashboard now
+  contains and stop. Suggest at most one follow-up topic; do not run it.
+- If a step fails (no data, insight not found), report it and continue with
+  the remaining topics rather than aborting the whole dashboard.

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -82,6 +82,10 @@ class AgentState(TypedDict):
     # search-blogs tool
     cited_articles: Annotated[list[CitedArticle], operator.add]
 
+    # create-dashboard / add-to-dashboard tools — the dashboard the
+    # conversation is working on (last created or added-to this thread).
+    dashboard_id: str
+
     # generate-insights tool
     insight: str
     follow_up_suggestions: list[str]

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -76,6 +76,17 @@ class InsightChart(BaseModel):
                 )
         return self
 
+    def available_columns(self) -> List[str]:
+        """Column names present across all data rows, in first-seen order.
+
+        Rows may be heterogeneous (a column can appear only in later rows),
+        so this unions keys over every row rather than trusting the first.
+        """
+        columns: dict = {}
+        for row in self.chart_data:
+            columns.update(dict.fromkeys(row))
+        return list(columns)
+
     # --- adapters -----------------------------------------------------------
 
     def to_orm_kwargs(self) -> dict:

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -168,3 +168,13 @@ class Insight(BaseModel):
         for chart in self.charts:
             chart.insight = self.primary_insight
         return self
+
+    @classmethod
+    def from_orm_row(cls, row) -> "Insight":
+        """Rebuild the full insight from a persisted `InsightOrm` row
+        (charts relationship loaded): the read twin of `insight_writer`."""
+        return cls(
+            charts=[InsightChart.from_orm_row(c) for c in (row.charts or [])],
+            primary_insight=row.insight_text,
+            follow_up_suggestions=row.follow_up_suggestions or [],
+        )

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -123,6 +123,26 @@ class InsightChart(BaseModel):
             chart_data=chart_data,
         )
 
+    @classmethod
+    def from_orm_row(cls, row) -> "InsightChart":
+        """Rebuild the seam model from a persisted `InsightChartOrm` row.
+
+        The inverse of `to_orm_kwargs()`: used when an existing insight is
+        loaded back from the DB to be restyled (no new data is pulled).
+        """
+        return cls(
+            position=row.position,
+            title=row.title,
+            chart_type=row.chart_type,
+            x_axis=row.x_axis,
+            y_axis=row.y_axis,
+            color_field=row.color_field,
+            stack_field=row.stack_field,
+            group_field=row.group_field,
+            series_fields=row.series_fields or [],
+            chart_data=row.chart_data or [],
+        )
+
 
 class Insight(BaseModel):
     """Resolved charts plus the narrative from the text stage."""

--- a/src/agent/subagents/analyst/code_executors/base.py
+++ b/src/agent/subagents/analyst/code_executors/base.py
@@ -3,10 +3,23 @@
 from base64 import b64encode
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional, get_args
 
 from pydantic import BaseModel, Field, model_validator
 
+# The chart types the frontend can render. `ChartType` is the validating
+# annotation; `CHART_TYPES` the same names as plain strings for prompts.
+ChartType = Literal[
+    "line",
+    "bar",
+    "stacked-bar",
+    "grouped-bar",
+    "pie",
+    "area",
+    "scatter",
+    "table",
+]
+CHART_TYPES: tuple[str, ...] = get_args(ChartType)
 CHART_TYPES_WITHOUT_AXIS = {"pie", "table"}
 
 
@@ -17,7 +30,7 @@ class ChartInsight(BaseModel):
 
     title: str = Field(description="Clear, descriptive title for the chart")
     chart_type: str = Field(
-        description="Chart type: 'line', 'bar', 'stacked-bar', 'grouped-bar', 'pie', 'area', 'scatter', or 'table'"
+        description="Chart type: " + ", ".join(f"'{t}'" for t in CHART_TYPES)
     )
     x_axis: str = Field(
         description="Name of the field to use for X-axis (for applicable chart types)"

--- a/src/agent/subagents/analyst/display_reviser.py
+++ b/src/agent/subagents/analyst/display_reviser.py
@@ -19,22 +19,14 @@ from pydantic import BaseModel, Field
 
 from src.agent.llms import SMALL_MODEL
 from src.agent.subagents.analyst.charts.model import Insight
+from src.agent.subagents.analyst.code_executors.base import (
+    CHART_TYPES,
+    ChartType,
+)
 from src.agent.subagents.analyst.prompts import WORDING_GUIDE
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-# The chart types the frontend can render (mirrors ChartInsight's description).
-ALLOWED_CHART_TYPES = [
-    "line",
-    "bar",
-    "stacked-bar",
-    "grouped-bar",
-    "pie",
-    "area",
-    "scatter",
-    "table",
-]
 
 
 class RevisedChart(BaseModel):
@@ -45,8 +37,8 @@ class RevisedChart(BaseModel):
         "position of an existing chart so the data can be re-attached."
     )
     title: str = Field(description="Clear, descriptive chart title")
-    chart_type: str = Field(
-        description=f"One of: {', '.join(ALLOWED_CHART_TYPES)}"
+    chart_type: ChartType = Field(
+        description=f"One of: {', '.join(CHART_TYPES)}"
     )
     x_axis: str = Field(
         default="", description="Existing column for the X-axis"
@@ -143,12 +135,12 @@ class InsightDisplayReviser:
 
         columns = "\n".join(
             f"- {chart.position}: "
-            f"{', '.join(chart.chart_data[0].keys()) if chart.chart_data else '(no data)'}"
+            f"{', '.join(chart.available_columns()) or '(no data)'}"
             for chart in insight.charts
         )
 
         inputs = {
-            "chart_types": ", ".join(ALLOWED_CHART_TYPES),
+            "chart_types": ", ".join(CHART_TYPES),
             "wording_guide": WORDING_GUIDE,
             "instruction": instruction or "(none provided)",
             "current": current,

--- a/src/agent/subagents/analyst/display_reviser.py
+++ b/src/agent/subagents/analyst/display_reviser.py
@@ -1,0 +1,165 @@
+"""Generative insight display reviser.
+
+Rewrites the *presentation* of an existing insight — narrative text, follow-up
+suggestions, chart titles, chart types and field mappings — without pulling new
+data or running new code. The underlying ``chart_data`` rows are fixed; the
+reviser may only restyle the charts and re-map among the columns that already
+exist in each chart's data.
+
+Like `InsightTextGenerator`, this is a LangChain runnable, so it nests as a span
+in the active Langfuse trace via the ambient `RunnableConfig`.
+"""
+
+import json
+from typing import List, Optional
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, Field
+
+from src.agent.llms import SMALL_MODEL
+from src.agent.subagents.analyst.charts.model import Insight
+from src.agent.subagents.analyst.prompts import WORDING_GUIDE
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# The chart types the frontend can render (mirrors ChartInsight's description).
+ALLOWED_CHART_TYPES = [
+    "line",
+    "bar",
+    "stacked-bar",
+    "grouped-bar",
+    "pie",
+    "area",
+    "scatter",
+    "table",
+]
+
+
+class RevisedChart(BaseModel):
+    """The restyled spec for one existing chart (no data, just presentation)."""
+
+    position: int = Field(
+        description="Position of the chart being revised; must match the "
+        "position of an existing chart so the data can be re-attached."
+    )
+    title: str = Field(description="Clear, descriptive chart title")
+    chart_type: str = Field(
+        description=f"One of: {', '.join(ALLOWED_CHART_TYPES)}"
+    )
+    x_axis: str = Field(
+        default="", description="Existing column for the X-axis"
+    )
+    y_axis: str = Field(
+        default="",
+        description="Existing column for the Y-axis (single-series charts)",
+    )
+    color_field: str = Field(
+        default="", description="Existing column for color"
+    )
+    stack_field: str = Field(
+        default="", description="Existing column to stack"
+    )
+    group_field: str = Field(
+        default="", description="Existing column to group"
+    )
+    series_fields: List[str] = Field(
+        default_factory=list,
+        description="Existing columns for multi-series charts",
+    )
+
+
+class RevisedInsight(BaseModel):
+    """Structured output: the restyled narrative + chart specs."""
+
+    primary_insight: str = Field(
+        description="Revised overall insight (2-3 sentences)"
+    )
+    follow_up_suggestions: List[str] = Field(
+        description="Revised 1-2 follow-up suggestions"
+    )
+    charts: List[RevisedChart] = Field(
+        description="One entry per existing chart, keyed by position"
+    )
+
+
+_SYSTEM = """You restyle an existing data insight — its narrative text, \
+follow-up suggestions, chart titles, chart types and field mappings.
+
+You are NOT given new data and you MUST NOT invent any: the underlying chart \
+rows are fixed. You may only:
+- reword the `primary_insight` and `follow_up_suggestions`,
+- rename chart titles,
+- change a chart's type (one of: {chart_types}),
+- re-map a chart to DIFFERENT columns that ALREADY EXIST in its data.
+
+Hard rules:
+- Never reference a column that is not listed as available for that chart.
+- Return exactly one revised chart per existing chart, keeping its `position`. \
+Do not add or remove charts.
+- For chart types other than 'pie' and 'table', set either `y_axis` (single \
+series) or `series_fields` (multi series).
+- Apply only what the instruction asks for; leave everything else as it was.
+
+{wording_guide}"""
+
+_USER = """## Instruction (what to change)
+{instruction}
+
+## Current insight
+{current}
+
+## Available columns per chart (position -> columns)
+{columns}"""
+
+_PROMPT = ChatPromptTemplate.from_messages(
+    [("system", _SYSTEM), ("user", _USER)]
+)
+
+
+class InsightDisplayReviser:
+    """Generates a restyled insight spec from an existing one + an instruction."""
+
+    def __init__(self, model=SMALL_MODEL):
+        self._chain = (
+            _PROMPT | model.with_structured_output(RevisedInsight)
+        ).with_config(run_name="revise_insight_display")
+
+    async def revise(
+        self,
+        insight: Insight,
+        instruction: str,
+        config: Optional[RunnableConfig] = None,
+    ) -> RevisedInsight:
+        # Show the spec but not the rows — the data is fixed and only inflates
+        # the prompt; available columns are surfaced separately below.
+        current = json.dumps(
+            insight.model_dump(
+                exclude={"charts": {"__all__": {"chart_data", "insight"}}}
+            ),
+            default=str,
+        )
+
+        columns = "\n".join(
+            f"- {chart.position}: "
+            f"{', '.join(chart.chart_data[0].keys()) if chart.chart_data else '(no data)'}"
+            for chart in insight.charts
+        )
+
+        inputs = {
+            "chart_types": ", ".join(ALLOWED_CHART_TYPES),
+            "wording_guide": WORDING_GUIDE,
+            "instruction": instruction or "(none provided)",
+            "current": current,
+            "columns": columns,
+        }
+        result: RevisedInsight = await self._chain.ainvoke(
+            inputs, config=config
+        )
+        logger.info(
+            "revised insight display",
+            charts=len(result.charts),
+            follow_ups=len(result.follow_up_suggestions),
+        )
+        return result

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -27,6 +27,7 @@ from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.agent.tools.pull_data import fetch_statistics_from_url
 from src.api.repositories.insight_writer import persist_insight
 from src.shared.logging_config import get_logger
+from src.shared.request_context import current_user_id
 
 logger = get_logger(__name__)
 
@@ -420,7 +421,7 @@ class Analyst:
         ctx = structlog.contextvars.get_contextvars()
         insight_id = await persist_insight(
             insight,
-            user_id=ctx.get("user_id"),
+            user_id=current_user_id(),
             thread_id=ctx.get("thread_id", ""),
             statistics_ids=_extract_statistics_ids(statistics),
             codeact_parts=codeact_parts,

--- a/src/agent/subagents/pick_aoi/tool.py
+++ b/src/agent/subagents/pick_aoi/tool.py
@@ -3,7 +3,6 @@ from enum import StrEnum
 from typing import Annotated, Literal, Optional
 
 import pandas as pd
-import structlog
 from dotenv import load_dotenv
 from langchain_core.messages import ToolMessage
 from langchain_core.prompts import ChatPromptTemplate
@@ -38,6 +37,7 @@ from src.shared.geocoding_helpers import (
     search_aois,
 )
 from src.shared.logging_config import get_logger
+from src.shared.request_context import current_user_id
 
 RESULT_LIMIT = 10
 SUBREGION_LIMIT_ADMIN = 1000
@@ -117,7 +117,7 @@ async def query_aoi_database(
         DataFrame containing location information
     """
     sources = [aoi_to_table[aoi_type]] if aoi_type is not None else None
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    user_id = current_user_id()
     return await search_aois(
         name=place_name,
         sources=sources,

--- a/src/agent/tools/add_map_widget.py
+++ b/src/agent/tools/add_map_widget.py
@@ -179,7 +179,9 @@ async def add_map_widget(
         dashboard_id=str(target_dashboard),
     )
 
-    dashboard = await load_editable_dashboard(target_dashboard)
+    dashboard = await load_editable_dashboard(
+        target_dashboard, "add_map_widget"
+    )
     if dashboard is None:
         return error_command(
             f"Dashboard {target_dashboard} not found or not editable.",

--- a/src/agent/tools/add_map_widget.py
+++ b/src/agent/tools/add_map_widget.py
@@ -1,0 +1,229 @@
+"""add_map_widget — put a map layer onto a dashboard as a widget.
+
+The third dashboard primitive next to create_dashboard and add_to_dashboard.
+A map widget snapshots the resolved layer already in agent state — either the
+dataset layer picked by pick_dataset or the Sentinel-2 mosaic built by
+show_imagery — into the widget's config, so the dashboard renders it without
+any chat state. The dashboard defaults to the one in state or the one the
+user is looking at (view_context). Owner-only, like the other primitives.
+
+The snapshot is an explicit key allowlist: only render-relevant fields are
+copied, so the prose fields on the dataset state (description, methodology,
+instructions, ...) can never leak into the database.
+"""
+
+from typing import Annotated, Dict, Optional
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.repositories import dashboard_writer
+from src.api.repositories.dashboard_access import is_editable_by_user
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_LAYER_KINDS = ("dataset", "imagery")
+
+# Render-relevant fields of the imagery state (ImageryState) — all of it.
+_IMAGERY_KEYS = (
+    "tile_url",
+    "tilejson_url",
+    "mosaic_id",
+    "item_count",
+    "date_start",
+    "date_end",
+    "target_date",
+    "window_days",
+    "max_cloud_cover",
+    "aoi_names",
+)
+
+
+def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=message,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+            ]
+        }
+    )
+
+
+def _dataset_config(state: dict) -> Optional[dict]:
+    """Project the dataset in state onto the widget-config snapshot.
+
+    Returns None when no dataset is selected or it carries no tile URL
+    (nothing to render). Dates fall back to the top-level effective range
+    set by pull_data.
+    """
+    dataset = state.get("dataset") or {}
+    if not dataset.get("tile_url"):
+        return None
+    parameters = dataset.get("parameters")
+    return {
+        "dataset_id": dataset.get("dataset_id"),
+        "dataset_name": dataset.get("dataset_name"),
+        "tile_url": dataset["tile_url"],
+        "context_layer": dataset.get("context_layer"),
+        "context_layers": dataset.get("context_layers"),
+        "parameters": [
+            {"name": p.get("name"), "values": p.get("values")}
+            for p in parameters
+        ]
+        if parameters
+        else None,
+        "start_date": dataset.get("start_date") or state.get("start_date"),
+        "end_date": dataset.get("end_date") or state.get("end_date"),
+    }
+
+
+def _imagery_config(state: dict) -> Optional[dict]:
+    """Snapshot the imagery in state (ImageryState shape) for the widget.
+
+    Returns None when no imagery was built this conversation or the state
+    lacks a tile URL / mosaic id to render from.
+    """
+    imagery = state.get("imagery") or {}
+    if not imagery.get("tile_url") or not imagery.get("mosaic_id"):
+        return None
+    return {key: imagery.get(key) for key in _IMAGERY_KEYS}
+
+
+@tool("add_map_widget")
+async def add_map_widget(
+    layer: str,
+    dashboard_id: Optional[str] = None,
+    title: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Add a map widget to a dashboard.
+
+    `layer="dataset"` snapshots the currently selected dataset layer
+    (pick_dataset must have run); `layer="imagery"` snapshots the Sentinel-2
+    mosaic from show_imagery. `dashboard_id` defaults to the dashboard in
+    state or the one the user is currently viewing; `title` optionally
+    overrides the widget header. The widget renders focused on the
+    dashboard's area. Only dashboards the user owns can be edited.
+    """
+    state = state or {}
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+
+    if layer not in _LAYER_KINDS:
+        return _error_command(
+            "layer must be 'dataset' or 'imagery'.", tool_call_id
+        )
+
+    if layer == "dataset":
+        snapshot = _dataset_config(state)
+        if snapshot is None:
+            return _error_command(
+                "No dataset layer selected. Run pick_dataset first, then "
+                "add the layer to the dashboard.",
+                tool_call_id,
+            )
+    else:
+        snapshot = _imagery_config(state)
+        if snapshot is None:
+            return _error_command(
+                "No imagery built this conversation. Run show_imagery "
+                "first, then add it to the dashboard.",
+                tool_call_id,
+            )
+
+    view = state.get("view_context") or {}
+    target_dashboard = (
+        dashboard_id or state.get("dashboard_id") or view.get("dashboard_id")
+    )
+    if not target_dashboard:
+        return _error_command(
+            "No dashboard to add to. Create one with create_dashboard, or "
+            "pass a dashboard_id.",
+            tool_call_id,
+        )
+
+    logger.info(
+        "add_map_widget tool called",
+        layer=layer,
+        dashboard_id=str(target_dashboard),
+    )
+
+    dashboard = await dashboard_writer.get_dashboard(str(target_dashboard))
+    if dashboard is None or not is_editable_by_user(dashboard, user_id):
+        return _error_command(
+            f"Dashboard {target_dashboard} not found or not editable.",
+            tool_call_id,
+        )
+
+    config: dict = {"default_view": "map", layer: snapshot}
+    if title:
+        config["title"] = title
+
+    widget_id = await dashboard_writer.add_widget(
+        str(target_dashboard),
+        widget_type="map",
+        config=config,
+    )
+    if widget_id is None:
+        return _error_command(
+            f"Dashboard {target_dashboard} disappeared before the map "
+            "widget could be added.",
+            tool_call_id,
+        )
+
+    if layer == "dataset":
+        summary = (
+            f"map widget for dataset '{snapshot['dataset_name']}' "
+            f"({snapshot['start_date']}–{snapshot['end_date']})"
+        )
+    else:
+        summary = (
+            f"Sentinel-2 imagery map widget (around "
+            f"{snapshot['target_date']}, areas: "
+            f"{', '.join(snapshot['aoi_names'] or [])})"
+        )
+    return Command(
+        update={
+            "dashboard_id": str(dashboard.id),
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Added {summary} to dashboard "
+                        f"'{dashboard.name}' ({dashboard.id})."
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    # The dashboard changed on disk: the frontend re-fetches
+                    # /api/dashboards/{id} on this signal.
+                    response_metadata={
+                        "msg_type": "dashboard_updated",
+                        "dashboard_id": str(dashboard.id),
+                    },
+                )
+            ],
+        },
+    )
+
+
+SPEC = ToolSpec(
+    tool=add_map_widget,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- add_map_widget(layer, dashboard_id?, title?): add a map widget to "
+        "a dashboard. layer='dataset' snapshots the currently selected "
+        "dataset layer (pick_dataset must have run); layer='imagery' "
+        "snapshots the Sentinel-2 mosaic from show_imagery. Dashboard "
+        "defaults to the one in state or on screen. Use when the user asks "
+        "to add a layer, map or satellite imagery to their dashboard."
+    ),
+)

--- a/src/agent/tools/add_map_widget.py
+++ b/src/agent/tools/add_map_widget.py
@@ -101,16 +101,18 @@ def _imagery_summary(snapshot: dict) -> str:
     )
 
 
-class _LayerKind(NamedTuple):
-    """Everything layer-specific about a map widget, in one row."""
+class LayerHandler(NamedTuple):
+    """How to build a map widget for one `layer` argument value: snapshot the
+    relevant agent state, summarize it for the reply, or explain why neither
+    is possible yet."""
 
     snapshot: Callable[[dict], Optional[dict]]
     summary: Callable[[dict], str]
     missing_message: str
 
 
-_LAYER_KINDS = {
-    "dataset": _LayerKind(
+LAYER_HANDLERS = {
+    "dataset": LayerHandler(
         snapshot=_dataset_config,
         summary=_dataset_summary,
         missing_message=(
@@ -118,7 +120,7 @@ _LAYER_KINDS = {
             "the layer to the dashboard."
         ),
     ),
-    "imagery": _LayerKind(
+    "imagery": LayerHandler(
         snapshot=_imagery_config,
         summary=_imagery_summary,
         missing_message=(
@@ -155,15 +157,15 @@ async def add_map_widget(
     """
     state = state or {}
 
-    kind = _LAYER_KINDS.get(layer)
-    if kind is None:
+    layer_type = LAYER_HANDLERS.get(layer)
+    if layer_type is None:
         return error_command(
             "layer must be 'dataset' or 'imagery'.", tool_call_id
         )
 
-    snapshot = kind.snapshot(state)
+    snapshot = layer_type.snapshot(state)
     if snapshot is None:
-        return error_command(kind.missing_message, tool_call_id)
+        return error_command(layer_type.missing_message, tool_call_id)
 
     target_dashboard = resolve_dashboard_id(state, dashboard_id)
     if not target_dashboard:
@@ -203,7 +205,7 @@ async def add_map_widget(
     return dashboard_updated_command(
         dashboard.id,
         (
-            f"Added {kind.summary(snapshot)} to dashboard "
+            f"Added {layer_type.summary(snapshot)} to dashboard "
             f"'{dashboard.name}' ({dashboard.id})."
         ),
         tool_call_id,

--- a/src/agent/tools/add_map_widget.py
+++ b/src/agent/tools/add_map_widget.py
@@ -12,23 +12,24 @@ copied, so the prose fields on the dataset state (description, methodology,
 instructions, ...) can never leak into the database.
 """
 
-from typing import Annotated, Dict, Optional
+from typing import Annotated, Callable, Dict, NamedTuple, Optional
 
-import structlog
-from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import (
+    dashboard_updated_command,
+    error_command,
+    load_editable_dashboard,
+    resolve_dashboard_id,
+)
 from src.api.repositories import dashboard_writer
-from src.api.repositories.dashboard_access import is_editable_by_user
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-_LAYER_KINDS = ("dataset", "imagery")
 
 # Render-relevant fields of the imagery state (ImageryState) — all of it.
 _IMAGERY_KEYS = (
@@ -43,20 +44,6 @@ _IMAGERY_KEYS = (
     "max_cloud_cover",
     "aoi_names",
 )
-
-
-def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
-    return Command(
-        update={
-            "messages": [
-                ToolMessage(
-                    content=message,
-                    tool_call_id=tool_call_id,
-                    status="error",
-                )
-            ]
-        }
-    )
 
 
 def _dataset_config(state: dict) -> Optional[dict]:
@@ -99,6 +86,56 @@ def _imagery_config(state: dict) -> Optional[dict]:
     return {key: imagery.get(key) for key in _IMAGERY_KEYS}
 
 
+def _dataset_summary(snapshot: dict) -> str:
+    return (
+        f"map widget for dataset '{snapshot['dataset_name']}' "
+        f"({snapshot['start_date']}–{snapshot['end_date']})"
+    )
+
+
+def _imagery_summary(snapshot: dict) -> str:
+    return (
+        f"Sentinel-2 imagery map widget (around "
+        f"{snapshot['target_date']}, areas: "
+        f"{', '.join(snapshot['aoi_names'] or [])})"
+    )
+
+
+class _LayerKind(NamedTuple):
+    """Everything layer-specific about a map widget, in one row."""
+
+    snapshot: Callable[[dict], Optional[dict]]
+    summary: Callable[[dict], str]
+    missing_message: str
+
+
+_LAYER_KINDS = {
+    "dataset": _LayerKind(
+        snapshot=_dataset_config,
+        summary=_dataset_summary,
+        missing_message=(
+            "No dataset layer selected. Run pick_dataset first, then add "
+            "the layer to the dashboard."
+        ),
+    ),
+    "imagery": _LayerKind(
+        snapshot=_imagery_config,
+        summary=_imagery_summary,
+        missing_message=(
+            "No imagery built this conversation. Run show_imagery first, "
+            "then add it to the dashboard."
+        ),
+    ),
+}
+
+
+def _widget_config(layer: str, snapshot: dict, title: Optional[str]) -> dict:
+    config: dict = {"default_view": "map", layer: snapshot}
+    if title:
+        config["title"] = title
+    return config
+
+
 @tool("add_map_widget")
 async def add_map_widget(
     layer: str,
@@ -117,36 +154,20 @@ async def add_map_widget(
     dashboard's area. Only dashboards the user owns can be edited.
     """
     state = state or {}
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
 
-    if layer not in _LAYER_KINDS:
-        return _error_command(
+    kind = _LAYER_KINDS.get(layer)
+    if kind is None:
+        return error_command(
             "layer must be 'dataset' or 'imagery'.", tool_call_id
         )
 
-    if layer == "dataset":
-        snapshot = _dataset_config(state)
-        if snapshot is None:
-            return _error_command(
-                "No dataset layer selected. Run pick_dataset first, then "
-                "add the layer to the dashboard.",
-                tool_call_id,
-            )
-    else:
-        snapshot = _imagery_config(state)
-        if snapshot is None:
-            return _error_command(
-                "No imagery built this conversation. Run show_imagery "
-                "first, then add it to the dashboard.",
-                tool_call_id,
-            )
+    snapshot = kind.snapshot(state)
+    if snapshot is None:
+        return error_command(kind.missing_message, tool_call_id)
 
-    view = state.get("view_context") or {}
-    target_dashboard = (
-        dashboard_id or state.get("dashboard_id") or view.get("dashboard_id")
-    )
+    target_dashboard = resolve_dashboard_id(state, dashboard_id)
     if not target_dashboard:
-        return _error_command(
+        return error_command(
             "No dashboard to add to. Create one with create_dashboard, or "
             "pass a dashboard_id.",
             tool_call_id,
@@ -158,60 +179,32 @@ async def add_map_widget(
         dashboard_id=str(target_dashboard),
     )
 
-    dashboard = await dashboard_writer.get_dashboard(str(target_dashboard))
-    if dashboard is None or not is_editable_by_user(dashboard, user_id):
-        return _error_command(
+    dashboard = await load_editable_dashboard(target_dashboard)
+    if dashboard is None:
+        return error_command(
             f"Dashboard {target_dashboard} not found or not editable.",
             tool_call_id,
         )
 
-    config: dict = {"default_view": "map", layer: snapshot}
-    if title:
-        config["title"] = title
-
     widget_id = await dashboard_writer.add_widget(
         str(target_dashboard),
         widget_type="map",
-        config=config,
+        config=_widget_config(layer, snapshot, title),
     )
     if widget_id is None:
-        return _error_command(
+        return error_command(
             f"Dashboard {target_dashboard} disappeared before the map "
             "widget could be added.",
             tool_call_id,
         )
 
-    if layer == "dataset":
-        summary = (
-            f"map widget for dataset '{snapshot['dataset_name']}' "
-            f"({snapshot['start_date']}–{snapshot['end_date']})"
-        )
-    else:
-        summary = (
-            f"Sentinel-2 imagery map widget (around "
-            f"{snapshot['target_date']}, areas: "
-            f"{', '.join(snapshot['aoi_names'] or [])})"
-        )
-    return Command(
-        update={
-            "dashboard_id": str(dashboard.id),
-            "messages": [
-                ToolMessage(
-                    content=(
-                        f"Added {summary} to dashboard "
-                        f"'{dashboard.name}' ({dashboard.id})."
-                    ),
-                    tool_call_id=tool_call_id,
-                    status="success",
-                    # The dashboard changed on disk: the frontend re-fetches
-                    # /api/dashboards/{id} on this signal.
-                    response_metadata={
-                        "msg_type": "dashboard_updated",
-                        "dashboard_id": str(dashboard.id),
-                    },
-                )
-            ],
-        },
+    return dashboard_updated_command(
+        dashboard.id,
+        (
+            f"Added {kind.summary(snapshot)} to dashboard "
+            f"'{dashboard.name}' ({dashboard.id})."
+        ),
+        tool_call_id,
     )
 
 

--- a/src/agent/tools/add_to_dashboard.py
+++ b/src/agent/tools/add_to_dashboard.py
@@ -1,0 +1,173 @@
+"""add_to_dashboard — put an existing insight onto a dashboard as a widget.
+
+A deterministic DB write, the second dashboard primitive next to
+create_dashboard. The insight defaults to the one in state (the last one
+generated or recalled this thread); the dashboard defaults to the one in
+state or the one the user is looking at (view_context). Owner-only on the
+dashboard; the insight must be visible to the user (own or public) — the
+same access rules the API applies.
+"""
+
+from typing import Annotated, Dict, Optional
+from uuid import UUID
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from sqlalchemy import select
+
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.data_models import InsightOrm
+from src.api.repositories import dashboard_writer
+from src.api.repositories.dashboard_access import is_editable_by_user
+from src.api.repositories.insight_access import is_visible_to_user
+from src.shared.database import get_session_from_pool
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=message,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+            ]
+        }
+    )
+
+
+async def _load_visible_insight(insight_id: str) -> Optional[InsightOrm]:
+    """Load an insight the current user may see (own + public rule).
+
+    Malformed ids are treated as not found. The user id comes from the
+    request-scoped logging context bound by the auth dependency.
+    """
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    try:
+        target = UUID(insight_id)
+    except (ValueError, TypeError):
+        return None
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm).where(InsightOrm.id == target)
+        )
+        row = result.scalar_one_or_none()
+    if row is None or not is_visible_to_user(row, user_id):
+        return None
+    return row
+
+
+@tool("add_to_dashboard")
+async def add_to_dashboard(
+    insight_id: Optional[str] = None,
+    dashboard_id: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Add an insight to a dashboard as a widget.
+
+    Defaults: `insight_id` to the current insight in state (the last one
+    generated or recalled this conversation); `dashboard_id` to the dashboard
+    in state or the one the user is currently viewing. Pass explicit ids to
+    target others. Only dashboards the user owns can be edited; the insight
+    must be one they can see.
+    """
+    state = state or {}
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+
+    target_insight = insight_id or state.get("insight_id")
+    if not target_insight:
+        return _error_command(
+            "No insight to add. Generate or recall an insight first, or "
+            "pass an insight_id.",
+            tool_call_id,
+        )
+
+    view = state.get("view_context") or {}
+    target_dashboard = (
+        dashboard_id or state.get("dashboard_id") or view.get("dashboard_id")
+    )
+    if not target_dashboard:
+        return _error_command(
+            "No dashboard to add to. Create one with create_dashboard, or "
+            "pass a dashboard_id.",
+            tool_call_id,
+        )
+
+    logger.info(
+        "add_to_dashboard tool called",
+        insight_id=str(target_insight),
+        dashboard_id=str(target_dashboard),
+    )
+
+    dashboard = await dashboard_writer.get_dashboard(str(target_dashboard))
+    if dashboard is None or not is_editable_by_user(dashboard, user_id):
+        return _error_command(
+            f"Dashboard {target_dashboard} not found or not editable.",
+            tool_call_id,
+        )
+
+    insight = await _load_visible_insight(str(target_insight))
+    if insight is None:
+        return _error_command(
+            f"Insight {target_insight} not found or not accessible.",
+            tool_call_id,
+        )
+
+    widget_id = await dashboard_writer.add_widget(
+        str(target_dashboard),
+        widget_type="insight",
+        insight_id=str(target_insight),
+    )
+    if widget_id is None:
+        return _error_command(
+            f"Dashboard {target_dashboard} disappeared before the insight "
+            "could be added.",
+            tool_call_id,
+        )
+
+    summary = (insight.insight_text or "").strip()
+    if len(summary) > 200:
+        summary = summary[:200] + "…"
+    return Command(
+        update={
+            "dashboard_id": str(dashboard.id),
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Added insight {target_insight} to dashboard "
+                        f"'{dashboard.name}' ({dashboard.id}).\n"
+                        f"Insight: {summary}"
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    # The dashboard changed on disk: the frontend re-fetches
+                    # /api/dashboards/{id} on this signal.
+                    response_metadata={
+                        "msg_type": "dashboard_updated",
+                        "dashboard_id": str(dashboard.id),
+                    },
+                )
+            ],
+        },
+    )
+
+
+SPEC = ToolSpec(
+    tool=add_to_dashboard,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- add_to_dashboard(insight_id?, dashboard_id?): add an insight to a "
+        "dashboard as a widget. Defaults to the current insight in state and "
+        "the dashboard in state or on screen. Use when the user asks to add "
+        "an analysis/insight to their dashboard."
+    ),
+)

--- a/src/agent/tools/add_to_dashboard.py
+++ b/src/agent/tools/add_to_dashboard.py
@@ -11,8 +11,6 @@ same access rules the API applies.
 from typing import Annotated, Dict, Optional
 from uuid import UUID
 
-import structlog
-from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
@@ -20,9 +18,15 @@ from langgraph.types import Command
 from sqlalchemy import select
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import (
+    current_user_id,
+    dashboard_updated_command,
+    error_command,
+    load_editable_dashboard,
+    resolve_dashboard_id,
+)
 from src.api.data_models import InsightOrm
 from src.api.repositories import dashboard_writer
-from src.api.repositories.dashboard_access import is_editable_by_user
 from src.api.repositories.insight_access import is_visible_to_user
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
@@ -30,27 +34,11 @@ from src.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
-    return Command(
-        update={
-            "messages": [
-                ToolMessage(
-                    content=message,
-                    tool_call_id=tool_call_id,
-                    status="error",
-                )
-            ]
-        }
-    )
-
-
 async def _load_visible_insight(insight_id: str) -> Optional[InsightOrm]:
     """Load an insight the current user may see (own + public rule).
 
-    Malformed ids are treated as not found. The user id comes from the
-    request-scoped logging context bound by the auth dependency.
+    Malformed ids are treated as not found.
     """
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
     try:
         target = UUID(insight_id)
     except (ValueError, TypeError):
@@ -60,9 +48,16 @@ async def _load_visible_insight(insight_id: str) -> Optional[InsightOrm]:
             select(InsightOrm).where(InsightOrm.id == target)
         )
         row = result.scalar_one_or_none()
-    if row is None or not is_visible_to_user(row, user_id):
+    if row is None or not is_visible_to_user(row, current_user_id()):
         return None
     return row
+
+
+def _insight_summary(insight: InsightOrm, max_chars: int = 200) -> str:
+    summary = (insight.insight_text or "").strip()
+    if len(summary) > max_chars:
+        summary = summary[:max_chars] + "…"
+    return summary
 
 
 @tool("add_to_dashboard")
@@ -81,22 +76,18 @@ async def add_to_dashboard(
     must be one they can see.
     """
     state = state or {}
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
 
     target_insight = insight_id or state.get("insight_id")
     if not target_insight:
-        return _error_command(
+        return error_command(
             "No insight to add. Generate or recall an insight first, or "
             "pass an insight_id.",
             tool_call_id,
         )
 
-    view = state.get("view_context") or {}
-    target_dashboard = (
-        dashboard_id or state.get("dashboard_id") or view.get("dashboard_id")
-    )
+    target_dashboard = resolve_dashboard_id(state, dashboard_id)
     if not target_dashboard:
-        return _error_command(
+        return error_command(
             "No dashboard to add to. Create one with create_dashboard, or "
             "pass a dashboard_id.",
             tool_call_id,
@@ -108,16 +99,16 @@ async def add_to_dashboard(
         dashboard_id=str(target_dashboard),
     )
 
-    dashboard = await dashboard_writer.get_dashboard(str(target_dashboard))
-    if dashboard is None or not is_editable_by_user(dashboard, user_id):
-        return _error_command(
+    dashboard = await load_editable_dashboard(target_dashboard)
+    if dashboard is None:
+        return error_command(
             f"Dashboard {target_dashboard} not found or not editable.",
             tool_call_id,
         )
 
     insight = await _load_visible_insight(str(target_insight))
     if insight is None:
-        return _error_command(
+        return error_command(
             f"Insight {target_insight} not found or not accessible.",
             tool_call_id,
         )
@@ -128,36 +119,20 @@ async def add_to_dashboard(
         insight_id=str(target_insight),
     )
     if widget_id is None:
-        return _error_command(
+        return error_command(
             f"Dashboard {target_dashboard} disappeared before the insight "
             "could be added.",
             tool_call_id,
         )
 
-    summary = (insight.insight_text or "").strip()
-    if len(summary) > 200:
-        summary = summary[:200] + "…"
-    return Command(
-        update={
-            "dashboard_id": str(dashboard.id),
-            "messages": [
-                ToolMessage(
-                    content=(
-                        f"Added insight {target_insight} to dashboard "
-                        f"'{dashboard.name}' ({dashboard.id}).\n"
-                        f"Insight: {summary}"
-                    ),
-                    tool_call_id=tool_call_id,
-                    status="success",
-                    # The dashboard changed on disk: the frontend re-fetches
-                    # /api/dashboards/{id} on this signal.
-                    response_metadata={
-                        "msg_type": "dashboard_updated",
-                        "dashboard_id": str(dashboard.id),
-                    },
-                )
-            ],
-        },
+    return dashboard_updated_command(
+        dashboard.id,
+        (
+            f"Added insight {target_insight} to dashboard "
+            f"'{dashboard.name}' ({dashboard.id}).\n"
+            f"Insight: {_insight_summary(insight)}"
+        ),
+        tool_call_id,
     )
 
 

--- a/src/agent/tools/add_to_dashboard.py
+++ b/src/agent/tools/add_to_dashboard.py
@@ -19,10 +19,10 @@ from sqlalchemy import select
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.agent.tools.common import (
-    current_user_id,
     dashboard_updated_command,
     error_command,
     load_editable_dashboard,
+    require_current_user_id,
     resolve_dashboard_id,
 )
 from src.api.data_models import InsightOrm
@@ -48,7 +48,9 @@ async def _load_visible_insight(insight_id: str) -> Optional[InsightOrm]:
             select(InsightOrm).where(InsightOrm.id == target)
         )
         row = result.scalar_one_or_none()
-    if row is None or not is_visible_to_user(row, current_user_id()):
+    if row is None or not is_visible_to_user(
+        row, require_current_user_id("add_to_dashboard")
+    ):
         return None
     return row
 
@@ -99,7 +101,9 @@ async def add_to_dashboard(
         dashboard_id=str(target_dashboard),
     )
 
-    dashboard = await load_editable_dashboard(target_dashboard)
+    dashboard = await load_editable_dashboard(
+        target_dashboard, "add_to_dashboard"
+    )
     if dashboard is None:
         return error_command(
             f"Dashboard {target_dashboard} not found or not editable.",

--- a/src/agent/tools/add_to_dashboard.py
+++ b/src/agent/tools/add_to_dashboard.py
@@ -117,11 +117,19 @@ async def add_to_dashboard(
             tool_call_id,
         )
 
-    widget_id = await dashboard_writer.add_widget(
-        str(target_dashboard),
-        widget_type="insight",
-        insight_id=str(target_insight),
-    )
+    try:
+        widget_id = await dashboard_writer.add_widget(
+            str(target_dashboard),
+            widget_type="insight",
+            insight_id=str(target_insight),
+        )
+    except dashboard_writer.DuplicateInsightWidgetError:
+        return error_command(
+            f"Insight {target_insight} is already on dashboard "
+            f"'{dashboard.name}' ({dashboard.id}) — nothing to add. Tell "
+            "the user it is already there; do not retry.",
+            tool_call_id,
+        )
     if widget_id is None:
         return error_command(
             f"Dashboard {target_dashboard} disappeared before the insight "

--- a/src/agent/tools/common.py
+++ b/src/agent/tools/common.py
@@ -16,7 +16,6 @@ resolve → check → write → reply steps.
 
 from typing import Optional
 
-import structlog
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
@@ -24,12 +23,7 @@ from src.agent.subagents.analyst.charts.model import Insight
 from src.api.data_models import DashboardOrm
 from src.api.repositories import dashboard_writer
 from src.api.repositories.dashboard_access import is_editable_by_user
-
-
-def current_user_id() -> Optional[str]:
-    """The authenticated user id, read from the request-scoped structlog
-    context bound by the auth dependency; None when unauthenticated."""
-    return structlog.contextvars.get_contextvars().get("user_id")
+from src.shared.request_context import current_user_id as current_user_id
 
 
 def error_command(message: str, tool_call_id: Optional[str]) -> Command:

--- a/src/agent/tools/common.py
+++ b/src/agent/tools/common.py
@@ -1,0 +1,119 @@
+"""Shared vocabulary for the persistence-backed agent tools.
+
+Every dashboard/insight tool speaks the same three dialects:
+
+- request context: who the user is (``current_user_id``) and which dashboard
+  a tool should target when none is named (``resolve_dashboard_id``,
+  ``load_editable_dashboard``);
+- error replies: a single error ToolMessage (``error_command``);
+- success replies that mutate a persisted artifact: Commands that pin the
+  artifact in state and tell the frontend to re-fetch it
+  (``dashboard_updated_command``, ``insight_updated_command``).
+
+Keeping these here makes each tool body a short, declarative sequence of
+resolve → check → write → reply steps.
+"""
+
+from typing import Optional
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from src.agent.subagents.analyst.charts.model import Insight
+from src.api.data_models import DashboardOrm
+from src.api.repositories import dashboard_writer
+from src.api.repositories.dashboard_access import is_editable_by_user
+
+
+def current_user_id() -> Optional[str]:
+    """The authenticated user id, read from the request-scoped structlog
+    context bound by the auth dependency; None when unauthenticated."""
+    return structlog.contextvars.get_contextvars().get("user_id")
+
+
+def error_command(message: str, tool_call_id: Optional[str]) -> Command:
+    """A Command carrying a single error ToolMessage back to the model."""
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=message,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+            ]
+        }
+    )
+
+
+def resolve_dashboard_id(
+    state: dict, explicit: Optional[str]
+) -> Optional[str]:
+    """The dashboard a tool should target, by precedence: the explicit
+    argument, the dashboard touched earlier this thread (state), then the
+    one the user is looking at (view_context)."""
+    view = state.get("view_context") or {}
+    return explicit or state.get("dashboard_id") or view.get("dashboard_id")
+
+
+async def load_editable_dashboard(dashboard_id) -> Optional[DashboardOrm]:
+    """Load a dashboard the current user may edit (owner-only rule);
+    None when it does not exist or the user may not touch it."""
+    dashboard = await dashboard_writer.get_dashboard(str(dashboard_id))
+    if dashboard is None or not is_editable_by_user(
+        dashboard, current_user_id()
+    ):
+        return None
+    return dashboard
+
+
+def dashboard_updated_command(
+    dashboard_id, content: str, tool_call_id: Optional[str]
+) -> Command:
+    """Success reply for a dashboard write: pins the dashboard in state and
+    signals the frontend to re-fetch /api/dashboards/{id}."""
+    return Command(
+        update={
+            "dashboard_id": str(dashboard_id),
+            "messages": [
+                ToolMessage(
+                    content=content,
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    response_metadata={
+                        "msg_type": "dashboard_updated",
+                        "dashboard_id": str(dashboard_id),
+                    },
+                )
+            ],
+        },
+    )
+
+
+def insight_updated_command(
+    insight_id, insight: Insight, content: str, tool_call_id: Optional[str]
+) -> Command:
+    """Success reply for an existing insight put (back) on screen: pushes the
+    insight into state in the shape `generate_insights` uses and signals the
+    frontend to re-fetch /api/insights/{id} (replace in place, not a new
+    card — distinct from the "human_feedback" msg_type of new insights)."""
+    return Command(
+        update={
+            "insight_id": str(insight_id),
+            "insight": insight.primary_insight,
+            "follow_up_suggestions": insight.follow_up_suggestions,
+            "charts_data": [c.to_frontend_dict() for c in insight.charts],
+            "messages": [
+                ToolMessage(
+                    content=content,
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    response_metadata={
+                        "msg_type": "insight_updated",
+                        "insight_id": str(insight_id),
+                    },
+                )
+            ],
+        },
+    )

--- a/src/agent/tools/common.py
+++ b/src/agent/tools/common.py
@@ -23,7 +23,33 @@ from src.agent.subagents.analyst.charts.model import Insight
 from src.api.data_models import DashboardOrm
 from src.api.repositories import dashboard_writer
 from src.api.repositories.dashboard_access import is_editable_by_user
+from src.shared.logging_config import get_logger
 from src.shared.request_context import current_user_id as current_user_id
+
+logger = get_logger(__name__)
+
+
+def require_current_user_id(tool_name: str) -> str:
+    """The authenticated user this tool call acts as; raises when unbound.
+
+    Every path into the agent binds an identity (the chat endpoint requires
+    auth, the CLI binds a default user), so a missing user id inside a tool
+    can only mean the identity channel itself broke — e.g. contextvar
+    propagation lost across an async boundary. Silently degrading instead
+    (searches narrowing to public rows, writes reporting "not found or not
+    editable") is indistinguishable from an ordinary permission miss, so
+    authorization-relevant reads in tools must come through here rather than
+    calling ``current_user_id`` directly. The raise lands in the generic
+    tool-error funnel, which logs it and returns a clean error to the model.
+    """
+    user_id = current_user_id()
+    if user_id is None:
+        logger.error("tool_invoked_without_identity", tool_name=tool_name)
+        raise RuntimeError(
+            f"{tool_name} invoked without an authenticated user id; "
+            "the request identity context is not bound."
+        )
+    return user_id
 
 
 def error_command(message: str, tool_call_id: Optional[str]) -> Command:
@@ -51,12 +77,14 @@ def resolve_dashboard_id(
     return explicit or state.get("dashboard_id") or view.get("dashboard_id")
 
 
-async def load_editable_dashboard(dashboard_id) -> Optional[DashboardOrm]:
+async def load_editable_dashboard(
+    dashboard_id, tool_name: str
+) -> Optional[DashboardOrm]:
     """Load a dashboard the current user may edit (owner-only rule);
     None when it does not exist or the user may not touch it."""
     dashboard = await dashboard_writer.get_dashboard(str(dashboard_id))
     if dashboard is None or not is_editable_by_user(
-        dashboard, current_user_id()
+        dashboard, require_current_user_id(tool_name)
     ):
         return None
     return dashboard

--- a/src/agent/tools/create_dashboard.py
+++ b/src/agent/tools/create_dashboard.py
@@ -1,0 +1,137 @@
+"""create_dashboard — persist a dashboard for the AOI the user is working on.
+
+A dashboard is a persistent, curated collection of insights for an area — a
+complement to the map view. This tool is a deterministic DB write: it takes
+the AOI selection already in state (run pick_aoi first if there is none) and
+creates an empty dashboard for it; widgets are added separately via
+add_to_dashboard. Orchestration ("build me a dashboard for X") lives in the
+`dashboard` skill, not here.
+"""
+
+from typing import Annotated, Dict, Optional
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.repositories import dashboard_writer
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=message,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+            ]
+        }
+    )
+
+
+def _aoi_refs(aois: list[dict]) -> list[dict]:
+    """Reduce state AOI dicts to the reference fields a dashboard stores."""
+    return [
+        {
+            "source": aoi["source"],
+            "src_id": aoi["src_id"],
+            "subtype": aoi["subtype"],
+            "name": aoi["name"],
+        }
+        for aoi in aois
+    ]
+
+
+@tool("create_dashboard")
+async def create_dashboard(
+    name: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Create a dashboard for the currently selected area.
+
+    Uses the AOI already in state (run pick_aoi first if none is selected).
+    The dashboard starts empty; add insights to it with add_to_dashboard.
+    `name` defaults to the selected area's name.
+    """
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    if not user_id:
+        return _error_command(
+            "Cannot create a dashboard: no authenticated user. Dashboards "
+            "are always owned.",
+            tool_call_id,
+        )
+
+    selection = (state or {}).get("aoi_selection") or {}
+    aois = selection.get("aois") or []
+    if not aois:
+        return _error_command(
+            "No area selected. Run pick_aoi to select the area the "
+            "dashboard is for, then create it.",
+            tool_call_id,
+        )
+    if len(aois) > 1:
+        return _error_command(
+            f"The current selection spans {len(aois)} areas, but dashboards "
+            "currently cover a single area (a country, a state, a protected "
+            "area). Ask the user which one area the dashboard is for and "
+            "re-run pick_aoi.",
+            tool_call_id,
+        )
+
+    dashboard_name = name or selection.get("name") or aois[0]["name"]
+
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user_id,
+        name=dashboard_name,
+        aois=_aoi_refs(aois),
+    )
+    logger.info(
+        "create_dashboard tool created dashboard",
+        dashboard_id=dashboard_id,
+        name=dashboard_name,
+    )
+
+    return Command(
+        update={
+            "dashboard_id": dashboard_id,
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Created dashboard '{dashboard_name}' "
+                        f"({dashboard_id}) for {aois[0]['name']}. It is "
+                        "empty — use add_to_dashboard to add insights."
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    # The dashboard is a persisted artifact: the frontend
+                    # re-fetches /api/dashboards/{id} on this signal.
+                    response_metadata={
+                        "msg_type": "dashboard_updated",
+                        "dashboard_id": dashboard_id,
+                    },
+                )
+            ],
+        },
+    )
+
+
+SPEC = ToolSpec(
+    tool=create_dashboard,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- create_dashboard(name?): create a persistent dashboard for the "
+        "currently selected area (run pick_aoi first if none). The dashboard "
+        "starts empty; add insights with add_to_dashboard. Name defaults to "
+        "the area's name. Use when the user asks to create/build a dashboard."
+    ),
+)

--- a/src/agent/tools/create_dashboard.py
+++ b/src/agent/tools/create_dashboard.py
@@ -10,32 +10,21 @@ add_to_dashboard. Orchestration ("build me a dashboard for X") lives in the
 
 from typing import Annotated, Dict, Optional
 
-import structlog
-from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import (
+    current_user_id,
+    dashboard_updated_command,
+    error_command,
+)
 from src.api.repositories import dashboard_writer
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-
-def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
-    return Command(
-        update={
-            "messages": [
-                ToolMessage(
-                    content=message,
-                    tool_call_id=tool_call_id,
-                    status="error",
-                )
-            ]
-        }
-    )
 
 
 def _aoi_refs(aois: list[dict]) -> list[dict]:
@@ -63,9 +52,9 @@ async def create_dashboard(
     The dashboard starts empty; add insights to it with add_to_dashboard.
     `name` defaults to the selected area's name.
     """
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    user_id = current_user_id()
     if not user_id:
-        return _error_command(
+        return error_command(
             "Cannot create a dashboard: no authenticated user. Dashboards "
             "are always owned.",
             tool_call_id,
@@ -74,13 +63,13 @@ async def create_dashboard(
     selection = (state or {}).get("aoi_selection") or {}
     aois = selection.get("aois") or []
     if not aois:
-        return _error_command(
+        return error_command(
             "No area selected. Run pick_aoi to select the area the "
             "dashboard is for, then create it.",
             tool_call_id,
         )
     if len(aois) > 1:
-        return _error_command(
+        return error_command(
             f"The current selection spans {len(aois)} areas, but dashboards "
             "currently cover a single area (a country, a state, a protected "
             "area). Ask the user which one area the dashboard is for and "
@@ -101,27 +90,14 @@ async def create_dashboard(
         name=dashboard_name,
     )
 
-    return Command(
-        update={
-            "dashboard_id": dashboard_id,
-            "messages": [
-                ToolMessage(
-                    content=(
-                        f"Created dashboard '{dashboard_name}' "
-                        f"({dashboard_id}) for {aois[0]['name']}. It is "
-                        "empty — use add_to_dashboard to add insights."
-                    ),
-                    tool_call_id=tool_call_id,
-                    status="success",
-                    # The dashboard is a persisted artifact: the frontend
-                    # re-fetches /api/dashboards/{id} on this signal.
-                    response_metadata={
-                        "msg_type": "dashboard_updated",
-                        "dashboard_id": dashboard_id,
-                    },
-                )
-            ],
-        },
+    return dashboard_updated_command(
+        dashboard_id,
+        (
+            f"Created dashboard '{dashboard_name}' ({dashboard_id}) for "
+            f"{aois[0]['name']}. It is empty — use add_to_dashboard to "
+            "add insights."
+        ),
+        tool_call_id,
     )
 
 

--- a/src/agent/tools/create_dashboard.py
+++ b/src/agent/tools/create_dashboard.py
@@ -17,9 +17,9 @@ from langgraph.types import Command
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.agent.tools.common import (
-    current_user_id,
     dashboard_updated_command,
     error_command,
+    require_current_user_id,
 )
 from src.api.repositories import dashboard_writer
 from src.shared.logging_config import get_logger
@@ -52,13 +52,7 @@ async def create_dashboard(
     The dashboard starts empty; add insights to it with add_to_dashboard.
     `name` defaults to the selected area's name.
     """
-    user_id = current_user_id()
-    if not user_id:
-        return error_command(
-            "Cannot create a dashboard: no authenticated user. Dashboards "
-            "are always owned.",
-            tool_call_id,
-        )
+    user_id = require_current_user_id("create_dashboard")
 
     selection = (state or {}).get("aoi_selection") or {}
     aois = selection.get("aois") or []

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -49,6 +49,7 @@ _KNOWN_KEYS = {
     "visible_aois",
     "visible_insights",
     "dashboard_id",
+    "dashboard_name",
 }
 
 

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -29,7 +29,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
-from src.api.data_models import InsightOrm
+from src.api.data_models import DashboardOrm, InsightOrm
+from src.api.repositories import dashboard_writer
+from src.api.repositories.dashboard_access import (
+    is_visible_to_user as dashboard_is_visible_to_user,
+)
 from src.api.repositories.insight_access import is_visible_to_user
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
@@ -44,6 +48,7 @@ _KNOWN_KEYS = {
     "visible_layers",
     "visible_aois",
     "visible_insights",
+    "dashboard_id",
 }
 
 
@@ -103,6 +108,12 @@ def format_view_context(view: dict) -> str:
         # Detail is loaded from the DB and appended by the tool; here we just
         # note the count so the line shows even if a load later turns up empty.
         lines.append(f"- Visible insights: {len(insights)} (detail below)")
+
+    if view.get("dashboard_id"):
+        # Same deal: the dashboard content is loaded from the DB by the tool.
+        lines.append(
+            f"- Dashboard being viewed: {view['dashboard_id']} (detail below)"
+        )
 
     # Surface any other keys the frontend sent so nothing is lost.
     extra = {k: v for k, v in view.items() if k not in _KNOWN_KEYS}
@@ -198,6 +209,54 @@ def format_insights(rows: list[InsightOrm]) -> str:
     return "\n".join(lines)
 
 
+async def _load_dashboard(dashboard_id) -> Optional[DashboardOrm]:
+    """Load the dashboard being viewed, if the current user may see it.
+
+    Visibility is the shared `dashboard_access` rule (own + public); rows the
+    user may not see are treated the same as missing ones.
+    """
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    if row is None or not dashboard_is_visible_to_user(row, user_id):
+        return None
+    return row
+
+
+async def format_dashboard(dashboard: DashboardOrm) -> str:
+    """Render the dashboard being viewed: name, area(s) and its widgets.
+
+    Insight widgets are expanded with the shared `format_insights` rendering
+    (visibility-filtered), so the agent can reason about what each widget
+    shows; other widgets are listed by type and config.
+    """
+    lines = [f"Dashboard being viewed: '{dashboard.name}' ({dashboard.id})"]
+    if dashboard.description:
+        lines.append(f"  Description: {dashboard.description}")
+    areas = ", ".join(
+        f"{aoi.name} ({aoi.source}/{aoi.subtype})"
+        for aoi in dashboard.aois or []
+    )
+    lines.append(f"  Area(s): {areas or 'none'}")
+
+    widgets = dashboard.widgets or []
+    lines.append(f"  Widgets: {len(widgets)}")
+    insight_ids = [w.insight_id for w in widgets if w.insight_id]
+    for widget in widgets:
+        if widget.widget_type == "insight":
+            continue  # detail comes from the insight rendering below
+        lines.append(
+            f"  Widget {widget.position} ({widget.widget_type}): "
+            f"{json.dumps(widget.config or {}, default=str)}"
+        )
+
+    sections = ["\n".join(lines)]
+    if insight_ids:
+        rows = await _load_insights(insight_ids)
+        if rows:
+            sections.append(format_insights(rows))
+    return "\n\n".join(sections)
+
+
 @tool("inspect_view_context")
 async def inspect_view_context(
     state: Annotated[Dict, InjectedState],
@@ -205,12 +264,14 @@ async def inspect_view_context(
 ) -> Command:
     """Return what the user is currently looking at in the app.
 
-    Reports the current page (map vs report), the map viewport, the layers and
-    AOIs visible on screen, and — when the frontend reports visible insights
-    (e.g. on the report page) — the key content of each insight: its summary,
-    chart titles and the variables behind each chart. Call this when the user
-    refers to "this", "here", the current view, the report, or an insight on
-    screen, and you need those details to answer.
+    Reports the current page (map vs report vs dashboard), the map viewport,
+    the layers and AOIs visible on screen, and — when the frontend reports
+    visible insights (e.g. on the report page) — the key content of each
+    insight: its summary, chart titles and the variables behind each chart.
+    When the user is viewing a dashboard, reports its name, area(s) and
+    widgets, with insight widgets expanded the same way. Call this when the
+    user refers to "this", "here", the current view, the report, the
+    dashboard, or an insight on screen, and you need those details to answer.
     """
     view = (state or {}).get("view_context") or {}
     logger.info(
@@ -237,6 +298,16 @@ async def inspect_view_context(
                 "(not found or not accessible)."
             )
 
+    if view.get("dashboard_id"):
+        dashboard = await _load_dashboard(view["dashboard_id"])
+        if dashboard is not None:
+            sections.append(await format_dashboard(dashboard))
+        else:
+            sections.append(
+                "Dashboard being viewed: referenced but could not be loaded "
+                "(not found or not accessible)."
+            )
+
     return Command(
         update={
             "messages": [
@@ -255,9 +326,10 @@ SPEC = ToolSpec(
     category=ToolCategory.PRIMITIVE,
     prompt_fragment=(
         "- inspect_view_context(): returns what the user is currently looking "
-        "at in the app (page, map viewport, visible layers, visible AOIs, and "
-        "the content of any insights on screen — summary, charts and "
-        "variables). Call this when the user refers to 'this', 'here', the "
-        "current view, the report, or an insight on screen."
+        "at in the app (page, map viewport, visible layers, visible AOIs, the "
+        "content of any insights on screen — summary, charts and variables — "
+        "and, on the dashboard page, the dashboard's name, areas and "
+        "widgets). Call this when the user refers to 'this', 'here', the "
+        "current view, the report, the dashboard, or an insight on screen."
     ),
 )

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -223,12 +223,40 @@ async def _load_dashboard(dashboard_id) -> Optional[DashboardOrm]:
     return row
 
 
+def _format_map_widget(config: dict) -> Optional[str]:
+    """One-line summary of a map widget's layer snapshot, sans tile URLs.
+
+    Returns None when the config carries neither a dataset nor an imagery
+    snapshot, so the caller can fall back to a raw dump.
+    """
+    dataset = config.get("dataset")
+    if isinstance(dataset, dict):
+        line = f"map: dataset '{dataset.get('dataset_name', '?')}'"
+        if dataset.get("start_date") or dataset.get("end_date"):
+            line += (
+                f" ({dataset.get('start_date', '?')}–"
+                f"{dataset.get('end_date', '?')})"
+            )
+        if dataset.get("context_layer"):
+            line += f", context layer {dataset['context_layer']}"
+        return line
+    imagery = config.get("imagery")
+    if isinstance(imagery, dict):
+        areas = ", ".join(imagery.get("aoi_names") or []) or "?"
+        return (
+            f"map: Sentinel-2 imagery around "
+            f"{imagery.get('target_date', '?')} ({areas})"
+        )
+    return None
+
+
 async def format_dashboard(dashboard: DashboardOrm) -> str:
     """Render the dashboard being viewed: name, area(s) and its widgets.
 
     Insight widgets are expanded with the shared `format_insights` rendering
     (visibility-filtered), so the agent can reason about what each widget
-    shows; other widgets are listed by type and config.
+    shows; map widgets are summarized by dataset name/dates or imagery
+    date/areas; anything else is listed by type and config.
     """
     lines = [f"Dashboard being viewed: '{dashboard.name}' ({dashboard.id})"]
     if dashboard.description:
@@ -245,9 +273,11 @@ async def format_dashboard(dashboard: DashboardOrm) -> str:
     for widget in widgets:
         if widget.widget_type == "insight":
             continue  # detail comes from the insight rendering below
+        summary = _format_map_widget(widget.config or {})
+        if summary is None:
+            summary = json.dumps(widget.config or {}, default=str)
         lines.append(
-            f"  Widget {widget.position} ({widget.widget_type}): "
-            f"{json.dumps(widget.config or {}, default=str)}"
+            f"  Widget {widget.position} ({widget.widget_type}): {summary}"
         )
 
     sections = ["\n".join(lines)]

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -19,7 +19,6 @@ import json
 from typing import Annotated, Dict, Optional
 from uuid import UUID
 
-import structlog
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
@@ -29,6 +28,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import current_user_id
 from src.api.data_models import DashboardOrm, InsightOrm
 from src.api.repositories import dashboard_writer
 from src.api.repositories.dashboard_access import (
@@ -152,7 +152,7 @@ async def _load_insights(insight_ids: list[UUID]) -> list[InsightOrm]:
     """
     if not insight_ids:
         return []
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    user_id = current_user_id()
     async with get_session_from_pool() as session:
         result = await session.execute(
             select(InsightOrm)
@@ -216,9 +216,8 @@ async def _load_dashboard(dashboard_id) -> Optional[DashboardOrm]:
     Visibility is the shared `dashboard_access` rule (own + public); rows the
     user may not see are treated the same as missing ones.
     """
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
     row = await dashboard_writer.get_dashboard(dashboard_id)
-    if row is None or not dashboard_is_visible_to_user(row, user_id):
+    if row is None or not dashboard_is_visible_to_user(row, current_user_id()):
         return None
     return row
 

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -216,14 +216,23 @@ async def inspect_view_context(
     refers to "this", "here", the current view, the report, or an insight on
     screen, and you need those details to answer.
     """
-    logger.info("inspect_view_context tool called")
     view = (state or {}).get("view_context") or {}
+    logger.info(
+        "inspect_view_context tool called",
+        page=view.get("page"),
+        has_view_context=bool(view),
+    )
 
     sections = [format_view_context(view)]
 
     insight_ids = _extract_insight_ids(view.get("visible_insights"))
     if insight_ids:
         rows = await _load_insights(insight_ids)
+        logger.info(
+            "inspect_view_context loaded insights",
+            requested=len(insight_ids),
+            loaded=len(rows),
+        )
         if rows:
             sections.append(format_insights(rows))
         else:

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -28,7 +28,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
-from src.agent.tools.common import current_user_id
+from src.agent.tools.common import require_current_user_id
 from src.api.data_models import DashboardOrm, InsightOrm
 from src.api.repositories import dashboard_writer
 from src.api.repositories.dashboard_access import (
@@ -148,11 +148,11 @@ async def _load_insights(insight_ids: list[UUID]) -> list[InsightOrm]:
     """Load insights (with charts) the current user is allowed to see.
 
     Visibility is the shared `insight_access` rule (own + public). The user id
-    comes from the request-scoped logging context bound by the auth dependency.
+    comes from the request context bound by the auth dependency.
     """
     if not insight_ids:
         return []
-    user_id = current_user_id()
+    user_id = require_current_user_id("inspect_view_context")
     async with get_session_from_pool() as session:
         result = await session.execute(
             select(InsightOrm)
@@ -217,7 +217,9 @@ async def _load_dashboard(dashboard_id) -> Optional[DashboardOrm]:
     user may not see are treated the same as missing ones.
     """
     row = await dashboard_writer.get_dashboard(dashboard_id)
-    if row is None or not dashboard_is_visible_to_user(row, current_user_id()):
+    if row is None or not dashboard_is_visible_to_user(
+        row, require_current_user_id("inspect_view_context")
+    ):
         return None
     return row
 

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -30,6 +30,7 @@ from sqlalchemy.orm import selectinload
 
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.data_models import InsightOrm
+from src.api.repositories.insight_access import is_visible_to_user
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
 
@@ -134,9 +135,8 @@ def _extract_insight_ids(refs: object) -> list[UUID]:
 async def _load_insights(insight_ids: list[UUID]) -> list[InsightOrm]:
     """Load insights (with charts) the current user is allowed to see.
 
-    Ownership mirrors the /api/insights/{id} endpoint: a user's own insights
-    plus any public one. The user id comes from the request-scoped logging
-    context bound by the auth dependency.
+    Visibility is the shared `insight_access` rule (own + public). The user id
+    comes from the request-scoped logging context bound by the auth dependency.
     """
     if not insight_ids:
         return []
@@ -148,11 +148,7 @@ async def _load_insights(insight_ids: list[UUID]) -> list[InsightOrm]:
             .where(InsightOrm.id.in_(insight_ids))
         )
         rows = result.scalars().all()
-    return [
-        row
-        for row in rows
-        if row.is_public or (user_id and row.user_id == user_id)
-    ]
+    return [row for row in rows if is_visible_to_user(row, user_id)]
 
 
 def _chart_variables(chart) -> str:

--- a/src/agent/tools/pull_data.py
+++ b/src/agent/tools/pull_data.py
@@ -15,6 +15,7 @@ from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.data_models import StatisticsOrm
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
+from src.shared.request_context import current_user_id
 
 logger = get_logger(__name__)
 
@@ -176,7 +177,7 @@ async def pull_data(
     ctx = structlog.contextvars.get_contextvars()
     async with get_session_from_pool() as session:
         statistics_row = StatisticsOrm(
-            user_id=ctx.get("user_id"),
+            user_id=current_user_id(),
             thread_id=ctx.get("thread_id"),
             dataset_name=statistics["dataset_name"],
             dataset_id=statistics["dataset_id"],

--- a/src/agent/tools/search_insights.py
+++ b/src/agent/tools/search_insights.py
@@ -10,7 +10,6 @@ the frontend renders it as a normal insight card.
 import re
 from typing import Annotated, Optional
 
-import structlog
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
@@ -18,8 +17,13 @@ from langgraph.types import Command
 from sqlalchemy import Text, cast, or_, select
 from sqlalchemy.orm import selectinload
 
-from src.agent.subagents.analyst.charts.model import Insight, InsightChart
+from src.agent.subagents.analyst.charts.model import Insight
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import (
+    current_user_id,
+    error_command,
+    insight_updated_command,
+)
 from src.api.data_models import InsightChartOrm, InsightOrm
 from src.api.repositories.insight_access import visible_insights_clause
 from src.shared.database import get_session_from_pool
@@ -62,23 +66,19 @@ def _score(row: InsightOrm, terms: list[str], phrase: str) -> int:
     return score
 
 
-async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
-    """Fetch candidate insights the user may see whose summary matches `query`.
-
-    Search spans ALL of the user's conversations — it is deliberately not scoped
-    to the current thread. Visibility is the shared rule from `insight_access`
-    (own + public), applied in SQL so invisible rows never consume the limit.
-    Matching is an ILIKE (per term or full phrase) across the summary, the
-    chart titles, and the chart data text — so place names and datasets that
-    only show up in a title or a data value are still found. Ranking is in Python.
-    """
-    terms = _terms(query)
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
-
-    patterns = [f"%{_escape_like(t)}%" for t in terms]
+def _like_patterns(query: str) -> list[str]:
+    """ILIKE patterns for a query: one per term, plus the full phrase."""
+    patterns = [f"%{_escape_like(t)}%" for t in _terms(query)]
     if query.strip():
         patterns.append(f"%{_escape_like(query.strip())}%")
-    text_match = or_(
+    return patterns
+
+
+def _text_match_clause(patterns: list[str]):
+    """SQL clause matching any pattern against the summary, the chart titles
+    or the chart data text — so place names and datasets that only show up in
+    a title or a data value are still found."""
+    return or_(
         *[
             cond
             for p in patterns
@@ -96,15 +96,48 @@ async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
         ]
     )
 
+
+async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
+    """Fetch candidate insights the user may see whose summary matches `query`.
+
+    Search spans ALL of the user's conversations — it is deliberately not scoped
+    to the current thread. Visibility is the shared rule from `insight_access`
+    (own + public), applied in SQL so invisible rows never consume the limit.
+    Ranking is in Python.
+    """
     async with get_session_from_pool() as session:
         result = await session.execute(
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
-            .where(visible_insights_clause(user_id), text_match)
+            .where(
+                visible_insights_clause(current_user_id()),
+                _text_match_clause(_like_patterns(query)),
+            )
             .order_by(InsightOrm.created_at.desc())
             .limit(limit)
         )
         return list(result.scalars().all())
+
+
+def _best_match(rows: list[InsightOrm], query: str) -> InsightOrm:
+    """The highest-scoring candidate; ties go to the most recent insight."""
+    terms = _terms(query)
+    return max(rows, key=lambda r: (_score(r, terms, query), r.created_at))
+
+
+def _recalled_message(insight_id, insight: Insight, query: str) -> str:
+    """The recall report to the model — including the stop instruction, since
+    the recalled insight is already on screen and terminal for this turn."""
+    chart_titles = ", ".join(c.title for c in insight.charts) or "(no charts)"
+    return (
+        f"Found a past insight ({insight_id}) matching '{query}'.\n"
+        f"Charts: {chart_titles}.\n\n"
+        f"Summary: {insight.primary_insight}\n\n"
+        "STOP HERE. This insight already exists and is now on screen. Do "
+        "NOT call pull_data, generate_insights or any other tool. Reply to "
+        "the user with a one-line summary of this recalled insight and "
+        "nothing else."
+    )
 
 
 @tool("search_insights")
@@ -125,20 +158,10 @@ async def search_insights(
     # Without at least one usable pattern the ILIKE degenerates to '%%' and
     # "matches" every insight — refuse instead of recalling an arbitrary one.
     if not _terms(query) and len(query.strip()) < 3:
-        return Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content=(
-                            "Query too short to search past insights. Describe "
-                            "the insight to recall, e.g. a place, dataset or "
-                            "phrase from its summary."
-                        ),
-                        tool_call_id=tool_call_id,
-                        status="error",
-                    )
-                ]
-            }
+        return error_command(
+            "Query too short to search past insights. Describe the insight "
+            "to recall, e.g. a place, dataset or phrase from its summary.",
+            tool_call_id,
         )
 
     rows = await _search_insights(query)
@@ -155,51 +178,19 @@ async def search_insights(
             }
         )
 
-    terms = _terms(query)
-    best = max(rows, key=lambda r: (_score(r, terms, query), r.created_at))
+    best = _best_match(rows, query)
     logger.info(
         "search_insights matched",
         insight_id=str(best.id),
         candidates=len(rows),
     )
 
-    insight = Insight(
-        charts=[InsightChart.from_orm_row(c) for c in (best.charts or [])],
-        primary_insight=best.insight_text,
-        follow_up_suggestions=best.follow_up_suggestions or [],
-    ).stamp_insight()
-
-    chart_titles = ", ".join(c.title for c in insight.charts) or "(no charts)"
-    return Command(
-        update={
-            "insight_id": str(best.id),
-            "insight": insight.primary_insight,
-            "follow_up_suggestions": insight.follow_up_suggestions,
-            "charts_data": [c.to_frontend_dict() for c in insight.charts],
-            "messages": [
-                ToolMessage(
-                    content=(
-                        f"Found a past insight ({best.id}) matching '{query}'.\n"
-                        f"Charts: {chart_titles}.\n\n"
-                        f"Summary: {insight.primary_insight}\n\n"
-                        "STOP HERE. This insight already exists and is now on "
-                        "screen. Do NOT call pull_data, generate_insights or any "
-                        "other tool. Reply to the user with a one-line summary "
-                        "of this recalled insight and nothing else."
-                    ),
-                    tool_call_id=tool_call_id,
-                    status="success",
-                    # Same signal as update_insight_display: the insight already
-                    # exists, so the frontend re-fetches /api/insights/{id} and
-                    # shows it (replacing in place, or rendering it if not yet
-                    # mounted) rather than treating it as a brand-new analysis.
-                    response_metadata={
-                        "msg_type": "insight_updated",
-                        "insight_id": str(best.id),
-                    },
-                )
-            ],
-        },
+    insight = Insight.from_orm_row(best).stamp_insight()
+    return insight_updated_command(
+        best.id,
+        insight,
+        _recalled_message(best.id, insight, query),
+        tool_call_id,
     )
 
 

--- a/src/agent/tools/search_insights.py
+++ b/src/agent/tools/search_insights.py
@@ -1,20 +1,19 @@
 """search_insights — find a past insight by free-text and re-surface it.
 
-Demo tooling: shows the agent can dig up an insight produced earlier (this
-thread or any the user owns / a public one) and put it back on screen. It does
-not generate anything — it searches the persisted `InsightOrm` rows by their
-summary text, picks the best match, and pushes it into state in the same shape
-`generate_insights` uses, so the frontend renders it as a normal insight card.
+Digs up an insight produced earlier (this thread or any the user owns, or a
+public one) and puts it back on screen. It does not generate anything — it
+searches the persisted `InsightOrm` rows by their summary text, picks the best
+match, and pushes it into state in the same shape `generate_insights` uses, so
+the frontend renders it as a normal insight card.
 """
 
 import re
-from typing import Annotated, Dict, Optional
+from typing import Annotated, Optional
 
 import structlog
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
-from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 from sqlalchemy import Text, cast, or_, select
 from sqlalchemy.orm import selectinload
@@ -22,6 +21,7 @@ from sqlalchemy.orm import selectinload
 from src.agent.subagents.analyst.charts.model import Insight, InsightChart
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.data_models import InsightChartOrm, InsightOrm
+from src.api.repositories.insight_access import visible_insights_clause
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
 
@@ -29,8 +29,14 @@ logger = get_logger(__name__)
 
 
 def _terms(query: str) -> list[str]:
-    """Split a query into lowercased search terms (drops punctuation/stopgaps)."""
+    """Split a query into lowercased terms, dropping punctuation and tokens
+    shorter than 3 characters."""
     return [t for t in re.split(r"\W+", query.lower()) if len(t) > 2]
+
+
+def _escape_like(text: str) -> str:
+    """Escape ILIKE metacharacters so user text matches literally."""
+    return text.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
 
 
 def _haystack(row: InsightOrm) -> str:
@@ -60,25 +66,31 @@ async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
     """Fetch candidate insights the user may see whose summary matches `query`.
 
     Search spans ALL of the user's conversations — it is deliberately not scoped
-    to the current thread. Visibility mirrors the insights API: the user's own
-    insights (from any thread) plus public ones and owner-less rows (e.g. CLI
-    runs). Matching is an ILIKE (per term or full phrase) across the summary,
-    the chart titles, and the chart data text — so place names and datasets that
+    to the current thread. Visibility is the shared rule from `insight_access`
+    (own + public), applied in SQL so invisible rows never consume the limit.
+    Matching is an ILIKE (per term or full phrase) across the summary, the
+    chart titles, and the chart data text — so place names and datasets that
     only show up in a title or a data value are still found. Ranking is in Python.
     """
     terms = _terms(query)
     user_id = structlog.contextvars.get_contextvars().get("user_id")
 
-    patterns = [f"%{t}%" for t in terms] + [f"%{query.strip()}%"]
+    patterns = [f"%{_escape_like(t)}%" for t in terms]
+    if query.strip():
+        patterns.append(f"%{_escape_like(query.strip())}%")
     text_match = or_(
         *[
             cond
             for p in patterns
             for cond in (
-                InsightOrm.insight_text.ilike(p),
-                InsightOrm.charts.any(InsightChartOrm.title.ilike(p)),
+                InsightOrm.insight_text.ilike(p, escape="\\"),
                 InsightOrm.charts.any(
-                    cast(InsightChartOrm.chart_data, Text).ilike(p)
+                    InsightChartOrm.title.ilike(p, escape="\\")
+                ),
+                InsightOrm.charts.any(
+                    cast(InsightChartOrm.chart_data, Text).ilike(
+                        p, escape="\\"
+                    )
                 ),
             )
         ]
@@ -88,25 +100,16 @@ async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
         result = await session.execute(
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
-            .where(text_match)
+            .where(visible_insights_clause(user_id), text_match)
             .order_by(InsightOrm.created_at.desc())
             .limit(limit)
         )
-        rows = result.scalars().all()
-
-    return [
-        row
-        for row in rows
-        if row.is_public
-        or row.user_id is None
-        or (user_id and row.user_id == user_id)
-    ]
+        return list(result.scalars().all())
 
 
 @tool("search_insights")
 async def search_insights(
     query: str,
-    state: Annotated[Dict, InjectedState] | None = None,
     tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
     """Find a previously generated insight by description and put it back on screen.
@@ -118,6 +121,25 @@ async def search_insights(
     before" or "pull up the one about fires in the Amazon".
     """
     logger.info("search_insights tool called", query=query)
+
+    # Without at least one usable pattern the ILIKE degenerates to '%%' and
+    # "matches" every insight — refuse instead of recalling an arbitrary one.
+    if not _terms(query) and len(query.strip()) < 3:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=(
+                            "Query too short to search past insights. Describe "
+                            "the insight to recall, e.g. a place, dataset or "
+                            "phrase from its summary."
+                        ),
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
+                ]
+            }
+        )
 
     rows = await _search_insights(query)
     if not rows:

--- a/src/agent/tools/search_insights.py
+++ b/src/agent/tools/search_insights.py
@@ -1,0 +1,196 @@
+"""search_insights — find a past insight by free-text and re-surface it.
+
+Demo tooling: shows the agent can dig up an insight produced earlier (this
+thread or any the user owns / a public one) and put it back on screen. It does
+not generate anything — it searches the persisted `InsightOrm` rows by their
+summary text, picks the best match, and pushes it into state in the same shape
+`generate_insights` uses, so the frontend renders it as a normal insight card.
+"""
+
+import re
+from typing import Annotated, Dict, Optional
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from sqlalchemy import Text, cast, or_, select
+from sqlalchemy.orm import selectinload
+
+from src.agent.subagents.analyst.charts.model import Insight, InsightChart
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.data_models import InsightChartOrm, InsightOrm
+from src.shared.database import get_session_from_pool
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _terms(query: str) -> list[str]:
+    """Split a query into lowercased search terms (drops punctuation/stopgaps)."""
+    return [t for t in re.split(r"\W+", query.lower()) if len(t) > 2]
+
+
+def _haystack(row: InsightOrm) -> str:
+    """All searchable text for a row: summary + chart titles + chart data.
+
+    Place names and dataset/metric names live in the chart titles and in the
+    chart_data values (e.g. {"country": "Brazil"}), not just the summary — so
+    they are all folded in here.
+    """
+    parts = [row.insight_text or ""]
+    for chart in row.charts or []:
+        parts.append(chart.title or "")
+        parts.append(str(chart.chart_data or ""))
+    return " ".join(parts).lower()
+
+
+def _score(row: InsightOrm, terms: list[str], phrase: str) -> int:
+    """Rough relevance: term hits across all searchable text, phrase bonus."""
+    haystack = _haystack(row)
+    score = sum(1 for t in terms if t in haystack)
+    if phrase and phrase.lower() in haystack:
+        score += len(terms) + 1  # full-phrase match outranks scattered terms
+    return score
+
+
+async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
+    """Fetch candidate insights the user may see whose summary matches `query`.
+
+    Search spans ALL of the user's conversations — it is deliberately not scoped
+    to the current thread. Visibility mirrors the insights API: the user's own
+    insights (from any thread) plus public ones and owner-less rows (e.g. CLI
+    runs). Matching is an ILIKE (per term or full phrase) across the summary,
+    the chart titles, and the chart data text — so place names and datasets that
+    only show up in a title or a data value are still found. Ranking is in Python.
+    """
+    terms = _terms(query)
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+
+    patterns = [f"%{t}%" for t in terms] + [f"%{query.strip()}%"]
+    text_match = or_(
+        *[
+            cond
+            for p in patterns
+            for cond in (
+                InsightOrm.insight_text.ilike(p),
+                InsightOrm.charts.any(InsightChartOrm.title.ilike(p)),
+                InsightOrm.charts.any(
+                    cast(InsightChartOrm.chart_data, Text).ilike(p)
+                ),
+            )
+        ]
+    )
+
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(text_match)
+            .order_by(InsightOrm.created_at.desc())
+            .limit(limit)
+        )
+        rows = result.scalars().all()
+
+    return [
+        row
+        for row in rows
+        if row.is_public
+        or row.user_id is None
+        or (user_id and row.user_id == user_id)
+    ]
+
+
+@tool("search_insights")
+async def search_insights(
+    query: str,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Find a previously generated insight by description and put it back on screen.
+
+    Searches past insights across ALL of the user's conversations (plus public
+    ones) by their summary text, picks the best match, and surfaces it so they see
+    the chart and summary again — without recomputing anything. Use this when the
+    user refers to an earlier finding, e.g. "show me that tree-cover insight from
+    before" or "pull up the one about fires in the Amazon".
+    """
+    logger.info("search_insights tool called", query=query)
+
+    rows = await _search_insights(query)
+    if not rows:
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"No past insight matched '{query}'.",
+                        tool_call_id=tool_call_id,
+                        status="success",
+                    )
+                ]
+            }
+        )
+
+    terms = _terms(query)
+    best = max(rows, key=lambda r: (_score(r, terms, query), r.created_at))
+    logger.info(
+        "search_insights matched",
+        insight_id=str(best.id),
+        candidates=len(rows),
+    )
+
+    insight = Insight(
+        charts=[InsightChart.from_orm_row(c) for c in (best.charts or [])],
+        primary_insight=best.insight_text,
+        follow_up_suggestions=best.follow_up_suggestions or [],
+    ).stamp_insight()
+
+    chart_titles = ", ".join(c.title for c in insight.charts) or "(no charts)"
+    return Command(
+        update={
+            "insight_id": str(best.id),
+            "insight": insight.primary_insight,
+            "follow_up_suggestions": insight.follow_up_suggestions,
+            "charts_data": [c.to_frontend_dict() for c in insight.charts],
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Found a past insight ({best.id}) matching '{query}'.\n"
+                        f"Charts: {chart_titles}.\n\n"
+                        f"Summary: {insight.primary_insight}\n\n"
+                        "STOP HERE. This insight already exists and is now on "
+                        "screen. Do NOT call pull_data, generate_insights or any "
+                        "other tool. Reply to the user with a one-line summary "
+                        "of this recalled insight and nothing else."
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    # Same signal as update_insight_display: the insight already
+                    # exists, so the frontend re-fetches /api/insights/{id} and
+                    # shows it (replacing in place, or rendering it if not yet
+                    # mounted) rather than treating it as a brand-new analysis.
+                    response_metadata={
+                        "msg_type": "insight_updated",
+                        "insight_id": str(best.id),
+                    },
+                )
+            ],
+        },
+    )
+
+
+SPEC = ToolSpec(
+    tool=search_insights,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- search_insights(query): find a previously generated insight by "
+        "description and put it back on screen (chart + summary), without "
+        "recomputing. Use when the user refers to an earlier finding, e.g. "
+        "'show that insight about fires in the Amazon again'. This is a "
+        "TERMINAL action: after it returns, do NOT call pull_data, "
+        "generate_insights or any other tool — just give a one-line summary "
+        "of the recalled insight and stop."
+    ),
+)

--- a/src/agent/tools/search_insights.py
+++ b/src/agent/tools/search_insights.py
@@ -20,9 +20,9 @@ from sqlalchemy.orm import selectinload
 from src.agent.subagents.analyst.charts.model import Insight
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.agent.tools.common import (
-    current_user_id,
     error_command,
     insight_updated_command,
+    require_current_user_id,
 )
 from src.api.data_models import InsightChartOrm, InsightOrm
 from src.api.repositories.insight_access import visible_insights_clause
@@ -110,7 +110,9 @@ async def _search_insights(query: str, limit: int = 25) -> list[InsightOrm]:
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
             .where(
-                visible_insights_clause(current_user_id()),
+                visible_insights_clause(
+                    require_current_user_id("search_insights")
+                ),
                 _text_match_clause(_like_patterns(query)),
             )
             .order_by(InsightOrm.created_at.desc())

--- a/src/agent/tools/show_imagery.py
+++ b/src/agent/tools/show_imagery.py
@@ -1,7 +1,6 @@
 from datetime import date
 from typing import Annotated, Dict, Optional
 
-import structlog
 from cogeo_mosaic.errors import MosaicNotFoundError
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
@@ -20,6 +19,7 @@ from src.api.services.mosaic import (
     create_sentinel2_mosaic,
 )
 from src.shared.logging_config import get_logger
+from src.shared.request_context import current_user_id
 
 logger = get_logger(__name__)
 
@@ -82,7 +82,7 @@ async def show_imagery(
     aoi_refs = tuple((a["source"], a["src_id"]) for a in aois)
     user_id = None
     if any(source == "custom" for source, _ in aoi_refs):
-        user_id = structlog.contextvars.get_contextvars().get("user_id")
+        user_id = current_user_id()
 
     recipe = MosaicRecipe(
         aois=aoi_refs,

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -29,9 +29,9 @@ from src.agent.subagents.analyst.display_reviser import (
 )
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.agent.tools.common import (
-    current_user_id,
     error_command,
     insight_updated_command,
+    require_current_user_id,
 )
 from src.api.data_models import InsightOrm
 from src.api.repositories.insight_access import is_editable_by_user
@@ -60,7 +60,9 @@ async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
             .where(InsightOrm.id == target)
         )
         row = result.scalar_one_or_none()
-    if row is None or not is_editable_by_user(row, current_user_id()):
+    if row is None or not is_editable_by_user(
+        row, require_current_user_id("update_insight_display")
+    ):
         return None
     return row
 

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -31,6 +31,7 @@ from src.agent.subagents.analyst.display_reviser import (
 )
 from src.agent.tool_spec import ToolCategory, ToolSpec
 from src.api.data_models import InsightOrm
+from src.api.repositories.insight_access import is_editable_by_user
 from src.api.repositories.insight_writer import update_insight
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
@@ -55,20 +56,23 @@ def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
 async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
     """Load an insight (with charts) the current user is allowed to edit.
 
-    Editable means the user owns it (or it has no owner, e.g. CLI runs). Public
-    insights owned by someone else are read-only and not returned.
+    Editable means the current user owns it (`insight_access` rule). Public or
+    owner-less insights are read-only; without an authenticated user nothing
+    is editable. Malformed ids are treated as not found.
     """
     user_id = structlog.contextvars.get_contextvars().get("user_id")
+    try:
+        target = UUID(insight_id)
+    except ValueError:
+        return None
     async with get_session_from_pool() as session:
         result = await session.execute(
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
-            .where(InsightOrm.id == UUID(insight_id))
+            .where(InsightOrm.id == target)
         )
         row = result.scalar_one_or_none()
-    if row is None:
-        return None
-    if row.user_id and user_id and row.user_id != user_id:
+    if row is None or not is_editable_by_user(row, user_id):
         return None
     return row
 
@@ -100,11 +104,7 @@ def _apply_revision(
     new_charts: list[InsightChart] = []
     for original in originals:
         rc = revised_by_pos.get(original.position)
-        available = (
-            set(original.chart_data[0].keys())
-            if original.chart_data
-            else set()
-        )
+        available = set(original.available_columns())
         if rc is None or not _referenced_columns(rc) <= available:
             if rc is not None:
                 logger.warning(

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -1,0 +1,235 @@
+"""update_insight_display — restyle an existing insight, no new data.
+
+Where `generate_insights` pulls data, runs code and builds an insight from
+scratch, this tool only touches the *display* layer of an insight that already
+exists: the narrative text, follow-up suggestions, chart titles, chart types and
+which existing columns each chart maps to. It never pulls data or runs code — the
+underlying chart rows are preserved untouched.
+
+The target is the current insight in state (the last one generated this thread)
+unless an explicit ``insight_id`` is given. The revised insight is persisted in
+place and pushed back onto state so the frontend re-renders it.
+"""
+
+from typing import Annotated, Dict, Optional
+from uuid import UUID
+
+import structlog
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from src.agent.subagents.analyst.charts.model import Insight, InsightChart
+from src.agent.subagents.analyst.display_reviser import (
+    InsightDisplayReviser,
+    RevisedChart,
+    RevisedInsight,
+)
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.api.data_models import InsightOrm
+from src.api.repositories.insight_writer import update_insight
+from src.shared.database import get_session_from_pool
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
+    return Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content=message,
+                    tool_call_id=tool_call_id,
+                    status="error",
+                )
+            ]
+        }
+    )
+
+
+async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
+    """Load an insight (with charts) the current user is allowed to edit.
+
+    Editable means the user owns it (or it has no owner, e.g. CLI runs). Public
+    insights owned by someone else are read-only and not returned.
+    """
+    user_id = structlog.contextvars.get_contextvars().get("user_id")
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(InsightOrm.id == UUID(insight_id))
+        )
+        row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    if row.user_id and user_id and row.user_id != user_id:
+        return None
+    return row
+
+
+def _referenced_columns(chart: RevisedChart) -> set[str]:
+    """Every non-empty column a revised chart points at."""
+    named = {
+        chart.x_axis,
+        chart.y_axis,
+        chart.color_field,
+        chart.stack_field,
+        chart.group_field,
+    }
+    named.update(chart.series_fields)
+    return {name for name in named if name}
+
+
+def _apply_revision(
+    originals: list[InsightChart], revised: RevisedInsight
+) -> Insight:
+    """Merge the revised display fields back onto the fixed chart data.
+
+    Charts are matched by `position`; the original `chart_data` is always kept.
+    A revision that references a column the data does not have is dropped (the
+    original chart is left as-is) so we never produce a chart that can't render.
+    """
+    revised_by_pos = {rc.position: rc for rc in revised.charts}
+
+    new_charts: list[InsightChart] = []
+    for original in originals:
+        rc = revised_by_pos.get(original.position)
+        available = (
+            set(original.chart_data[0].keys())
+            if original.chart_data
+            else set()
+        )
+        if rc is None or not _referenced_columns(rc) <= available:
+            if rc is not None:
+                logger.warning(
+                    "update_insight_display: revision references unknown "
+                    "columns, keeping original chart",
+                    position=original.position,
+                )
+            new_charts.append(original)
+            continue
+        new_charts.append(
+            InsightChart(
+                position=original.position,
+                title=rc.title,
+                chart_type=rc.chart_type,
+                x_axis=rc.x_axis,
+                y_axis=rc.y_axis,
+                color_field=rc.color_field,
+                stack_field=rc.stack_field,
+                group_field=rc.group_field,
+                series_fields=rc.series_fields,
+                chart_data=original.chart_data,
+            )
+        )
+
+    return Insight(
+        charts=new_charts,
+        primary_insight=revised.primary_insight,
+        follow_up_suggestions=revised.follow_up_suggestions,
+    ).stamp_insight()
+
+
+@tool("update_insight_display")
+async def update_insight_display(
+    instruction: str,
+    insight_id: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Restyle an existing insight without pulling new data or running code.
+
+    Use this for presentation-only changes the user asks for on an insight that
+    already exists: reword the summary or follow-up suggestions, rename a chart,
+    change a chart type (e.g. bar -> line), or re-map a chart to other columns it
+    already has. It cannot add data, compute new metrics or create charts — use
+    generate_insights for anything that needs new data or analysis.
+
+    By default it updates the most recent insight in this conversation; pass
+    `insight_id` to target a specific one (e.g. an insight visible on screen).
+    """
+    target_id = insight_id or (state or {}).get("insight_id")
+    if not target_id:
+        return _error_command(
+            "No insight to update. Generate an insight first, or pass an "
+            "insight_id.",
+            tool_call_id,
+        )
+
+    logger.info("update_insight_display tool called", insight_id=target_id)
+
+    row = await _load_editable_insight(str(target_id))
+    if row is None:
+        return _error_command(
+            f"Insight {target_id} not found or not editable.", tool_call_id
+        )
+
+    current = Insight(
+        charts=[InsightChart.from_orm_row(c) for c in (row.charts or [])],
+        primary_insight=row.insight_text,
+        follow_up_suggestions=row.follow_up_suggestions or [],
+    )
+
+    revised = await InsightDisplayReviser().revise(current, instruction)
+
+    try:
+        updated = _apply_revision(current.charts, revised)
+    except ValueError as exc:
+        logger.warning("update_insight_display: invalid revision: %s", exc)
+        return _error_command(
+            f"Could not apply that change: {exc}", tool_call_id
+        )
+
+    if not await update_insight(str(target_id), updated):
+        return _error_command(
+            f"Insight {target_id} disappeared before it could be updated.",
+            tool_call_id,
+        )
+
+    chart_titles = ", ".join(c.title for c in updated.charts)
+    return Command(
+        update={
+            "insight_id": str(target_id),
+            "insight": updated.primary_insight,
+            "follow_up_suggestions": updated.follow_up_suggestions,
+            "charts_data": [c.to_frontend_dict() for c in updated.charts],
+            "messages": [
+                ToolMessage(
+                    content=(
+                        f"Updated insight {target_id}. "
+                        f"Charts: {chart_titles}.\n\n"
+                        f"Summary: {updated.primary_insight}"
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="success",
+                    # Distinct from "human_feedback" (a new insight) so the
+                    # frontend replaces the existing insight in place / re-fetches
+                    # /api/insights/{insight_id} rather than rendering a new card.
+                    response_metadata={
+                        "msg_type": "insight_updated",
+                        "insight_id": str(target_id),
+                    },
+                )
+            ],
+        }
+    )
+
+
+SPEC = ToolSpec(
+    tool=update_insight_display,
+    category=ToolCategory.SUBAGENT,
+    prompt_fragment=(
+        "- update_insight_display(instruction, insight_id?): restyle an "
+        "existing insight without new data — reword the summary or follow-ups, "
+        "rename charts, change a chart type, or re-map a chart to columns it "
+        "already has. Defaults to the most recent insight; pass insight_id to "
+        "target a specific one. Use generate_insights when new data or "
+        "analysis is needed."
+    ),
+)

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -14,8 +14,6 @@ place and pushed back onto state so the frontend re-renders it.
 from typing import Annotated, Dict, Optional
 from uuid import UUID
 
-import structlog
-from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
@@ -30,6 +28,11 @@ from src.agent.subagents.analyst.display_reviser import (
     RevisedInsight,
 )
 from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import (
+    current_user_id,
+    error_command,
+    insight_updated_command,
+)
 from src.api.data_models import InsightOrm
 from src.api.repositories.insight_access import is_editable_by_user
 from src.api.repositories.insight_writer import update_insight
@@ -39,20 +42,6 @@ from src.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def _error_command(message: str, tool_call_id: Optional[str]) -> Command:
-    return Command(
-        update={
-            "messages": [
-                ToolMessage(
-                    content=message,
-                    tool_call_id=tool_call_id,
-                    status="error",
-                )
-            ]
-        }
-    )
-
-
 async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
     """Load an insight (with charts) the current user is allowed to edit.
 
@@ -60,7 +49,6 @@ async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
     owner-less insights are read-only; without an authenticated user nothing
     is editable. Malformed ids are treated as not found.
     """
-    user_id = structlog.contextvars.get_contextvars().get("user_id")
     try:
         target = UUID(insight_id)
     except ValueError:
@@ -72,7 +60,7 @@ async def _load_editable_insight(insight_id: str) -> Optional[InsightOrm]:
             .where(InsightOrm.id == target)
         )
         row = result.scalar_one_or_none()
-    if row is None or not is_editable_by_user(row, user_id):
+    if row is None or not is_editable_by_user(row, current_user_id()):
         return None
     return row
 
@@ -156,7 +144,7 @@ async def update_insight_display(
     """
     target_id = insight_id or (state or {}).get("insight_id")
     if not target_id:
-        return _error_command(
+        return error_command(
             "No insight to update. Generate an insight first, or pass an "
             "insight_id.",
             tool_call_id,
@@ -166,58 +154,36 @@ async def update_insight_display(
 
     row = await _load_editable_insight(str(target_id))
     if row is None:
-        return _error_command(
+        return error_command(
             f"Insight {target_id} not found or not editable.", tool_call_id
         )
 
-    current = Insight(
-        charts=[InsightChart.from_orm_row(c) for c in (row.charts or [])],
-        primary_insight=row.insight_text,
-        follow_up_suggestions=row.follow_up_suggestions or [],
-    )
-
+    current = Insight.from_orm_row(row)
     revised = await InsightDisplayReviser().revise(current, instruction)
 
     try:
         updated = _apply_revision(current.charts, revised)
     except ValueError as exc:
         logger.warning("update_insight_display: invalid revision: %s", exc)
-        return _error_command(
+        return error_command(
             f"Could not apply that change: {exc}", tool_call_id
         )
 
     if not await update_insight(str(target_id), updated):
-        return _error_command(
+        return error_command(
             f"Insight {target_id} disappeared before it could be updated.",
             tool_call_id,
         )
 
     chart_titles = ", ".join(c.title for c in updated.charts)
-    return Command(
-        update={
-            "insight_id": str(target_id),
-            "insight": updated.primary_insight,
-            "follow_up_suggestions": updated.follow_up_suggestions,
-            "charts_data": [c.to_frontend_dict() for c in updated.charts],
-            "messages": [
-                ToolMessage(
-                    content=(
-                        f"Updated insight {target_id}. "
-                        f"Charts: {chart_titles}.\n\n"
-                        f"Summary: {updated.primary_insight}"
-                    ),
-                    tool_call_id=tool_call_id,
-                    status="success",
-                    # Distinct from "human_feedback" (a new insight) so the
-                    # frontend replaces the existing insight in place / re-fetches
-                    # /api/insights/{insight_id} rather than rendering a new card.
-                    response_metadata={
-                        "msg_type": "insight_updated",
-                        "insight_id": str(target_id),
-                    },
-                )
-            ],
-        }
+    return insight_updated_command(
+        target_id,
+        updated,
+        (
+            f"Updated insight {target_id}. Charts: {chart_titles}.\n\n"
+            f"Summary: {updated.primary_insight}"
+        ),
+        tool_call_id,
     )
 
 

--- a/src/agent/view_pages.py
+++ b/src/agent/view_pages.py
@@ -1,0 +1,130 @@
+"""What each frontend surface (``view_context["page"]``) means to the agent.
+
+The frontend reports which page the user is on with every chat request
+(``ChatRequest.view_context``), but the page value alone is an opaque string.
+This module is the single place page *semantics* live — for each known
+surface, two renderings of the same knowledge:
+
+- ``session_line``: the one-line scope hint injected into the per-turn
+  session block (``SessionContextMiddleware``), so the agent always knows
+  where the user is and what "this"/"here" refers to without a tool call.
+- ``prompt_section``: a short "# Current surface" block for the system
+  prompt (``get_prompt``), carrying the behavioral/routing hints for that
+  surface.
+
+Both stay terse on purpose: the bulky view snapshot (viewport, layer lists,
+widget contents) remains behind the ``inspect_view_context`` tool. Pages not
+registered here degrade to the generic breadcrumb — the frontend owns the
+``view_context`` shape and may ship new pages before the backend knows them.
+
+Deliberately NOT done here: eagerly merging view scope into agent selections
+(e.g. pre-filling ``aoi_selection`` from the dashboard's area). Ambient view
+state stays reference material; tools *default* from it on explicit intent
+(``add_to_dashboard`` reads ``view_context["dashboard_id"]``). See
+docs/view-context-pages.md for the full design.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+def on_screen_counts(view: dict) -> list[str]:
+    """The on-screen item counts shared by the breadcrumb renderings."""
+    parts = []
+    layers = view.get("visible_layers") or []
+    if layers:
+        parts.append(f"{len(layers)} layer(s)")
+    aois = view.get("visible_aois") or []
+    if aois:
+        parts.append(f"{len(aois)} AOI(s) visible")
+    insights = view.get("visible_insights") or []
+    if insights:
+        parts.append(f"{len(insights)} insight(s) on screen")
+    return parts
+
+
+def _map_session_line(view: dict) -> str:
+    parts = on_screen_counts(view)
+    detail = " · ".join(parts) if parts else "nothing reported on screen"
+    return (
+        f"View: map explorer — free exploration; {detail}. "
+        "'Here' / 'this area' = what is on the map "
+        "(call inspect_view_context for details)."
+    )
+
+
+def _dashboard_session_line(view: dict) -> str:
+    dashboard_id = view.get("dashboard_id")
+    name = view.get("dashboard_name")
+    if name and dashboard_id:
+        label = f"'{name}' ({dashboard_id})"
+    elif dashboard_id:
+        label = str(dashboard_id)
+    else:
+        label = "(id not reported)"
+    return (
+        f"View: dashboard {label} — a persistent collection of insight "
+        "widgets for one area. 'This dashboard' = the one on screen; "
+        "add_to_dashboard targets it by default "
+        "(call inspect_view_context for its area and widgets)."
+    )
+
+
+@dataclass(frozen=True)
+class ViewPage:
+    """One frontend surface: its session-line and system-prompt renderings."""
+
+    name: str
+    session_line: Callable[[dict], str]
+    prompt_section: str
+
+
+_MAP_PROMPT = (
+    "The user is on the map explorer — free exploration of areas and "
+    "layers. 'This area', 'here' or 'what I'm looking at' refer to what is "
+    "on the map: check the session block or call inspect_view_context "
+    "before asking the user for a location."
+)
+
+_DASHBOARD_PROMPT = (
+    "The user is viewing a dashboard — a persistent collection of insight "
+    "widgets for one area. 'Add this' / 'add it to my dashboard' means "
+    "add_to_dashboard, which defaults to the dashboard on screen. New "
+    "analyses should use the dashboard's area unless the user names another "
+    "place. Call inspect_view_context to see the dashboard's area and "
+    "widgets; read skill `dashboard` for the compose workflow."
+)
+
+PAGES: dict[str, ViewPage] = {
+    page.name: page
+    for page in (
+        ViewPage(
+            name="map",
+            session_line=_map_session_line,
+            prompt_section=_MAP_PROMPT,
+        ),
+        ViewPage(
+            name="dashboard",
+            session_line=_dashboard_session_line,
+            prompt_section=_DASHBOARD_PROMPT,
+        ),
+    )
+}
+
+
+def get_page(view: Optional[dict]) -> Optional[ViewPage]:
+    """Resolve the registered page for a view snapshot, if any."""
+    if not view:
+        return None
+    page = view.get("page")
+    if not isinstance(page, str):
+        return None
+    return PAGES.get(page)
+
+
+def prompt_section(page_name: Optional[str]) -> Optional[str]:
+    """System-prompt surface hints for a page name; None when unknown."""
+    if not isinstance(page_name, str):
+        return None
+    page = PAGES.get(page_name)
+    return page.prompt_section if page else None

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -25,6 +25,7 @@ from src.api.routers import (
     traces,
     users,
 )
+from src.shared.config import SharedSettings
 from src.shared.database import close_global_pool, initialize_global_pool
 from src.shared.logging_config import get_logger
 from src.shared.version import get_version
@@ -34,6 +35,15 @@ logger = get_logger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Deploy logs must show the *effective* values of host settings that a
+    # deployed env var can override: a rotated default in code (e.g. the
+    # eoapi cache host) is silently shadowed by a stale override, and tile
+    # URLs then break browser-side only, with no server-side signal.
+    logger.info(
+        "settings_resolved",
+        eoapi_base_url=SharedSettings.eoapi_base_url,
+        api_base_url=SharedSettings.api_base_url,
+    )
     blog_data_ok, blog_data_detail = data_status()
     if blog_data_ok:
         logger.info("Blog search data ready", detail=blog_data_detail)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -14,6 +14,7 @@ from src.api.routers import (
     aois,
     chat,
     custom_areas,
+    dashboards,
     geometry,
     insights,
     jobs,
@@ -144,6 +145,7 @@ app.include_router(aois.router)
 app.include_router(geometry.router)
 app.include_router(thumbnails.router)
 app.include_router(insights.router)
+app.include_router(dashboards.router)
 app.include_router(metadata.router)
 app.include_router(admin.router)
 app.include_router(traces.router)

--- a/src/api/auth/dependencies.py
+++ b/src/api/auth/dependencies.py
@@ -18,6 +18,7 @@ from src.api.data_models import UserOrm, UserType
 from src.api.schemas import UserModel
 from src.shared.database import get_session_from_pool_dependency
 from src.shared.logging_config import bind_request_logging_context, get_logger
+from src.shared.request_context import set_current_user_id
 
 logger = get_logger(__name__)
 
@@ -134,6 +135,7 @@ async def require_auth(
 
     user = await _get_or_create_user(user_info, session)
     bind_request_logging_context(user_id=user.id)
+    set_current_user_id(user.id)
     return _orm_to_user_model(user)
 
 
@@ -147,6 +149,7 @@ async def optional_auth(
 
     user = await _get_or_create_user(user_info, session)
     bind_request_logging_context(user_id=user.id)
+    set_current_user_id(user.id)
     return _orm_to_user_model(user)
 
 

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -267,6 +267,104 @@ class InsightChartOrm(Base):
     insight = relationship("InsightOrm", back_populates="charts")
 
 
+class DashboardOrm(Base):
+    __tablename__ = "dashboards"
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    is_public = Column(Boolean, nullable=False, server_default="false")
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=datetime.now,
+        onupdate=datetime.now,
+    )
+
+    aois = relationship(
+        "DashboardAoiOrm",
+        back_populates="dashboard",
+        cascade="all, delete-orphan",
+        order_by="DashboardAoiOrm.position",
+    )
+    widgets = relationship(
+        "DashboardWidgetOrm",
+        back_populates="dashboard",
+        cascade="all, delete-orphan",
+        order_by="DashboardWidgetOrm.position",
+    )
+
+
+class DashboardAoiOrm(Base):
+    """An AOI reference on a dashboard — the canonical (source, src_id,
+    subtype) address plus a denormalized display name, never geometry."""
+
+    __tablename__ = "dashboard_aois"
+    __table_args__ = (
+        UniqueConstraint(
+            "dashboard_id",
+            "source",
+            "src_id",
+            name="uq_dashboard_aois_dashboard_source_src_id",
+        ),
+    )
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    dashboard_id = Column(
+        PostgresUUID, ForeignKey("dashboards.id"), nullable=False
+    )
+    source = Column(String, nullable=False)
+    src_id = Column(String, nullable=False)
+    subtype = Column(String, nullable=False)
+    name = Column(String, nullable=False)
+    position = Column(Integer, nullable=False, server_default="0")
+
+    dashboard = relationship("DashboardOrm", back_populates="aois")
+
+
+class DashboardWidgetOrm(Base):
+    """One widget on a dashboard: a reference to an insight (or a map layer
+    described in `config`) plus presentation config — never chart data,
+    geometry or tile URLs."""
+
+    __tablename__ = "dashboard_widgets"
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    dashboard_id = Column(
+        PostgresUUID, ForeignKey("dashboards.id"), nullable=False
+    )
+    position = Column(Integer, nullable=False, server_default="0")
+    # "insight" | "map" — plain String like JobOrm.type; validated in Pydantic.
+    widget_type = Column(String, nullable=False)
+    # Deleting an insight silently drops widgets that reference it.
+    insight_id = Column(
+        PostgresUUID,
+        ForeignKey("insights.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    # Presentation only: default_view ("map"|"chart"|"table"), optional title
+    # override; for map widgets dataset_id, start_date/end_date, viewport.
+    # A future `refresh` key (relative date window) is reserved, not implemented.
+    config = Column(JSONB, nullable=False, server_default="{}")
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+
+    dashboard = relationship("DashboardOrm", back_populates="widgets")
+
+
 class JobOrm(Base):
     __tablename__ = "jobs"
 

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -333,9 +333,10 @@ class DashboardAoiOrm(Base):
 
 
 class DashboardWidgetOrm(Base):
-    """One widget on a dashboard: a reference to an insight (or a map layer
-    described in `config`) plus presentation config — never chart data,
-    geometry or tile URLs."""
+    """One widget on a dashboard. Insight widgets reference an insight and
+    carry presentation config only. Map widgets are self-contained: their
+    `config` snapshots the resolved layer (tile URLs included by design)
+    under a `dataset` or `imagery` key — never chart data or geometry."""
 
     __tablename__ = "dashboard_widgets"
 
@@ -356,8 +357,10 @@ class DashboardWidgetOrm(Base):
         ForeignKey("insights.id", ondelete="CASCADE"),
         nullable=True,
     )
-    # Presentation only: default_view ("map"|"chart"|"table"), optional title
-    # override; for map widgets dataset_id, start_date/end_date, viewport.
+    # default_view ("map"|"chart"|"table"), optional title override; for map
+    # widgets a layer snapshot under exactly one of "dataset" (resolved
+    # tile_url, context layers, parameters, dates) or "imagery" (Sentinel-2
+    # mosaic_id + tile URLs), plus an optional viewport override.
     # A future `refresh` key (relative date window) is reserved, not implemented.
     config = Column(JSONB, nullable=False, server_default="{}")
     created_at = Column(DateTime, nullable=False, default=datetime.now)

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -340,6 +340,19 @@ class DashboardWidgetOrm(Base):
 
     __tablename__ = "dashboard_widgets"
 
+    # An insight appears on a dashboard at most once, enforced at the DB so
+    # retries (agent after an ambiguous error, REST client after a dropped
+    # response) cannot duplicate widgets. Map/text widgets are exempt.
+    __table_args__ = (
+        Index(
+            "uq_dashboard_widgets_dashboard_insight",
+            "dashboard_id",
+            "insight_id",
+            unique=True,
+            postgresql_where=text("widget_type = 'insight'"),
+        ),
+    )
+
     id = Column(
         PostgresUUID,
         primary_key=True,

--- a/src/api/repositories/dashboard_access.py
+++ b/src/api/repositories/dashboard_access.py
@@ -1,0 +1,43 @@
+"""Who may see or edit a dashboard — the single place that rule lives.
+
+Read rule: a user sees their own dashboards plus public ones.
+Edit rule: only the owner may edit. Dashboards are always owned
+(``user_id`` NOT NULL), but the rules tolerate owner-less rows the same way
+``insight_access`` does: neither visible nor editable through the agent tools.
+
+Both rules take the user id from the caller (the agent tools read it from the
+request-scoped structlog context bound by the auth dependency) and treat a
+missing user id as "not authenticated": nothing private is visible, nothing is
+editable.
+
+The API router (``src/api/routers/dashboards.py``) implements the same read
+rule with two extras that don't apply to agent tools — admin/superuser
+override and HTTP error semantics — so it stays separate.
+"""
+
+from typing import Optional
+
+from sqlalchemy import or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from src.api.data_models import DashboardOrm
+
+
+def visible_dashboards_clause(user_id: Optional[str]) -> ColumnElement:
+    """SQL WHERE clause selecting the dashboards `user_id` may see."""
+    if user_id:
+        return or_(
+            DashboardOrm.is_public.is_(True),
+            DashboardOrm.user_id == user_id,
+        )
+    return DashboardOrm.is_public.is_(True)
+
+
+def is_visible_to_user(row: DashboardOrm, user_id: Optional[str]) -> bool:
+    """Python twin of `visible_dashboards_clause` for already-loaded rows."""
+    return bool(row.is_public or (user_id and row.user_id == user_id))
+
+
+def is_editable_by_user(row: DashboardOrm, user_id: Optional[str]) -> bool:
+    """Only the owner may edit; unauthenticated callers edit nothing."""
+    return bool(user_id and row.user_id == user_id)

--- a/src/api/repositories/dashboard_writer.py
+++ b/src/api/repositories/dashboard_writer.py
@@ -11,6 +11,7 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import func, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from src.api.data_models import (
@@ -24,6 +25,22 @@ from src.shared.logging_config import get_logger
 from src.shared.tile_urls import relativize_widget_config
 
 logger = get_logger(__name__)
+
+
+class DuplicateInsightWidgetError(Exception):
+    """The dashboard already has a widget for this insight.
+
+    Raised by ``add_widget`` when the partial unique index on
+    ``(dashboard_id, insight_id)`` rejects the insert — the signal that a
+    retry (agent or REST) is re-adding rather than adding.
+    """
+
+    def __init__(self, dashboard_id: str, insight_id: str):
+        self.dashboard_id = dashboard_id
+        self.insight_id = insight_id
+        super().__init__(
+            f"insight {insight_id} is already on dashboard {dashboard_id}"
+        )
 
 
 def _parse_uuid(value) -> Optional[UUID]:
@@ -141,7 +158,19 @@ async def add_widget(
             position=position,
         )
         session.add(widget)
-        await session.commit()
+        try:
+            await session.commit()
+        except IntegrityError as exc:
+            if "uq_dashboard_widgets_dashboard_insight" not in str(exc.orig):
+                raise
+            logger.warning(
+                "dashboard_widget_duplicate",
+                dashboard_id=str(target),
+                insight_id=insight_id,
+            )
+            raise DuplicateInsightWidgetError(
+                str(target), str(insight_id)
+            ) from exc
         widget_id = str(widget.id)
 
     logger.info(

--- a/src/api/repositories/dashboard_writer.py
+++ b/src/api/repositories/dashboard_writer.py
@@ -21,6 +21,7 @@ from src.api.data_models import (
 )
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
+from src.shared.tile_urls import relativize_widget_config
 
 logger = get_logger(__name__)
 
@@ -136,7 +137,7 @@ async def add_widget(
             dashboard_id=target,
             widget_type=widget_type,
             insight_id=insight_uuid,
-            config=config or {},
+            config=relativize_widget_config(config) or {},
             position=position,
         )
         session.add(widget)
@@ -170,7 +171,7 @@ async def update_widget(
         if position is not None:
             widget.position = position
         if config is not None:
-            widget.config = config
+            widget.config = relativize_widget_config(config)
         await session.commit()
 
     logger.info("dashboard_widget_updated", widget_id=str(target))

--- a/src/api/repositories/dashboard_writer.py
+++ b/src/api/repositories/dashboard_writer.py
@@ -1,0 +1,291 @@
+"""Centralized dashboard persistence shared by the API router and agent tools.
+
+Both paths write the same ``DashboardOrm`` / ``DashboardAoiOrm`` /
+``DashboardWidgetOrm`` rows; this is the single place that mapping lives.
+Ownership checks live in the callers (router/tools) via ``dashboard_access``
+— the same split as insights. Malformed UUIDs are treated as not-found
+(None/False) rather than raising.
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+from sqlalchemy.orm import selectinload
+
+from src.api.data_models import (
+    DashboardAoiOrm,
+    DashboardOrm,
+    DashboardWidgetOrm,
+    InsightOrm,
+)
+from src.shared.database import get_session_from_pool
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _parse_uuid(value) -> Optional[UUID]:
+    """UUID or None for malformed input — not-found, never an exception."""
+    try:
+        return UUID(str(value))
+    except (ValueError, TypeError):
+        return None
+
+
+async def create_dashboard(
+    *,
+    user_id: str,
+    name: str,
+    description: Optional[str] = None,
+    aois: list[dict],
+) -> str:
+    """Create a dashboard with its AOI references; return the new id (str).
+
+    Each entry in ``aois`` carries the canonical address plus display name:
+    ``{"source", "src_id", "subtype", "name"}``. Positions follow list order.
+    """
+    async with get_session_from_pool() as session:
+        dashboard = DashboardOrm(
+            user_id=user_id,
+            name=name,
+            description=description,
+        )
+        session.add(dashboard)
+        await session.flush()
+
+        session.add_all(
+            DashboardAoiOrm(
+                dashboard_id=dashboard.id,
+                source=aoi["source"],
+                src_id=aoi["src_id"],
+                subtype=aoi["subtype"],
+                name=aoi["name"],
+                position=position,
+            )
+            for position, aoi in enumerate(aois)
+        )
+
+        await session.commit()
+        dashboard_id = str(dashboard.id)
+
+    logger.info(
+        "dashboard_created",
+        dashboard_id=dashboard_id,
+        user_id=user_id,
+        aois_count=len(aois),
+    )
+    return dashboard_id
+
+
+async def get_dashboard(dashboard_id) -> Optional[DashboardOrm]:
+    """Load a dashboard with its AOIs and widgets; caller applies access check."""
+    target = _parse_uuid(dashboard_id)
+    if target is None:
+        return None
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(DashboardOrm)
+            .options(
+                selectinload(DashboardOrm.aois),
+                selectinload(DashboardOrm.widgets),
+            )
+            .where(DashboardOrm.id == target)
+        )
+        return result.scalar_one_or_none()
+
+
+async def add_widget(
+    dashboard_id,
+    *,
+    widget_type: str,
+    insight_id: Optional[str] = None,
+    config: Optional[dict] = None,
+    position: Optional[int] = None,
+) -> Optional[str]:
+    """Append a widget to a dashboard; return the new widget id (str).
+
+    Position defaults to max+1 (end of the dashboard). Returns None if the
+    dashboard does not exist or an id is malformed.
+    """
+    target = _parse_uuid(dashboard_id)
+    if target is None:
+        return None
+    insight_uuid = None
+    if insight_id is not None:
+        insight_uuid = _parse_uuid(insight_id)
+        if insight_uuid is None:
+            return None
+
+    async with get_session_from_pool() as session:
+        exists = await session.scalar(
+            select(DashboardOrm.id).where(DashboardOrm.id == target)
+        )
+        if exists is None:
+            return None
+
+        if position is None:
+            max_position = await session.scalar(
+                select(func.max(DashboardWidgetOrm.position)).where(
+                    DashboardWidgetOrm.dashboard_id == target
+                )
+            )
+            position = 0 if max_position is None else max_position + 1
+
+        widget = DashboardWidgetOrm(
+            dashboard_id=target,
+            widget_type=widget_type,
+            insight_id=insight_uuid,
+            config=config or {},
+            position=position,
+        )
+        session.add(widget)
+        await session.commit()
+        widget_id = str(widget.id)
+
+    logger.info(
+        "dashboard_widget_added",
+        dashboard_id=str(target),
+        widget_id=widget_id,
+        widget_type=widget_type,
+        insight_id=insight_id,
+    )
+    return widget_id
+
+
+async def update_widget(
+    widget_id,
+    *,
+    position: Optional[int] = None,
+    config: Optional[dict] = None,
+) -> bool:
+    """Reorder a widget and/or replace its presentation config."""
+    target = _parse_uuid(widget_id)
+    if target is None:
+        return False
+    async with get_session_from_pool() as session:
+        widget = await session.get(DashboardWidgetOrm, target)
+        if widget is None:
+            return False
+        if position is not None:
+            widget.position = position
+        if config is not None:
+            widget.config = config
+        await session.commit()
+
+    logger.info("dashboard_widget_updated", widget_id=str(target))
+    return True
+
+
+async def remove_widget(widget_id) -> bool:
+    """Delete a widget; the referenced insight is left intact."""
+    target = _parse_uuid(widget_id)
+    if target is None:
+        return False
+    async with get_session_from_pool() as session:
+        widget = await session.get(DashboardWidgetOrm, target)
+        if widget is None:
+            return False
+        await session.delete(widget)
+        await session.commit()
+
+    logger.info("dashboard_widget_removed", widget_id=str(target))
+    return True
+
+
+async def update_dashboard(
+    dashboard_id,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> bool:
+    """Rename a dashboard and/or replace its description."""
+    target = _parse_uuid(dashboard_id)
+    if target is None:
+        return False
+    async with get_session_from_pool() as session:
+        dashboard = await session.get(DashboardOrm, target)
+        if dashboard is None:
+            return False
+        if name is not None:
+            dashboard.name = name
+        if description is not None:
+            dashboard.description = description
+        await session.commit()
+
+    logger.info("dashboard_updated", dashboard_id=str(target))
+    return True
+
+
+async def delete_dashboard(dashboard_id) -> bool:
+    """Delete a dashboard with its AOIs and widgets; insights are left intact."""
+    target = _parse_uuid(dashboard_id)
+    if target is None:
+        return False
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(DashboardOrm)
+            .options(
+                selectinload(DashboardOrm.aois),
+                selectinload(DashboardOrm.widgets),
+            )
+            .where(DashboardOrm.id == target)
+        )
+        dashboard = result.scalar_one_or_none()
+        if dashboard is None:
+            return False
+        await session.delete(dashboard)
+        await session.commit()
+
+    logger.info("dashboard_deleted", dashboard_id=str(target))
+    return True
+
+
+async def set_dashboard_public(
+    dashboard_id, is_public: bool
+) -> Optional[list[str]]:
+    """Set a dashboard's is_public flag; return the insight ids it publicized.
+
+    Publishing cascades ``is_public=True`` to all insights referenced by the
+    dashboard's widgets in the same transaction — otherwise a public dashboard
+    renders empty for viewers. Unpublishing does NOT cascade (the insights may
+    be shared elsewhere). Returns the list of newly-publicized insight ids
+    (empty when unsetting or nothing needed flipping), or None if the
+    dashboard does not exist / the id is malformed.
+    """
+    target = _parse_uuid(dashboard_id)
+    if target is None:
+        return None
+    async with get_session_from_pool() as session:
+        dashboard = await session.get(DashboardOrm, target)
+        if dashboard is None:
+            return None
+
+        dashboard.is_public = is_public
+
+        publicized: list[str] = []
+        if is_public:
+            referenced = select(DashboardWidgetOrm.insight_id).where(
+                DashboardWidgetOrm.dashboard_id == target,
+                DashboardWidgetOrm.insight_id.is_not(None),
+            )
+            result = await session.execute(
+                update(InsightOrm)
+                .where(
+                    InsightOrm.id.in_(referenced),
+                    InsightOrm.is_public.is_(False),
+                )
+                .values(is_public=True)
+                .returning(InsightOrm.id)
+            )
+            publicized = [str(row_id) for row_id in result.scalars()]
+
+        await session.commit()
+
+    logger.info(
+        "dashboard_public_set",
+        dashboard_id=str(target),
+        is_public=is_public,
+        publicized_insights=len(publicized),
+    )
+    return publicized

--- a/src/api/repositories/insight_access.py
+++ b/src/api/repositories/insight_access.py
@@ -1,0 +1,42 @@
+"""Who may see or edit an insight — the single place that rule lives.
+
+Read rule: a user sees their own insights plus public ones.
+Edit rule: only the owner may edit. Owner-less rows (user_id NULL, e.g. old
+CLI runs) are neither visible nor editable through the agent tools.
+
+Both rules take the user id from the caller (the agent tools read it from the
+request-scoped structlog context bound by the auth dependency) and treat a
+missing user id as "not authenticated": nothing private is visible, nothing is
+editable.
+
+The API router (``src/api/routers/insights.py``) implements the same read rule
+with two extras that don't apply to agent tools — admin/superuser override and
+HTTP error semantics — so it stays separate.
+"""
+
+from typing import Optional
+
+from sqlalchemy import or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from src.api.data_models import InsightOrm
+
+
+def visible_insights_clause(user_id: Optional[str]) -> ColumnElement:
+    """SQL WHERE clause selecting the insights `user_id` may see."""
+    if user_id:
+        return or_(
+            InsightOrm.is_public.is_(True),
+            InsightOrm.user_id == user_id,
+        )
+    return InsightOrm.is_public.is_(True)
+
+
+def is_visible_to_user(row: InsightOrm, user_id: Optional[str]) -> bool:
+    """Python twin of `visible_insights_clause` for already-loaded rows."""
+    return bool(row.is_public or (user_id and row.user_id == user_id))
+
+
+def is_editable_by_user(row: InsightOrm, user_id: Optional[str]) -> bool:
+    """Only the owner may edit; unauthenticated callers edit nothing."""
+    return bool(user_id and row.user_id == user_id)

--- a/src/api/repositories/insight_writer.py
+++ b/src/api/repositories/insight_writer.py
@@ -75,13 +75,19 @@ async def update_insight(insight_id: str, insight: Insight) -> bool:
     the `codeact_*` provenance and `created_at` are deliberately left untouched:
     this path restyles an insight, it does not pull new data or re-run code.
 
-    Returns ``True`` on success, ``False`` if the insight no longer exists.
+    Returns ``True`` on success, ``False`` if the insight no longer exists
+    (or the id is malformed).
     """
+    try:
+        target = UUID(insight_id)
+    except ValueError:
+        return False
+
     async with get_session_from_pool() as session:
         result = await session.execute(
             select(InsightOrm)
             .options(selectinload(InsightOrm.charts))
-            .where(InsightOrm.id == UUID(insight_id))
+            .where(InsightOrm.id == target)
         )
         insight_orm = result.scalar_one_or_none()
         if insight_orm is None:

--- a/src/api/repositories/insight_writer.py
+++ b/src/api/repositories/insight_writer.py
@@ -6,6 +6,10 @@ the single place that mapping lives, driven by the canonical `Insight`.
 """
 
 from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from src.agent.subagents.analyst.charts.model import Insight
 from src.api.data_models import InsightChartOrm, InsightOrm
@@ -60,3 +64,43 @@ async def persist_insight(
         charts_count=len(insight.charts),
     )
     return insight_id
+
+
+async def update_insight(insight_id: str, insight: Insight) -> bool:
+    """Rewrite an existing insight's display layer in place.
+
+    Only the generative/presentation fields are replaced — narrative text,
+    follow-up suggestions and the chart specs (titles, types, field mappings,
+    per-chart `chart_data`). Ownership (`user_id`/`thread_id`), `statistics_ids`,
+    the `codeact_*` provenance and `created_at` are deliberately left untouched:
+    this path restyles an insight, it does not pull new data or re-run code.
+
+    Returns ``True`` on success, ``False`` if the insight no longer exists.
+    """
+    async with get_session_from_pool() as session:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(InsightOrm.id == UUID(insight_id))
+        )
+        insight_orm = result.scalar_one_or_none()
+        if insight_orm is None:
+            return False
+
+        insight_orm.insight_text = insight.primary_insight
+        insight_orm.follow_up_suggestions = insight.follow_up_suggestions
+        # Reassigning the collection lets the delete-orphan cascade drop the old
+        # chart rows and insert the revised ones in their place.
+        insight_orm.charts = [
+            InsightChartOrm(**chart.to_orm_kwargs())
+            for chart in insight.charts
+        ]
+
+        await session.commit()
+
+    logger.info(
+        "insight_updated",
+        insight_id=insight_id,
+        charts_count=len(insight.charts),
+    )
+    return True

--- a/src/api/routers/dashboards.py
+++ b/src/api/routers/dashboards.py
@@ -272,13 +272,19 @@ async def add_widget(
         ):
             raise HTTPException(status_code=404, detail="Insight not found")
 
-    await dashboard_writer.add_widget(
-        dashboard_id,
-        widget_type=body.widget_type,
-        insight_id=str(body.insight_id) if body.insight_id else None,
-        config=body.config,
-        position=body.position,
-    )
+    try:
+        await dashboard_writer.add_widget(
+            dashboard_id,
+            widget_type=body.widget_type,
+            insight_id=str(body.insight_id) if body.insight_id else None,
+            config=body.config,
+            position=body.position,
+        )
+    except dashboard_writer.DuplicateInsightWidgetError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="insight is already on this dashboard",
+        )
     return _row_to_response(await _refetch_dashboard(dashboard_id))
 
 

--- a/src/api/routers/dashboards.py
+++ b/src/api/routers/dashboards.py
@@ -1,0 +1,332 @@
+"""Dashboard management endpoints.
+
+A dashboard is a persistent, curated collection of insights, layers and AOIs.
+Widgets reference insights (payloads are expanded on the single-dashboard
+endpoint so the frontend renders them like insights); AOIs are stored as
+canonical (source, src_id, subtype) references plus a display name, never
+geometry. Same access rules as insights (own + public read, owner-only edit,
+admin/superuser override, 404 for not-found *and* not-owned), with one twist:
+publishing a dashboard cascades ``is_public=True`` to its referenced insights,
+otherwise a public dashboard renders empty for viewers.
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.api.auth.dependencies import optional_auth, require_auth
+from src.api.data_models import DashboardOrm, InsightOrm, UserType
+from src.api.repositories import dashboard_writer
+from src.api.repositories.insight_access import (
+    is_visible_to_user as insight_is_visible_to_user,
+)
+from src.api.routers.insights import (
+    _row_to_response as _insight_row_to_response,
+)
+from src.api.schemas import (
+    DashboardAoiResponse,
+    DashboardCreateRequest,
+    DashboardPublicToggleRequest,
+    DashboardPublicToggleResponse,
+    DashboardResponse,
+    DashboardUpdateRequest,
+    DashboardWidgetCreateRequest,
+    DashboardWidgetResponse,
+    DashboardWidgetUpdateRequest,
+    UserModel,
+)
+from src.shared.database import get_session_from_pool_dependency
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+def _is_privileged(user: Optional[UserModel]) -> bool:
+    return user is not None and user.user_type in (
+        UserType.ADMIN,
+        UserType.SUPERUSER,
+    )
+
+
+def _row_to_response(
+    row: DashboardOrm,
+    insights_by_id: Optional[dict] = None,
+) -> DashboardResponse:
+    """Map a dashboard row (with aois + widgets loaded) to the response.
+
+    ``insights_by_id`` carries the pre-loaded insight rows the viewer may see;
+    widgets referencing anything else keep ``insight=None``.
+    """
+    insights_by_id = insights_by_id or {}
+    return DashboardResponse(
+        id=row.id,
+        user_id=row.user_id,
+        name=row.name,
+        description=row.description,
+        is_public=row.is_public,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        aois=[
+            DashboardAoiResponse.model_validate(aoi) for aoi in row.aois or []
+        ],
+        widgets=[
+            DashboardWidgetResponse(
+                id=widget.id,
+                position=widget.position,
+                widget_type=widget.widget_type,
+                insight_id=widget.insight_id,
+                config=widget.config or {},
+                created_at=widget.created_at,
+                insight=(
+                    _insight_row_to_response(insights_by_id[widget.insight_id])
+                    if widget.insight_id in insights_by_id
+                    else None
+                ),
+            )
+            for widget in row.widgets or []
+        ],
+    )
+
+
+async def _get_owned_dashboard(
+    dashboard_id: UUID, user: UserModel
+) -> DashboardOrm:
+    """Load a dashboard the user may edit, or raise 404 (not-found and
+    not-owned are indistinguishable, like insights)."""
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    if row is None or (row.user_id != user.id and not _is_privileged(user)):
+        raise HTTPException(status_code=404, detail="Dashboard not found")
+    return row
+
+
+async def _refetch_dashboard(dashboard_id) -> DashboardOrm:
+    """Re-load a dashboard just written to; 404 only on a concurrent delete."""
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Dashboard not found")
+    return row
+
+
+@router.post(
+    "/api/dashboards",
+    response_model=DashboardResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_dashboard(
+    body: DashboardCreateRequest,
+    user: UserModel = Depends(require_auth),
+):
+    """Create a dashboard for one area (MVP: exactly one AOI)."""
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id,
+        name=body.name or body.aois[0].name,
+        description=body.description,
+        aois=[aoi.model_dump() for aoi in body.aois],
+    )
+    return _row_to_response(await _refetch_dashboard(dashboard_id))
+
+
+@router.get("/api/dashboards", response_model=list[DashboardResponse])
+async def list_dashboards(
+    user: UserModel = Depends(require_auth),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+):
+    """List the authenticated user's dashboards, newest first."""
+    result = await session.execute(
+        select(DashboardOrm)
+        .options(
+            selectinload(DashboardOrm.aois),
+            selectinload(DashboardOrm.widgets),
+        )
+        .where(DashboardOrm.user_id == user.id)
+        .order_by(DashboardOrm.created_at.desc())
+    )
+    return [_row_to_response(row) for row in result.scalars().all()]
+
+
+@router.get("/api/dashboards/{dashboard_id}", response_model=DashboardResponse)
+async def get_dashboard(
+    dashboard_id: UUID,
+    user: Optional[UserModel] = Depends(optional_auth),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+):
+    """
+    Get a single dashboard with widget insight payloads expanded.
+
+    Public dashboards can be accessed by anyone; private ones require
+    authentication and ownership. Same read rule as
+    `src.api.repositories.dashboard_access` (used by the agent tools), plus
+    the admin/superuser override and HTTP error semantics.
+    """
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Dashboard not found")
+
+    if not row.is_public:
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication required",
+            )
+        if row.user_id != user.id and not _is_privileged(user):
+            raise HTTPException(status_code=404, detail="Dashboard not found")
+
+    # Expand widget insights the viewer may see (own + public; read-through
+    # access for private insights on public dashboards is deliberately not
+    # granted). Privileged users see everything.
+    insight_ids = [w.insight_id for w in row.widgets if w.insight_id]
+    insights_by_id = {}
+    if insight_ids:
+        result = await session.execute(
+            select(InsightOrm)
+            .options(selectinload(InsightOrm.charts))
+            .where(InsightOrm.id.in_(insight_ids))
+        )
+        user_id = user.id if user else None
+        insights_by_id = {
+            insight.id: insight
+            for insight in result.scalars().all()
+            if insight_is_visible_to_user(insight, user_id)
+            or _is_privileged(user)
+        }
+    return _row_to_response(row, insights_by_id)
+
+
+@router.patch(
+    "/api/dashboards/{dashboard_id}", response_model=DashboardResponse
+)
+async def update_dashboard(
+    dashboard_id: UUID,
+    body: DashboardUpdateRequest,
+    user: UserModel = Depends(require_auth),
+):
+    """Rename a dashboard or update its description (owner only)."""
+    await _get_owned_dashboard(dashboard_id, user)
+    await dashboard_writer.update_dashboard(
+        dashboard_id, name=body.name, description=body.description
+    )
+    return _row_to_response(await _refetch_dashboard(dashboard_id))
+
+
+@router.patch(
+    "/api/dashboards/{dashboard_id}/public",
+    response_model=DashboardPublicToggleResponse,
+)
+async def toggle_dashboard_public(
+    dashboard_id: UUID,
+    body: DashboardPublicToggleRequest,
+    user: UserModel = Depends(require_auth),
+):
+    """Set or unset is_public on a dashboard owned by the authenticated user.
+
+    Publishing cascades ``is_public=True`` to all insights referenced by the
+    dashboard's widgets; the response lists the insight ids it publicized.
+    Unpublishing does not cascade.
+    """
+    await _get_owned_dashboard(dashboard_id, user)
+    publicized = await dashboard_writer.set_dashboard_public(
+        dashboard_id, body.is_public
+    )
+    base = _row_to_response(await _refetch_dashboard(dashboard_id))
+    return DashboardPublicToggleResponse(
+        **base.model_dump(),
+        publicized_insight_ids=[UUID(i) for i in publicized or []],
+    )
+
+
+@router.post(
+    "/api/dashboards/{dashboard_id}/widgets",
+    response_model=DashboardResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_widget(
+    dashboard_id: UUID,
+    body: DashboardWidgetCreateRequest,
+    user: UserModel = Depends(require_auth),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+):
+    """Add a widget to a dashboard (owner only).
+
+    Insight widgets must reference an insight the user can see (own or
+    public) — the same rule the agent tools apply.
+    """
+    await _get_owned_dashboard(dashboard_id, user)
+
+    if body.widget_type == "insight":
+        if body.insight_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail="insight widgets require an insight_id",
+            )
+        insight = await session.get(InsightOrm, body.insight_id)
+        if insight is None or not (
+            insight_is_visible_to_user(insight, user.id)
+            or _is_privileged(user)
+        ):
+            raise HTTPException(status_code=404, detail="Insight not found")
+
+    await dashboard_writer.add_widget(
+        dashboard_id,
+        widget_type=body.widget_type,
+        insight_id=str(body.insight_id) if body.insight_id else None,
+        config=body.config,
+        position=body.position,
+    )
+    return _row_to_response(await _refetch_dashboard(dashboard_id))
+
+
+@router.patch(
+    "/api/dashboards/{dashboard_id}/widgets/{widget_id}",
+    response_model=DashboardResponse,
+)
+async def update_widget(
+    dashboard_id: UUID,
+    widget_id: UUID,
+    body: DashboardWidgetUpdateRequest,
+    user: UserModel = Depends(require_auth),
+):
+    """Reorder a widget or update its presentation config (owner only)."""
+    row = await _get_owned_dashboard(dashboard_id, user)
+    if widget_id not in {w.id for w in row.widgets}:
+        raise HTTPException(status_code=404, detail="Widget not found")
+    await dashboard_writer.update_widget(
+        widget_id, position=body.position, config=body.config
+    )
+    return _row_to_response(await _refetch_dashboard(dashboard_id))
+
+
+@router.delete(
+    "/api/dashboards/{dashboard_id}/widgets/{widget_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_widget(
+    dashboard_id: UUID,
+    widget_id: UUID,
+    user: UserModel = Depends(require_auth),
+):
+    """Remove a widget from a dashboard (owner only); the insight it
+    references is left intact."""
+    row = await _get_owned_dashboard(dashboard_id, user)
+    if widget_id not in {w.id for w in row.widgets}:
+        raise HTTPException(status_code=404, detail="Widget not found")
+    await dashboard_writer.remove_widget(widget_id)
+
+
+@router.delete(
+    "/api/dashboards/{dashboard_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_dashboard(
+    dashboard_id: UUID,
+    user: UserModel = Depends(require_auth),
+):
+    """Delete a dashboard with its widgets (owner only); referenced insights
+    are left intact."""
+    await _get_owned_dashboard(dashboard_id, user)
+    await dashboard_writer.delete_dashboard(dashboard_id)

--- a/src/api/routers/dashboards.py
+++ b/src/api/routers/dashboards.py
@@ -41,6 +41,7 @@ from src.api.schemas import (
 )
 from src.shared.database import get_session_from_pool_dependency
 from src.shared.logging_config import get_logger
+from src.shared.tile_urls import absolutize_widget_config
 
 logger = get_logger(__name__)
 
@@ -81,7 +82,7 @@ def _row_to_response(
                 position=widget.position,
                 widget_type=widget.widget_type,
                 insight_id=widget.insight_id,
-                config=widget.config or {},
+                config=absolutize_widget_config(widget.config) or {},
                 created_at=widget.created_at,
                 insight=(
                     _insight_row_to_response(insights_by_id[widget.insight_id])

--- a/src/api/routers/insights.py
+++ b/src/api/routers/insights.py
@@ -89,6 +89,9 @@ async def get_insight(
     """
     Get a single insight. Public insights can be accessed by anyone.
     Private insights require authentication and ownership.
+
+    Same read rule as `src.api.repositories.insight_access` (used by the
+    agent tools), plus the admin/superuser override and HTTP error semantics.
     """
     result = await session.execute(
         select(InsightOrm)

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -570,12 +570,12 @@ class DashboardPublicToggleRequest(BaseModel):
     is_public: bool
 
 
-_WIDGET_TYPES = ("insight", "map")
+_WIDGET_TYPES = ("insight", "map", "text")
 
 
 class DashboardWidgetCreateRequest(BaseModel):
     widget_type: str = Field(
-        description="Widget kind: `insight` or `map`.",
+        description="Widget kind: `insight`, `map` or `text`.",
     )
     insight_id: Optional[UUID] = Field(
         default=None,
@@ -590,7 +590,8 @@ class DashboardWidgetCreateRequest(BaseModel):
             "of the keys `dataset` (resolved tile_url, context layers, "
             "parameters, dates) or `imagery` (Sentinel-2 mosaic_id and tile "
             "URLs); optional `viewport` override — by default map widgets "
-            "render fitted to the dashboard's area."
+            "render fitted to the dashboard's area. "
+            "Text widgets: `text` (markdown string)."
         ),
     )
     position: Optional[int] = None
@@ -623,6 +624,18 @@ class DashboardWidgetCreateRequest(BaseModel):
         if not isinstance(layer, dict) or not layer.get("tile_url"):
             raise ValueError(
                 f"map widget {kinds[0]} config requires a tile_url"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_text_config(self) -> "DashboardWidgetCreateRequest":
+        """Text widgets carry their markdown body in config.text."""
+        if self.widget_type != "text":
+            return self
+        config = self.config or {}
+        if not isinstance(config.get("text"), str):
+            raise ValueError(
+                "text widgets require a config with a 'text' string"
             )
         return self
 

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -9,6 +9,7 @@ from pydantic import (
     Field,
     alias_generators,
     field_validator,
+    model_validator,
 )
 
 from src.api.data_models import UserType
@@ -583,9 +584,13 @@ class DashboardWidgetCreateRequest(BaseModel):
     config: Optional[dict] = Field(
         default=None,
         description=(
-            "Presentation config: `default_view` (map|chart|table), optional "
-            "`title` override; for map widgets `dataset_id`, `start_date`/"
-            "`end_date`, optional viewport."
+            "Widget config. Insight widgets: presentation only — "
+            "`default_view` (map|chart|table), optional `title` override. "
+            "Map widgets: a self-contained layer snapshot under exactly one "
+            "of the keys `dataset` (resolved tile_url, context layers, "
+            "parameters, dates) or `imagery` (Sentinel-2 mosaic_id and tile "
+            "URLs); optional `viewport` override — by default map widgets "
+            "render fitted to the dashboard's area."
         ),
     )
     position: Optional[int] = None
@@ -597,6 +602,29 @@ class DashboardWidgetCreateRequest(BaseModel):
                 f"widget_type must be one of {', '.join(_WIDGET_TYPES)}"
             )
         return v
+
+    @model_validator(mode="after")
+    def validate_map_config(self) -> "DashboardWidgetCreateRequest":
+        """Map widgets need a renderable layer snapshot in config.
+
+        Only the discriminator and its tile_url are checked — the remaining
+        snapshot keys may evolve without a schema change here.
+        """
+        if self.widget_type != "map":
+            return self
+        config = self.config or {}
+        kinds = [k for k in ("dataset", "imagery") if k in config]
+        if len(kinds) != 1:
+            raise ValueError(
+                "map widgets require a config with exactly one of "
+                "'dataset' or 'imagery'"
+            )
+        layer = config[kinds[0]]
+        if not isinstance(layer, dict) or not layer.get("tile_url"):
+            raise ValueError(
+                f"map widget {kinds[0]} config requires a tile_url"
+            )
+        return self
 
 
 class DashboardWidgetUpdateRequest(BaseModel):

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -358,7 +358,8 @@ class ChatRequest(BaseModel):
     #   {"page": "map" | "report",
     #    "viewport": {"bbox": [minx, miny, maxx, maxy], "zoom": 5},
     #    "visible_layers": [{"id": "...", "name": "..."}],
-    #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}]}
+    #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}],
+    #    "visible_insights": ["<uuid>", "<uuid>"]}
     view_context: Optional[dict] = Field(
         None,
         description="Ambient frontend view state (page, viewport, visible layers/AOIs)",

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -360,6 +360,8 @@ class ChatRequest(BaseModel):
     #    "visible_layers": [{"id": "...", "name": "..."}],
     #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}],
     #    "visible_insights": ["<uuid>", "<uuid>"]}
+    # On the dashboard page the snapshot carries the dashboard being viewed:
+    #   {"page": "dashboard", "dashboard_id": "<uuid>"}
     view_context: Optional[dict] = Field(
         None,
         description="Ambient frontend view state (page, viewport, visible layers/AOIs)",
@@ -534,5 +536,115 @@ class AnalyzeRequest(BaseModel):
             "Agent thread ID. When provided, the results are written into "
             "the agent state for that thread so follow-up chat messages can "
             "reference the data without re-fetching."
+        ),
+    )
+
+
+class DashboardAoi(AreaOfInterest):
+    """An AOI reference on a dashboard: canonical address plus display name."""
+
+    name: str = Field(description="Display name of the area, e.g. `Paraná`.")
+
+
+class DashboardCreateRequest(BaseModel):
+    name: Optional[str] = Field(
+        default=None,
+        description="Dashboard name; defaults to the first AOI's name.",
+    )
+    description: Optional[str] = None
+    # min/max length 1 is the MVP single-area constraint — the schema supports
+    # multiple areas (portfolios); lift later by raising max_length.
+    aois: List[DashboardAoi] = Field(min_length=1, max_length=1)
+
+
+class DashboardUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+class DashboardPublicToggleRequest(BaseModel):
+    is_public: bool
+
+
+_WIDGET_TYPES = ("insight", "map")
+
+
+class DashboardWidgetCreateRequest(BaseModel):
+    widget_type: str = Field(
+        description="Widget kind: `insight` or `map`.",
+    )
+    insight_id: Optional[UUID] = Field(
+        default=None,
+        description="Insight the widget references; required for `insight` widgets.",
+    )
+    config: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Presentation config: `default_view` (map|chart|table), optional "
+            "`title` override; for map widgets `dataset_id`, `start_date`/"
+            "`end_date`, optional viewport."
+        ),
+    )
+    position: Optional[int] = None
+
+    @field_validator("widget_type")
+    def validate_widget_type(cls, v):
+        if v not in _WIDGET_TYPES:
+            raise ValueError(
+                f"widget_type must be one of {', '.join(_WIDGET_TYPES)}"
+            )
+        return v
+
+
+class DashboardWidgetUpdateRequest(BaseModel):
+    position: Optional[int] = None
+    config: Optional[dict] = None
+
+
+class DashboardAoiResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    source: str
+    src_id: str
+    subtype: str
+    name: str
+    position: int
+
+
+class DashboardWidgetResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    position: int
+    widget_type: str
+    insight_id: Optional[UUID] = None
+    config: dict
+    created_at: datetime
+    # Expanded insight payload (same shape the insights endpoints return) so
+    # the frontend renders widgets like insights. Populated on the single-
+    # dashboard endpoint; None when the insight is not visible to the viewer.
+    insight: Optional[InsightResponse] = None
+
+
+class DashboardResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: str
+    name: str
+    description: Optional[str] = None
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime
+    aois: List[DashboardAoiResponse] = []
+    widgets: List[DashboardWidgetResponse] = []
+
+
+class DashboardPublicToggleResponse(DashboardResponse):
+    publicized_insight_ids: List[UUID] = Field(
+        default=[],
+        description=(
+            "Insights flipped to public because this dashboard was published."
         ),
     )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -361,7 +361,10 @@ class ChatRequest(BaseModel):
     #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}],
     #    "visible_insights": ["<uuid>", "<uuid>"]}
     # On the dashboard page the snapshot carries the dashboard being viewed:
-    #   {"page": "dashboard", "dashboard_id": "<uuid>"}
+    #   {"page": "dashboard", "dashboard_id": "<uuid>", "dashboard_name": "…"}
+    # Known "page" values get scope semantics on the backend (session-block
+    # line + system-prompt section) via src/agent/view_pages.py; see
+    # docs/view-context-pages.md. Unknown pages degrade gracefully.
     view_context: Optional[dict] = Field(
         None,
         description="Ambient frontend view state (page, viewport, visible layers/AOIs)",

--- a/src/api/services/chat.py
+++ b/src/api/services/chat.py
@@ -134,7 +134,14 @@ async def stream_chat(
         "metadata": langfuse_metadata,
     }
 
-    zeno_async = await fetch_zeno(ff=ff, registry=registry)
+    # The page the user is on conditions the "# Current surface" prompt
+    # section; the rest of view_context stays ambient (see below).
+    page = (view_context or {}).get("page")
+    zeno_async = await fetch_zeno(
+        ff=ff,
+        registry=registry,
+        page=page if isinstance(page, str) else None,
+    )
 
     messages = []
     ui_action_message = []

--- a/src/api/services/langfuse/parse.py
+++ b/src/api/services/langfuse/parse.py
@@ -44,6 +44,7 @@ EXPECTED_STATE_KEYS = frozenset(
         "statistics",
         "imagery",
         "cited_articles",
+        "dashboard_id",
         "insight",
         "insight_id",
         "follow_up_suggestions",

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -18,9 +18,12 @@ class _SharedSettings(BaseSettings):
     db_pool_timeout: int = Field(default=30, alias="DB_POOL_TIMEOUT")
     db_pool_recycle: int = Field(default=3600, alias="DB_POOL_RECYCLE")
 
-    # External API endpoints
+    # External API endpoints. The eoapi cache is the canonical tile host:
+    # eoapi.globalnaturewatch.org serves a certificate that does not cover
+    # the hostname and the staging host's certificate is expired (both
+    # verified 2026-07-03), so browsers refuse tiles from either.
     eoapi_base_url: str = Field(
-        default="https://eoapi.staging.globalnaturewatch.org",
+        default="https://eoapi-cache.globalnaturewatch.org",
         alias="EOAPI_BASE_URL",
     )
 

--- a/src/shared/geocoding_helpers.py
+++ b/src/shared/geocoding_helpers.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional, Union
 from uuid import UUID
 
 import pandas as pd
-import structlog
 from sqlalchemy import select, text
 
 from src.api.data_models import CustomAreaOrm
@@ -12,6 +11,7 @@ from src.shared.database import (
     get_session_from_pool,
 )
 from src.shared.logging_config import get_logger
+from src.shared.request_context import current_user_id
 
 logger = get_logger(__name__)
 
@@ -303,9 +303,7 @@ async def get_geometry_data(
 
     async with get_session_from_pool() as session:
         if source == "custom":
-            user_id = user_id or structlog.contextvars.get_contextvars().get(
-                "user_id"
-            )
+            user_id = user_id or current_user_id()
             if not user_id:
                 raise ValueError("user_id required for custom areas")
 

--- a/src/shared/request_context.py
+++ b/src/shared/request_context.py
@@ -1,0 +1,41 @@
+"""Request-scoped identity of the authenticated user.
+
+A dedicated ``contextvars.ContextVar`` — not structlog's — because "who is
+making this request" is a correctness/authorization concern, deep tool code
+depends on it being right, and it shouldn't ride along inside the logging
+library's context (which exists for log enrichment and could be cleared or
+reconfigured independently). Set once per request/session by the API auth
+dependencies or the CLI entrypoint; read anywhere downstream (tools, nested
+helpers) without threading a parameter through every call.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator, Optional
+
+_current_user_id: ContextVar[Optional[str]] = ContextVar(
+    "current_user_id", default=None
+)
+
+
+def set_current_user_id(user_id: Optional[str]) -> None:
+    """Bind the authenticated user id for the remainder of this context
+    (request, task, or CLI invocation)."""
+    _current_user_id.set(user_id)
+
+
+def current_user_id() -> Optional[str]:
+    """The authenticated user id bound by ``set_current_user_id``; None when
+    unauthenticated or unset."""
+    return _current_user_id.get()
+
+
+@contextmanager
+def bound_user_id(user_id: Optional[str]) -> Iterator[None]:
+    """Bind ``user_id`` for the duration of the ``with`` block; for tests
+    that need to simulate an authenticated request."""
+    token = _current_user_id.set(user_id)
+    try:
+        yield
+    finally:
+        _current_user_id.reset(token)

--- a/src/shared/request_context.py
+++ b/src/shared/request_context.py
@@ -1,12 +1,14 @@
 """Request-scoped identity of the authenticated user.
 
-A dedicated ``contextvars.ContextVar`` — not structlog's — because "who is
-making this request" is a correctness/authorization concern, deep tool code
-depends on it being right, and it shouldn't ride along inside the logging
-library's context (which exists for log enrichment and could be cleared or
-reconfigured independently). Set once per request/session by the API auth
-dependencies or the CLI entrypoint; read anywhere downstream (tools, nested
-helpers) without threading a parameter through every call.
+Kept in its own ``ContextVar`` rather than structlog's context (the
+``bind_contextvars``/``clear_contextvars`` calls in ``api/app.py`` and
+``agent/cli.py``), because the current user id is an authorization concern
+that deep tool code depends on being correct. It must not be reset or
+cleared as a side effect of that log-enrichment context's own lifecycle.
+
+Set once per request/session by the API auth dependencies or the CLI
+entrypoint; read anywhere downstream (tools, nested helpers) without
+threading a parameter through every call.
 """
 
 from contextlib import contextmanager

--- a/src/shared/tile_urls.py
+++ b/src/shared/tile_urls.py
@@ -1,0 +1,71 @@
+"""Widget tile URLs and the rotating eoapi host.
+
+Map widgets snapshot the tile layer they render into their JSONB config.
+An absolute tile URL frozen into the database breaks silently — browser-side
+only, with no server-side signal — whenever the eoapi host rotates, and it
+already has once (this branch moved the default to the cache host because
+the certificates broke). So persisted configs are host-less: on write, a
+``tile_url`` on the configured eoapi host is reduced to its ``tile_path``;
+on read, the *currently configured* host is prepended again. Host rotation
+then becomes a config change instead of an orphaning of every persisted map
+widget. URLs on any other host (e.g. the GFW tiles service that serves
+imagery mosaics) pass through untouched, so the API contract — responses
+always carry an absolute ``tile_url`` — is unchanged.
+"""
+
+from typing import Optional
+
+from src.shared.config import SharedSettings
+
+# Widget-config keys whose value is a layer snapshot carrying a tile_url.
+_LAYER_KEYS = ("dataset", "imagery")
+
+
+def _base_url() -> str:
+    return SharedSettings.eoapi_base_url.rstrip("/")
+
+
+def relativize_widget_config(config: Optional[dict]) -> Optional[dict]:
+    """A copy of a widget config with eoapi tile URLs reduced to tile_path.
+
+    Layers whose tile_url lives on another host keep it verbatim. The input
+    is never mutated (callers pass request bodies and agent state).
+    """
+    if not config:
+        return config
+    base = _base_url()
+    out = dict(config)
+    for key in _LAYER_KEYS:
+        layer = out.get(key)
+        if not isinstance(layer, dict):
+            continue
+        tile_url = layer.get("tile_url")
+        if isinstance(tile_url, str) and tile_url.startswith(base + "/"):
+            layer = dict(layer)
+            layer["tile_path"] = tile_url[len(base) :]
+            layer.pop("tile_url")
+            out[key] = layer
+    return out
+
+
+def absolutize_widget_config(config: Optional[dict]) -> Optional[dict]:
+    """A copy of a widget config with tile_path expanded to an absolute
+    tile_url on the currently configured eoapi host.
+
+    Configs that already carry a tile_url (foreign-host layers, or rows
+    written before tile_path existed) are returned unchanged.
+    """
+    if not config:
+        return config
+    base = _base_url()
+    out = dict(config)
+    for key in _LAYER_KEYS:
+        layer = out.get(key)
+        if not isinstance(layer, dict):
+            continue
+        tile_path = layer.get("tile_path")
+        if isinstance(tile_path, str) and not layer.get("tile_url"):
+            layer = dict(layer)
+            layer["tile_url"] = base + tile_path
+            out[key] = layer
+    return out

--- a/tests/agent/test_add_map_widget.py
+++ b/tests/agent/test_add_map_widget.py
@@ -4,13 +4,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-import structlog
-
 from src.agent.tools.add_map_widget import (
     _dataset_config,
     _imagery_config,
     add_map_widget,
 )
+from src.shared.request_context import bound_user_id
 
 
 def _content(command):
@@ -89,7 +88,7 @@ async def test_add_map_widget_dataset_from_state():
     with (
         get_dash,
         add_widget as add_widget_mock,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_map_widget.coroutine(
             layer="dataset", state=state, tool_call_id="t1"
@@ -132,7 +131,7 @@ async def test_add_map_widget_imagery_from_state():
     with (
         get_dash,
         add_widget as add_widget_mock,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_map_widget.coroutine(
             layer="imagery", state=state, tool_call_id="t1"
@@ -153,7 +152,7 @@ async def test_add_map_widget_title_passthrough():
     with (
         get_dash,
         add_widget as add_widget_mock,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         await add_map_widget.coroutine(
             layer="dataset", title="Loss layer", state=state, tool_call_id="t1"
@@ -174,7 +173,7 @@ async def test_add_map_widget_falls_back_to_view_context():
     with (
         get_dash,
         add_widget,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_map_widget.coroutine(
             layer="dataset", state=state, tool_call_id="t1"
@@ -184,7 +183,7 @@ async def test_add_map_widget_falls_back_to_view_context():
 
 
 async def test_add_map_widget_rejects_unknown_layer():
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await add_map_widget.coroutine(
             layer="chart", state={}, tool_call_id="t1"
         )
@@ -193,7 +192,7 @@ async def test_add_map_widget_rejects_unknown_layer():
 
 
 async def test_add_map_widget_requires_dataset_in_state():
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await add_map_widget.coroutine(
             layer="dataset",
             dashboard_id=str(uuid4()),
@@ -206,7 +205,7 @@ async def test_add_map_widget_requires_dataset_in_state():
 
 async def test_add_map_widget_requires_dataset_tile_url():
     state = {"dataset": {"dataset_id": 4, "dataset_name": "TCL"}}
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await add_map_widget.coroutine(
             layer="dataset",
             dashboard_id=str(uuid4()),
@@ -218,7 +217,7 @@ async def test_add_map_widget_requires_dataset_tile_url():
 
 
 async def test_add_map_widget_requires_imagery_in_state():
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await add_map_widget.coroutine(
             layer="imagery",
             dashboard_id=str(uuid4()),
@@ -230,7 +229,7 @@ async def test_add_map_widget_requires_imagery_in_state():
 
 
 async def test_add_map_widget_requires_dashboard():
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await add_map_widget.coroutine(
             layer="dataset",
             state={"dataset": _dataset_state()},
@@ -248,7 +247,7 @@ async def test_add_map_widget_owner_only():
     with (
         get_dash,
         add_widget as add_widget_mock,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_map_widget.coroutine(
             layer="dataset",

--- a/tests/agent/test_add_map_widget.py
+++ b/tests/agent/test_add_map_widget.py
@@ -1,0 +1,286 @@
+"""Tests for the add_map_widget agent tool."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import structlog
+
+from src.agent.tools.add_map_widget import (
+    _dataset_config,
+    _imagery_config,
+    add_map_widget,
+)
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _dashboard(user_id="user-1", name="Paraná"):
+    return SimpleNamespace(
+        id=uuid4(), user_id=user_id, name=name, is_public=False
+    )
+
+
+def _dataset_state():
+    """A dataset state dump with render keys plus prose keys to strip."""
+    return {
+        "dataset_id": 4,
+        "dataset_name": "Tree cover loss",
+        "tile_url": "https://tiles.example.com/tcl/{z}/{x}/{y}.png?t=30",
+        "context_layer": "driver",
+        "context_layers": [
+            {"name": "driver", "tile_url": "https://tiles.example.com/d.png"}
+        ],
+        "parameters": [
+            {
+                "name": "canopy_cover",
+                "description": "Minimum canopy density.",
+                "values": [30],
+            }
+        ],
+        "start_date": "2024-01-01",
+        "end_date": "2024-12-31",
+        # Prose fields that must never end up in widget config.
+        "description": "A long dataset description.",
+        "methodology": "Hansen et al.",
+        "prompt_instructions": "Do things.",
+        "cautions": "Beware.",
+        "citation": "Someone 2024",
+        "reason": "Best match.",
+        "analytics_api_endpoint": "tree-cover-loss",
+        "content_date": "2024",
+    }
+
+
+def _imagery_state():
+    return {
+        "tile_url": "https://tiles.example.com/mosaic/{z}/{x}/{y}.png?url=x",
+        "tilejson_url": "https://tiles.example.com/tilejson.json?url=x",
+        "mosaic_id": "abc123",
+        "item_count": 12,
+        "date_start": "2024-05-28",
+        "date_end": "2024-06-04",
+        "target_date": "2024-06-01",
+        "window_days": 7,
+        "max_cloud_cover": 20,
+        "aoi_names": ["Paraná"],
+    }
+
+
+def _patches(dashboard, widget_id="widget-1"):
+    return (
+        patch(
+            "src.api.repositories.dashboard_writer.get_dashboard",
+            new=AsyncMock(return_value=dashboard),
+        ),
+        patch(
+            "src.api.repositories.dashboard_writer.add_widget",
+            new=AsyncMock(return_value=widget_id),
+        ),
+    )
+
+
+async def test_add_map_widget_dataset_from_state():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard)
+    state = {"dataset": _dataset_state(), "dashboard_id": str(dashboard.id)}
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_map_widget.coroutine(
+            layer="dataset", state=state, tool_call_id="t1"
+        )
+
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata == {
+        "msg_type": "dashboard_updated",
+        "dashboard_id": str(dashboard.id),
+    }
+    assert command.update["dashboard_id"] == str(dashboard.id)
+    add_widget_mock.assert_awaited_once()
+    kwargs = add_widget_mock.await_args.kwargs
+    assert kwargs["widget_type"] == "map"
+    config = kwargs["config"]
+    assert config["default_view"] == "map"
+    assert "viewport" not in config
+    dataset = config["dataset"]
+    assert set(dataset) == {
+        "dataset_id",
+        "dataset_name",
+        "tile_url",
+        "context_layer",
+        "context_layers",
+        "parameters",
+        "start_date",
+        "end_date",
+    }
+    assert dataset["dataset_id"] == 4
+    assert dataset["tile_url"].startswith("https://tiles.example.com/tcl")
+    # Parameter prose is projected away.
+    assert dataset["parameters"] == [{"name": "canopy_cover", "values": [30]}]
+
+
+async def test_add_map_widget_imagery_from_state():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard)
+    state = {"imagery": _imagery_state(), "dashboard_id": str(dashboard.id)}
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_map_widget.coroutine(
+            layer="imagery", state=state, tool_call_id="t1"
+        )
+
+    assert command.update["messages"][0].status == "success"
+    config = add_widget_mock.await_args.kwargs["config"]
+    imagery = config["imagery"]
+    assert imagery == _imagery_state()
+    assert imagery["mosaic_id"] == "abc123"
+    assert imagery["tilejson_url"].startswith("https://")
+
+
+async def test_add_map_widget_title_passthrough():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard)
+    state = {"dataset": _dataset_state(), "dashboard_id": str(dashboard.id)}
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        await add_map_widget.coroutine(
+            layer="dataset", title="Loss layer", state=state, tool_call_id="t1"
+        )
+    assert add_widget_mock.await_args.kwargs["config"]["title"] == "Loss layer"
+
+
+async def test_add_map_widget_falls_back_to_view_context():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard)
+    state = {
+        "dataset": _dataset_state(),
+        "view_context": {
+            "page": "dashboard",
+            "dashboard_id": str(dashboard.id),
+        },
+    }
+    with (
+        get_dash,
+        add_widget,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_map_widget.coroutine(
+            layer="dataset", state=state, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "success"
+    assert command.update["dashboard_id"] == str(dashboard.id)
+
+
+async def test_add_map_widget_rejects_unknown_layer():
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await add_map_widget.coroutine(
+            layer="chart", state={}, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "layer must be" in _content(command)
+
+
+async def test_add_map_widget_requires_dataset_in_state():
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await add_map_widget.coroutine(
+            layer="dataset",
+            dashboard_id=str(uuid4()),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No dataset layer selected" in _content(command)
+
+
+async def test_add_map_widget_requires_dataset_tile_url():
+    state = {"dataset": {"dataset_id": 4, "dataset_name": "TCL"}}
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await add_map_widget.coroutine(
+            layer="dataset",
+            dashboard_id=str(uuid4()),
+            state=state,
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No dataset layer selected" in _content(command)
+
+
+async def test_add_map_widget_requires_imagery_in_state():
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await add_map_widget.coroutine(
+            layer="imagery",
+            dashboard_id=str(uuid4()),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No imagery built" in _content(command)
+
+
+async def test_add_map_widget_requires_dashboard():
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await add_map_widget.coroutine(
+            layer="dataset",
+            state={"dataset": _dataset_state()},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No dashboard to add to" in _content(command)
+
+
+async def test_add_map_widget_owner_only():
+    # A public dashboard someone else owns is readable but not editable.
+    dashboard = _dashboard(user_id="someone-else")
+    dashboard.is_public = True
+    get_dash, add_widget = _patches(dashboard)
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_map_widget.coroutine(
+            layer="dataset",
+            dashboard_id=str(dashboard.id),
+            state={"dataset": _dataset_state()},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not editable" in _content(command)
+    add_widget_mock.assert_not_awaited()
+
+
+def test_dataset_config_date_fallback_to_state():
+    dataset = _dataset_state()
+    dataset["start_date"] = None
+    dataset["end_date"] = None
+    state = {
+        "dataset": dataset,
+        "start_date": "2023-01-01",
+        "end_date": "2023-12-31",
+    }
+    config = _dataset_config(state)
+    assert config["start_date"] == "2023-01-01"
+    assert config["end_date"] == "2023-12-31"
+
+
+def test_dataset_config_none_without_tile_url():
+    assert _dataset_config({}) is None
+    assert _dataset_config({"dataset": {"tile_url": ""}}) is None
+
+
+def test_imagery_config_none_without_essentials():
+    assert _imagery_config({}) is None
+    assert _imagery_config({"imagery": {"tile_url": "x"}}) is None
+    assert _imagery_config({"imagery": {"mosaic_id": "x"}}) is None

--- a/tests/agent/test_add_to_dashboard.py
+++ b/tests/agent/test_add_to_dashboard.py
@@ -4,9 +4,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-import structlog
-
 from src.agent.tools.add_to_dashboard import add_to_dashboard
+from src.shared.request_context import bound_user_id
 
 
 def _content(command):
@@ -57,7 +56,7 @@ async def test_add_to_dashboard_defaults_from_state():
         get_dash,
         load_insight,
         add_widget as add_widget_mock,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_to_dashboard.coroutine(
             state=state, tool_call_id="t1"
@@ -92,7 +91,7 @@ async def test_add_to_dashboard_falls_back_to_view_context():
         get_dash,
         load_insight,
         add_widget,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_to_dashboard.coroutine(
             state=state, tool_call_id="t1"
@@ -102,7 +101,7 @@ async def test_add_to_dashboard_falls_back_to_view_context():
 
 
 async def test_add_to_dashboard_requires_insight():
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await add_to_dashboard.coroutine(
             dashboard_id=str(uuid4()), state={}, tool_call_id="t1"
         )
@@ -111,7 +110,7 @@ async def test_add_to_dashboard_requires_insight():
 
 
 async def test_add_to_dashboard_requires_dashboard():
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await add_to_dashboard.coroutine(
             insight_id=str(uuid4()), state={}, tool_call_id="t1"
         )
@@ -129,7 +128,7 @@ async def test_add_to_dashboard_owner_only():
         get_dash,
         load_insight,
         add_widget as add_widget_mock,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_to_dashboard.coroutine(
             insight_id=str(insight.id),
@@ -149,7 +148,7 @@ async def test_add_to_dashboard_insight_must_be_visible():
         get_dash,
         load_insight,
         add_widget as add_widget_mock,
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await add_to_dashboard.coroutine(
             insight_id=str(uuid4()),

--- a/tests/agent/test_add_to_dashboard.py
+++ b/tests/agent/test_add_to_dashboard.py
@@ -1,0 +1,162 @@
+"""Tests for the add_to_dashboard agent tool."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import structlog
+
+from src.agent.tools.add_to_dashboard import add_to_dashboard
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _dashboard(user_id="user-1", name="Paraná"):
+    return SimpleNamespace(
+        id=uuid4(), user_id=user_id, name=name, is_public=False
+    )
+
+
+def _insight(user_id="user-1"):
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        is_public=False,
+        insight_text="Tree cover loss rose 12%.",
+    )
+
+
+def _patches(dashboard, insight, widget_id="widget-1"):
+    return (
+        patch(
+            "src.api.repositories.dashboard_writer.get_dashboard",
+            new=AsyncMock(return_value=dashboard),
+        ),
+        patch(
+            "src.agent.tools.add_to_dashboard._load_visible_insight",
+            new=AsyncMock(return_value=insight),
+        ),
+        patch(
+            "src.api.repositories.dashboard_writer.add_widget",
+            new=AsyncMock(return_value=widget_id),
+        ),
+    )
+
+
+async def test_add_to_dashboard_defaults_from_state():
+    dashboard = _dashboard()
+    insight = _insight()
+    get_dash, load_insight, add_widget = _patches(dashboard, insight)
+    state = {
+        "insight_id": str(insight.id),
+        "dashboard_id": str(dashboard.id),
+    }
+    with (
+        get_dash,
+        load_insight,
+        add_widget as add_widget_mock,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_to_dashboard.coroutine(
+            state=state, tool_call_id="t1"
+        )
+
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata == {
+        "msg_type": "dashboard_updated",
+        "dashboard_id": str(dashboard.id),
+    }
+    assert command.update["dashboard_id"] == str(dashboard.id)
+    add_widget_mock.assert_awaited_once_with(
+        str(dashboard.id),
+        widget_type="insight",
+        insight_id=str(insight.id),
+    )
+
+
+async def test_add_to_dashboard_falls_back_to_view_context():
+    dashboard = _dashboard()
+    insight = _insight()
+    get_dash, load_insight, add_widget = _patches(dashboard, insight)
+    state = {
+        "insight_id": str(insight.id),
+        "view_context": {
+            "page": "dashboard",
+            "dashboard_id": str(dashboard.id),
+        },
+    }
+    with (
+        get_dash,
+        load_insight,
+        add_widget,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_to_dashboard.coroutine(
+            state=state, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "success"
+    assert command.update["dashboard_id"] == str(dashboard.id)
+
+
+async def test_add_to_dashboard_requires_insight():
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await add_to_dashboard.coroutine(
+            dashboard_id=str(uuid4()), state={}, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No insight to add" in _content(command)
+
+
+async def test_add_to_dashboard_requires_dashboard():
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await add_to_dashboard.coroutine(
+            insight_id=str(uuid4()), state={}, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No dashboard to add to" in _content(command)
+
+
+async def test_add_to_dashboard_owner_only():
+    # A public dashboard someone else owns is readable but not editable.
+    dashboard = _dashboard(user_id="someone-else")
+    dashboard.is_public = True
+    insight = _insight()
+    get_dash, load_insight, add_widget = _patches(dashboard, insight)
+    with (
+        get_dash,
+        load_insight,
+        add_widget as add_widget_mock,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_to_dashboard.coroutine(
+            insight_id=str(insight.id),
+            dashboard_id=str(dashboard.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not editable" in _content(command)
+    add_widget_mock.assert_not_awaited()
+
+
+async def test_add_to_dashboard_insight_must_be_visible():
+    dashboard = _dashboard()
+    get_dash, load_insight, add_widget = _patches(dashboard, insight=None)
+    with (
+        get_dash,
+        load_insight,
+        add_widget as add_widget_mock,
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await add_to_dashboard.coroutine(
+            insight_id=str(uuid4()),
+            dashboard_id=str(dashboard.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not accessible" in _content(command)
+    add_widget_mock.assert_not_awaited()

--- a/tests/agent/test_create_dashboard.py
+++ b/tests/agent/test_create_dashboard.py
@@ -2,9 +2,8 @@
 
 from unittest.mock import AsyncMock, patch
 
-import structlog
-
 from src.agent.tools.create_dashboard import create_dashboard
+from src.shared.request_context import bound_user_id
 
 
 def _content(command):
@@ -31,7 +30,7 @@ async def test_create_dashboard_from_state_aoi():
         patch(
             "src.api.repositories.dashboard_writer.create_dashboard", create
         ),
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         command = await create_dashboard.coroutine(
             state=_state(), tool_call_id="t1"
@@ -68,7 +67,7 @@ async def test_create_dashboard_explicit_name():
         patch(
             "src.api.repositories.dashboard_writer.create_dashboard", create
         ),
-        structlog.contextvars.bound_contextvars(user_id="user-1"),
+        bound_user_id("user-1"),
     ):
         await create_dashboard.coroutine(
             name="Forest monitoring", state=_state(), tool_call_id="t1"
@@ -86,7 +85,7 @@ async def test_create_dashboard_requires_user():
 
 
 async def test_create_dashboard_requires_aoi():
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await create_dashboard.coroutine(state={}, tool_call_id="t1")
     assert command.update["messages"][0].status == "error"
     assert "No area selected" in _content(command)
@@ -107,7 +106,7 @@ async def test_create_dashboard_rejects_multi_aoi_selection():
             "name": "Argentina",
         },
     ]
-    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+    with bound_user_id("user-1"):
         command = await create_dashboard.coroutine(
             state=_state(aois=aois, name="Brazil and Argentina"),
             tool_call_id="t1",

--- a/tests/agent/test_create_dashboard.py
+++ b/tests/agent/test_create_dashboard.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from src.agent.tools.create_dashboard import create_dashboard
 from src.shared.request_context import bound_user_id
 
@@ -75,13 +77,12 @@ async def test_create_dashboard_explicit_name():
     assert create.await_args.kwargs["name"] == "Forest monitoring"
 
 
-async def test_create_dashboard_requires_user():
-    command = await create_dashboard.coroutine(
-        state=_state(), tool_call_id="t1"
-    )
-    assert command.update["messages"][0].status == "error"
-    assert "no authenticated user" in _content(command)
-    assert "dashboard_id" not in command.update
+async def test_create_dashboard_raises_without_user():
+    """A missing identity means the request context channel broke — every
+    entry point binds a user — so the tool raises (into the generic error
+    funnel) instead of degrading into a misleading permission error."""
+    with pytest.raises(RuntimeError, match="without an authenticated user"):
+        await create_dashboard.coroutine(state=_state(), tool_call_id="t1")
 
 
 async def test_create_dashboard_requires_aoi():

--- a/tests/agent/test_create_dashboard.py
+++ b/tests/agent/test_create_dashboard.py
@@ -1,0 +1,116 @@
+"""Tests for the create_dashboard agent tool."""
+
+from unittest.mock import AsyncMock, patch
+
+import structlog
+
+from src.agent.tools.create_dashboard import create_dashboard
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _state(aois=None, name="Paraná"):
+    if aois is None:
+        aois = [
+            {
+                "source": "gadm",
+                "src_id": "BRA.16_1",
+                "subtype": "state-province",
+                "name": "Paraná",
+                "bbox": [-54.6, -26.7, -48.0, -22.5],
+            }
+        ]
+    return {"aoi_selection": {"name": name, "aois": aois}}
+
+
+async def test_create_dashboard_from_state_aoi():
+    create = AsyncMock(return_value="dash-1")
+    with (
+        patch(
+            "src.api.repositories.dashboard_writer.create_dashboard", create
+        ),
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        command = await create_dashboard.coroutine(
+            state=_state(), tool_call_id="t1"
+        )
+
+    # Dashboard id lands in state and in the frontend refetch signal.
+    assert command.update["dashboard_id"] == "dash-1"
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata == {
+        "msg_type": "dashboard_updated",
+        "dashboard_id": "dash-1",
+    }
+    assert "Paraná" in message.content
+
+    # Only the reference fields are persisted — no bbox, no geometry.
+    create.assert_awaited_once_with(
+        user_id="user-1",
+        name="Paraná",
+        aois=[
+            {
+                "source": "gadm",
+                "src_id": "BRA.16_1",
+                "subtype": "state-province",
+                "name": "Paraná",
+            }
+        ],
+    )
+
+
+async def test_create_dashboard_explicit_name():
+    create = AsyncMock(return_value="dash-1")
+    with (
+        patch(
+            "src.api.repositories.dashboard_writer.create_dashboard", create
+        ),
+        structlog.contextvars.bound_contextvars(user_id="user-1"),
+    ):
+        await create_dashboard.coroutine(
+            name="Forest monitoring", state=_state(), tool_call_id="t1"
+        )
+    assert create.await_args.kwargs["name"] == "Forest monitoring"
+
+
+async def test_create_dashboard_requires_user():
+    command = await create_dashboard.coroutine(
+        state=_state(), tool_call_id="t1"
+    )
+    assert command.update["messages"][0].status == "error"
+    assert "no authenticated user" in _content(command)
+    assert "dashboard_id" not in command.update
+
+
+async def test_create_dashboard_requires_aoi():
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await create_dashboard.coroutine(state={}, tool_call_id="t1")
+    assert command.update["messages"][0].status == "error"
+    assert "No area selected" in _content(command)
+
+
+async def test_create_dashboard_rejects_multi_aoi_selection():
+    aois = [
+        {
+            "source": "gadm",
+            "src_id": "BRA",
+            "subtype": "country",
+            "name": "Brazil",
+        },
+        {
+            "source": "gadm",
+            "src_id": "ARG",
+            "subtype": "country",
+            "name": "Argentina",
+        },
+    ]
+    with structlog.contextvars.bound_contextvars(user_id="user-1"):
+        command = await create_dashboard.coroutine(
+            state=_state(aois=aois, name="Brazil and Argentina"),
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "single area" in _content(command)

--- a/tests/agent/test_dashboards_db.py
+++ b/tests/agent/test_dashboards_db.py
@@ -1,0 +1,281 @@
+"""DB-integration tests for dashboard persistence and access.
+
+These exercise the real SQL paths the tool unit tests mock out: the
+dashboard_writer repository (create/widget lifecycle/publish cascade/delete),
+the owner-only rule through the add_to_dashboard tool, and the FK cascade
+from insights to widgets. The single-area constraint deliberately does NOT
+live here — it is API validation (max_length=1), so the repo happily stores
+multiple AOIs (portfolio-ready schema).
+"""
+
+from uuid import UUID, uuid4
+
+import structlog
+from sqlalchemy import select
+
+from src.agent.tools.add_to_dashboard import add_to_dashboard
+from src.api.data_models import (
+    DashboardAoiOrm,
+    DashboardOrm,
+    DashboardWidgetOrm,
+    InsightOrm,
+)
+from src.api.repositories import dashboard_writer
+from tests.conftest import async_session_maker
+
+PARANA = {
+    "source": "gadm",
+    "src_id": "BRA.16_1",
+    "subtype": "state-province",
+    "name": "Paraná",
+}
+BRAZIL = {
+    "source": "gadm",
+    "src_id": "BRA",
+    "subtype": "country",
+    "name": "Brazil",
+}
+
+
+async def _insert_insight(*, user_id, text="An insight.", is_public=False):
+    async with async_session_maker() as session:
+        row = InsightOrm(
+            user_id=user_id,
+            thread_id="thread-1",
+            insight_text=text,
+            is_public=is_public,
+        )
+        session.add(row)
+        await session.commit()
+        return row.id
+
+
+async def _widget_ids(dashboard_id) -> list:
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(DashboardWidgetOrm.id)
+            .where(DashboardWidgetOrm.dashboard_id == UUID(str(dashboard_id)))
+            .order_by(DashboardWidgetOrm.position)
+        )
+        return list(result.scalars().all())
+
+
+async def test_create_and_get_dashboard(user):
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id,
+        name="Paraná",
+        description="Forest monitoring",
+        aois=[PARANA],
+    )
+
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    assert row.name == "Paraná"
+    assert row.description == "Forest monitoring"
+    assert row.user_id == user.id
+    assert row.is_public is False
+    assert [(a.source, a.src_id, a.name) for a in row.aois] == [
+        ("gadm", "BRA.16_1", "Paraná")
+    ]
+    assert row.widgets == []
+
+    assert await dashboard_writer.get_dashboard(str(uuid4())) is None
+    assert await dashboard_writer.get_dashboard("not-a-uuid") is None
+
+
+async def test_repo_accepts_multiple_aois(user):
+    # Portfolio-ready schema: single-area is API validation, not a repo rule.
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Portfolio", aois=[PARANA, BRAZIL]
+    )
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    assert [a.position for a in row.aois] == [0, 1]
+    assert [a.name for a in row.aois] == ["Paraná", "Brazil"]
+
+
+async def test_widget_add_reorder_remove(user):
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    insight_id = await _insert_insight(user_id=user.id)
+
+    w1 = await dashboard_writer.add_widget(
+        dashboard_id, widget_type="insight", insight_id=str(insight_id)
+    )
+    w2 = await dashboard_writer.add_widget(
+        dashboard_id,
+        widget_type="map",
+        config={"dataset_id": 4, "default_view": "map"},
+    )
+
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    # Position defaults to max+1 (append at the end).
+    assert [(str(w.id), w.position) for w in row.widgets] == [
+        (w1, 0),
+        (w2, 1),
+    ]
+    assert row.widgets[0].insight_id == insight_id
+    assert row.widgets[1].config == {"dataset_id": 4, "default_view": "map"}
+
+    # Reorder + config update.
+    assert await dashboard_writer.update_widget(w2, position=0) is True
+    assert (
+        await dashboard_writer.update_widget(
+            w1, position=1, config={"default_view": "table"}
+        )
+        is True
+    )
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    assert [str(w.id) for w in row.widgets] == [w2, w1]
+    assert row.widgets[1].config == {"default_view": "table"}
+
+    # Remove: the widget goes, the insight stays.
+    assert await dashboard_writer.remove_widget(w1) is True
+    assert await _widget_ids(dashboard_id) == [UUID(w2)]
+    async with async_session_maker() as session:
+        assert await session.get(InsightOrm, insight_id) is not None
+
+    # Missing / malformed ids are not-found, not errors.
+    assert await dashboard_writer.remove_widget(w1) is False
+    assert await dashboard_writer.update_widget("not-a-uuid") is False
+    assert (
+        await dashboard_writer.add_widget(str(uuid4()), widget_type="map")
+        is None
+    )
+
+
+async def test_add_to_dashboard_tool_owner_only_edit(user, user_ds):
+    """The full tool path: own dashboard editable, someone else's is not."""
+    theirs = await dashboard_writer.create_dashboard(
+        user_id=user_ds.id, name="Theirs", aois=[PARANA]
+    )
+    mine = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Mine", aois=[PARANA]
+    )
+    insight_id = await _insert_insight(user_id=user.id)
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        denied = await add_to_dashboard.coroutine(
+            insight_id=str(insight_id),
+            dashboard_id=theirs,
+            state={},
+            tool_call_id="t1",
+        )
+        allowed = await add_to_dashboard.coroutine(
+            insight_id=str(insight_id),
+            dashboard_id=mine,
+            state={},
+            tool_call_id="t2",
+        )
+
+    assert denied.update["messages"][0].status == "error"
+    assert await _widget_ids(theirs) == []
+
+    message = allowed.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata["msg_type"] == "dashboard_updated"
+    assert message.response_metadata["dashboard_id"] == mine
+    assert allowed.update["dashboard_id"] == mine
+    assert len(await _widget_ids(mine)) == 1
+
+
+async def test_update_and_delete_dashboard(user):
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Old name", aois=[PARANA]
+    )
+    insight_id = await _insert_insight(user_id=user.id)
+    await dashboard_writer.add_widget(
+        dashboard_id, widget_type="insight", insight_id=str(insight_id)
+    )
+
+    assert (
+        await dashboard_writer.update_dashboard(
+            dashboard_id, name="New name", description="Now described"
+        )
+        is True
+    )
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    assert (row.name, row.description) == ("New name", "Now described")
+
+    # Delete removes the dashboard with its AOIs and widgets ...
+    assert await dashboard_writer.delete_dashboard(dashboard_id) is True
+    assert await dashboard_writer.get_dashboard(dashboard_id) is None
+    async with async_session_maker() as session:
+        aois = (await session.execute(select(DashboardAoiOrm))).scalars().all()
+        widgets = (
+            (await session.execute(select(DashboardWidgetOrm))).scalars().all()
+        )
+        # ... but the referenced insight is left intact.
+        insight = await session.get(InsightOrm, insight_id)
+    assert aois == []
+    assert widgets == []
+    assert insight is not None
+
+    assert await dashboard_writer.delete_dashboard(dashboard_id) is False
+    assert await dashboard_writer.delete_dashboard("not-a-uuid") is False
+    assert await dashboard_writer.update_dashboard("not-a-uuid") is False
+
+
+async def test_publish_cascades_to_referenced_insights(user, user_ds):
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    private_insight = await _insert_insight(user_id=user.id)
+    public_insight = await _insert_insight(user_id=user.id, is_public=True)
+    unreferenced = await _insert_insight(user_id=user.id)
+    for insight_id in (private_insight, public_insight):
+        await dashboard_writer.add_widget(
+            dashboard_id, widget_type="insight", insight_id=str(insight_id)
+        )
+
+    publicized = await dashboard_writer.set_dashboard_public(
+        dashboard_id, True
+    )
+    # Only the insight that actually flipped is reported.
+    assert publicized == [str(private_insight)]
+
+    async with async_session_maker() as session:
+        assert (await session.get(DashboardOrm, UUID(dashboard_id))).is_public
+        assert (await session.get(InsightOrm, private_insight)).is_public
+        assert (await session.get(InsightOrm, public_insight)).is_public
+        # Insights not on the dashboard are untouched.
+        assert not (await session.get(InsightOrm, unreferenced)).is_public
+
+    # Unpublishing does not cascade — the insights may be shared elsewhere.
+    assert (
+        await dashboard_writer.set_dashboard_public(dashboard_id, False) == []
+    )
+    async with async_session_maker() as session:
+        assert not (
+            await session.get(DashboardOrm, UUID(dashboard_id))
+        ).is_public
+        assert (await session.get(InsightOrm, private_insight)).is_public
+
+    assert (
+        await dashboard_writer.set_dashboard_public(str(uuid4()), True) is None
+    )
+    assert (
+        await dashboard_writer.set_dashboard_public("not-a-uuid", True) is None
+    )
+
+
+async def test_deleting_insight_cascades_widget_removal(user):
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    insight_id = await _insert_insight(user_id=user.id)
+    await dashboard_writer.add_widget(
+        dashboard_id, widget_type="insight", insight_id=str(insight_id)
+    )
+    keeper = await dashboard_writer.add_widget(
+        dashboard_id, widget_type="map", config={"dataset_id": 4}
+    )
+
+    async with async_session_maker() as session:
+        insight = await session.get(InsightOrm, insight_id)
+        await session.delete(insight)
+        await session.commit()
+
+    # The widget referencing the insight is silently dropped (FK ON DELETE
+    # CASCADE); the dashboard and its other widgets survive.
+    assert await _widget_ids(dashboard_id) == [UUID(keeper)]
+    assert await dashboard_writer.get_dashboard(dashboard_id) is not None

--- a/tests/agent/test_dashboards_db.py
+++ b/tests/agent/test_dashboards_db.py
@@ -20,6 +20,7 @@ from src.api.data_models import (
     InsightOrm,
 )
 from src.api.repositories import dashboard_writer
+from src.shared.config import SharedSettings
 from src.shared.request_context import bound_user_id
 from tests.conftest import async_session_maker
 
@@ -173,6 +174,34 @@ async def test_map_widget_persists_config(user):
     assert widget.widget_type == "map"
     assert widget.insight_id is None
     assert widget.config == config
+
+
+async def test_map_widget_eoapi_tile_url_persisted_host_less(user):
+    # Tile URLs on the configured eoapi host are stored as a relative
+    # tile_path so a host rotation (a config change) never orphans persisted
+    # widgets; the API read path prepends the current host again.
+    base = SharedSettings.eoapi_base_url.rstrip("/")
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    config = {
+        "default_view": "map",
+        "dataset": {
+            "dataset_name": "Tree cover loss",
+            "tile_url": f"{base}/raster/tiles/{{z}}/{{x}}/{{y}}.png?tcd=30",
+        },
+    }
+
+    await dashboard_writer.add_widget(
+        dashboard_id, widget_type="map", config=config
+    )
+
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    (widget,) = row.widgets
+    assert widget.config["dataset"] == {
+        "dataset_name": "Tree cover loss",
+        "tile_path": "/raster/tiles/{z}/{x}/{y}.png?tcd=30",
+    }
 
 
 async def test_add_to_dashboard_tool_owner_only_edit(user, user_ds):

--- a/tests/agent/test_dashboards_db.py
+++ b/tests/agent/test_dashboards_db.py
@@ -10,6 +10,7 @@ multiple AOIs (portfolio-ready schema).
 
 from uuid import UUID, uuid4
 
+import pytest
 from sqlalchemy import select
 
 from src.agent.tools.add_to_dashboard import add_to_dashboard
@@ -202,6 +203,79 @@ async def test_map_widget_eoapi_tile_url_persisted_host_less(user):
         "dataset_name": "Tree cover loss",
         "tile_path": "/raster/tiles/{z}/{x}/{y}.png?tcd=30",
     }
+
+
+async def test_add_widget_same_insight_twice_raises(user):
+    """The partial unique index makes insight adds idempotent: a retry
+    (agent after an ambiguous error, REST after a dropped response) raises
+    instead of silently duplicating the widget."""
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    other_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Other", aois=[PARANA]
+    )
+    insight_id = await _insert_insight(user_id=user.id)
+
+    first = await dashboard_writer.add_widget(
+        dashboard_id, widget_type="insight", insight_id=str(insight_id)
+    )
+    assert first is not None
+
+    with pytest.raises(dashboard_writer.DuplicateInsightWidgetError):
+        await dashboard_writer.add_widget(
+            dashboard_id, widget_type="insight", insight_id=str(insight_id)
+        )
+
+    # Only insight widgets dedupe; the same insight on another dashboard and
+    # additional map widgets are fine.
+    assert (
+        await dashboard_writer.add_widget(
+            other_id, widget_type="insight", insight_id=str(insight_id)
+        )
+        is not None
+    )
+    for _ in range(2):
+        assert (
+            await dashboard_writer.add_widget(
+                dashboard_id,
+                widget_type="map",
+                config={"dataset": {"tile_url": "https://t/{z}"}},
+            )
+            is not None
+        )
+
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    assert len(row.widgets) == 3  # one insight + two maps
+
+
+async def test_add_to_dashboard_tool_reports_duplicate(user):
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    insight_id = await _insert_insight(user_id=user.id)
+
+    with bound_user_id(user.id):
+        first = await add_to_dashboard.coroutine(
+            insight_id=str(insight_id),
+            dashboard_id=dashboard_id,
+            state={},
+            tool_call_id="t1",
+        )
+        again = await add_to_dashboard.coroutine(
+            insight_id=str(insight_id),
+            dashboard_id=dashboard_id,
+            state={},
+            tool_call_id="t2",
+        )
+
+    assert first.update["messages"][0].status == "success"
+    message = again.update["messages"][0]
+    assert message.status == "error"
+    assert "already on dashboard" in message.content
+
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    assert len(row.widgets) == 1
 
 
 async def test_add_to_dashboard_tool_owner_only_edit(user, user_ds):

--- a/tests/agent/test_dashboards_db.py
+++ b/tests/agent/test_dashboards_db.py
@@ -143,6 +143,38 @@ async def test_widget_add_reorder_remove(user):
     )
 
 
+async def test_map_widget_persists_config(user):
+    # A map widget's config is a self-contained layer snapshot (nested dicts,
+    # lists, nulls) that must round-trip through JSONB unchanged.
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    config = {
+        "default_view": "map",
+        "dataset": {
+            "dataset_id": 4,
+            "dataset_name": "Tree cover loss",
+            "tile_url": "https://tiles.example.com/{z}/{x}/{y}.png?t=30",
+            "context_layer": None,
+            "context_layers": [{"name": "driver", "tile_url": "https://d"}],
+            "parameters": [{"name": "canopy_cover", "values": [30]}],
+            "start_date": "2024-01-01",
+            "end_date": None,
+        },
+    }
+
+    widget_id = await dashboard_writer.add_widget(
+        dashboard_id, widget_type="map", config=config
+    )
+
+    row = await dashboard_writer.get_dashboard(dashboard_id)
+    (widget,) = row.widgets
+    assert str(widget.id) == widget_id
+    assert widget.widget_type == "map"
+    assert widget.insight_id is None
+    assert widget.config == config
+
+
 async def test_add_to_dashboard_tool_owner_only_edit(user, user_ds):
     """The full tool path: own dashboard editable, someone else's is not."""
     theirs = await dashboard_writer.create_dashboard(

--- a/tests/agent/test_dashboards_db.py
+++ b/tests/agent/test_dashboards_db.py
@@ -10,7 +10,6 @@ multiple AOIs (portfolio-ready schema).
 
 from uuid import UUID, uuid4
 
-import structlog
 from sqlalchemy import select
 
 from src.agent.tools.add_to_dashboard import add_to_dashboard
@@ -21,6 +20,7 @@ from src.api.data_models import (
     InsightOrm,
 )
 from src.api.repositories import dashboard_writer
+from src.shared.request_context import bound_user_id
 from tests.conftest import async_session_maker
 
 PARANA = {
@@ -185,7 +185,7 @@ async def test_add_to_dashboard_tool_owner_only_edit(user, user_ds):
     )
     insight_id = await _insert_insight(user_id=user.id)
 
-    with structlog.contextvars.bound_contextvars(user_id=user.id):
+    with bound_user_id(user.id):
         denied = await add_to_dashboard.coroutine(
             insight_id=str(insight_id),
             dashboard_id=theirs,

--- a/tests/agent/test_insights_db.py
+++ b/tests/agent/test_insights_db.py
@@ -9,7 +9,6 @@ replacement + provenance preservation in `update_insight`.
 from datetime import datetime
 from uuid import uuid4
 
-import structlog
 from sqlalchemy import func, select
 
 from src.agent.subagents.analyst.charts.model import Insight, InsightChart
@@ -17,6 +16,7 @@ from src.agent.tools.search_insights import _search_insights
 from src.agent.tools.update_insight_display import _load_editable_insight
 from src.api.data_models import InsightChartOrm, InsightOrm
 from src.api.repositories.insight_writer import update_insight
+from src.shared.request_context import bound_user_id
 from tests.conftest import async_session_maker
 
 
@@ -91,7 +91,7 @@ async def test_search_returns_own_and_public_only(user, user_ds):
         user_id=None, text="Ownerless Amazon CLI insight."
     )
 
-    with structlog.contextvars.bound_contextvars(user_id=user.id):
+    with bound_user_id(user.id):
         rows = await _search_insights("amazon")
 
     assert {row.id for row in rows} == {own, theirs_public}
@@ -112,7 +112,7 @@ async def test_invisible_rows_do_not_consume_the_limit(user, user_ds):
             created_at=datetime(2026, 6, day),
         )
 
-    with structlog.contextvars.bound_contextvars(user_id=user.id):
+    with bound_user_id(user.id):
         rows = await _search_insights("amazon", limit=1)
 
     assert [row.id for row in rows] == [own]
@@ -126,7 +126,7 @@ async def test_search_matches_chart_title_and_data(user):
         chart_data=[{"country": "Brazil", "fires": 120}],
     )
 
-    with structlog.contextvars.bound_contextvars(user_id=user.id):
+    with bound_user_id(user.id):
         by_title = await _search_insights("para fires")
         by_data = await _search_insights("brazil")
 
@@ -141,7 +141,7 @@ async def test_load_editable_insight_owner_only(user, user_ds):
     )
     ownerless = await _insert_insight(user_id=None, text="Ownerless.")
 
-    with structlog.contextvars.bound_contextvars(user_id=user.id):
+    with bound_user_id(user.id):
         assert (await _load_editable_insight(str(own))).id == own
         assert await _load_editable_insight(str(theirs)) is None
         assert await _load_editable_insight(str(ownerless)) is None

--- a/tests/agent/test_insights_db.py
+++ b/tests/agent/test_insights_db.py
@@ -1,0 +1,196 @@
+"""DB-integration tests for insight recall and in-place update.
+
+These exercise the real SQL paths the tool unit tests mock out: the shared
+visibility clause in `_search_insights` (including its interaction with
+LIMIT), the ownership rule in `_load_editable_insight`, and the chart
+replacement + provenance preservation in `update_insight`.
+"""
+
+from datetime import datetime
+from uuid import uuid4
+
+import structlog
+from sqlalchemy import func, select
+
+from src.agent.subagents.analyst.charts.model import Insight, InsightChart
+from src.agent.tools.search_insights import _search_insights
+from src.agent.tools.update_insight_display import _load_editable_insight
+from src.api.data_models import InsightChartOrm, InsightOrm
+from src.api.repositories.insight_writer import update_insight
+from tests.conftest import async_session_maker
+
+
+async def _insert_insight(
+    *,
+    user_id,
+    text,
+    is_public=False,
+    created_at=datetime(2026, 6, 1),
+    chart_title="Annual tree cover loss",
+    chart_data=None,
+):
+    async with async_session_maker() as session:
+        row = InsightOrm(
+            user_id=user_id,
+            thread_id="thread-1",
+            insight_text=text,
+            follow_up_suggestions=["old follow-up"],
+            statistics_ids=["stat-1"],
+            codeact_types=["code"],
+            codeact_contents=["cHJpbnQoKQ=="],
+            is_public=is_public,
+            created_at=created_at,
+        )
+        session.add(row)
+        await session.flush()
+        session.add(
+            InsightChartOrm(
+                insight_id=row.id,
+                position=0,
+                title=chart_title,
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss",
+                chart_data=chart_data or [{"year": 2020, "loss": 5}],
+            )
+        )
+        await session.commit()
+        return row.id
+
+
+def _revised_insight():
+    return Insight(
+        charts=[
+            InsightChart(
+                position=0,
+                title="New title",
+                chart_type="line",
+                x_axis="year",
+                y_axis="loss",
+                chart_data=[{"year": 2020, "loss": 5}],
+            )
+        ],
+        primary_insight="New summary.",
+        follow_up_suggestions=["new follow-up"],
+    ).stamp_insight()
+
+
+async def test_search_returns_own_and_public_only(user, user_ds):
+    own = await _insert_insight(
+        user_id=user.id, text="Tree cover loss in the Amazon rose."
+    )
+    theirs_public = await _insert_insight(
+        user_id=user_ds.id,
+        text="Amazon fires spiked in 2025.",
+        is_public=True,
+    )
+    await _insert_insight(  # other's private: must not appear
+        user_id=user_ds.id, text="Private Amazon deforestation note."
+    )
+    await _insert_insight(  # ownerless: must not appear
+        user_id=None, text="Ownerless Amazon CLI insight."
+    )
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        rows = await _search_insights("amazon")
+
+    assert {row.id for row in rows} == {own, theirs_public}
+
+
+async def test_invisible_rows_do_not_consume_the_limit(user, user_ds):
+    own = await _insert_insight(
+        user_id=user.id,
+        text="Tree cover loss in the Amazon rose.",
+        created_at=datetime(2026, 6, 1),
+    )
+    # Newer matching rows the user may not see: with the visibility filter
+    # applied after LIMIT these would crowd out the real match.
+    for day in range(2, 5):
+        await _insert_insight(
+            user_id=user_ds.id,
+            text="Private Amazon note.",
+            created_at=datetime(2026, 6, day),
+        )
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        rows = await _search_insights("amazon", limit=1)
+
+    assert [row.id for row in rows] == [own]
+
+
+async def test_search_matches_chart_title_and_data(user):
+    insight_id = await _insert_insight(
+        user_id=user.id,
+        text="Deforestation summary.",
+        chart_title="Fires in Para",
+        chart_data=[{"country": "Brazil", "fires": 120}],
+    )
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        by_title = await _search_insights("para fires")
+        by_data = await _search_insights("brazil")
+
+    assert insight_id in {row.id for row in by_title}
+    assert insight_id in {row.id for row in by_data}
+
+
+async def test_load_editable_insight_owner_only(user, user_ds):
+    own = await _insert_insight(user_id=user.id, text="Mine.")
+    theirs = await _insert_insight(
+        user_id=user_ds.id, text="Theirs.", is_public=True
+    )
+    ownerless = await _insert_insight(user_id=None, text="Ownerless.")
+
+    with structlog.contextvars.bound_contextvars(user_id=user.id):
+        assert (await _load_editable_insight(str(own))).id == own
+        assert await _load_editable_insight(str(theirs)) is None
+        assert await _load_editable_insight(str(ownerless)) is None
+        assert await _load_editable_insight("not-a-uuid") is None
+
+    # Without an authenticated user nothing is editable.
+    assert await _load_editable_insight(str(own)) is None
+
+
+async def test_update_insight_replaces_charts_preserves_provenance(user):
+    insight_id = await _insert_insight(user_id=user.id, text="Old summary.")
+
+    assert await update_insight(str(insight_id), _revised_insight()) is True
+
+    async with async_session_maker() as session:
+        row = await session.get(InsightOrm, insight_id)
+        charts = (
+            (
+                await session.execute(
+                    select(InsightChartOrm).where(
+                        InsightChartOrm.insight_id == insight_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        orphans = await session.scalar(
+            select(func.count())
+            .select_from(InsightChartOrm)
+            .where(InsightChartOrm.insight_id != insight_id)
+        )
+
+    # Display layer replaced...
+    assert row.insight_text == "New summary."
+    assert row.follow_up_suggestions == ["new follow-up"]
+    assert len(charts) == 1
+    assert charts[0].title == "New title"
+    assert charts[0].chart_type == "line"
+    assert orphans == 0
+    # ...provenance untouched.
+    assert row.user_id == user.id
+    assert row.thread_id == "thread-1"
+    assert row.statistics_ids == ["stat-1"]
+    assert row.codeact_types == ["code"]
+    assert row.codeact_contents == ["cHJpbnQoKQ=="]
+    assert row.created_at == datetime(2026, 6, 1)
+
+
+async def test_update_insight_missing_or_malformed_id():
+    assert await update_insight(str(uuid4()), _revised_insight()) is False
+    assert await update_insight("not-a-uuid", _revised_insight()) is False

--- a/tests/agent/test_inspect_view_context.py
+++ b/tests/agent/test_inspect_view_context.py
@@ -11,6 +11,8 @@ from src.agent.middleware import format_session_block
 from src.agent.tools.inspect_view_context import (
     _chart_variables,
     _extract_insight_ids,
+    _format_map_widget,
+    format_dashboard,
     format_insights,
     format_view_context,
     inspect_view_context,
@@ -134,6 +136,91 @@ def test_format_insights_prints_key_content():
     assert "x=year, y=loss_ha" in out
     assert "2 data point(s)" in out
     assert "Follow-ups: Compare to fires; Break down by driver" in out
+
+
+def test_format_map_widget_dataset():
+    line = _format_map_widget(
+        {
+            "dataset": {
+                "dataset_name": "Tree cover loss",
+                "tile_url": "https://tiles.example.com/{z}/{x}/{y}.png",
+                "start_date": "2024-01-01",
+                "end_date": "2024-12-31",
+                "context_layer": "driver",
+            }
+        }
+    )
+    assert line == (
+        "map: dataset 'Tree cover loss' (2024-01-01–2024-12-31), "
+        "context layer driver"
+    )
+    assert "tile_url" not in line
+
+
+def test_format_map_widget_imagery():
+    line = _format_map_widget(
+        {
+            "imagery": {
+                "tile_url": "https://tiles.example.com/{z}/{x}/{y}.png",
+                "target_date": "2024-06-01",
+                "aoi_names": ["Paraná", "Santa Catarina"],
+            }
+        }
+    )
+    assert line == (
+        "map: Sentinel-2 imagery around 2024-06-01 (Paraná, Santa Catarina)"
+    )
+    assert "tiles.example.com" not in line
+
+
+def test_format_map_widget_unknown_config():
+    assert _format_map_widget({}) is None
+    assert _format_map_widget({"default_view": "map"}) is None
+
+
+@pytest.mark.asyncio
+async def test_format_dashboard_summarizes_map_widgets():
+    dashboard = SimpleNamespace(
+        id=uuid4(),
+        name="Paraná",
+        description=None,
+        aois=[
+            SimpleNamespace(
+                name="Paraná", source="gadm", subtype="state-province"
+            )
+        ],
+        widgets=[
+            SimpleNamespace(
+                widget_type="map",
+                position=0,
+                insight_id=None,
+                config={
+                    "dataset": {
+                        "dataset_name": "Tree cover loss",
+                        "tile_url": "https://t/{z}",
+                        "start_date": "2024-01-01",
+                        "end_date": "2024-12-31",
+                    }
+                },
+            ),
+            SimpleNamespace(
+                widget_type="map",
+                position=1,
+                insight_id=None,
+                config={
+                    "imagery": {
+                        "tile_url": "https://t/{z}",
+                        "target_date": "2024-06-01",
+                        "aoi_names": ["Paraná"],
+                    }
+                },
+            ),
+        ],
+    )
+    out = await format_dashboard(dashboard)
+    assert "map: dataset 'Tree cover loss' (2024-01-01–2024-12-31)" in out
+    assert "map: Sentinel-2 imagery around 2024-06-01 (Paraná)" in out
+    assert "https://t/{z}" not in out
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_search_insights.py
+++ b/tests/agent/test_search_insights.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 
 from src.agent.tools.search_insights import (
+    _escape_like,
     _score,
     _terms,
     search_insights,
@@ -53,6 +54,10 @@ def test_terms_drops_short_tokens_and_lowercases():
         "the",
         "amazon",
     ]
+
+
+def test_escape_like_escapes_metacharacters():
+    assert _escape_like("100%_gain\\") == "100\\%\\_gain\\\\"
 
 
 def test_score_rewards_phrase_match():
@@ -108,6 +113,15 @@ async def test_search_insights_picks_highest_scoring():
             query="tree cover amazon", tool_call_id="t1"
         )
     assert command.update["insight_id"] == str(strong.id)
+
+
+@pytest.mark.asyncio
+async def test_search_insights_rejects_empty_query():
+    # No DB call: an empty query would ILIKE-match every insight.
+    command = await search_insights.coroutine(query="  ", tool_call_id="t1")
+    assert command.update["messages"][0].status == "error"
+    assert "too short" in _content(command)
+    assert "insight_id" not in command.update
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_search_insights.py
+++ b/tests/agent/test_search_insights.py
@@ -1,0 +1,123 @@
+"""Tests for the search_insights agent tool."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.agent.tools.search_insights import (
+    _score,
+    _terms,
+    search_insights,
+)
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _fake_insight(**kwargs):
+    """Object shaped like InsightOrm (+ chart rows)."""
+    defaults = dict(
+        id=uuid4(),
+        user_id="user-1",
+        is_public=False,
+        insight_text="Tree cover loss in the Amazon rose 12% over the period.",
+        follow_up_suggestions=["Compare to fires"],
+        created_at=datetime(2026, 6, 1),
+        charts=[
+            SimpleNamespace(
+                position=0,
+                title="Annual tree cover loss",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss_ha",
+                color_field="",
+                stack_field="",
+                group_field="",
+                series_fields=[],
+                chart_data=[{"year": 2020, "loss_ha": 5}],
+            )
+        ],
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_terms_drops_short_tokens_and_lowercases():
+    assert _terms("Tree cover IN the Amazon") == [
+        "tree",
+        "cover",
+        "the",
+        "amazon",
+    ]
+
+
+def test_score_rewards_phrase_match():
+    row = _fake_insight()
+    terms = _terms("amazon tree cover")
+    phrase_hit = _score(row, terms, "tree cover loss in the amazon")
+    scattered = _score(row, terms, "amazon tree cover")
+    assert phrase_hit > scattered > 0
+
+
+@pytest.mark.asyncio
+async def test_search_insights_surfaces_best_match():
+    insight = _fake_insight()
+    with patch(
+        "src.agent.tools.search_insights._search_insights",
+        new=AsyncMock(return_value=[insight]),
+    ):
+        command = await search_insights.coroutine(
+            query="tree cover in the amazon", tool_call_id="t1"
+        )
+
+    # Surfaced into state exactly like the generator would.
+    assert command.update["insight_id"] == str(insight.id)
+    assert "Tree cover loss" in command.update["insight"]
+    assert (
+        command.update["charts_data"][0]["title"] == "Annual tree cover loss"
+    )
+    assert command.update["charts_data"][0]["type"] == "bar"
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    # Frontend treats it as an update (re-fetch/replace by id), not a new card.
+    assert message.response_metadata["msg_type"] == "insight_updated"
+    assert message.response_metadata["insight_id"] == str(insight.id)
+    assert "Found a past insight" in message.content
+
+
+@pytest.mark.asyncio
+async def test_search_insights_picks_highest_scoring():
+    weak = _fake_insight(
+        insight_text="Fire alerts spiked in Indonesia.",
+        created_at=datetime(2026, 6, 10),  # newer, but weaker match
+        charts=[],
+    )
+    strong = _fake_insight(
+        insight_text="Tree cover loss in the Amazon rose sharply.",
+        created_at=datetime(2026, 6, 1),
+    )
+    with patch(
+        "src.agent.tools.search_insights._search_insights",
+        new=AsyncMock(return_value=[weak, strong]),
+    ):
+        command = await search_insights.coroutine(
+            query="tree cover amazon", tool_call_id="t1"
+        )
+    assert command.update["insight_id"] == str(strong.id)
+
+
+@pytest.mark.asyncio
+async def test_search_insights_no_match():
+    with patch(
+        "src.agent.tools.search_insights._search_insights",
+        new=AsyncMock(return_value=[]),
+    ):
+        command = await search_insights.coroutine(
+            query="penguins in antarctica", tool_call_id="t1"
+        )
+    assert "No past insight matched" in _content(command)
+    assert "insight_id" not in command.update

--- a/tests/agent/test_update_insight_display.py
+++ b/tests/agent/test_update_insight_display.py
@@ -1,0 +1,177 @@
+"""Tests for the update_insight_display tool and its merge logic."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.agent.subagents.analyst.charts.model import InsightChart
+from src.agent.subagents.analyst.display_reviser import (
+    RevisedChart,
+    RevisedInsight,
+)
+from src.agent.tools.update_insight_display import (
+    _apply_revision,
+    update_insight_display,
+)
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _original_chart():
+    return InsightChart(
+        position=0,
+        title="Old title",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="loss",
+        chart_data=[{"year": 2020, "loss": 5, "gain": 2}],
+    )
+
+
+def _fake_orm_row(**kwargs):
+    """Object shaped like InsightOrm (+ chart rows) for the load path."""
+    defaults = dict(
+        id=uuid4(),
+        user_id="user-1",
+        insight_text="Old summary.",
+        follow_up_suggestions=["old follow-up"],
+        charts=[
+            SimpleNamespace(
+                position=0,
+                title="Old title",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss",
+                color_field="",
+                stack_field="",
+                group_field="",
+                series_fields=[],
+                chart_data=[{"year": 2020, "loss": 5, "gain": 2}],
+            )
+        ],
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_apply_revision_restyles_and_keeps_data():
+    revised = RevisedInsight(
+        primary_insight="New summary",
+        follow_up_suggestions=["f1"],
+        charts=[
+            RevisedChart(
+                position=0,
+                title="New title",
+                chart_type="line",
+                x_axis="year",
+                y_axis="gain",  # different but existing column
+            )
+        ],
+    )
+    out = _apply_revision([_original_chart()], revised)
+    chart = out.charts[0]
+    assert out.primary_insight == "New summary"
+    assert out.follow_up_suggestions == ["f1"]
+    assert chart.title == "New title"
+    assert chart.chart_type == "line"
+    assert chart.y_axis == "gain"
+    # Underlying rows are untouched (no new data).
+    assert chart.chart_data == [{"year": 2020, "loss": 5, "gain": 2}]
+    # stamp_insight copies the primary onto each chart.
+    assert chart.insight == "New summary"
+
+
+def test_apply_revision_drops_unknown_columns():
+    revised = RevisedInsight(
+        primary_insight="x",
+        follow_up_suggestions=["f"],
+        charts=[
+            RevisedChart(
+                position=0,
+                title="Bad",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="does_not_exist",
+            )
+        ],
+    )
+    out = _apply_revision([_original_chart()], revised)
+    # Original chart is preserved untouched rather than producing a broken one.
+    assert out.charts[0].title == "Old title"
+    assert out.charts[0].y_axis == "loss"
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_no_target_errors():
+    command = await update_insight_display.coroutine(
+        instruction="make it a line chart", state={}, tool_call_id="t1"
+    )
+    assert command.update["messages"][0].status == "error"
+    assert "No insight to update" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_not_editable_errors():
+    with patch(
+        "src.agent.tools.update_insight_display._load_editable_insight",
+        new=AsyncMock(return_value=None),
+    ):
+        command = await update_insight_display.coroutine(
+            instruction="rename it",
+            insight_id=str(uuid4()),
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not editable" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_happy_path():
+    row = _fake_orm_row()
+    revised = RevisedInsight(
+        primary_insight="New summary",
+        follow_up_suggestions=["f1"],
+        charts=[
+            RevisedChart(
+                position=0, title="New title", chart_type="line", y_axis="gain"
+            )
+        ],
+    )
+    with (
+        patch(
+            "src.agent.tools.update_insight_display._load_editable_insight",
+            new=AsyncMock(return_value=row),
+        ),
+        patch(
+            "src.agent.tools.update_insight_display.InsightDisplayReviser.revise",
+            new=AsyncMock(return_value=revised),
+        ),
+        patch(
+            "src.agent.tools.update_insight_display.update_insight",
+            new=AsyncMock(return_value=True),
+        ) as mock_update,
+    ):
+        command = await update_insight_display.coroutine(
+            instruction="change to a line chart and reword",
+            state={"insight_id": str(row.id)},
+            tool_call_id="t1",
+        )
+
+    assert command.update["insight"] == "New summary"
+    assert command.update["follow_up_suggestions"] == ["f1"]
+    charts_data = command.update["charts_data"]
+    assert charts_data[0]["title"] == "New title"
+    assert charts_data[0]["type"] == "line"
+    # Persisted in place under the same id.
+    persisted_id, persisted_insight = mock_update.call_args.args
+    assert persisted_id == str(row.id)
+    assert persisted_insight.primary_insight == "New summary"
+    # Distinct signal so the frontend replaces the insight in place.
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata["msg_type"] == "insight_updated"
+    assert message.response_metadata["insight_id"] == str(row.id)

--- a/tests/agent/test_update_insight_display.py
+++ b/tests/agent/test_update_insight_display.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from src.agent.subagents.analyst.charts.model import InsightChart
 from src.agent.subagents.analyst.display_reviser import (
@@ -105,6 +106,42 @@ def test_apply_revision_drops_unknown_columns():
     assert out.charts[0].y_axis == "loss"
 
 
+def test_revised_chart_rejects_unknown_chart_type():
+    # chart_type is a Literal: an off-list value from the LLM fails structured
+    # output validation instead of being persisted for the frontend to choke on.
+    with pytest.raises(ValidationError):
+        RevisedChart(
+            position=0, title="Bad", chart_type="sankey", y_axis="loss"
+        )
+
+
+def test_apply_revision_finds_columns_in_later_rows():
+    # 'gain' only appears from the second data row on; the revision must not
+    # be dropped just because the first row lacks it.
+    original = InsightChart(
+        position=0,
+        title="Old title",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="loss",
+        chart_data=[
+            {"year": 2020, "loss": 5},
+            {"year": 2021, "loss": 3, "gain": 2},
+        ],
+    )
+    revised = RevisedInsight(
+        primary_insight="x",
+        follow_up_suggestions=["f"],
+        charts=[
+            RevisedChart(
+                position=0, title="Gain", chart_type="bar", y_axis="gain"
+            )
+        ],
+    )
+    out = _apply_revision([original], revised)
+    assert out.charts[0].y_axis == "gain"
+
+
 @pytest.mark.asyncio
 async def test_update_insight_display_no_target_errors():
     command = await update_insight_display.coroutine(
@@ -125,6 +162,16 @@ async def test_update_insight_display_not_editable_errors():
             insight_id=str(uuid4()),
             tool_call_id="t1",
         )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not editable" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_update_insight_display_malformed_id_errors():
+    # UUID parsing fails before any DB access; same error as "not found".
+    command = await update_insight_display.coroutine(
+        instruction="rename it", insight_id="not-a-uuid", tool_call_id="t1"
+    )
     assert command.update["messages"][0].status == "error"
     assert "not found or not editable" in _content(command)
 

--- a/tests/api/test_dashboards.py
+++ b/tests/api/test_dashboards.py
@@ -477,7 +477,30 @@ async def test_map_widget_config_accepted(client, auth_override):
     assert all(w["insight"] is None for w in widgets)
 
 
-@pytest.mark.asyncio
+async def test_add_same_insight_widget_twice_conflicts(client, auth_override):
+    """A retried POST cannot duplicate an insight widget: the second add
+    of the same insight to the same dashboard is a 409."""
+    user = await _create_user("widget-duplicate")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    insight = await _create_insight(user_id=user.id)
+
+    url = f"/api/dashboards/{dashboard['id']}/widgets"
+    body = {"widget_type": "insight", "insight_id": str(insight.id)}
+
+    first = await client.post(url, headers=AUTH, json=body)
+    assert first.status_code == 201
+
+    again = await client.post(url, headers=AUTH, json=body)
+    assert again.status_code == 409
+    assert "already on this dashboard" in again.json()["detail"]
+
+    rendered = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    assert len(rendered.json()["widgets"]) == 1
+
+
 async def test_map_widget_eoapi_tile_url_follows_host_rotation(
     client, auth_override, monkeypatch
 ):

--- a/tests/api/test_dashboards.py
+++ b/tests/api/test_dashboards.py
@@ -423,6 +423,99 @@ async def test_widget_insight_must_be_visible(client, auth_override):
 
 
 @pytest.mark.asyncio
+async def test_map_widget_config_accepted(client, auth_override):
+    user = await _create_user("map-widget-ok")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    dataset_config = {
+        "default_view": "map",
+        "dataset": {
+            "dataset_id": 4,
+            "dataset_name": "Tree cover loss",
+            "tile_url": "https://tiles.example.com/{z}/{x}/{y}.png",
+            "context_layer": None,
+            "context_layers": [],
+            "parameters": None,
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        },
+    }
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "map", "config": dataset_config},
+    )
+    assert response.status_code == 201
+
+    imagery_config = {
+        "default_view": "map",
+        "imagery": {
+            "tile_url": "https://tiles.example.com/mosaic/{z}/{x}/{y}.png",
+            "tilejson_url": "https://tiles.example.com/tilejson.json",
+            "mosaic_id": "abc123",
+            "target_date": "2024-06-01",
+            "window_days": 7,
+            "max_cloud_cover": 20,
+            "aoi_names": ["Paraná"],
+        },
+    }
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "map", "config": imagery_config},
+    )
+    assert response.status_code == 201
+
+    # Configs are echoed verbatim on the render endpoint; no insight payload.
+    rendered = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    widgets = rendered.json()["widgets"]
+    assert [w["config"] for w in widgets] == [dataset_config, imagery_config]
+    assert all(w["insight"] is None for w in widgets)
+
+
+@pytest.mark.asyncio
+async def test_map_widget_config_validated(client, auth_override):
+    user = await _create_user("map-widget-bad")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    url = f"/api/dashboards/{dashboard['id']}/widgets"
+    layer = {"tile_url": "https://t/{z}"}
+
+    bad_bodies = [
+        # No config at all.
+        {"widget_type": "map"},
+        # Neither dataset nor imagery.
+        {"widget_type": "map", "config": {"default_view": "map"}},
+        # Both at once.
+        {
+            "widget_type": "map",
+            "config": {"dataset": layer, "imagery": layer},
+        },
+        # Missing tile_url.
+        {"widget_type": "map", "config": {"dataset": {"dataset_id": 4}}},
+    ]
+    for body in bad_bodies:
+        response = await client.post(url, headers=AUTH, json=body)
+        assert response.status_code == 422, body
+
+    # Insight widgets keep their plain presentation config.
+    insight = await _create_insight(user_id=user.id)
+    response = await client.post(
+        url,
+        headers=AUTH,
+        json={
+            "widget_type": "insight",
+            "insight_id": str(insight.id),
+            "config": {"default_view": "chart"},
+        },
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.asyncio
 async def test_widget_add_reorder_remove(client, auth_override):
     user = await _create_user("widget-lifecycle")
     auth_override(user.id)
@@ -437,7 +530,13 @@ async def test_widget_add_reorder_remove(client, auth_override):
     map_widget = await client.post(
         f"/api/dashboards/{dashboard['id']}/widgets",
         headers=AUTH,
-        json={"widget_type": "map", "config": {"dataset_id": 4}},
+        json={
+            "widget_type": "map",
+            "config": {
+                "default_view": "map",
+                "dataset": {"dataset_id": 4, "tile_url": "https://t/{z}"},
+            },
+        },
     )
     widgets = map_widget.json()["widgets"]
     assert [w["position"] for w in widgets] == [0, 1]

--- a/tests/api/test_dashboards.py
+++ b/tests/api/test_dashboards.py
@@ -516,6 +516,43 @@ async def test_map_widget_config_validated(client, auth_override):
 
 
 @pytest.mark.asyncio
+async def test_text_widget_config_validated(client, auth_override):
+    user = await _create_user("text-widget")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    url = f"/api/dashboards/{dashboard['id']}/widgets"
+
+    bad_bodies = [
+        # No config at all.
+        {"widget_type": "text"},
+        # No text key.
+        {"widget_type": "text", "config": {"default_view": "chart"}},
+        # Non-string text.
+        {"widget_type": "text", "config": {"text": 42}},
+    ]
+    for body in bad_bodies:
+        response = await client.post(url, headers=AUTH, json=body)
+        assert response.status_code == 422, body
+
+    text_config = {"text": "## Notes\n\nDeforestation slowed in 2024."}
+    response = await client.post(
+        url,
+        headers=AUTH,
+        json={"widget_type": "text", "config": text_config},
+    )
+    assert response.status_code == 201
+
+    # Config echoed verbatim on the render endpoint; no insight payload.
+    rendered = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    widgets = rendered.json()["widgets"]
+    assert widgets[-1]["widget_type"] == "text"
+    assert widgets[-1]["config"] == text_config
+    assert widgets[-1]["insight"] is None
+
+
+@pytest.mark.asyncio
 async def test_widget_add_reorder_remove(client, auth_override):
     user = await _create_user("widget-lifecycle")
     auth_override(user.id)

--- a/tests/api/test_dashboards.py
+++ b/tests/api/test_dashboards.py
@@ -1,0 +1,530 @@
+"""Tests for dashboard endpoints: CRUD, widgets, publish cascade, auth."""
+
+import uuid
+
+import pytest
+
+from src.api.data_models import InsightOrm, UserOrm
+from tests.conftest import async_session_maker
+
+PARANA = {
+    "source": "gadm",
+    "src_id": "BRA.16_1",
+    "subtype": "state-province",
+    "name": "Paraná",
+}
+BRAZIL = {
+    "source": "gadm",
+    "src_id": "BRA",
+    "subtype": "country",
+    "name": "Brazil",
+}
+AUTH = {"Authorization": "Bearer t"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+async def _create_user(user_id: str) -> UserOrm:
+    async with async_session_maker() as session:
+        user = UserOrm(
+            id=user_id, name=user_id, email=f"{user_id}@example.com"
+        )
+        session.add(user)
+        await session.commit()
+        return user
+
+
+async def _create_insight(
+    *, user_id: str | None, is_public: bool = False
+) -> InsightOrm:
+    async with async_session_maker() as session:
+        row = InsightOrm(
+            user_id=user_id,
+            thread_id="thread-1",
+            insight_text="Sample insight text",
+            is_public=is_public,
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        return row
+
+
+async def _create_dashboard(client, *, name=None, aois=None) -> dict:
+    body = {"aois": aois or [PARANA]}
+    if name:
+        body["name"] = name
+    response = await client.post("/api/dashboards", headers=AUTH, json=body)
+    assert response.status_code == 201
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/dashboards
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_create_dashboard_requires_auth(client):
+    response = await client.post("/api/dashboards", json={"aois": [PARANA]})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_dashboard_name_defaults_to_aoi(client, auth_override):
+    user = await _create_user("dash-creator")
+    auth_override(user.id)
+
+    body = await _create_dashboard(client)
+    assert body["name"] == "Paraná"
+    assert body["user_id"] == user.id
+    assert body["is_public"] is False
+    assert body["widgets"] == []
+    assert len(body["aois"]) == 1
+    assert body["aois"][0]["src_id"] == "BRA.16_1"
+
+
+@pytest.mark.asyncio
+async def test_create_dashboard_two_aois_rejected(client, auth_override):
+    """The MVP single-area constraint is API validation, not schema."""
+    user = await _create_user("dash-multi")
+    auth_override(user.id)
+
+    response = await client.post(
+        "/api/dashboards",
+        headers=AUTH,
+        json={"aois": [PARANA, BRAZIL]},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_dashboard_zero_aois_rejected(client, auth_override):
+    user = await _create_user("dash-empty")
+    auth_override(user.id)
+
+    response = await client.post(
+        "/api/dashboards", headers=AUTH, json={"aois": []}
+    )
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/dashboards (list)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_list_dashboards_own_only_newest_first(client, auth_override):
+    owner = await _create_user("list-owner")
+    other = await _create_user("list-other")
+
+    auth_override(other.id)
+    await _create_dashboard(client, name="Other's")
+
+    auth_override(owner.id)
+    first = await _create_dashboard(client, name="First")
+    second = await _create_dashboard(client, name="Second")
+
+    response = await client.get("/api/dashboards", headers=AUTH)
+    assert response.status_code == 200
+    assert [d["id"] for d in response.json()] == [
+        second["id"],
+        first["id"],
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/dashboards/{id}
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_own_private_dashboard(client, auth_override):
+    user = await _create_user("get-owner")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    response = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    assert response.status_code == 200
+    assert response.json()["id"] == dashboard["id"]
+
+
+@pytest.mark.asyncio
+async def test_get_private_dashboard_other_user_returns_404(
+    client, auth_override
+):
+    owner = await _create_user("private-owner")
+    other = await _create_user("private-other")
+    auth_override(owner.id)
+    dashboard = await _create_dashboard(client)
+
+    auth_override(other.id)
+    response = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_private_dashboard_no_auth_returns_401(
+    client, auth_override
+):
+    user = await _create_user("noauth-owner")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    from src.api.app import app
+    from src.api.auth.dependencies import fetch_user_from_rw_api
+
+    app.dependency_overrides.pop(fetch_user_from_rw_api, None)
+    response = await client.get(f"/api/dashboards/{dashboard['id']}")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_dashboard_returns_404(client, auth_override):
+    await _create_user("get-miss")
+    auth_override("get-miss")
+
+    response = await client.get(
+        f"/api/dashboards/{uuid.uuid4()}", headers=AUTH
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_can_access_private_dashboard(
+    client, auth_override, admin_user_factory
+):
+    owner = await _create_user("admin-target-owner")
+    admin = await admin_user_factory("dash-admin@example.com")
+    auth_override(owner.id)
+    dashboard = await _create_dashboard(client)
+
+    auth_override(admin.id)
+    response = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_expands_insight_widgets(client, auth_override):
+    user = await _create_user("expand-owner")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    insight = await _create_insight(user_id=user.id)
+
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "insight", "insight_id": str(insight.id)},
+    )
+    assert response.status_code == 201
+
+    response = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    widget = response.json()["widgets"][0]
+    assert widget["widget_type"] == "insight"
+    assert widget["insight_id"] == str(insight.id)
+    # Same shape the insights endpoints return, nested in the widget.
+    assert widget["insight"]["insight_text"] == "Sample insight text"
+    assert widget["insight"]["id"] == str(insight.id)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/dashboards/{id}
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_rename_dashboard(client, auth_override):
+    user = await _create_user("rename-owner")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}",
+        headers=AUTH,
+        json={"name": "Renamed", "description": "With description"},
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "Renamed"
+    assert response.json()["description"] == "With description"
+
+
+@pytest.mark.asyncio
+async def test_rename_dashboard_other_user_returns_404(client, auth_override):
+    owner = await _create_user("rename-victim")
+    other = await _create_user("rename-attacker")
+    auth_override(owner.id)
+    dashboard = await _create_dashboard(client)
+
+    auth_override(other.id)
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}",
+        headers=AUTH,
+        json={"name": "Hijacked"},
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/dashboards/{id}/public
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_publish_cascades_to_insights_and_lists_them(
+    client, auth_override
+):
+    user = await _create_user("publish-owner")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    private_insight = await _create_insight(user_id=user.id)
+    public_insight = await _create_insight(user_id=user.id, is_public=True)
+    for insight in (private_insight, public_insight):
+        await client.post(
+            f"/api/dashboards/{dashboard['id']}/widgets",
+            headers=AUTH,
+            json={"widget_type": "insight", "insight_id": str(insight.id)},
+        )
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/public",
+        headers=AUTH,
+        json={"is_public": True},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["is_public"] is True
+    # Only the insight that actually flipped is listed.
+    assert body["publicized_insight_ids"] == [str(private_insight.id)]
+
+    # The dashboard and the cascaded insight are now readable anonymously.
+    from src.api.app import app
+    from src.api.auth.dependencies import fetch_user_from_rw_api
+
+    app.dependency_overrides.pop(fetch_user_from_rw_api, None)
+    anon = await client.get(f"/api/dashboards/{dashboard['id']}")
+    assert anon.status_code == 200
+    assert all(
+        widget["insight"] is not None for widget in anon.json()["widgets"]
+    )
+    assert (
+        await client.get(f"/api/insights/{private_insight.id}")
+    ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_unpublish_does_not_cascade(client, auth_override):
+    user = await _create_user("unpublish-owner")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    insight = await _create_insight(user_id=user.id)
+    await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "insight", "insight_id": str(insight.id)},
+    )
+    await client.patch(
+        f"/api/dashboards/{dashboard['id']}/public",
+        headers=AUTH,
+        json={"is_public": True},
+    )
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/public",
+        headers=AUTH,
+        json={"is_public": False},
+    )
+    assert response.status_code == 200
+    assert response.json()["is_public"] is False
+    assert response.json()["publicized_insight_ids"] == []
+
+    # The insight stays public — it may be shared elsewhere.
+    insight_response = await client.get(
+        f"/api/insights/{insight.id}", headers=AUTH
+    )
+    assert insight_response.json()["is_public"] is True
+
+
+@pytest.mark.asyncio
+async def test_publish_other_user_returns_404(client, auth_override):
+    owner = await _create_user("publish-victim")
+    other = await _create_user("publish-attacker")
+    auth_override(owner.id)
+    dashboard = await _create_dashboard(client)
+
+    auth_override(other.id)
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/public",
+        headers=AUTH,
+        json={"is_public": True},
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Widget endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_insight_widget_requires_insight_id(client, auth_override):
+    user = await _create_user("widget-no-insight")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "insight"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_widget_type_validated(client, auth_override):
+    user = await _create_user("widget-bad-type")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "carousel"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_widget_insight_must_be_visible(client, auth_override):
+    owner = await _create_user("widget-owner")
+    other = await _create_user("widget-other")
+    someone_elses_insight = await _create_insight(user_id=other.id)
+    auth_override(owner.id)
+    dashboard = await _create_dashboard(client)
+
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={
+            "widget_type": "insight",
+            "insight_id": str(someone_elses_insight.id),
+        },
+    )
+    assert response.status_code == 404
+
+    # A public insight owned by someone else is fine.
+    public_insight = await _create_insight(user_id=other.id, is_public=True)
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={
+            "widget_type": "insight",
+            "insight_id": str(public_insight.id),
+        },
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_widget_add_reorder_remove(client, auth_override):
+    user = await _create_user("widget-lifecycle")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    insight = await _create_insight(user_id=user.id)
+
+    created = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "insight", "insight_id": str(insight.id)},
+    )
+    map_widget = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "map", "config": {"dataset_id": 4}},
+    )
+    widgets = map_widget.json()["widgets"]
+    assert [w["position"] for w in widgets] == [0, 1]
+    insight_widget_id = created.json()["widgets"][0]["id"]
+    map_widget_id = widgets[1]["id"]
+
+    # Reorder.
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{map_widget_id}",
+        headers=AUTH,
+        json={"position": 0},
+    )
+    assert response.status_code == 200
+
+    # Remove; the insight itself survives.
+    response = await client.delete(
+        f"/api/dashboards/{dashboard['id']}/widgets/{insight_widget_id}",
+        headers=AUTH,
+    )
+    assert response.status_code == 204
+    remaining = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    assert [w["id"] for w in remaining.json()["widgets"]] == [map_widget_id]
+    assert (
+        await client.get(f"/api/insights/{insight.id}", headers=AUTH)
+    ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_widget_of_other_dashboard_returns_404(client, auth_override):
+    user = await _create_user("widget-cross")
+    auth_override(user.id)
+    dashboard_a = await _create_dashboard(client, name="A")
+    dashboard_b = await _create_dashboard(client, name="B")
+    insight = await _create_insight(user_id=user.id)
+    created = await client.post(
+        f"/api/dashboards/{dashboard_a['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "insight", "insight_id": str(insight.id)},
+    )
+    widget_id = created.json()["widgets"][0]["id"]
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard_b['id']}/widgets/{widget_id}",
+        headers=AUTH,
+        json={"position": 3},
+    )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/dashboards/{id}
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_delete_dashboard_leaves_insights(client, auth_override):
+    user = await _create_user("delete-owner")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    insight = await _create_insight(user_id=user.id)
+    await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "insight", "insight_id": str(insight.id)},
+    )
+
+    response = await client.delete(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    assert response.status_code == 204
+    assert (
+        await client.get(f"/api/dashboards/{dashboard['id']}", headers=AUTH)
+    ).status_code == 404
+    assert (
+        await client.get(f"/api/insights/{insight.id}", headers=AUTH)
+    ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_delete_dashboard_other_user_returns_404(client, auth_override):
+    owner = await _create_user("delete-victim")
+    other = await _create_user("delete-attacker")
+    auth_override(owner.id)
+    dashboard = await _create_dashboard(client)
+
+    auth_override(other.id)
+    response = await client.delete(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    assert response.status_code == 404

--- a/tests/api/test_dashboards.py
+++ b/tests/api/test_dashboards.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 
 from src.api.data_models import InsightOrm, UserOrm
+from src.shared.config import SharedSettings
 from tests.conftest import async_session_maker
 
 PARANA = {
@@ -474,6 +475,46 @@ async def test_map_widget_config_accepted(client, auth_override):
     widgets = rendered.json()["widgets"]
     assert [w["config"] for w in widgets] == [dataset_config, imagery_config]
     assert all(w["insight"] is None for w in widgets)
+
+
+@pytest.mark.asyncio
+async def test_map_widget_eoapi_tile_url_follows_host_rotation(
+    client, auth_override, monkeypatch
+):
+    """eoapi tile URLs are persisted host-less and reassembled per request,
+    so rotating the tile host (a config change) re-points every existing
+    map widget instead of orphaning it browser-side."""
+    user = await _create_user("map-widget-rotate")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    base = SharedSettings.eoapi_base_url.rstrip("/")
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={
+            "widget_type": "map",
+            "config": {
+                "default_view": "map",
+                "dataset": {
+                    "dataset_name": "Tree cover loss",
+                    "tile_url": f"{base}/raster/tiles/{{z}}/{{x}}/{{y}}.png",
+                },
+            },
+        },
+    )
+    assert response.status_code == 201
+
+    monkeypatch.setattr(
+        SharedSettings, "eoapi_base_url", "https://eoapi-next.example.org"
+    )
+    rendered = await client.get(
+        f"/api/dashboards/{dashboard['id']}", headers=AUTH
+    )
+    (widget,) = rendered.json()["widgets"]
+    assert widget["config"]["dataset"]["tile_url"] == (
+        "https://eoapi-next.example.org/raster/tiles/{z}/{x}/{y}.png"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
-import structlog
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import NullPool, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -22,6 +21,7 @@ from src.shared.database import (
     get_session_from_pool_dependency,
     initialize_global_pool,
 )
+from src.shared.request_context import bound_user_id
 
 # Test database settings
 if os.getenv("TEST_DATABASE_URL"):
@@ -220,8 +220,8 @@ async def thread_factory():
 
 @pytest.fixture(scope="function")
 def structlog_context():
-    """Provide structlog context with test user ID for all tests."""
-    with structlog.contextvars.bound_contextvars(user_id="test-user-123"):
+    """Bind the request-context test user ID for all tests."""
+    with bound_user_id("test-user-123"):
         yield
 
 

--- a/tests/tools/test_pick_aoi.py
+++ b/tests/tools/test_pick_aoi.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, patch
 
 import pandas as pd
 import pytest
-import structlog
 
 from src.agent.subagents.pick_aoi import Geocoder
 from src.agent.subagents.pick_aoi.tool import AOIIndex
+from src.shared.request_context import bound_user_id
 
 # Use session-scoped event loop to match conftest.py fixtures and avoid
 # "Event loop is closed" errors when running with other test modules
@@ -176,7 +176,7 @@ async def test_custom_area_selection(auth_override, client, structlog_context):
     assert create_response.status_code == 200
 
     # Ensure user_id is bound to structlog context for the pick_aoi call
-    with structlog.contextvars.bound_contextvars(user_id="test-user-123"):
+    with bound_user_id("test-user-123"):
         command = await Geocoder().lookup(
             question="Measure deforestation in My Custom Area",
             places=["My Custom Area"],

--- a/tests/tools/test_pull_data.py
+++ b/tests/tools/test_pull_data.py
@@ -4,7 +4,6 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 
 import pytest
-import structlog
 from sqlalchemy import select
 
 from src.agent.datasets.config import DATASETS
@@ -18,6 +17,7 @@ from src.api.app import app
 from src.api.auth.dependencies import fetch_user_from_rw_api
 from src.api.data_models import StatisticsOrm
 from src.api.schemas import UserModel
+from src.shared.request_context import bound_user_id
 from tests.conftest import async_session_maker
 
 # Use session-scoped event loop to match conftest.py fixtures and avoid
@@ -438,7 +438,7 @@ async def test_pull_data_custom_area(auth_override, client, structlog_context):
     }
     query = f"find commodities in {aoi_data['query_description']}"
     # Ensure user_id is bound to structlog context for the pick_aoi call
-    with structlog.contextvars.bound_contextvars(user_id="test-user-123"):
+    with bound_user_id("test-user-123"):
         tool_call = {
             "type": "tool_call",
             "name": "pull_data",

--- a/tests/unit/agent/test_tool_error_funnel.py
+++ b/tests/unit/agent/test_tool_error_funnel.py
@@ -1,0 +1,75 @@
+"""The generic tool-error funnel (graph.handle_tool_errors).
+
+It is the last-resort safety net for exceptions no tool anticipated, and the
+only place standing between a raw driver error and the browser: the returned
+ToolMessage is streamed to the client, so it must be marked as an error, name
+the tool, and never leak SQL/ORM text.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import structlog
+from langchain.messages import ToolMessage
+
+from src.agent.graph import handle_tool_errors
+
+pytestmark = pytest.mark.asyncio
+
+
+def _request(name="add_to_dashboard", args=None):
+    return SimpleNamespace(
+        tool_call={
+            "name": name,
+            "id": "call-123",
+            "args": args if args is not None else {},
+        }
+    )
+
+
+async def test_success_passes_through_untouched():
+    sentinel = ToolMessage(content="ok", tool_call_id="call-123")
+
+    async def handler(request):
+        return sentinel
+
+    result = await handle_tool_errors.awrap_tool_call(_request(), handler)
+    assert result is sentinel
+
+
+async def test_failure_returns_error_status_and_sanitized_content():
+    raw_error = 'relation "dashboard_widgets" does not exist\nSELECT * FROM'
+
+    async def handler(request):
+        raise RuntimeError(raw_error)
+
+    result = await handle_tool_errors.awrap_tool_call(_request(), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.tool_call_id == "call-123"
+    # The model sees which tool failed and the exception class...
+    assert "add_to_dashboard" in result.content
+    assert "RuntimeError" in result.content
+    # ...but never the raw driver text.
+    assert "dashboard_widgets" not in result.content
+    assert "SELECT" not in result.content
+
+
+async def test_failure_log_carries_tool_name_and_target_ids():
+    async def handler(request):
+        raise ValueError("boom")
+
+    request = _request(
+        args={"dashboard_id": "dash-1", "insight_id": "ins-9", "query": "x"}
+    )
+    with structlog.testing.capture_logs() as logs:
+        await handle_tool_errors.awrap_tool_call(request, handler)
+
+    (record,) = [r for r in logs if r["event"] == "tool_execution_failed"]
+    assert record["tool_name"] == "add_to_dashboard"
+    assert record["tool_call_id"] == "call-123"
+    assert record["dashboard_id"] == "dash-1"
+    assert record["insight_id"] == "ins-9"
+    # Free-text args are not ids; they stay out of the log fields.
+    assert "query" not in record

--- a/tests/unit/agent/test_view_pages.py
+++ b/tests/unit/agent/test_view_pages.py
@@ -1,0 +1,117 @@
+"""Tests for the view-page registry and its two renderings.
+
+Covers: page-aware session lines through format_session_block (Layer 1),
+the "# Current surface" prompt section through get_prompt (Layer 2), and
+the graceful fallback for unknown/absent pages.
+"""
+
+from src.agent.middleware import format_session_block
+from src.agent.view_pages import get_page, prompt_section
+
+MAP_STATE = {
+    "view_context": {
+        "page": "map",
+        "viewport": {"bbox": [-74, -34, -34, 5], "zoom": 5},
+        "visible_layers": [{"id": "tree-cover", "name": "Tree cover"}],
+        "visible_aois": [
+            {"source": "gadm", "src_id": "BRA.24_1", "name": "São Paulo"}
+        ],
+    }
+}
+
+DASHBOARD_STATE = {
+    "view_context": {
+        "page": "dashboard",
+        "dashboard_id": "5c9f7dd8-0000-0000-0000-000000000000",
+        "dashboard_name": "Paraná",
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry resolution
+# ---------------------------------------------------------------------------
+def test_get_page_resolves_registered_pages():
+    assert get_page(MAP_STATE["view_context"]).name == "map"
+    assert get_page(DASHBOARD_STATE["view_context"]).name == "dashboard"
+
+
+def test_get_page_unknown_or_malformed():
+    assert get_page(None) is None
+    assert get_page({}) is None
+    assert get_page({"page": "report"}) is None  # unregistered page
+    assert get_page({"page": {"nested": "junk"}}) is None  # not a string
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: session-block lines
+# ---------------------------------------------------------------------------
+def test_map_session_line_carries_scope_semantics():
+    block = format_session_block(MAP_STATE)
+    assert "View: map explorer" in block
+    assert "1 layer(s)" in block and "1 AOI(s) visible" in block
+    assert "'this area'" in block.lower() or "'Here'" in block
+    # Bulky detail stays behind the tool.
+    assert "BRA.24_1" not in block
+    assert "inspect_view_context" in block
+
+
+def test_dashboard_session_line_names_the_dashboard():
+    block = format_session_block(DASHBOARD_STATE)
+    assert "View: dashboard 'Paraná'" in block
+    assert "5c9f7dd8" in block
+    assert "add_to_dashboard targets it by default" in block
+
+
+def test_dashboard_session_line_without_name_or_id():
+    no_name = {
+        "view_context": {"page": "dashboard", "dashboard_id": "abc-123"}
+    }
+    assert "View: dashboard abc-123" in format_session_block(no_name)
+
+    bare = {"view_context": {"page": "dashboard"}}
+    assert "(id not reported)" in format_session_block(bare)
+
+
+def test_unregistered_page_falls_back_to_generic_breadcrumb():
+    state = {
+        "view_context": {
+            "page": "report",
+            "visible_insights": [{}, {}],
+        }
+    }
+    block = format_session_block(state)
+    assert "View: report page · 2 insight(s) on screen" in block
+    assert "call inspect_view_context for details" in block
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: system-prompt surface section
+# ---------------------------------------------------------------------------
+def test_prompt_section_for_registered_pages():
+    assert "map explorer" in prompt_section("map")
+    dashboard = prompt_section("dashboard")
+    assert "add_to_dashboard" in dashboard
+    assert "dashboard's area" in dashboard
+    assert "skill `dashboard`" in dashboard
+
+
+def test_prompt_section_unknown_is_none():
+    assert prompt_section(None) is None
+    assert prompt_section("report") is None
+    assert prompt_section("") is None
+
+
+def test_get_prompt_includes_surface_section_only_for_known_pages():
+    from src.agent.graph import get_prompt
+
+    plain = get_prompt()
+    assert "# Current surface" not in plain
+
+    dashboard = get_prompt(page="dashboard")
+    assert "# Current surface" in dashboard
+    assert "add_to_dashboard, which defaults to the dashboard" in dashboard
+    # The rest of the prompt is unchanged.
+    assert "# Routing" in dashboard
+
+    assert "# Current surface" not in get_prompt(page="report")

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -19,10 +19,11 @@ def test_load_skills():
     assert "ui-selections" not in names
 
 
-def test_skills_registry_is_the_six_recipes():
+def test_skills_registry_is_the_seven_recipes():
     assert {s.name for s in all_skills()} == {
         "analyze",
         "capabilities",
+        "dashboard",
         "explore",
         "pull-data",
         "wri-insights",

--- a/tests/unit/agent/tools/test_common.py
+++ b/tests/unit/agent/tools/test_common.py
@@ -1,0 +1,33 @@
+"""require_current_user_id — the identity read for authorization in tools.
+
+Every entry point binds a user id (chat requires auth, the CLI binds a
+default), so an unbound identity inside a tool means the request-context
+channel broke. The helper must fail loudly — raise into the tool-error
+funnel — and leave a searchable log event, never degrade silently.
+"""
+
+import pytest
+import structlog
+
+from src.agent.tools.common import require_current_user_id
+from src.shared.request_context import bound_user_id
+
+
+def test_returns_bound_user_id():
+    with bound_user_id("user-42"):
+        assert require_current_user_id("search_insights") == "user-42"
+
+
+def test_raises_and_logs_when_unbound():
+    with bound_user_id(None):
+        with structlog.testing.capture_logs() as logs:
+            with pytest.raises(
+                RuntimeError, match="without an authenticated user"
+            ):
+                require_current_user_id("search_insights")
+
+    (record,) = [
+        r for r in logs if r["event"] == "tool_invoked_without_identity"
+    ]
+    assert record["tool_name"] == "search_insights"
+    assert record["log_level"] == "error"

--- a/tests/unit/api/repositories/test_dashboard_writer.py
+++ b/tests/unit/api/repositories/test_dashboard_writer.py
@@ -1,0 +1,74 @@
+"""Unit tests for dashboard_writer's malformed-id contract.
+
+The module's documented rule: malformed UUIDs are treated as not-found
+(None/False), never an exception. These tests also pin down that the early
+return happens *before* a database session is opened — the DB pool is patched
+to fail loudly if touched.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.api.repositories import dashboard_writer
+from src.api.repositories.dashboard_writer import _parse_uuid
+
+BAD_IDS = ["not-a-uuid", "", None, 42, {"id": "x"}]
+
+
+@pytest.fixture(autouse=True)
+def no_database(monkeypatch):
+    """Fail the test if any function under test opens a DB session."""
+    pool = MagicMock(side_effect=AssertionError("must not open a DB session"))
+    monkeypatch.setattr(dashboard_writer, "get_session_from_pool", pool)
+
+
+class TestParseUuid:
+    def test_uuid_string(self):
+        value = uuid4()
+        assert _parse_uuid(str(value)) == value
+
+    def test_uuid_instance(self):
+        value = uuid4()
+        assert _parse_uuid(value) == value
+
+    @pytest.mark.parametrize("bad", BAD_IDS)
+    def test_malformed_is_none(self, bad):
+        assert _parse_uuid(bad) is None
+
+
+@pytest.mark.parametrize("bad", BAD_IDS)
+class TestMalformedIdsAreNotFound:
+    async def test_get_dashboard(self, bad):
+        assert await dashboard_writer.get_dashboard(bad) is None
+
+    async def test_add_widget(self, bad):
+        assert (
+            await dashboard_writer.add_widget(bad, widget_type="insight")
+            is None
+        )
+
+    async def test_update_widget(self, bad):
+        assert await dashboard_writer.update_widget(bad, position=1) is False
+
+    async def test_remove_widget(self, bad):
+        assert await dashboard_writer.remove_widget(bad) is False
+
+    async def test_update_dashboard(self, bad):
+        assert await dashboard_writer.update_dashboard(bad, name="x") is False
+
+    async def test_delete_dashboard(self, bad):
+        assert await dashboard_writer.delete_dashboard(bad) is False
+
+    async def test_set_dashboard_public(self, bad):
+        assert await dashboard_writer.set_dashboard_public(bad, True) is None
+
+
+async def test_add_widget_malformed_insight_id_is_not_found():
+    assert (
+        await dashboard_writer.add_widget(
+            str(uuid4()), widget_type="insight", insight_id="not-a-uuid"
+        )
+        is None
+    )

--- a/tests/unit/api/repositories/test_insight_writer.py
+++ b/tests/unit/api/repositories/test_insight_writer.py
@@ -1,0 +1,23 @@
+"""Unit tests for insight_writer's malformed-id contract."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agent.subagents.analyst.charts.model import Insight
+from src.api.repositories import insight_writer
+
+
+@pytest.fixture(autouse=True)
+def no_database(monkeypatch):
+    """Fail the test if update_insight opens a DB session."""
+    pool = MagicMock(side_effect=AssertionError("must not open a DB session"))
+    monkeypatch.setattr(insight_writer, "get_session_from_pool", pool)
+
+
+@pytest.mark.parametrize("bad", ["not-a-uuid", ""])
+async def test_update_insight_malformed_id_is_false(bad):
+    insight = Insight(
+        charts=[], primary_insight="text", follow_up_suggestions=[]
+    )
+    assert await insight_writer.update_insight(bad, insight) is False

--- a/tests/unit/api/routers/test_dashboards_router.py
+++ b/tests/unit/api/routers/test_dashboards_router.py
@@ -1,0 +1,160 @@
+"""Unit tests for the dashboards router's pure mapping helpers."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from src.api.data_models import UserType
+from src.api.routers.dashboards import _is_privileged, _row_to_response
+from src.api.schemas import UserModel
+
+NOW = datetime(2026, 7, 7, 12, 0, 0)
+
+
+def _user(user_type=UserType.REGULAR):
+    return UserModel(
+        id="user-1",
+        name="Test User",
+        email="test@example.com",
+        created_at=NOW,
+        updated_at=NOW,
+        user_type=user_type,
+    )
+
+
+def _aoi_row(position=0, name="Paraná"):
+    return SimpleNamespace(
+        id=uuid4(),
+        source="gadm",
+        src_id="BRA.16_1",
+        subtype="state-province",
+        name=name,
+        position=position,
+    )
+
+
+def _widget_row(widget_type="insight", insight_id=None, config=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        position=0,
+        widget_type=widget_type,
+        insight_id=insight_id,
+        config=config,
+        created_at=NOW,
+    )
+
+
+def _insight_row(insight_id):
+    return SimpleNamespace(
+        id=insight_id,
+        user_id="user-1",
+        thread_id="thread-1",
+        insight_text="Tree cover loss peaked in 2016.",
+        follow_up_suggestions=["Compare with 2023"],
+        statistics_ids=[],
+        charts=[],
+        codeact_types=[],
+        codeact_contents=[],
+        is_public=False,
+        created_at=NOW,
+    )
+
+
+def _dashboard_row(aois=None, widgets=None, **overrides):
+    row = SimpleNamespace(
+        id=uuid4(),
+        user_id="user-1",
+        name="Paraná",
+        description=None,
+        is_public=False,
+        created_at=NOW,
+        updated_at=NOW,
+        aois=aois or [],
+        widgets=widgets or [],
+    )
+    for key, value in overrides.items():
+        setattr(row, key, value)
+    return row
+
+
+@pytest.mark.parametrize(
+    ("user", "privileged"),
+    [
+        (None, False),
+        (_user(UserType.REGULAR), False),
+        (_user(UserType.ADMIN), True),
+        (_user(UserType.SUPERUSER), True),
+    ],
+)
+def test_is_privileged(user, privileged):
+    assert _is_privileged(user) is privileged
+
+
+class TestRowToResponse:
+    def test_maps_dashboard_fields(self):
+        row = _dashboard_row(description="Notes", is_public=True)
+        response = _row_to_response(row)
+        assert response.id == row.id
+        assert response.user_id == "user-1"
+        assert response.name == "Paraná"
+        assert response.description == "Notes"
+        assert response.is_public is True
+        assert response.aois == []
+        assert response.widgets == []
+
+    def test_maps_aois_in_row_order(self):
+        row = _dashboard_row(
+            aois=[_aoi_row(0, "Paraná"), _aoi_row(1, "Santa Catarina")]
+        )
+        response = _row_to_response(row)
+        assert [a.name for a in response.aois] == [
+            "Paraná",
+            "Santa Catarina",
+        ]
+        assert [a.position for a in response.aois] == [0, 1]
+
+    def test_widget_config_none_becomes_empty_dict(self):
+        row = _dashboard_row(widgets=[_widget_row(config=None)])
+        assert _row_to_response(row).widgets[0].config == {}
+
+    def test_widget_insight_expanded_when_preloaded(self):
+        insight_id = uuid4()
+        row = _dashboard_row(widgets=[_widget_row(insight_id=insight_id)])
+        response = _row_to_response(
+            row, insights_by_id={insight_id: _insight_row(insight_id)}
+        )
+        widget = response.widgets[0]
+        assert widget.insight_id == insight_id
+        assert widget.insight is not None
+        assert widget.insight.insight_text == (
+            "Tree cover loss peaked in 2016."
+        )
+
+    def test_widget_insight_none_when_not_preloaded(self):
+        """A widget whose insight the viewer may not see keeps insight=None."""
+        visible_id, hidden_id = uuid4(), uuid4()
+        row = _dashboard_row(
+            widgets=[
+                _widget_row(insight_id=visible_id),
+                _widget_row(insight_id=hidden_id),
+            ]
+        )
+        response = _row_to_response(
+            row, insights_by_id={visible_id: _insight_row(visible_id)}
+        )
+        by_id = {w.insight_id: w for w in response.widgets}
+        assert by_id[visible_id].insight is not None
+        assert by_id[hidden_id].insight is None
+        assert by_id[hidden_id].insight_id == hidden_id
+
+    def test_non_insight_widget_has_no_insight(self):
+        config = {"dataset": {"tile_url": "https://t.example/x"}}
+        row = _dashboard_row(
+            widgets=[_widget_row(widget_type="map", config=config)]
+        )
+        widget = _row_to_response(row).widgets[0]
+        assert widget.widget_type == "map"
+        assert widget.insight is None
+        assert widget.config == config

--- a/tests/unit/api/test_dashboard_access.py
+++ b/tests/unit/api/test_dashboard_access.py
@@ -1,0 +1,45 @@
+"""Tests for the shared dashboard visibility/edit rules."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.repositories.dashboard_access import (
+    is_editable_by_user,
+    is_visible_to_user,
+)
+
+
+def _row(user_id="owner", is_public=False):
+    return SimpleNamespace(user_id=user_id, is_public=is_public)
+
+
+@pytest.mark.parametrize(
+    ("row", "user_id", "visible"),
+    [
+        (_row(user_id="me"), "me", True),  # own private
+        (_row(user_id="someone-else"), "me", False),  # other's private
+        (_row(user_id="someone-else", is_public=True), "me", True),  # public
+        (_row(user_id=None), "me", False),  # ownerless private
+        (_row(user_id=None, is_public=True), "me", True),  # ownerless public
+        (_row(user_id="me"), None, False),  # unauthenticated, private
+        (_row(user_id="me", is_public=True), None, True),  # unauth, public
+    ],
+)
+def test_is_visible_to_user(row, user_id, visible):
+    assert is_visible_to_user(row, user_id) is visible
+
+
+@pytest.mark.parametrize(
+    ("row", "user_id", "editable"),
+    [
+        (_row(user_id="me"), "me", True),  # own
+        (_row(user_id="someone-else"), "me", False),  # other's
+        (_row(user_id="someone-else", is_public=True), "me", False),  # public
+        (_row(user_id=None), "me", False),  # ownerless
+        (_row(user_id="me"), None, False),  # unauthenticated
+        (_row(user_id=None), None, False),  # unauthenticated + ownerless
+    ],
+)
+def test_is_editable_by_user(row, user_id, editable):
+    assert is_editable_by_user(row, user_id) is editable

--- a/tests/unit/api/test_dashboard_access.py
+++ b/tests/unit/api/test_dashboard_access.py
@@ -3,10 +3,13 @@
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import or_
 
+from src.api.data_models import DashboardOrm
 from src.api.repositories.dashboard_access import (
     is_editable_by_user,
     is_visible_to_user,
+    visible_dashboards_clause,
 )
 
 
@@ -43,3 +46,17 @@ def test_is_visible_to_user(row, user_id, visible):
 )
 def test_is_editable_by_user(row, user_id, editable):
     assert is_editable_by_user(row, user_id) is editable
+
+
+def test_visible_clause_with_user_selects_public_or_own():
+    expected = or_(
+        DashboardOrm.is_public.is_(True),
+        DashboardOrm.user_id == "me",
+    )
+    assert visible_dashboards_clause("me").compare(expected)
+
+
+def test_visible_clause_without_user_selects_public_only():
+    expected = DashboardOrm.is_public.is_(True)
+    assert visible_dashboards_clause(None).compare(expected)
+    assert visible_dashboards_clause("").compare(expected)

--- a/tests/unit/api/test_dashboard_schemas.py
+++ b/tests/unit/api/test_dashboard_schemas.py
@@ -1,0 +1,220 @@
+"""Unit tests for the dashboard request schemas.
+
+The widget-config rules these check are the API's contract with the frontend:
+map widgets must carry a renderable layer snapshot, text widgets a markdown
+body, and the MVP allows exactly one AOI per dashboard.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.schemas import (
+    DashboardCreateRequest,
+    DashboardUpdateRequest,
+    DashboardWidgetCreateRequest,
+    DashboardWidgetUpdateRequest,
+)
+
+AOI = {
+    "source": "gadm",
+    "src_id": "BRA.16_1",
+    "subtype": "state-province",
+    "name": "Paraná",
+}
+
+DATASET_SNAPSHOT = {
+    "dataset_id": 4,
+    "dataset_name": "Tree cover loss",
+    "tile_url": "https://tiles.example.com/tcl/{z}/{x}/{y}.png",
+    "start_date": "2024-01-01",
+    "end_date": "2024-12-31",
+}
+
+IMAGERY_SNAPSHOT = {
+    "tile_url": "https://tiles.example.com/mosaic/{z}/{x}/{y}.png",
+    "mosaic_id": "abc123",
+    "target_date": "2024-06-01",
+}
+
+
+class TestDashboardCreateRequest:
+    def test_single_aoi_accepted(self):
+        body = DashboardCreateRequest(aois=[AOI])
+        assert body.aois[0].name == "Paraná"
+        assert body.name is None
+        assert body.description is None
+
+    def test_zero_aois_rejected(self):
+        with pytest.raises(ValidationError):
+            DashboardCreateRequest(aois=[])
+
+    def test_two_aois_rejected_mvp_single_area(self):
+        with pytest.raises(ValidationError):
+            DashboardCreateRequest(aois=[AOI, AOI])
+
+    @pytest.mark.parametrize(
+        "missing", ["source", "src_id", "subtype", "name"]
+    )
+    def test_aoi_reference_fields_required(self, missing):
+        aoi = {k: v for k, v in AOI.items() if k != missing}
+        with pytest.raises(ValidationError):
+            DashboardCreateRequest(aois=[aoi])
+
+    def test_name_and_description_carried(self):
+        body = DashboardCreateRequest(
+            name="My dashboard", description="Notes", aois=[AOI]
+        )
+        assert body.name == "My dashboard"
+        assert body.description == "Notes"
+
+
+class TestWidgetType:
+    @pytest.mark.parametrize("widget_type", ["insight", "map", "text"])
+    def test_known_types_accepted(self, widget_type):
+        config = {
+            "insight": None,
+            "map": {"dataset": DATASET_SNAPSHOT},
+            "text": {"text": "# Hello"},
+        }[widget_type]
+        body = DashboardWidgetCreateRequest(
+            widget_type=widget_type, config=config
+        )
+        assert body.widget_type == widget_type
+
+    @pytest.mark.parametrize("widget_type", ["chart", "", "Map", "iframe"])
+    def test_unknown_types_rejected(self, widget_type):
+        with pytest.raises(ValidationError, match="widget_type"):
+            DashboardWidgetCreateRequest(widget_type=widget_type)
+
+
+class TestInsightWidget:
+    def test_config_optional(self):
+        body = DashboardWidgetCreateRequest(widget_type="insight")
+        assert body.config is None
+        assert body.insight_id is None
+        assert body.position is None
+
+    def test_insight_id_parsed_as_uuid(self):
+        body = DashboardWidgetCreateRequest(
+            widget_type="insight",
+            insight_id="7c9e6679-7425-40de-944b-e07fc1f90ae7",
+        )
+        assert str(body.insight_id) == "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+
+    def test_malformed_insight_id_rejected(self):
+        with pytest.raises(ValidationError):
+            DashboardWidgetCreateRequest(
+                widget_type="insight", insight_id="not-a-uuid"
+            )
+
+    def test_presentation_config_passes_through(self):
+        body = DashboardWidgetCreateRequest(
+            widget_type="insight",
+            config={"default_view": "chart", "title": "Custom"},
+        )
+        assert body.config == {"default_view": "chart", "title": "Custom"}
+
+
+class TestMapWidgetConfig:
+    def test_requires_config(self):
+        with pytest.raises(ValidationError, match="dataset.*imagery"):
+            DashboardWidgetCreateRequest(widget_type="map")
+
+    def test_requires_a_layer_key(self):
+        with pytest.raises(ValidationError, match="dataset.*imagery"):
+            DashboardWidgetCreateRequest(
+                widget_type="map", config={"default_view": "map"}
+            )
+
+    def test_dataset_and_imagery_together_rejected(self):
+        with pytest.raises(ValidationError, match="exactly one"):
+            DashboardWidgetCreateRequest(
+                widget_type="map",
+                config={
+                    "dataset": DATASET_SNAPSHOT,
+                    "imagery": IMAGERY_SNAPSHOT,
+                },
+            )
+
+    @pytest.mark.parametrize("kind", ["dataset", "imagery"])
+    def test_layer_must_be_a_dict(self, kind):
+        with pytest.raises(ValidationError, match="tile_url"):
+            DashboardWidgetCreateRequest(
+                widget_type="map", config={kind: "https://tiles.example.com"}
+            )
+
+    @pytest.mark.parametrize("kind", ["dataset", "imagery"])
+    def test_layer_requires_tile_url(self, kind):
+        with pytest.raises(ValidationError, match="tile_url"):
+            DashboardWidgetCreateRequest(
+                widget_type="map", config={kind: {"name": "no tiles here"}}
+            )
+
+    def test_valid_dataset_snapshot_accepted(self):
+        body = DashboardWidgetCreateRequest(
+            widget_type="map", config={"dataset": DATASET_SNAPSHOT}
+        )
+        assert body.config["dataset"]["tile_url"]
+
+    def test_valid_imagery_snapshot_accepted(self):
+        body = DashboardWidgetCreateRequest(
+            widget_type="map", config={"imagery": IMAGERY_SNAPSHOT}
+        )
+        assert body.config["imagery"]["mosaic_id"] == "abc123"
+
+    def test_extra_config_keys_tolerated(self):
+        # The snapshot shape may evolve without a schema change here — only
+        # the discriminator and tile_url are load-bearing.
+        body = DashboardWidgetCreateRequest(
+            widget_type="map",
+            config={
+                "dataset": {**DATASET_SNAPSHOT, "future_key": 1},
+                "viewport": {"bbox": [-54.6, -26.7, -48.0, -22.5], "zoom": 6},
+                "title": "Loss layer",
+            },
+        )
+        assert body.config["viewport"]["zoom"] == 6
+
+
+class TestTextWidgetConfig:
+    def test_requires_config(self):
+        with pytest.raises(ValidationError, match="'text' string"):
+            DashboardWidgetCreateRequest(widget_type="text")
+
+    def test_requires_text_key(self):
+        with pytest.raises(ValidationError, match="'text' string"):
+            DashboardWidgetCreateRequest(
+                widget_type="text", config={"markdown": "# Hello"}
+            )
+
+    @pytest.mark.parametrize("text", [None, 42, ["# Hello"], {"md": "x"}])
+    def test_text_must_be_a_string(self, text):
+        with pytest.raises(ValidationError, match="'text' string"):
+            DashboardWidgetCreateRequest(
+                widget_type="text", config={"text": text}
+            )
+
+    def test_valid_text_widget_accepted(self):
+        body = DashboardWidgetCreateRequest(
+            widget_type="text", config={"text": "# Notes\nSome context."}
+        )
+        assert body.config["text"].startswith("# Notes")
+
+
+class TestUpdateRequests:
+    def test_dashboard_update_fields_optional(self):
+        body = DashboardUpdateRequest()
+        assert body.name is None
+        assert body.description is None
+
+    def test_widget_update_fields_optional(self):
+        body = DashboardWidgetUpdateRequest()
+        assert body.position is None
+        assert body.config is None
+
+    def test_widget_update_carries_position_and_config(self):
+        body = DashboardWidgetUpdateRequest(
+            position=3, config={"default_view": "table"}
+        )
+        assert body.position == 3
+        assert body.config == {"default_view": "table"}

--- a/tests/unit/api/test_insight_access.py
+++ b/tests/unit/api/test_insight_access.py
@@ -3,10 +3,13 @@
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import or_
 
+from src.api.data_models import InsightOrm
 from src.api.repositories.insight_access import (
     is_editable_by_user,
     is_visible_to_user,
+    visible_insights_clause,
 )
 
 
@@ -43,3 +46,17 @@ def test_is_visible_to_user(row, user_id, visible):
 )
 def test_is_editable_by_user(row, user_id, editable):
     assert is_editable_by_user(row, user_id) is editable
+
+
+def test_visible_clause_with_user_selects_public_or_own():
+    expected = or_(
+        InsightOrm.is_public.is_(True),
+        InsightOrm.user_id == "me",
+    )
+    assert visible_insights_clause("me").compare(expected)
+
+
+def test_visible_clause_without_user_selects_public_only():
+    expected = InsightOrm.is_public.is_(True)
+    assert visible_insights_clause(None).compare(expected)
+    assert visible_insights_clause("").compare(expected)

--- a/tests/unit/api/test_insight_access.py
+++ b/tests/unit/api/test_insight_access.py
@@ -1,0 +1,45 @@
+"""Tests for the shared insight visibility/edit rules."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.repositories.insight_access import (
+    is_editable_by_user,
+    is_visible_to_user,
+)
+
+
+def _row(user_id="owner", is_public=False):
+    return SimpleNamespace(user_id=user_id, is_public=is_public)
+
+
+@pytest.mark.parametrize(
+    ("row", "user_id", "visible"),
+    [
+        (_row(user_id="me"), "me", True),  # own private
+        (_row(user_id="someone-else"), "me", False),  # other's private
+        (_row(user_id="someone-else", is_public=True), "me", True),  # public
+        (_row(user_id=None), "me", False),  # ownerless private
+        (_row(user_id=None, is_public=True), "me", True),  # ownerless public
+        (_row(user_id="me"), None, False),  # unauthenticated, private
+        (_row(user_id="me", is_public=True), None, True),  # unauth, public
+    ],
+)
+def test_is_visible_to_user(row, user_id, visible):
+    assert is_visible_to_user(row, user_id) is visible
+
+
+@pytest.mark.parametrize(
+    ("row", "user_id", "editable"),
+    [
+        (_row(user_id="me"), "me", True),  # own
+        (_row(user_id="someone-else"), "me", False),  # other's
+        (_row(user_id="someone-else", is_public=True), "me", False),  # public
+        (_row(user_id=None), "me", False),  # ownerless
+        (_row(user_id="me"), None, False),  # unauthenticated
+        (_row(user_id=None), None, False),  # unauthenticated + ownerless
+    ],
+)
+def test_is_editable_by_user(row, user_id, editable):
+    assert is_editable_by_user(row, user_id) is editable

--- a/tests/unit/shared/test_tile_urls.py
+++ b/tests/unit/shared/test_tile_urls.py
@@ -1,0 +1,74 @@
+"""Host-less persistence of widget tile URLs (src/shared/tile_urls.py).
+
+Persisted absolute tile URLs orphan every map widget when the eoapi host
+rotates — a browser-side-only failure with no server signal. Configs are
+stored with a relative tile_path and reassembled against the currently
+configured host on read; foreign-host layers pass through untouched.
+"""
+
+from src.shared import tile_urls
+from src.shared.config import SharedSettings
+from src.shared.tile_urls import (
+    absolutize_widget_config,
+    relativize_widget_config,
+)
+
+BASE = SharedSettings.eoapi_base_url.rstrip("/")
+
+
+def test_eoapi_tile_url_stored_as_path():
+    config = {
+        "default_view": "map",
+        "dataset": {
+            "dataset_name": "TCL",
+            "tile_url": f"{BASE}/raster/tiles/{{z}}/{{x}}/{{y}}.png?x=1",
+        },
+    }
+    stored = relativize_widget_config(config)
+    assert stored["dataset"]["tile_path"] == (
+        "/raster/tiles/{z}/{x}/{y}.png?x=1"
+    )
+    assert "tile_url" not in stored["dataset"]
+    # Input is never mutated: callers pass request bodies and agent state.
+    assert "tile_url" in config["dataset"]
+
+
+def test_foreign_host_tile_url_kept_verbatim():
+    config = {
+        "imagery": {
+            "tile_url": "https://tiles.globalforestwatch.org/m/{z}/{x}/{y}",
+            "mosaic_id": "abc",
+        }
+    }
+    assert relativize_widget_config(config) == config
+    assert absolutize_widget_config(config) == config
+
+
+def test_round_trip_serves_currently_configured_host(monkeypatch):
+    stored = relativize_widget_config(
+        {"dataset": {"tile_url": f"{BASE}/raster/tiles/{{z}}.png"}}
+    )
+    monkeypatch.setattr(
+        tile_urls.SharedSettings,
+        "eoapi_base_url",
+        "https://eoapi-next.example.org",
+    )
+    served = absolutize_widget_config(stored)
+    assert served["dataset"]["tile_url"] == (
+        "https://eoapi-next.example.org/raster/tiles/{z}.png"
+    )
+
+
+def test_legacy_absolute_config_served_unchanged():
+    """Rows written before tile_path existed keep their absolute URL."""
+    config = {"dataset": {"tile_url": f"{BASE}/raster/tiles/{{z}}.png"}}
+    assert absolutize_widget_config(config) == config
+
+
+def test_empty_and_layerless_configs_pass_through():
+    assert relativize_widget_config(None) is None
+    assert absolutize_widget_config({}) == {}
+    text = {"text": "# Notes"}
+    assert relativize_widget_config(text) == text
+    malformed = {"dataset": "not-a-dict"}
+    assert relativize_widget_config(malformed) == malformed

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.2.1"
+version = "2026.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.2"
+version = "2026.7.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -31,11 +31,11 @@ wheels = [
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.6.2"
+version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.115.0"
+version = "0.115.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -142,9 +142,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/52/b9022707a25fd263b8ff5e11f480dcc9cd6da0a380c486e5be053c01d995/anthropic-0.115.0.tar.gz", hash = "sha256:6bb25184441d51544f8bc9877a7efbddd9bc4a6207cce898536d84b233310f4a", size = 949136, upload-time = "2026-06-30T19:47:33.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/e2/e27b1e70b1ddcda72362d6a26c9c699a46173d48a6c7ba966e8cc97a6c4d/anthropic-0.115.1.tar.gz", hash = "sha256:040287319abb909acf1cc49d83c0405dc0b1121ef257034b02c2b54151cf2446", size = 949185, upload-time = "2026-07-01T21:54:19.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/89/cd08c2fb41f10fc902593579cb81717ce0ce5489fdf9dcb8e04ea9825fb2/anthropic-0.115.0-py3-none-any.whl", hash = "sha256:aa4bbea9272fa1cced6749728f18d0af9d7934b7268779e84d6f5a246f4b998d", size = 960664, upload-time = "2026-06-30T19:47:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/85/3c/501c58a8f8c68811079e218a25d8672fe4fb9a650a4655e499e24d9375e9/anthropic-0.115.1-py3-none-any.whl", hash = "sha256:685fa94964c1b9428f6a76e42d0dbae49aa2016f5ad386a96becac04c5e80ef9", size = 957006, upload-time = "2026-07-01T21:54:17.392Z" },
 ]
 
 [[package]]
@@ -970,7 +970,7 @@ standard = [
 
 [[package]]
 name = "fastapi-cloud-cli"
-version = "0.22.0"
+version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "detect-installer" },
@@ -983,9 +983,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/85/f1bba93afc0c3d6457e2e455fd627796f71035771e7e25c0fb255afb31e1/fastapi_cloud_cli-0.22.0.tar.gz", hash = "sha256:cde14470227fc9275075ff537977d2991e8ce1baf947055d7a4149726de27e08", size = 94373, upload-time = "2026-06-30T17:08:49.15Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/e5/bee77aa542ec66bcc55b458d606f3356a58f5bb9f2c59006f6ff53a3869b/fastapi_cloud_cli-0.22.1.tar.gz", hash = "sha256:50d80de6ce397a4959e6f3509574edac65d0a6998655215c95d077b18ec2f4b1", size = 94501, upload-time = "2026-07-01T22:09:03.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/1b/3575ec4052a3fe241ddaa24807a5200e3cc33211318d5786d8b792eedc19/fastapi_cloud_cli-0.22.0-py3-none-any.whl", hash = "sha256:799e263140d1b6e679390fc6e90da404556aee6730fd479d3b52475e850073bf", size = 77649, upload-time = "2026-06-30T17:08:48.134Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0c/9e3069ff571142e571d68156aa4c1ab1d51c0b87f21bbe0f44c10029b19b/fastapi_cloud_cli-0.22.1-py3-none-any.whl", hash = "sha256:4ba307b97b08282d1efb2daef5f1e88af23e02fe2286c25273c1794e399df509", size = 77739, upload-time = "2026-07-01T22:09:02.359Z" },
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.4"
+version = "0.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2239,9 +2239,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/a7/a78b4105d1c01ee8d404d122d9acc047b8b9f628f3733cb837a321b2f6c6/langsmith-0.9.4.tar.gz", hash = "sha256:36c15e5a692e7812ee927e43d777c6166c839eb02b1d482ba9a805b438b1d91c", size = 4576594, upload-time = "2026-06-30T10:20:43.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/dc/ca2ab3b74f3a5a2089aee1483e86b6aa7ae15fba96f73866a16e31356319/langsmith-0.9.6.tar.gz", hash = "sha256:1df590a40352b2f40a36229d90e2ef6af276a0bc9f1e44a87b829f879eed2130", size = 4714803, upload-time = "2026-07-02T11:14:30.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/15/79367a3d159141fe4fc138f41db4ef21eb4759cd64cf8f635f41d55ded67/langsmith-0.9.4-py3-none-any.whl", hash = "sha256:f10f07438c7c6f9f907e8c810d8f338268fe863a74c37ded3d8a90830bb25451", size = 603804, upload-time = "2026-06-30T10:20:41.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/8f/6e8f1f3e12be9848993c297c879f63f225361eb594f8343ff42c2b26c6fd/langsmith-0.9.6-py3-none-any.whl", hash = "sha256:c5e5f2425dcb8fe363b9e1fa87a9cb9cf5631389bf7e168aa4f325f580ca284c", size = 660131, upload-time = "2026-07-02T11:14:28.552Z" },
 ]
 
 [[package]]
@@ -4464,11 +4464,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds insight recall/restyle tools (`search_insights`, `update_insight_display`) to the experimental profile, plus their access-rule hardening.
- Adds the dashboards MVP: `DashboardOrm`/`DashboardAoiOrm`/`DashboardWidgetOrm` models, `dashboard_access`/`dashboard_writer` repositories, the `/api/dashboards` REST API, and the `create_dashboard`/`add_to_dashboard` agent tools + `dashboard` skill (single area per dashboard; schema is portfolio-ready).
- Teaches the agent which page the user is on via a `view_pages` registry, so dashboard-aware chat can default AOI/dashboard targeting from context.
- Extends dashboards with map widgets: a new `add_map_widget` tool snapshots either the currently selected dataset layer or a Sentinel-2 imagery mosaic into a widget's `config`, so a dashboard renders maps without live chat state.
- Fixes eoapi tile loading by pointing `EOAPI_BASE_URL` at the healthy cache host (both direct eoapi hosts currently fail TLS verification).

See `docs/dashboards-mvp-plan.md`, `docs/view-context-pages.md`, `docs/dashboards-frontend-handoff.md`, and `docs/dashboards-map-widgets-handoff.md` for full design/contract details (the last two are written for the separate frontend repo).

## Data model

```mermaid
erDiagram
    USERS ||--o{ DASHBOARDS : owns
    USERS ||--o{ INSIGHTS : owns
    DASHBOARDS ||--o{ DASHBOARD_AOIS : "contains (MVP: 1 area)"
    DASHBOARDS ||--o{ DASHBOARD_WIDGETS : contains
    DASHBOARD_WIDGETS }o--o| INSIGHTS : "embeds (nullable, ON DELETE CASCADE)"
    INSIGHTS ||--o{ INSIGHT_CHARTS : contains

    DASHBOARDS {
        uuid id PK
        string user_id FK
        string name
        string description "nullable"
        boolean is_public "default false"
        timestamp created_at
        timestamp updated_at
    }
    DASHBOARD_AOIS {
        uuid id PK
        uuid dashboard_id FK
        string source
        string src_id
        string subtype
        string name
        int position
    }
    DASHBOARD_WIDGETS {
        uuid id PK
        uuid dashboard_id FK
        int position
        string widget_type "insight | map"
        uuid insight_id FK "nullable, ON DELETE CASCADE"
        jsonb config "shape depends on widget_type"
        timestamp created_at
    }
    INSIGHTS {
        uuid id PK
        string user_id FK "nullable"
        string thread_id
        string insight_text
        boolean is_public
        jsonb follow_up_suggestions
        jsonb statistics_ids
    }
    INSIGHT_CHARTS {
        uuid id PK
        uuid insight_id FK
        int position
        string title
        string chart_type
        jsonb chart_data
    }
    USERS {
        string id PK
    }
```

**Notes**
- New tables this PR: `dashboards`, `dashboard_aois`, `dashboard_widgets`. `insights`/`insight_charts` shown for context (unchanged).
- `dashboard_aois` already supports N rows per dashboard — the MVP caps it to one area via API validation (`max_length=1`), not the schema, so portfolio dashboards need no migration.
- `dashboard_widgets.config` shape depends on `widget_type`: insight widgets carry `{default_view, title?}`; map widgets snapshot exactly one of `dataset{tile_url,...}` or `imagery{mosaic_id,...}` (Pydantic-validated only, not DB-enforced).
- Publishing a dashboard (`is_public=true`) cascades to every insight it references.

## Test plan
- [x] `uv run pytest tests/unit tests/agent tests/api/test_dashboards.py` (test DB via docker compose `test-db`)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` on changed files
- [x] Manual tile fetch through the eoapi cache host confirmed 200/PNG
- [ ] Manual agent CLI smoke test (pick area → pick dataset → create dashboard → add map widget; show_imagery → add imagery widget) — not yet run