### PR TITLE
Add turn information to traces for easier analysis

### DIFF
--- a/db/alembic/versions/b1f7a3c9d2e5_add_turn_index_to_langfuse_traces.py
+++ b/db/alembic/versions/b1f7a3c9d2e5_add_turn_index_to_langfuse_traces.py
@@ -1,0 +1,137 @@
+"""add turn_index to langfuse_traces
+
+Revision ID: b1f7a3c9d2e5
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-03 10:00:00.000000
+
+Hand-written (alembic autogenerate is disabled). Adds a stored per-turn ordinal
+(``turn_index``, 1-based position within a session ordered by trace_timestamp) so
+turn-position analytics is index-filterable rather than a per-request window, and
+starts populating the previously-unused ``is_final_turn_in_thread`` column.
+
+Session-less traces (null session_id) are singleton threads via
+COALESCE(session_id, id) -> turn_index 1, is_final True. Ongoing rows are kept
+current by a session-scoped recompute in the ingest path; this migration backfills
+existing rows once.
+
+The ``langfuse_traces_analytics`` view is rewritten to read the *stored*
+``is_final_turn_in_thread`` (dropping its own row_number() window) and to expose
+``turn_index``.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1f7a3c9d2e5"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_VIEW = "langfuse_traces_analytics"
+
+# Base column projection shared by both the new and old view definitions.
+_VIEW_BASE_COLS = """
+    id,
+    session_id,
+    user_id,
+    environment,
+    trace_timestamp,
+    outcome,
+    has_answer,
+    answer_is_refusal,
+    had_tool_call,
+    tool_error_count,
+    aoi_name,
+    aoi_type,
+    primary_dataset_name,
+    has_insight,
+    is_global,
+    insight_id,
+    turn_input_tokens,
+    turn_output_tokens,
+    turn_tokens,
+    turn_tool_calls,
+    latency_seconds,
+    total_cost,
+    prompt"""
+
+# New: read the stored is_final_turn_in_thread and expose turn_index (both now
+# maintained on the base table), so the view is a plain projection with no window.
+_VIEW_NEW = f"""
+CREATE OR REPLACE VIEW {_VIEW} AS
+SELECT{_VIEW_BASE_COLS},
+    is_final_turn_in_thread,
+    turn_index
+FROM langfuse_traces;
+"""
+
+# Old: is_final_turn_in_thread computed via a row_number() window, no turn_index.
+_VIEW_OLD = f"""
+CREATE OR REPLACE VIEW {_VIEW} AS
+SELECT{_VIEW_BASE_COLS},
+    (
+        row_number() OVER (
+            PARTITION BY COALESCE(session_id, id)
+            ORDER BY trace_timestamp DESC NULLS LAST, id DESC
+        ) = 1
+    ) AS is_final_turn_in_thread
+FROM langfuse_traces;
+"""
+
+# Backfill turn_index (1-based, ascending) and is_final_turn_in_thread for every
+# row. COALESCE(session_id, id) makes null-session rows singleton threads.
+_BACKFILL = """
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER w AS rn,
+           count(*)     OVER (PARTITION BY COALESCE(session_id, id)) AS n
+    FROM langfuse_traces
+    WINDOW w AS (
+        PARTITION BY COALESCE(session_id, id)
+        ORDER BY trace_timestamp ASC NULLS LAST, id ASC
+    )
+)
+UPDATE langfuse_traces t
+SET turn_index = ranked.rn,
+    is_final_turn_in_thread = (ranked.rn = ranked.n)
+FROM ranked
+WHERE t.id = ranked.id;
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "langfuse_traces", sa.Column("turn_index", sa.Integer(), nullable=True)
+    )
+    op.execute(_BACKFILL)
+    op.create_index(
+        "ix_langfuse_traces_turn_index", "langfuse_traces", ["turn_index"]
+    )
+    # Serves the common "first turns, newest first" read directly (no sort).
+    op.create_index(
+        "ix_langfuse_traces_first_turn",
+        "langfuse_traces",
+        [sa.text("trace_timestamp DESC")],
+        postgresql_where=sa.text("turn_index = 1"),
+    )
+    # View now reads the stored is_final_turn_in_thread + exposes turn_index.
+    op.execute(_VIEW_NEW)
+
+
+def downgrade() -> None:
+    # The old view has fewer columns than the new one, so REPLACE can't shrink it.
+    op.execute(f"DROP VIEW IF EXISTS {_VIEW};")
+    op.execute(_VIEW_OLD)
+    op.drop_index(
+        "ix_langfuse_traces_first_turn", table_name="langfuse_traces"
+    )
+    op.drop_index(
+        "ix_langfuse_traces_turn_index", table_name="langfuse_traces"
+    )
+    # is_final_turn_in_thread was unpopulated before this migration.
+    op.execute("UPDATE langfuse_traces SET is_final_turn_in_thread = NULL;")
+    op.drop_column("langfuse_traces", "turn_index")

--- a/db/alembic/versions/b1f7a3c9d2e5_add_turn_index_to_langfuse_traces.py
+++ b/db/alembic/versions/b1f7a3c9d2e5_add_turn_index_to_langfuse_traces.py
@@ -6,12 +6,14 @@ Create Date: 2026-07-03 10:00:00.000000
 
 Hand-written (autogenerate disabled). Adds the stored per-turn ordinal ``turn_index``
 (1-based within a session by trace_timestamp) so turn-position analytics is
-index-filterable rather than a per-request window, and starts populating
-``is_final_turn_in_thread``. Null-session traces are singleton threads via
-COALESCE(session_id, id) -> turn_index 1. The ``langfuse_traces_analytics`` view is
-rewritten to read the stored flag (dropping its row_number() window) and expose
-``turn_index``. Ongoing rows are kept current by the ingest recompute; this backfills
-existing rows once.
+index-filterable rather than a per-request window, and starts using
+``is_final_turn_in_thread``. The ``langfuse_traces_analytics`` view is rewritten to
+read the stored flag (dropping its row_number() window) and expose ``turn_index``.
+
+Schema only: new rows are populated by the ingest recompute, and existing rows by the
+out-of-band ``backfill-turn-fields`` CLI command (data backfills stay out of the
+blocking deploy migration). Both columns read NULL for existing rows until that command
+runs — endpoints and the view tolerate NULL.
 """
 
 from typing import Sequence, Union
@@ -77,32 +79,11 @@ SELECT{_VIEW_BASE_COLS},
 FROM langfuse_traces;
 """
 
-# Backfill turn_index (1-based, ascending) and is_final_turn_in_thread for every
-# row. COALESCE(session_id, id) makes null-session rows singleton threads.
-_BACKFILL = """
-WITH ranked AS (
-    SELECT id,
-           row_number() OVER w AS rn,
-           count(*)     OVER (PARTITION BY COALESCE(session_id, id)) AS n
-    FROM langfuse_traces
-    WINDOW w AS (
-        PARTITION BY COALESCE(session_id, id)
-        ORDER BY trace_timestamp ASC NULLS LAST, id ASC
-    )
-)
-UPDATE langfuse_traces t
-SET turn_index = ranked.rn,
-    is_final_turn_in_thread = (ranked.rn = ranked.n)
-FROM ranked
-WHERE t.id = ranked.id;
-"""
-
 
 def upgrade() -> None:
     op.add_column(
         "langfuse_traces", sa.Column("turn_index", sa.Integer(), nullable=True)
     )
-    op.execute(_BACKFILL)
     op.create_index(
         "ix_langfuse_traces_turn_index", "langfuse_traces", ["turn_index"]
     )

--- a/db/alembic/versions/b1f7a3c9d2e5_add_turn_index_to_langfuse_traces.py
+++ b/db/alembic/versions/b1f7a3c9d2e5_add_turn_index_to_langfuse_traces.py
@@ -4,19 +4,14 @@ Revision ID: b1f7a3c9d2e5
 Revises: a1b2c3d4e5f6
 Create Date: 2026-07-03 10:00:00.000000
 
-Hand-written (alembic autogenerate is disabled). Adds a stored per-turn ordinal
-(``turn_index``, 1-based position within a session ordered by trace_timestamp) so
-turn-position analytics is index-filterable rather than a per-request window, and
-starts populating the previously-unused ``is_final_turn_in_thread`` column.
-
-Session-less traces (null session_id) are singleton threads via
-COALESCE(session_id, id) -> turn_index 1, is_final True. Ongoing rows are kept
-current by a session-scoped recompute in the ingest path; this migration backfills
+Hand-written (autogenerate disabled). Adds the stored per-turn ordinal ``turn_index``
+(1-based within a session by trace_timestamp) so turn-position analytics is
+index-filterable rather than a per-request window, and starts populating
+``is_final_turn_in_thread``. Null-session traces are singleton threads via
+COALESCE(session_id, id) -> turn_index 1. The ``langfuse_traces_analytics`` view is
+rewritten to read the stored flag (dropping its row_number() window) and expose
+``turn_index``. Ongoing rows are kept current by the ingest recompute; this backfills
 existing rows once.
-
-The ``langfuse_traces_analytics`` view is rewritten to read the *stored*
-``is_final_turn_in_thread`` (dropping its own row_number() window) and to expose
-``turn_index``.
 """
 
 from typing import Sequence, Union

--- a/db/alembic/versions/c2e8b4d1f6a7_add_per_turn_diffs_to_langfuse_traces.py
+++ b/db/alembic/versions/c2e8b4d1f6a7_add_per_turn_diffs_to_langfuse_traces.py
@@ -9,10 +9,10 @@ thread-cumulative fields:
 - ``insight_created_this_turn``: insight_id became non-null on this turn.
 - ``datasets_analysed_this_turn``: this turn's derived->datasets_analysed_cumulative
   minus the previous turn's.
-Both are cross-row, so ongoing rows are maintained by the same ingest recompute as
-``turn_index``; this backfills existing rows once, partitioned by
-COALESCE(session_id, id) (null-session singletons have no predecessor). List-surface
-only, so no view change.
+Both are cross-row (depend on the previous turn), so new rows are maintained by the
+same ingest recompute as ``turn_index`` and existing rows by the out-of-band
+``backfill-turn-fields`` CLI command (schema only here — data backfills stay out of the
+blocking deploy migration). List-surface only, so no view change.
 """
 
 from typing import Sequence, Union
@@ -25,43 +25,6 @@ revision: str = "c2e8b4d1f6a7"
 down_revision: Union[str, None] = "b1f7a3c9d2e5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
-
-
-# Backfill the per-turn diffs for every row from current table state, using the
-# same COALESCE(session_id, id) partition/order as the turn_index backfill so a row
-# and its predecessor are adjacent in the window.
-#   - insight_created_this_turn: insight_id present and differs from the prior turn.
-#   - datasets_analysed_this_turn: this turn's cumulative datasets minus the prior
-#     turn's (EXCEPT over the unnested arrays; prior is {} on the first turn).
-_BACKFILL = """
-WITH ranked AS (
-    SELECT id,
-           insight_id,
-           lag(insight_id) OVER w AS prev_insight,
-           ARRAY(SELECT jsonb_array_elements_text(
-               COALESCE(derived->'datasets_analysed_cumulative', '[]'::jsonb)
-           )) AS cur_ds,
-           lag(ARRAY(SELECT jsonb_array_elements_text(
-               COALESCE(derived->'datasets_analysed_cumulative', '[]'::jsonb)
-           ))) OVER w AS prev_ds
-    FROM langfuse_traces
-    WINDOW w AS (
-        PARTITION BY COALESCE(session_id, id)
-        ORDER BY trace_timestamp ASC NULLS LAST, id ASC
-    )
-)
-UPDATE langfuse_traces t
-SET insight_created_this_turn =
-        (ranked.insight_id IS NOT NULL
-         AND ranked.insight_id IS DISTINCT FROM ranked.prev_insight),
-    datasets_analysed_this_turn = ARRAY(
-        SELECT unnest(ranked.cur_ds)
-        EXCEPT
-        SELECT unnest(COALESCE(ranked.prev_ds, ARRAY[]::text[]))
-    )
-FROM ranked
-WHERE t.id = ranked.id;
-"""
 
 
 def upgrade() -> None:
@@ -77,7 +40,6 @@ def upgrade() -> None:
             nullable=True,
         ),
     )
-    op.execute(_BACKFILL)
 
 
 def downgrade() -> None:

--- a/db/alembic/versions/c2e8b4d1f6a7_add_per_turn_diffs_to_langfuse_traces.py
+++ b/db/alembic/versions/c2e8b4d1f6a7_add_per_turn_diffs_to_langfuse_traces.py
@@ -1,0 +1,90 @@
+"""add per-turn diff columns to langfuse_traces
+
+Revision ID: c2e8b4d1f6a7
+Revises: b1f7a3c9d2e5
+Create Date: 2026-07-03 11:00:00.000000
+
+Hand-written (alembic autogenerate is disabled). Adds two honest per-turn signals
+that complement the thread-cumulative fields already on the table:
+
+- ``insight_created_this_turn``: the turn's ``insight_id`` became non-null on this
+  turn (vs. reflecting an insight created several turns earlier).
+- ``datasets_analysed_this_turn``: datasets new to *this* turn, i.e. this turn's
+  ``derived->datasets_analysed_cumulative`` minus the previous turn's.
+
+Both are cross-row (depend on the previous turn), so ongoing rows are maintained by
+the same session-scoped recompute in the ingest path as ``turn_index``; this
+migration backfills existing rows once. The backfill partitions by
+COALESCE(session_id, id) so null-session traces are singleton turn-1 threads (no
+predecessor -> insight_created = insight present, datasets_this_turn = the full
+cumulative list). No view change: these columns are list-surface only.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2e8b4d1f6a7"
+down_revision: Union[str, None] = "b1f7a3c9d2e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Backfill the per-turn diffs for every row from current table state, using the
+# same COALESCE(session_id, id) partition/order as the turn_index backfill so a row
+# and its predecessor are adjacent in the window.
+#   - insight_created_this_turn: insight_id present and differs from the prior turn.
+#   - datasets_analysed_this_turn: this turn's cumulative datasets minus the prior
+#     turn's (EXCEPT over the unnested arrays; prior is {} on the first turn).
+_BACKFILL = """
+WITH ranked AS (
+    SELECT id,
+           insight_id,
+           lag(insight_id) OVER w AS prev_insight,
+           ARRAY(SELECT jsonb_array_elements_text(
+               COALESCE(derived->'datasets_analysed_cumulative', '[]'::jsonb)
+           )) AS cur_ds,
+           lag(ARRAY(SELECT jsonb_array_elements_text(
+               COALESCE(derived->'datasets_analysed_cumulative', '[]'::jsonb)
+           ))) OVER w AS prev_ds
+    FROM langfuse_traces
+    WINDOW w AS (
+        PARTITION BY COALESCE(session_id, id)
+        ORDER BY trace_timestamp ASC NULLS LAST, id ASC
+    )
+)
+UPDATE langfuse_traces t
+SET insight_created_this_turn =
+        (ranked.insight_id IS NOT NULL
+         AND ranked.insight_id IS DISTINCT FROM ranked.prev_insight),
+    datasets_analysed_this_turn = ARRAY(
+        SELECT unnest(ranked.cur_ds)
+        EXCEPT
+        SELECT unnest(COALESCE(ranked.prev_ds, ARRAY[]::text[]))
+    )
+FROM ranked
+WHERE t.id = ranked.id;
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "langfuse_traces",
+        sa.Column("insight_created_this_turn", sa.Boolean(), nullable=True),
+    )
+    op.add_column(
+        "langfuse_traces",
+        sa.Column(
+            "datasets_analysed_this_turn",
+            sa.ARRAY(sa.String()),
+            nullable=True,
+        ),
+    )
+    op.execute(_BACKFILL)
+
+
+def downgrade() -> None:
+    op.drop_column("langfuse_traces", "datasets_analysed_this_turn")
+    op.drop_column("langfuse_traces", "insight_created_this_turn")

--- a/db/alembic/versions/c2e8b4d1f6a7_add_per_turn_diffs_to_langfuse_traces.py
+++ b/db/alembic/versions/c2e8b4d1f6a7_add_per_turn_diffs_to_langfuse_traces.py
@@ -4,20 +4,15 @@ Revision ID: c2e8b4d1f6a7
 Revises: b1f7a3c9d2e5
 Create Date: 2026-07-03 11:00:00.000000
 
-Hand-written (alembic autogenerate is disabled). Adds two honest per-turn signals
-that complement the thread-cumulative fields already on the table:
-
-- ``insight_created_this_turn``: the turn's ``insight_id`` became non-null on this
-  turn (vs. reflecting an insight created several turns earlier).
-- ``datasets_analysed_this_turn``: datasets new to *this* turn, i.e. this turn's
-  ``derived->datasets_analysed_cumulative`` minus the previous turn's.
-
-Both are cross-row (depend on the previous turn), so ongoing rows are maintained by
-the same session-scoped recompute in the ingest path as ``turn_index``; this
-migration backfills existing rows once. The backfill partitions by
-COALESCE(session_id, id) so null-session traces are singleton turn-1 threads (no
-predecessor -> insight_created = insight present, datasets_this_turn = the full
-cumulative list). No view change: these columns are list-surface only.
+Hand-written (autogenerate disabled). Adds two per-turn signals complementing the
+thread-cumulative fields:
+- ``insight_created_this_turn``: insight_id became non-null on this turn.
+- ``datasets_analysed_this_turn``: this turn's derived->datasets_analysed_cumulative
+  minus the previous turn's.
+Both are cross-row, so ongoing rows are maintained by the same ingest recompute as
+``turn_index``; this backfills existing rows once, partitioned by
+COALESCE(session_id, id) (null-session singletons have no predecessor). List-surface
+only, so no view change.
 """
 
 from typing import Sequence, Union

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -110,6 +110,36 @@ kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' 
 - Each run prints a summary line: `fetched=… upserted=… chunks=… failed=… status=… watermark=…`.
 - The watermark only advances on fully-completed chunks, so an interrupted run is safe to re-run.
 
+### backfill-turn-fields
+
+Backfills the turn-analytics columns (`turn_index`, `is_final_turn_in_thread`,
+`insight_created_this_turn`, `datasets_analysed_this_turn`) for rows that predate the
+feature. The migrations add these columns **empty** — this command populates them
+out-of-band, keeping the data pass out of the blocking deploy migration. **Run it once
+after deploying the turn-analytics migrations.** New rows are set automatically during
+ingest, so this is a one-time catch-up; it's idempotent and safe to re-run (writes
+nothing the second time).
+
+**Usage:**
+```bash
+# Preview how many rows would change
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py backfill-turn-fields --dry-run
+
+# Run the backfill
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py backfill-turn-fields
+```
+
+**Parameters:**
+- `--batch-size` (default 500): sessions renumbered per committed batch (bounds the transaction).
+- `--dry-run`: report how many rows would change without writing.
+
+**Notes:**
+- Requires `DATABASE_URL` in the pod environment.
+- Until it runs, pre-existing rows report NULL turn fields — the API tolerates this
+  (analytics is just incomplete for those rows), so there's no rush within a deploy.
+
 ## Error Handling
 
 The command includes error handling:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.16"
+version = "2026.7.21"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -760,5 +760,41 @@ def ingest_langfuse_traces_command(
     asyncio.run(_run())
 
 
+@cli.command("backfill-turn-fields")
+@click.option(
+    "--batch-size",
+    type=int,
+    default=500,
+    help="Sessions renumbered per committed batch.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Report how many rows would change without writing.",
+)
+def backfill_turn_fields_command(batch_size: int, dry_run: bool):
+    """Backfill turn_index / is_final / per-turn diffs for pre-existing rows.
+
+    Run once after deploying the turn-analytics migrations (which add these columns
+    empty, keeping the data pass out of the blocking deploy path). New rows are set
+    during normal ingest. Idempotent — safe to re-run (writes nothing the 2nd time).
+    """
+    from src.api.services.langfuse.ingest import backfill_turn_fields
+
+    async def _run():
+        db = DatabaseManager()
+        try:
+            async with db.async_session() as session:
+                written = await backfill_turn_fields(
+                    session, batch_size=batch_size, dry_run=dry_run
+                )
+                verb = "would update" if dry_run else "updated"
+                click.echo(f"backfill-turn-fields: {verb} {written} row(s)")
+        finally:
+            await db.close()
+
+    asyncio.run(_run())
+
+
 if __name__ == "__main__":
     cli()

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -480,6 +480,11 @@ class LangfuseTraceOrm(Base):
     has_insight = Column(Boolean, nullable=True)
     is_global = Column(Boolean, nullable=True)
     insight_id = Column(String, nullable=True)  # soft FK -> insights.id
+    # Turn position within the session (1-based, ordered by trace_timestamp).
+    # Stored (not a query-time window) so it is index-filterable; maintained by a
+    # session-scoped recompute in the ingest path. Null-session traces are
+    # singleton threads (turn_index 1, is_final True).
+    turn_index = Column(Integer, nullable=True)
     is_final_turn_in_thread = Column(Boolean, nullable=True)
 
     # Long-tail + cumulative derived fields, kept out of the column set to keep
@@ -504,6 +509,13 @@ class LangfuseTraceOrm(Base):
         Index("ix_langfuse_traces_session_id", "session_id"),
         Index("ix_langfuse_traces_insight_id", "insight_id"),
         Index("ix_langfuse_traces_env_ts", "environment", "trace_timestamp"),
+        Index("ix_langfuse_traces_turn_index", "turn_index"),
+        # Serves "first turns, newest first" (first_turn_only) directly.
+        Index(
+            "ix_langfuse_traces_first_turn",
+            text("trace_timestamp DESC"),
+            postgresql_where=text("turn_index = 1"),
+        ),
     )
 
 

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -487,6 +487,14 @@ class LangfuseTraceOrm(Base):
     turn_index = Column(Integer, nullable=True)
     is_final_turn_in_thread = Column(Boolean, nullable=True)
 
+    # --- Per-turn diffs (honest "this turn" signals vs. the cumulative fields
+    # above). Cross-row, so maintained by the same ingest recompute as turn_index
+    # (null-session singletons are set directly in build_row).
+    # insight_created_this_turn: insight_id changed to non-null on this turn.
+    # datasets_analysed_this_turn: datasets new this turn (cumulative minus prior).
+    insight_created_this_turn = Column(Boolean, nullable=True)
+    datasets_analysed_this_turn = Column(ARRAY(String), nullable=True)
+
     # Long-tail + cumulative derived fields, kept out of the column set to keep
     # migrations rare. Includes turn_tools_used, turn_datasets, aoi_source,
     # aoi_count, aois, primary_dataset_id, analysis_start/end_date,

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -13,8 +13,9 @@ labelled as such. Only ``/sessions`` groups by session.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -161,90 +162,80 @@ def _list_item_from_row(r: dict[str, Any]) -> TraceListItem:
     )
 
 
-def _filters(
-    environment: Optional[str],
-    outcome: Optional[str],
-    user_id: Optional[str],
-    session_id: Optional[str],
-    start: Optional[datetime],
-    end: Optional[datetime],
-    prompt_contains: Optional[str],
-    turn_index: Optional[int] = None,
-    min_turn_index: Optional[int] = None,
-    max_turn_index: Optional[int] = None,
-    first_turn_only: bool = False,
-) -> list[Any]:
+@dataclass
+class TurnAnalyticsFilters:
+    """Shared query-param filter set for the list + analytics endpoints. The
+    turn-position filters compare the stored, indexed ``turn_index`` (so no window);
+    ``first_turn_only`` is a convenience alias for ``turn_index == 1``."""
+
+    environment: Annotated[Optional[str], Query()] = None
+    outcome: Annotated[Optional[str], Query()] = None
+    user_id: Annotated[Optional[str], Query()] = None
+    start: Annotated[
+        Optional[datetime], Query(description="trace_timestamp >= (ISO)")
+    ] = None
+    end: Annotated[
+        Optional[datetime], Query(description="trace_timestamp < (ISO)")
+    ] = None
+    turn_index: Annotated[
+        Optional[int],
+        Query(ge=1, description="exact 1-based turn position in the session"),
+    ] = None
+    min_turn_index: Annotated[Optional[int], Query(ge=1)] = None
+    max_turn_index: Annotated[Optional[int], Query(ge=1)] = None
+    first_turn_only: Annotated[
+        bool, Query(description="only first turns (alias for turn_index=1)")
+    ] = False
+
+    def __post_init__(self) -> None:
+        _check_turn_range(self.min_turn_index, self.max_turn_index)
+
+
+@dataclass
+class ListFilters(TurnAnalyticsFilters):
+    """TurnAnalyticsFilters plus the list-only text filters."""
+
+    session_id: Annotated[Optional[str], Query()] = None
+    prompt_contains: Annotated[Optional[str], Query()] = None
+
+
+def _filters(flt: ListFilters) -> list[Any]:
     conds: list[Any] = []
-    if environment:
-        conds.append(LangfuseTraceOrm.environment == environment)
-    if outcome:
-        conds.append(LangfuseTraceOrm.outcome == outcome)
-    if user_id:
-        conds.append(LangfuseTraceOrm.user_id == user_id)
-    if session_id:
-        conds.append(LangfuseTraceOrm.session_id == session_id)
-    if start:
-        conds.append(LangfuseTraceOrm.trace_timestamp >= start)
-    if end:
-        conds.append(LangfuseTraceOrm.trace_timestamp < end)
-    if prompt_contains:
-        conds.append(LangfuseTraceOrm.prompt.ilike(f"%{prompt_contains}%"))
-    # Turn-position filters (stored turn_index -> true position, index-backed).
-    # first_turn_only is a convenience alias for turn_index == 1.
-    if first_turn_only:
+    if flt.environment:
+        conds.append(LangfuseTraceOrm.environment == flt.environment)
+    if flt.outcome:
+        conds.append(LangfuseTraceOrm.outcome == flt.outcome)
+    if flt.user_id:
+        conds.append(LangfuseTraceOrm.user_id == flt.user_id)
+    if flt.session_id:
+        conds.append(LangfuseTraceOrm.session_id == flt.session_id)
+    if flt.start:
+        conds.append(LangfuseTraceOrm.trace_timestamp >= flt.start)
+    if flt.end:
+        conds.append(LangfuseTraceOrm.trace_timestamp < flt.end)
+    if flt.prompt_contains:
+        conds.append(LangfuseTraceOrm.prompt.ilike(f"%{flt.prompt_contains}%"))
+    if flt.first_turn_only:
         conds.append(LangfuseTraceOrm.turn_index == 1)
-    if turn_index is not None:
-        conds.append(LangfuseTraceOrm.turn_index == turn_index)
-    if min_turn_index is not None:
-        conds.append(LangfuseTraceOrm.turn_index >= min_turn_index)
-    if max_turn_index is not None:
-        conds.append(LangfuseTraceOrm.turn_index <= max_turn_index)
+    if flt.turn_index is not None:
+        conds.append(LangfuseTraceOrm.turn_index == flt.turn_index)
+    if flt.min_turn_index is not None:
+        conds.append(LangfuseTraceOrm.turn_index >= flt.min_turn_index)
+    if flt.max_turn_index is not None:
+        conds.append(LangfuseTraceOrm.turn_index <= flt.max_turn_index)
     return conds
 
 
 @router.get("", response_model=TraceListResponse)
 async def list_traces(
-    environment: Optional[str] = Query(None),
-    outcome: Optional[str] = Query(None),
-    user_id: Optional[str] = Query(None),
-    session_id: Optional[str] = Query(None),
-    start: Optional[datetime] = Query(
-        None, description="trace_timestamp >= (ISO)"
-    ),
-    end: Optional[datetime] = Query(
-        None, description="trace_timestamp < (ISO)"
-    ),
-    prompt_contains: Optional[str] = Query(None),
-    turn_index: Optional[int] = Query(
-        None,
-        ge=1,
-        description="exact 1-based turn position within the session",
-    ),
-    min_turn_index: Optional[int] = Query(None, ge=1),
-    max_turn_index: Optional[int] = Query(None, ge=1),
-    first_turn_only: bool = Query(
-        False, description="only first turns (alias for turn_index=1)"
-    ),
+    flt: ListFilters = Depends(),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     _reader: UserModel = Depends(require_scope(TRACES_READ)),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceListResponse:
     """List/filter traces (derived columns only — never raw/output)."""
-    _check_turn_range(min_turn_index, max_turn_index)
-    conds = _filters(
-        environment,
-        outcome,
-        user_id,
-        session_id,
-        start,
-        end,
-        prompt_contains,
-        turn_index,
-        min_turn_index,
-        max_turn_index,
-        first_turn_only,
-    )
+    conds = _filters(flt)
 
     count_stmt = select(func.count()).select_from(LangfuseTraceOrm)
     for c in conds:
@@ -368,54 +359,41 @@ class SessionListResponse(BaseModel):
 
 
 def _where_sql(
-    environment: Optional[str],
-    outcome: Optional[str],
-    user_id: Optional[str],
-    start: Optional[datetime],
-    end: Optional[datetime],
-    *,
-    require_session: bool = False,
-    turn_index: Optional[int] = None,
-    min_turn_index: Optional[int] = None,
-    max_turn_index: Optional[int] = None,
-    first_turn_only: bool = False,
+    flt: TurnAnalyticsFilters, *, require_session: bool = False
 ) -> tuple[str, dict[str, Any]]:
-    """Build a parameterised WHERE clause (bound params — no injection).
-
-    The turn-position filters compare the stored, indexed ``turn_index``
-    (``ix_langfuse_traces_turn_index``), so the aggregate SQL stays window-free.
-    ``first_turn_only`` is a convenience alias for ``turn_index = 1``.
-    """
+    """Build a parameterised WHERE clause (bound params — no injection). The
+    turn-position filters compare the stored, indexed ``turn_index``, so the
+    aggregate SQL stays window-free."""
     clauses: list[str] = []
     params: dict[str, Any] = {}
     if require_session:
         clauses.append("session_id IS NOT NULL")
-    if environment:
+    if flt.environment:
         clauses.append("environment = :environment")
-        params["environment"] = environment
-    if outcome:
+        params["environment"] = flt.environment
+    if flt.outcome:
         clauses.append("outcome = :outcome")
-        params["outcome"] = outcome
-    if user_id:
+        params["outcome"] = flt.outcome
+    if flt.user_id:
         clauses.append("user_id = :user_id")
-        params["user_id"] = user_id
-    if start:
+        params["user_id"] = flt.user_id
+    if flt.start:
         clauses.append("trace_timestamp >= :start")
-        params["start"] = start
-    if end:
+        params["start"] = flt.start
+    if flt.end:
         clauses.append("trace_timestamp < :end")
-        params["end"] = end
-    if first_turn_only:
+        params["end"] = flt.end
+    if flt.first_turn_only:
         clauses.append("turn_index = 1")
-    if turn_index is not None:
+    if flt.turn_index is not None:
         clauses.append("turn_index = :turn_index")
-        params["turn_index"] = turn_index
-    if min_turn_index is not None:
+        params["turn_index"] = flt.turn_index
+    if flt.min_turn_index is not None:
         clauses.append("turn_index >= :min_turn_index")
-        params["min_turn_index"] = min_turn_index
-    if max_turn_index is not None:
+        params["min_turn_index"] = flt.min_turn_index
+    if flt.max_turn_index is not None:
         clauses.append("turn_index <= :max_turn_index")
-        params["max_turn_index"] = max_turn_index
+        params["max_turn_index"] = flt.max_turn_index
     where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
     return where, params
 
@@ -484,43 +462,15 @@ def _metrics_dict(r: Any) -> dict[str, Any]:
 
 @router.get("/analytics", response_model=TraceAnalytics)
 async def trace_analytics(
-    environment: Optional[str] = Query(None),
-    outcome: Optional[str] = Query(None),
-    user_id: Optional[str] = Query(None),
-    start: Optional[datetime] = Query(None),
-    end: Optional[datetime] = Query(None),
-    turn_index: Optional[int] = Query(
-        None,
-        ge=1,
-        description="exact 1-based turn position within the session",
-    ),
-    min_turn_index: Optional[int] = Query(None, ge=1),
-    max_turn_index: Optional[int] = Query(None, ge=1),
-    first_turn_only: bool = Query(
-        False, description="only first turns (alias for turn_index=1)"
-    ),
+    flt: TurnAnalyticsFilters = Depends(),
     _reader: UserModel = Depends(require_scope(TRACES_READ)),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceAnalytics:
     """Server-side aggregates over the filtered trace set. All metrics are
-    turn-level (one row per trace), so counts/sums are not double-counted.
-
-    The turn-position filters let one endpoint answer "how does turn 1 differ
-    from turn 3+" via two calls — they filter the indexed stored ``turn_index``,
-    so the aggregates stay window-free.
-    """
-    _check_turn_range(min_turn_index, max_turn_index)
-    where, params = _where_sql(
-        environment,
-        outcome,
-        user_id,
-        start,
-        end,
-        turn_index=turn_index,
-        min_turn_index=min_turn_index,
-        max_turn_index=max_turn_index,
-        first_turn_only=first_turn_only,
-    )
+    turn-level (one row per trace), so counts/sums are not double-counted. The
+    turn-position filters answer "how does turn 1 differ from turn 3+" via two
+    calls, filtering the indexed ``turn_index`` (no window)."""
+    where, params = _where_sql(flt)
 
     summary = (
         (
@@ -595,17 +545,7 @@ async def trace_analytics(
 
 @router.get("/analytics/by-turn", response_model=TurnAnalytics)
 async def trace_analytics_by_turn(
-    environment: Optional[str] = Query(None),
-    outcome: Optional[str] = Query(None),
-    user_id: Optional[str] = Query(None),
-    start: Optional[datetime] = Query(None),
-    end: Optional[datetime] = Query(None),
-    turn_index: Optional[int] = Query(None, ge=1),
-    min_turn_index: Optional[int] = Query(None, ge=1),
-    max_turn_index: Optional[int] = Query(None, ge=1),
-    first_turn_only: bool = Query(
-        False, description="only first turns (alias for turn_index=1)"
-    ),
+    flt: TurnAnalyticsFilters = Depends(),
     turn_bucket_cap: int = Query(
         10,
         ge=1,
@@ -620,18 +560,7 @@ async def trace_analytics_by_turn(
     ``turn_bucket_cap`` collapse into one terminal bucket. Any turn-position filter
     applies *before* bucketing (filter, then bucket). Filters compose with the
     stored, indexed ``turn_index`` — no window, no view."""
-    _check_turn_range(min_turn_index, max_turn_index)
-    where, params = _where_sql(
-        environment,
-        outcome,
-        user_id,
-        start,
-        end,
-        turn_index=turn_index,
-        min_turn_index=min_turn_index,
-        max_turn_index=max_turn_index,
-        first_turn_only=first_turn_only,
-    )
+    where, params = _where_sql(flt)
 
     # Grand total over the whole filtered set (includes NULL-turn rows), plus the
     # NULL-turn count so groups (which exclude NULLs) reconcile against it.
@@ -705,7 +634,10 @@ async def list_sessions(
     """Conversation browser: one row per session (thread), newest first, with the
     first prompt of the thread and a turn count."""
     where, params = _where_sql(
-        environment, None, user_id, start, end, require_session=True
+        TurnAnalyticsFilters(
+            environment=environment, user_id=user_id, start=start, end=end
+        ),
+        require_session=True,
     )
 
     total = int(

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -315,8 +315,17 @@ def _where_sql(
     end: Optional[datetime],
     *,
     require_session: bool = False,
+    turn_index: Optional[int] = None,
+    min_turn_index: Optional[int] = None,
+    max_turn_index: Optional[int] = None,
+    first_turn_only: bool = False,
 ) -> tuple[str, dict[str, Any]]:
-    """Build a parameterised WHERE clause (bound params — no injection)."""
+    """Build a parameterised WHERE clause (bound params — no injection).
+
+    The turn-position filters compare the stored, indexed ``turn_index``
+    (``ix_langfuse_traces_turn_index``), so the aggregate SQL stays window-free.
+    ``first_turn_only`` is a convenience alias for ``turn_index = 1``.
+    """
     clauses: list[str] = []
     params: dict[str, Any] = {}
     if require_session:
@@ -336,6 +345,17 @@ def _where_sql(
     if end:
         clauses.append("trace_timestamp < :end")
         params["end"] = end
+    if first_turn_only:
+        clauses.append("turn_index = 1")
+    if turn_index is not None:
+        clauses.append("turn_index = :turn_index")
+        params["turn_index"] = turn_index
+    if min_turn_index is not None:
+        clauses.append("turn_index >= :min_turn_index")
+        params["min_turn_index"] = min_turn_index
+    if max_turn_index is not None:
+        clauses.append("turn_index <= :max_turn_index")
+        params["max_turn_index"] = max_turn_index
     where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
     return where, params
 
@@ -351,12 +371,37 @@ async def trace_analytics(
     user_id: Optional[str] = Query(None),
     start: Optional[datetime] = Query(None),
     end: Optional[datetime] = Query(None),
+    turn_index: Optional[int] = Query(
+        None,
+        ge=1,
+        description="exact 1-based turn position within the session",
+    ),
+    min_turn_index: Optional[int] = Query(None, ge=1),
+    max_turn_index: Optional[int] = Query(None, ge=1),
+    first_turn_only: bool = Query(
+        False, description="only first turns (alias for turn_index=1)"
+    ),
     _reader: UserModel = Depends(require_scope(TRACES_READ)),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceAnalytics:
     """Server-side aggregates over the filtered trace set. All metrics are
-    turn-level (one row per trace), so counts/sums are not double-counted."""
-    where, params = _where_sql(environment, outcome, user_id, start, end)
+    turn-level (one row per trace), so counts/sums are not double-counted.
+
+    The turn-position filters let one endpoint answer "how does turn 1 differ
+    from turn 3+" via two calls — they filter the indexed stored ``turn_index``,
+    so the aggregates stay window-free.
+    """
+    where, params = _where_sql(
+        environment,
+        outcome,
+        user_id,
+        start,
+        end,
+        turn_index=turn_index,
+        min_turn_index=min_turn_index,
+        max_turn_index=max_turn_index,
+        first_turn_only=first_turn_only,
+    )
 
     summary = (
         (

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -3,10 +3,11 @@
 Gated on the ``traces:read`` scope: a superuser human or a machine key carrying
 that scope (see ``require_scope``).
 
-Read path over ``langfuse_traces`` (see src/api/services/langfuse for ingestion).
-List/detail here; analytics + conversation views live alongside. All derived
-fields are turn-level (per the parser); cumulative thread state lives under
-``derived`` and the analytics surface dedups per session.
+Read path over ``langfuse_traces`` (see src/api/services/langfuse for ingestion):
+list/detail, per-turn and turn-bucketed analytics, and a session (thread) view.
+Each row is one turn; most fields are per-turn, but a few (``datasets_analysed``,
+``has_insight``, ``primary_dataset_name``) carry thread-cumulative state and are
+labelled as such. Only ``/sessions`` groups by session.
 """
 
 from __future__ import annotations
@@ -230,6 +231,7 @@ async def list_traces(
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ) -> TraceListResponse:
     """List/filter traces (derived columns only — never raw/output)."""
+    _check_turn_range(min_turn_index, max_turn_index)
     conds = _filters(
         environment,
         outcome,
@@ -422,6 +424,20 @@ def _f(x: Any) -> Optional[float]:
     return round(float(x), 4) if x is not None else None
 
 
+def _check_turn_range(
+    min_turn_index: Optional[int], max_turn_index: Optional[int]
+) -> None:
+    if (
+        min_turn_index is not None
+        and max_turn_index is not None
+        and min_turn_index > max_turn_index
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="min_turn_index must be <= max_turn_index",
+        )
+
+
 # The scalar aggregate expressions shared by /analytics' summary and
 # /analytics/by-turn's grand-total + grouped queries, so the two can't drift.
 # Consumed via _metrics_from_row (reads the aliased columns below).
@@ -440,29 +456,30 @@ _SCALAR_METRICS_SQL = """
 """.strip()
 
 
-def _metrics_from_row(r: Any) -> TurnMetrics:
-    """Map a result row carrying the _SCALAR_METRICS_SQL columns into TurnMetrics."""
-    return TurnMetrics(
-        total_traces=int(r["total"] or 0),
-        latency={
+def _metrics_dict(r: Any) -> dict[str, Any]:
+    """Map a result row carrying the _SCALAR_METRICS_SQL columns into the
+    TurnMetrics field dict (splat into TurnMetrics or TurnGroup)."""
+    return {
+        "total_traces": int(r["total"] or 0),
+        "latency": {
             "avg": _f(r["lat_avg"]),
             "p50": _f(r["lat_p50"]),
             "p95": _f(r["lat_p95"]),
         },
-        cost={
+        "cost": {
             "avg": _f(r["cost_avg"]),
             "p95": _f(r["cost_p95"]),
             "total": _f(r["cost_total"]),
         },
-        tokens={
+        "tokens": {
             "avg_turn_tokens": _f(r["tok_avg"]),
             "total_turn_tokens": _f(r["tok_total"]),
         },
-        tool_usage={
+        "tool_usage": {
             "avg_tool_calls": _f(r["tool_avg"]),
             "tool_error_rate": _f(r["tool_err_rate"]),
         },
-    )
+    }
 
 
 @router.get("/analytics", response_model=TraceAnalytics)
@@ -492,6 +509,7 @@ async def trace_analytics(
     from turn 3+" via two calls — they filter the indexed stored ``turn_index``,
     so the aggregates stay window-free.
     """
+    _check_turn_range(min_turn_index, max_turn_index)
     where, params = _where_sql(
         environment,
         outcome,
@@ -519,7 +537,7 @@ async def trace_analytics(
         .mappings()
         .one()
     )
-    metrics = _metrics_from_row(summary)
+    metrics = _metrics_dict(summary)
 
     outcomes = (
         (
@@ -566,16 +584,12 @@ async def trace_analytics(
     )
 
     return TraceAnalytics(
-        total_traces=metrics.total_traces,
         unique_sessions=int(summary["sessions"] or 0),
         unique_users=int(summary["users"] or 0),
         outcome_breakdown=[NamedCount(**dict(r)) for r in outcomes],
         daily_volume=[DailyCount(**dict(r)) for r in daily],
         aoi_type_breakdown=[NamedCount(**dict(r)) for r in aoi],
-        latency=metrics.latency,
-        cost=metrics.cost,
-        tokens=metrics.tokens,
-        tool_usage=metrics.tool_usage,
+        **metrics,
     )
 
 
@@ -606,6 +620,7 @@ async def trace_analytics_by_turn(
     ``turn_bucket_cap`` collapse into one terminal bucket. Any turn-position filter
     applies *before* bucketing (filter, then bucket). Filters compose with the
     stored, indexed ``turn_index`` — no window, no view."""
+    _check_turn_range(min_turn_index, max_turn_index)
     where, params = _where_sql(
         environment,
         outcome,
@@ -663,7 +678,7 @@ async def trace_analytics_by_turn(
             turn_index_min=int(r["turn_index_min"]),
             turn_index_max=int(r["turn_index_max"]),
             sessions_reaching=int(r["sessions_reaching"] or 0),
-            **_metrics_from_row(r).model_dump(),
+            **_metrics_dict(r),
         )
         for r in group_rows
     ]
@@ -671,7 +686,7 @@ async def trace_analytics_by_turn(
     return TurnAnalytics(
         turn_bucket_cap=turn_bucket_cap,
         ungrouped_traces=int(grand["ungrouped"] or 0),
-        grand_total=_metrics_from_row(grand),
+        grand_total=TurnMetrics(**_metrics_dict(grand)),
         groups=groups,
     )
 

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -290,6 +290,64 @@ class TraceAnalytics(BaseModel):
     tool_usage: dict[str, Optional[float]]
 
 
+class TurnMetrics(BaseModel):
+    """The scalar metric block shared by ``/analytics/by-turn``'s grand total and
+    each per-turn bucket (same shape as the corresponding fields on
+    ``TraceAnalytics``)."""
+
+    total_traces: int
+    latency: dict[str, Optional[float]]  # {avg, p50, p95}
+    cost: dict[str, Optional[float]] = Field(
+        ...,
+        description=(
+            "{avg, p95, total}. The sums (total) are within-bucket totals and are "
+            "NOT comparable across buckets — the terminal bucket aggregates many "
+            "turn positions. Compare averages/percentiles across buckets."
+        ),
+    )
+    tokens: dict[str, Optional[float]]  # {avg_turn_tokens, total_turn_tokens}
+    tool_usage: dict[str, Optional[float]]  # {avg_tool_calls, tool_error_rate}
+
+
+class TurnGroup(TurnMetrics):
+    """One turn-position bucket. Positions at/above ``turn_bucket_cap`` collapse
+    into a single terminal bucket, so ``turn_index`` is the bucket label
+    (``== cap`` means "cap or more") while ``turn_index_min``/``turn_index_max``
+    give the true range within it."""
+
+    turn_index: int
+    is_terminal: bool = Field(
+        ...,
+        description=(
+            "The collapsing bucket (turn_index == turn_bucket_cap). True here does "
+            "NOT by itself mean turns beyond the cap exist — check turn_index_max > "
+            "turn_bucket_cap for that."
+        ),
+    )
+    turn_index_min: int
+    turn_index_max: int
+    sessions_reaching: int = Field(
+        ...,
+        description=(
+            "Distinct sessions that reached this turn position (a funnel/retention "
+            "curve). A session spans buckets, so this is NOT summable across buckets."
+        ),
+    )
+
+
+class TurnAnalytics(BaseModel):
+    turn_bucket_cap: int
+    ungrouped_traces: int = Field(
+        ...,
+        description=(
+            "Traces with a NULL turn_index (excluded from groups). "
+            "sum(groups.total_traces) + ungrouped_traces == grand_total.total_traces."
+        ),
+    )
+    grand_total: TurnMetrics
+    groups: list[TurnGroup]
+
+
 class SessionItem(BaseModel):
     session_id: str
     user_id: Optional[str] = None
@@ -364,6 +422,49 @@ def _f(x: Any) -> Optional[float]:
     return round(float(x), 4) if x is not None else None
 
 
+# The scalar aggregate expressions shared by /analytics' summary and
+# /analytics/by-turn's grand-total + grouped queries, so the two can't drift.
+# Consumed via _metrics_from_row (reads the aliased columns below).
+_SCALAR_METRICS_SQL = """
+  count(*) AS total,
+  avg(latency_seconds) AS lat_avg,
+  percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_seconds) AS lat_p50,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_seconds) AS lat_p95,
+  avg(total_cost) AS cost_avg,
+  percentile_cont(0.95) WITHIN GROUP (ORDER BY total_cost) AS cost_p95,
+  sum(total_cost) AS cost_total,
+  avg(turn_tokens) AS tok_avg,
+  sum(turn_tokens) AS tok_total,
+  avg(turn_tool_calls) AS tool_avg,
+  avg(CASE WHEN tool_error_count > 0 THEN 1.0 ELSE 0.0 END) AS tool_err_rate
+""".strip()
+
+
+def _metrics_from_row(r: Any) -> TurnMetrics:
+    """Map a result row carrying the _SCALAR_METRICS_SQL columns into TurnMetrics."""
+    return TurnMetrics(
+        total_traces=int(r["total"] or 0),
+        latency={
+            "avg": _f(r["lat_avg"]),
+            "p50": _f(r["lat_p50"]),
+            "p95": _f(r["lat_p95"]),
+        },
+        cost={
+            "avg": _f(r["cost_avg"]),
+            "p95": _f(r["cost_p95"]),
+            "total": _f(r["cost_total"]),
+        },
+        tokens={
+            "avg_turn_tokens": _f(r["tok_avg"]),
+            "total_turn_tokens": _f(r["tok_total"]),
+        },
+        tool_usage={
+            "avg_tool_calls": _f(r["tool_avg"]),
+            "tool_error_rate": _f(r["tool_err_rate"]),
+        },
+    )
+
+
 @router.get("/analytics", response_model=TraceAnalytics)
 async def trace_analytics(
     environment: Optional[str] = Query(None),
@@ -407,23 +508,10 @@ async def trace_analytics(
         (
             await session.execute(
                 text(
-                    f"""
-                SELECT
-                  count(*) AS total,
-                  count(DISTINCT session_id) AS sessions,
-                  count(DISTINCT user_id) AS users,
-                  avg(latency_seconds) AS lat_avg,
-                  percentile_cont(0.5) WITHIN GROUP (ORDER BY latency_seconds) AS lat_p50,
-                  percentile_cont(0.95) WITHIN GROUP (ORDER BY latency_seconds) AS lat_p95,
-                  avg(total_cost) AS cost_avg,
-                  percentile_cont(0.95) WITHIN GROUP (ORDER BY total_cost) AS cost_p95,
-                  sum(total_cost) AS cost_total,
-                  avg(turn_tokens) AS tok_avg,
-                  sum(turn_tokens) AS tok_total,
-                  avg(turn_tool_calls) AS tool_avg,
-                  avg(CASE WHEN tool_error_count > 0 THEN 1.0 ELSE 0.0 END) AS tool_err_rate
-                FROM langfuse_traces{where}
-                """
+                    f"SELECT {_SCALAR_METRICS_SQL}, "
+                    f"count(DISTINCT session_id) AS sessions, "
+                    f"count(DISTINCT user_id) AS users "
+                    f"FROM langfuse_traces{where}"
                 ),
                 params,
             )
@@ -431,6 +519,7 @@ async def trace_analytics(
         .mappings()
         .one()
     )
+    metrics = _metrics_from_row(summary)
 
     outcomes = (
         (
@@ -477,30 +566,113 @@ async def trace_analytics(
     )
 
     return TraceAnalytics(
-        total_traces=int(summary["total"] or 0),
+        total_traces=metrics.total_traces,
         unique_sessions=int(summary["sessions"] or 0),
         unique_users=int(summary["users"] or 0),
         outcome_breakdown=[NamedCount(**dict(r)) for r in outcomes],
         daily_volume=[DailyCount(**dict(r)) for r in daily],
         aoi_type_breakdown=[NamedCount(**dict(r)) for r in aoi],
-        latency={
-            "avg": _f(summary["lat_avg"]),
-            "p50": _f(summary["lat_p50"]),
-            "p95": _f(summary["lat_p95"]),
-        },
-        cost={
-            "avg": _f(summary["cost_avg"]),
-            "p95": _f(summary["cost_p95"]),
-            "total": _f(summary["cost_total"]),
-        },
-        tokens={
-            "avg_turn_tokens": _f(summary["tok_avg"]),
-            "total_turn_tokens": _f(summary["tok_total"]),
-        },
-        tool_usage={
-            "avg_tool_calls": _f(summary["tool_avg"]),
-            "tool_error_rate": _f(summary["tool_err_rate"]),
-        },
+        latency=metrics.latency,
+        cost=metrics.cost,
+        tokens=metrics.tokens,
+        tool_usage=metrics.tool_usage,
+    )
+
+
+@router.get("/analytics/by-turn", response_model=TurnAnalytics)
+async def trace_analytics_by_turn(
+    environment: Optional[str] = Query(None),
+    outcome: Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
+    start: Optional[datetime] = Query(None),
+    end: Optional[datetime] = Query(None),
+    turn_index: Optional[int] = Query(None, ge=1),
+    min_turn_index: Optional[int] = Query(None, ge=1),
+    max_turn_index: Optional[int] = Query(None, ge=1),
+    first_turn_only: bool = Query(
+        False, description="only first turns (alias for turn_index=1)"
+    ),
+    turn_bucket_cap: int = Query(
+        10,
+        ge=1,
+        le=50,
+        description="turn positions >= this collapse into one terminal bucket",
+    ),
+    _reader: UserModel = Depends(require_scope(TRACES_READ)),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+) -> TurnAnalytics:
+    """The same scalar metrics as ``/analytics`` but broken down per turn position,
+    so "how do turns evolve within a session" is a single call. Positions at/above
+    ``turn_bucket_cap`` collapse into one terminal bucket. Any turn-position filter
+    applies *before* bucketing (filter, then bucket). Filters compose with the
+    stored, indexed ``turn_index`` — no window, no view."""
+    where, params = _where_sql(
+        environment,
+        outcome,
+        user_id,
+        start,
+        end,
+        turn_index=turn_index,
+        min_turn_index=min_turn_index,
+        max_turn_index=max_turn_index,
+        first_turn_only=first_turn_only,
+    )
+
+    # Grand total over the whole filtered set (includes NULL-turn rows), plus the
+    # NULL-turn count so groups (which exclude NULLs) reconcile against it.
+    grand = (
+        (
+            await session.execute(
+                text(
+                    f"SELECT {_SCALAR_METRICS_SQL}, "
+                    f"count(*) FILTER (WHERE turn_index IS NULL) AS ungrouped "
+                    f"FROM langfuse_traces{where}"
+                ),
+                params,
+            )
+        )
+        .mappings()
+        .one()
+    )
+
+    # Per-bucket: LEAST(turn_index, cap) folds the tail; min/max expose the true
+    # range (so the terminal label is honest); sessions_reaching is the funnel.
+    group_rows = (
+        (
+            await session.execute(
+                text(
+                    f"SELECT LEAST(turn_index, :cap) AS turn_index, "
+                    f"min(turn_index) AS turn_index_min, "
+                    f"max(turn_index) AS turn_index_max, "
+                    f"count(DISTINCT session_id) AS sessions_reaching, "
+                    f"{_SCALAR_METRICS_SQL} FROM langfuse_traces{where}"
+                    f"{' AND' if where else ' WHERE'} turn_index IS NOT NULL "
+                    f"GROUP BY 1 ORDER BY 1"
+                ),
+                {**params, "cap": turn_bucket_cap},
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    groups = [
+        TurnGroup(
+            turn_index=int(r["turn_index"]),
+            is_terminal=int(r["turn_index"]) == turn_bucket_cap,
+            turn_index_min=int(r["turn_index_min"]),
+            turn_index_max=int(r["turn_index_max"]),
+            sessions_reaching=int(r["sessions_reaching"] or 0),
+            **_metrics_from_row(r).model_dump(),
+        )
+        for r in group_rows
+    ]
+
+    return TurnAnalytics(
+        turn_bucket_cap=turn_bucket_cap,
+        ungrouped_traces=int(grand["ungrouped"] or 0),
+        grand_total=_metrics_from_row(grand),
+        groups=groups,
     )
 
 

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -16,7 +16,7 @@ from datetime import date, datetime
 from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -43,19 +43,52 @@ class TraceListItem(BaseModel):
     prompt: Optional[str] = None
     aoi_name: Optional[str] = None
     aoi_type: Optional[str] = None
-    primary_dataset_name: Optional[str] = None
-    has_insight: Optional[bool] = None
+    primary_dataset_name: Optional[str] = Field(
+        None,
+        description=(
+            "Thread-cumulative as of this turn: the primary dataset in effect at "
+            "this turn, which may have been selected on an earlier turn. For the "
+            "datasets newly analysed on this turn use datasets_analysed_this_turn."
+        ),
+    )
+    has_insight: Optional[bool] = Field(
+        None,
+        description=(
+            "Thread-cumulative as of this turn: whether an insight exists in the "
+            "thread as of this turn (possibly created earlier). For whether *this* "
+            "turn created one use insight_created_this_turn."
+        ),
+    )
     is_global: Optional[bool] = None
     # 1-based position of this turn within its session (ordered by
     # trace_timestamp); session-less traces are singletons (turn_index 1).
     turn_index: Optional[int] = None
+    # Per-turn diffs (honest "this turn" signals, vs. the cumulative fields above).
+    insight_created_this_turn: Optional[bool] = Field(
+        None,
+        description="True only on the turn whose insight_id first became non-null.",
+    )
+    datasets_analysed_this_turn: Optional[list[str]] = Field(
+        None,
+        description=(
+            "Datasets new to this turn (this turn's cumulative set minus the "
+            "previous turn's), vs. datasets_analysed which is thread-cumulative."
+        ),
+    )
     turn_tokens: Optional[int] = None
     turn_tool_calls: Optional[int] = None
     tool_error_count: Optional[int] = None
     latency_seconds: Optional[float] = None
     total_cost: Optional[float] = None
     # Sourced from the ``derived`` JSONB (long-tail fields kept out of columns).
-    datasets_analysed: Optional[list[str]] = None
+    datasets_analysed: Optional[list[str]] = Field(
+        None,
+        description=(
+            "Thread-cumulative as of this turn: every dataset analysed in the "
+            "thread up to and including this turn. For the per-turn delta use "
+            "datasets_analysed_this_turn."
+        ),
+    )
     language: Optional[str] = None
     language_confidence: Optional[float] = None
 
@@ -101,6 +134,8 @@ _LIST_COLUMNS = (
     LangfuseTraceOrm.has_insight,
     LangfuseTraceOrm.is_global,
     LangfuseTraceOrm.turn_index,
+    LangfuseTraceOrm.insight_created_this_turn,
+    LangfuseTraceOrm.datasets_analysed_this_turn,
     LangfuseTraceOrm.turn_tokens,
     LangfuseTraceOrm.turn_tool_calls,
     LangfuseTraceOrm.tool_error_count,
@@ -530,6 +565,8 @@ async def get_trace(
         has_insight=row.has_insight,
         is_global=row.is_global,
         turn_index=row.turn_index,
+        insight_created_this_turn=row.insight_created_this_turn,
+        datasets_analysed_this_turn=row.datasets_analysed_this_turn,
         insight_id=row.insight_id,
         turn_tokens=row.turn_tokens,
         turn_input_tokens=row.turn_input_tokens,

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -46,6 +46,9 @@ class TraceListItem(BaseModel):
     primary_dataset_name: Optional[str] = None
     has_insight: Optional[bool] = None
     is_global: Optional[bool] = None
+    # 1-based position of this turn within its session (ordered by
+    # trace_timestamp); session-less traces are singletons (turn_index 1).
+    turn_index: Optional[int] = None
     turn_tokens: Optional[int] = None
     turn_tool_calls: Optional[int] = None
     tool_error_count: Optional[int] = None
@@ -97,6 +100,7 @@ _LIST_COLUMNS = (
     LangfuseTraceOrm.primary_dataset_name,
     LangfuseTraceOrm.has_insight,
     LangfuseTraceOrm.is_global,
+    LangfuseTraceOrm.turn_index,
     LangfuseTraceOrm.turn_tokens,
     LangfuseTraceOrm.turn_tool_calls,
     LangfuseTraceOrm.tool_error_count,
@@ -129,6 +133,10 @@ def _filters(
     start: Optional[datetime],
     end: Optional[datetime],
     prompt_contains: Optional[str],
+    turn_index: Optional[int] = None,
+    min_turn_index: Optional[int] = None,
+    max_turn_index: Optional[int] = None,
+    first_turn_only: bool = False,
 ) -> list[Any]:
     conds: list[Any] = []
     if environment:
@@ -145,6 +153,16 @@ def _filters(
         conds.append(LangfuseTraceOrm.trace_timestamp < end)
     if prompt_contains:
         conds.append(LangfuseTraceOrm.prompt.ilike(f"%{prompt_contains}%"))
+    # Turn-position filters (stored turn_index -> true position, index-backed).
+    # first_turn_only is a convenience alias for turn_index == 1.
+    if first_turn_only:
+        conds.append(LangfuseTraceOrm.turn_index == 1)
+    if turn_index is not None:
+        conds.append(LangfuseTraceOrm.turn_index == turn_index)
+    if min_turn_index is not None:
+        conds.append(LangfuseTraceOrm.turn_index >= min_turn_index)
+    if max_turn_index is not None:
+        conds.append(LangfuseTraceOrm.turn_index <= max_turn_index)
     return conds
 
 
@@ -161,6 +179,16 @@ async def list_traces(
         None, description="trace_timestamp < (ISO)"
     ),
     prompt_contains: Optional[str] = Query(None),
+    turn_index: Optional[int] = Query(
+        None,
+        ge=1,
+        description="exact 1-based turn position within the session",
+    ),
+    min_turn_index: Optional[int] = Query(None, ge=1),
+    max_turn_index: Optional[int] = Query(None, ge=1),
+    first_turn_only: bool = Query(
+        False, description="only first turns (alias for turn_index=1)"
+    ),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     _reader: UserModel = Depends(require_scope(TRACES_READ)),
@@ -168,7 +196,17 @@ async def list_traces(
 ) -> TraceListResponse:
     """List/filter traces (derived columns only — never raw/output)."""
     conds = _filters(
-        environment, outcome, user_id, session_id, start, end, prompt_contains
+        environment,
+        outcome,
+        user_id,
+        session_id,
+        start,
+        end,
+        prompt_contains,
+        turn_index,
+        min_turn_index,
+        max_turn_index,
+        first_turn_only,
     )
 
     count_stmt = select(func.count()).select_from(LangfuseTraceOrm)
@@ -491,6 +529,7 @@ async def get_trace(
         primary_dataset_name=row.primary_dataset_name,
         has_insight=row.has_insight,
         is_global=row.is_global,
+        turn_index=row.turn_index,
         insight_id=row.insight_id,
         turn_tokens=row.turn_tokens,
         turn_input_tokens=row.turn_input_tokens,

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -167,31 +167,46 @@ _RECOMPUTE_SQL = text(
             PARTITION BY session_id
             ORDER BY trace_timestamp ASC NULLS LAST, id ASC
         )
+    ),
+    computed AS (
+        SELECT id,
+               rn AS turn_index,
+               (rn = n) AS is_final,
+               (insight_id IS NOT NULL
+                AND insight_id IS DISTINCT FROM prev_insight) AS created,
+               ARRAY(
+                   SELECT unnest(cur_ds)
+                   EXCEPT
+                   SELECT unnest(COALESCE(prev_ds, ARRAY[]::text[]))
+               )::varchar[] AS new_ds  -- match the column type for the guard below
+        FROM ranked
     )
     UPDATE langfuse_traces t
-    SET turn_index = ranked.rn,
-        is_final_turn_in_thread = (ranked.rn = ranked.n),
-        insight_created_this_turn =
-            (ranked.insight_id IS NOT NULL
-             AND ranked.insight_id IS DISTINCT FROM ranked.prev_insight),
-        datasets_analysed_this_turn = ARRAY(
-            SELECT unnest(ranked.cur_ds)
-            EXCEPT
-            SELECT unnest(COALESCE(ranked.prev_ds, ARRAY[]::text[]))
-        )
-    FROM ranked
-    WHERE t.id = ranked.id
+    SET turn_index = c.turn_index,
+        is_final_turn_in_thread = c.is_final,
+        insight_created_this_turn = c.created,
+        datasets_analysed_this_turn = c.new_ds
+    FROM computed c
+    WHERE t.id = c.id
+      -- Skip rows already current: an UPDATE writes a new tuple even when nothing
+      -- changed, so this guard avoids re-versioning every sibling each recompute.
+      AND (t.turn_index                 IS DISTINCT FROM c.turn_index
+        OR t.is_final_turn_in_thread    IS DISTINCT FROM c.is_final
+        OR t.insight_created_this_turn  IS DISTINCT FROM c.created
+        OR t.datasets_analysed_this_turn IS DISTINCT FROM c.new_ds)
     """
 )
 
 
 async def recompute_turn_positions(
     session: AsyncSession, session_ids: set[str]
-) -> None:
+) -> int:
+    """Returns rows actually rewritten (0 when all sessions are already current)."""
     ids = [s for s in session_ids if s]
     if not ids:
-        return
-    await session.execute(_RECOMPUTE_SQL, {"ids": ids})
+        return 0
+    result = await session.execute(_RECOMPUTE_SQL, {"ids": ids})
+    return result.rowcount or 0
 
 
 # --------------------------------------------------------------------------- #

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -80,15 +80,22 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
     """Map a trace to a langfuse_traces (derived analytics) row dict. Parse
     failures still yield a row (identity + parse_error) so one bad trace never
     aborts the batch."""
+    session_id = trace.get("sessionId")
+    # Null-session traces are singleton threads (COALESCE(session_id, id)); set
+    # their turn position directly. Session-scoped rows get it from the post-upsert
+    # recompute (cross-row), so they carry None here to be filled in-transaction.
+    is_singleton = session_id is None
     row: dict[str, Any] = {
         "id": trace.get("id"),
-        "session_id": trace.get("sessionId"),
+        "session_id": session_id,
         "user_id": trace.get("userId"),
         "environment": trace.get("environment"),
         "trace_timestamp": _parse_dt(trace.get("timestamp")),
         "trace_updated_at": _parse_dt(trace.get("updatedAt")),
         "latency_seconds": trace.get("latency"),
         "total_cost": trace.get("totalCost"),
+        "turn_index": 1 if is_singleton else None,
+        "is_final_turn_in_thread": True if is_singleton else None,
         "parsed_at": _utcnow(),
         "parse_error": None,
     }
@@ -123,6 +130,42 @@ async def _upsert(session: AsyncSession, rows: list[dict[str, Any]]) -> int:
     stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_cols)
     await session.execute(stmt)
     return len(rows)
+
+
+# Recompute turn_index / is_final_turn_in_thread for the given sessions from
+# current table state. Cross-row (a new/late/out-of-order trace shifts its
+# siblings' ordinals), so it runs once per chunk over the *full* touched
+# session(s), not per batch. Deterministic -> re-ingesting a window is idempotent.
+# Null-session rows are singleton threads set in build_row and never renumbered.
+_RECOMPUTE_SQL = text(
+    """
+    WITH ranked AS (
+        SELECT id,
+               row_number() OVER w AS rn,
+               count(*)     OVER (PARTITION BY session_id) AS n
+        FROM langfuse_traces
+        WHERE session_id = ANY(:ids)
+        WINDOW w AS (
+            PARTITION BY session_id
+            ORDER BY trace_timestamp ASC NULLS LAST, id ASC
+        )
+    )
+    UPDATE langfuse_traces t
+    SET turn_index = ranked.rn,
+        is_final_turn_in_thread = (ranked.rn = ranked.n)
+    FROM ranked
+    WHERE t.id = ranked.id
+    """
+)
+
+
+async def recompute_turn_positions(
+    session: AsyncSession, session_ids: set[str]
+) -> None:
+    ids = [s for s in session_ids if s]
+    if not ids:
+        return
+    await session.execute(_RECOMPUTE_SQL, {"ids": ids})
 
 
 # --------------------------------------------------------------------------- #
@@ -215,6 +258,9 @@ class WindowStats:
     fetched: int = 0
     upserted: int = 0
     max_ts: Optional[datetime] = None
+    # Session ids upserted this window; their turn positions are recomputed once
+    # at the chunk boundary (see run_ingestion).
+    touched_sessions: set[str] = field(default_factory=set)
 
 
 async def ingest_window(
@@ -262,6 +308,9 @@ async def _flush(
     await _accumulate_fk(session, batch, metrics)
     if not dry_run:
         stats.upserted += await _upsert(session, batch)
+        stats.touched_sessions.update(
+            r["session_id"] for r in batch if r.get("session_id")
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -356,6 +405,9 @@ async def run_ingestion(
         result.fetched += ws.fetched
         result.upserted += ws.upserted
         if not dry_run:
+            # Renumber turn positions for touched sessions from current table
+            # state, in-transaction, before the chunk is committed.
+            await recompute_turn_positions(session, ws.touched_sessions)
             await session.commit()  # persist chunk before advancing watermark
         result.watermark = cto  # contiguous advance
         logger.info(

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -209,6 +209,67 @@ async def recompute_turn_positions(
     return result.rowcount or 0
 
 
+# Null-session rows are singleton threads with no predecessor: set their turn fields
+# directly (mirrors build_row's singleton branch). Guarded like _RECOMPUTE_SQL so a
+# re-run rewrites nothing.
+_BACKFILL_SINGLETONS_SQL = text(
+    """
+    UPDATE langfuse_traces t
+    SET turn_index = 1,
+        is_final_turn_in_thread = true,
+        insight_created_this_turn = c.created,
+        datasets_analysed_this_turn = c.new_ds
+    FROM (
+        SELECT id,
+               (insight_id IS NOT NULL) AS created,
+               ARRAY(SELECT jsonb_array_elements_text(
+                   COALESCE(derived->'datasets_analysed_cumulative', '[]'::jsonb)
+               ))::varchar[] AS new_ds
+        FROM langfuse_traces
+        WHERE session_id IS NULL
+    ) c
+    WHERE t.id = c.id
+      AND (t.turn_index                 IS DISTINCT FROM 1
+        OR t.is_final_turn_in_thread    IS DISTINCT FROM true
+        OR t.insight_created_this_turn  IS DISTINCT FROM c.created
+        OR t.datasets_analysed_this_turn IS DISTINCT FROM c.new_ds)
+    """
+)
+
+_DISTINCT_SESSIONS_SQL = text(
+    "SELECT DISTINCT session_id FROM langfuse_traces WHERE session_id IS NOT NULL"
+)
+
+
+async def backfill_turn_fields(
+    session: AsyncSession, *, batch_size: int = 500, dry_run: bool = False
+) -> int:
+    """One-off catch-up of the turn fields for rows predating the feature (new rows
+    are set during ingest). Idempotent — reuses the no-op-guarded recompute, so a
+    re-run writes 0 rows. Sessions are processed in committed batches to bound the
+    transaction. Returns the number of rows that would be / were written.
+
+    This is the out-of-band alternative to a migration backfill: run it manually after
+    deploying (``backfill-turn-fields`` CLI command), not in the deploy path.
+    """
+    written = 0
+    # Singletons first (independent of sessions), then each session renumbered.
+    written += (await session.execute(_BACKFILL_SINGLETONS_SQL)).rowcount or 0
+    session_ids = (
+        (await session.execute(_DISTINCT_SESSIONS_SQL)).scalars().all()
+    )
+    for i in range(0, len(session_ids), batch_size):
+        batch = set(session_ids[i : i + batch_size])
+        written += await recompute_turn_positions(session, batch)
+        if not dry_run:
+            await session.commit()
+    if dry_run:
+        await session.rollback()
+    else:
+        await session.commit()  # covers the singleton-only case (no sessions)
+    return written
+
+
 # --------------------------------------------------------------------------- #
 # Per-run metric accumulation
 # --------------------------------------------------------------------------- #

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -81,9 +81,9 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
     failures still yield a row (identity + parse_error) so one bad trace never
     aborts the batch."""
     session_id = trace.get("sessionId")
-    # Null-session traces are singleton threads (COALESCE(session_id, id)); set
-    # their turn position directly. Session-scoped rows get it from the post-upsert
-    # recompute (cross-row), so they carry None here to be filled in-transaction.
+    # Turn position + per-turn diffs are cross-row. Session rows carry None and are
+    # filled by the post-upsert recompute; null-session rows are singleton threads
+    # (COALESCE(session_id, id)) never renumbered, so they're set directly below.
     is_singleton = session_id is None
     row: dict[str, Any] = {
         "id": trace.get("id"),
@@ -94,8 +94,6 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         "trace_updated_at": _parse_dt(trace.get("updatedAt")),
         "latency_seconds": trace.get("latency"),
         "total_cost": trace.get("totalCost"),
-        # Turn position + per-turn diffs are cross-row: session rows carry None and
-        # are filled by the post-upsert recompute; singletons are set below.
         "turn_index": 1 if is_singleton else None,
         "is_final_turn_in_thread": True if is_singleton else None,
         "insight_created_this_turn": None,
@@ -118,9 +116,8 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         row["parser_version"] = P.PARSER_VERSION
         row["recognized_contract"] = None
     if is_singleton:
-        # No predecessor: a singleton turn "creates" any insight it carries, and
-        # its whole cumulative dataset list is new this turn. Parse-failure rows
-        # (no insight_id / derived) fall back to False / empty.
+        # No predecessor: the turn "creates" any insight it carries and its whole
+        # cumulative dataset list is new. Parse failures fall back to False / [].
         derived = row.get("derived") or {}
         row["insight_created_this_turn"] = row.get("insight_id") is not None
         row["datasets_analysed_this_turn"] = (
@@ -145,14 +142,11 @@ async def _upsert(session: AsyncSession, rows: list[dict[str, Any]]) -> int:
     return len(rows)
 
 
-# Recompute the cross-row turn fields for the given sessions from current table
-# state: turn_index / is_final_turn_in_thread (position) plus the per-turn diffs
-# insight_created_this_turn / datasets_analysed_this_turn (this turn vs. the prior
-# one). All depend on siblings (a new/late/out-of-order trace shifts ordinals and
-# the neighbouring diffs), so it runs once per chunk over the *full* touched
-# session(s), not per batch, on a single window. Deterministic -> re-ingesting a
-# window is idempotent. Null-session rows are singleton threads set in build_row
-# and never touched here.
+# Recompute the cross-row turn fields (turn_index, is_final_turn_in_thread, and the
+# per-turn diffs) for the given sessions from current table state. Each depends on
+# siblings, so a late/out-of-order trace can shift them; running once per chunk over
+# the *full* touched session(s) on a single window keeps it deterministic (hence
+# idempotent). Null-session singletons are set in build_row and never touched here.
 _RECOMPUTE_SQL = text(
     """
     WITH ranked AS (
@@ -308,7 +302,7 @@ async def ingest_window(
 ) -> WindowStats:
     """Fetch one closed window, parse, and upsert (chunked). The sync fetch runs
     in a thread so it doesn't block the event loop. Fetch page size is clamped to
-    the Langfuse API max (100); the upsert batch size is independent."""
+    the Langfuse list-page max (``MAX_PAGE_SIZE``); the upsert batch is independent."""
     page_size = min(batch_size, MAX_PAGE_SIZE)
     traces = await asyncio.to_thread(
         client.fetch_window, from_ts, to_ts, environment, page_size

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -94,8 +94,12 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         "trace_updated_at": _parse_dt(trace.get("updatedAt")),
         "latency_seconds": trace.get("latency"),
         "total_cost": trace.get("totalCost"),
+        # Turn position + per-turn diffs are cross-row: session rows carry None and
+        # are filled by the post-upsert recompute; singletons are set below.
         "turn_index": 1 if is_singleton else None,
         "is_final_turn_in_thread": True if is_singleton else None,
+        "insight_created_this_turn": None,
+        "datasets_analysed_this_turn": None,
         "parsed_at": _utcnow(),
         "parse_error": None,
     }
@@ -113,6 +117,15 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         row["parse_error"] = str(e)[:500]
         row["parser_version"] = P.PARSER_VERSION
         row["recognized_contract"] = None
+    if is_singleton:
+        # No predecessor: a singleton turn "creates" any insight it carries, and
+        # its whole cumulative dataset list is new this turn. Parse-failure rows
+        # (no insight_id / derived) fall back to False / empty.
+        derived = row.get("derived") or {}
+        row["insight_created_this_turn"] = row.get("insight_id") is not None
+        row["datasets_analysed_this_turn"] = (
+            derived.get("datasets_analysed_cumulative") or []
+        )
     return _strip_nul(row)
 
 
@@ -132,17 +145,28 @@ async def _upsert(session: AsyncSession, rows: list[dict[str, Any]]) -> int:
     return len(rows)
 
 
-# Recompute turn_index / is_final_turn_in_thread for the given sessions from
-# current table state. Cross-row (a new/late/out-of-order trace shifts its
-# siblings' ordinals), so it runs once per chunk over the *full* touched
-# session(s), not per batch. Deterministic -> re-ingesting a window is idempotent.
-# Null-session rows are singleton threads set in build_row and never renumbered.
+# Recompute the cross-row turn fields for the given sessions from current table
+# state: turn_index / is_final_turn_in_thread (position) plus the per-turn diffs
+# insight_created_this_turn / datasets_analysed_this_turn (this turn vs. the prior
+# one). All depend on siblings (a new/late/out-of-order trace shifts ordinals and
+# the neighbouring diffs), so it runs once per chunk over the *full* touched
+# session(s), not per batch, on a single window. Deterministic -> re-ingesting a
+# window is idempotent. Null-session rows are singleton threads set in build_row
+# and never touched here.
 _RECOMPUTE_SQL = text(
     """
     WITH ranked AS (
         SELECT id,
                row_number() OVER w AS rn,
-               count(*)     OVER (PARTITION BY session_id) AS n
+               count(*)     OVER (PARTITION BY session_id) AS n,
+               insight_id,
+               lag(insight_id) OVER w AS prev_insight,
+               ARRAY(SELECT jsonb_array_elements_text(
+                   COALESCE(derived->'datasets_analysed_cumulative', '[]'::jsonb)
+               )) AS cur_ds,
+               lag(ARRAY(SELECT jsonb_array_elements_text(
+                   COALESCE(derived->'datasets_analysed_cumulative', '[]'::jsonb)
+               ))) OVER w AS prev_ds
         FROM langfuse_traces
         WHERE session_id = ANY(:ids)
         WINDOW w AS (
@@ -152,7 +176,15 @@ _RECOMPUTE_SQL = text(
     )
     UPDATE langfuse_traces t
     SET turn_index = ranked.rn,
-        is_final_turn_in_thread = (ranked.rn = ranked.n)
+        is_final_turn_in_thread = (ranked.rn = ranked.n),
+        insight_created_this_turn =
+            (ranked.insight_id IS NOT NULL
+             AND ranked.insight_id IS DISTINCT FROM ranked.prev_insight),
+        datasets_analysed_this_turn = ARRAY(
+            SELECT unnest(ranked.cur_ds)
+            EXCEPT
+            SELECT unnest(COALESCE(ranked.prev_ds, ARRAY[]::text[]))
+        )
     FROM ranked
     WHERE t.id = ranked.id
     """

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -1,6 +1,6 @@
 """Tests for the superuser-gated Langfuse trace explorer endpoints."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import Request
@@ -367,6 +367,233 @@ async def test_analytics_requires_superuser(client, auth_override, user):
     auth_override(user.id)
     assert (
         await client.get("/api/traces/analytics", headers=H)
+    ).status_code == 403
+
+
+# --- analytics/by-turn -----------------------------------------------------
+_BASE = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+async def _seed_session_turns(session_id: str, n: int, **kw) -> None:
+    """Seed a session as n turns, turn_index 1..n (timestamps spaced by minute)."""
+    for ti in range(1, n + 1):
+        await _seed_trace(
+            f"{session_id}_{ti}",
+            session_id=session_id,
+            turn_index=ti,
+            trace_timestamp=_BASE + timedelta(minutes=ti),
+            **kw,
+        )
+
+
+def _by_index(body) -> dict:
+    return {g["turn_index"]: g for g in body["groups"]}
+
+
+@pytest.mark.asyncio
+async def test_by_turn_buckets_and_terminal(
+    client, auth_override, superuser_factory
+):
+    """15 turns, cap=10 -> buckets 1..10; the terminal bucket collapses turns
+    10..15 and reports the true range."""
+    su = await superuser_factory("su_bt1@example.com")
+    auth_override(su.id)
+    await _seed_session_turns("bt", 15, total_cost=0.01)
+
+    body = (
+        await client.get(
+            "/api/traces/analytics/by-turn?turn_bucket_cap=10", headers=H
+        )
+    ).json()
+    assert body["turn_bucket_cap"] == 10
+    assert body["ungrouped_traces"] == 0
+    assert body["grand_total"]["total_traces"] == 15
+
+    groups = _by_index(body)
+    assert sorted(groups) == list(range(1, 11))
+    assert sum(g["total_traces"] for g in body["groups"]) == 15
+
+    # non-terminal buckets are a single exact position
+    assert groups[1]["is_terminal"] is False
+    assert groups[1]["total_traces"] == 1
+    assert groups[1]["turn_index_min"] == groups[1]["turn_index_max"] == 1
+
+    # terminal bucket aggregates turns 10..15, honestly labelled
+    term = groups[10]
+    assert term["is_terminal"] is True
+    assert term["total_traces"] == 6
+    assert term["turn_index_min"] == 10
+    assert term["turn_index_max"] == 15
+
+
+@pytest.mark.asyncio
+async def test_by_turn_no_overflow(client, auth_override, superuser_factory):
+    """Max turn below the cap -> no bucket is terminal."""
+    su = await superuser_factory("su_bt2@example.com")
+    auth_override(su.id)
+    await _seed_session_turns("bt", 4)
+
+    body = (
+        await client.get(
+            "/api/traces/analytics/by-turn?turn_bucket_cap=10", headers=H
+        )
+    ).json()
+    groups = _by_index(body)
+    assert sorted(groups) == [1, 2, 3, 4]
+    assert all(g["is_terminal"] is False for g in body["groups"])
+    assert all(
+        g["turn_index_min"] == g["turn_index_max"] == g["turn_index"]
+        for g in body["groups"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_by_turn_terminal_exactly_at_cap(
+    client, auth_override, superuser_factory
+):
+    """Max turn == cap with nothing beyond: the terminal bucket exists and is
+    flagged, but turn_index_max == cap proves is_terminal is NOT 'rows beyond
+    the cap exist'."""
+    su = await superuser_factory("su_bt3@example.com")
+    auth_override(su.id)
+    await _seed_session_turns("bt", 10)
+
+    body = (
+        await client.get(
+            "/api/traces/analytics/by-turn?turn_bucket_cap=10", headers=H
+        )
+    ).json()
+    term = _by_index(body)[10]
+    assert term["is_terminal"] is True
+    assert term["total_traces"] == 1
+    assert term["turn_index_max"] == 10  # nothing beyond the cap
+
+
+@pytest.mark.asyncio
+async def test_by_turn_reconciles_null_turn_rows(
+    client, auth_override, superuser_factory
+):
+    """NULL-turn rows are excluded from groups but counted in ungrouped_traces,
+    so the buckets + ungrouped reconcile against the grand total."""
+    su = await superuser_factory("su_bt4@example.com")
+    auth_override(su.id)
+    await _seed_session_turns("bt", 2)
+    await _seed_trace("bt_null", session_id="bt_late", turn_index=None)
+
+    body = (
+        await client.get("/api/traces/analytics/by-turn", headers=H)
+    ).json()
+    assert body["ungrouped_traces"] == 1
+    grouped = sum(g["total_traces"] for g in body["groups"])
+    assert grouped == 2
+    assert (
+        grouped + body["ungrouped_traces"]
+        == body["grand_total"]["total_traces"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_by_turn_empty(client, auth_override, superuser_factory):
+    """A filter matching nothing -> groups [] and zeroed grand total, not a 500."""
+    su = await superuser_factory("su_bt5@example.com")
+    auth_override(su.id)
+    await _seed_session_turns("bt", 3)
+
+    resp = await client.get(
+        "/api/traces/analytics/by-turn?user_id=nobody", headers=H
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["groups"] == []
+    assert body["grand_total"]["total_traces"] == 0
+    assert body["ungrouped_traces"] == 0
+
+
+@pytest.mark.asyncio
+async def test_by_turn_sessions_reaching_funnel(
+    client, auth_override, superuser_factory
+):
+    """sessions_reaching is a funnel: distinct sessions per depth, non-increasing
+    and NOT summing to the session total."""
+    su = await superuser_factory("su_bt6@example.com")
+    auth_override(su.id)
+    await _seed_session_turns("sa", 3)
+    await _seed_session_turns("sb", 2)
+
+    body = (
+        await client.get("/api/traces/analytics/by-turn", headers=H)
+    ).json()
+    reaching = {
+        g["turn_index"]: g["sessions_reaching"] for g in body["groups"]
+    }
+    assert reaching == {1: 2, 2: 2, 3: 1}
+
+
+@pytest.mark.asyncio
+async def test_by_turn_filter_applies_before_bucketing(
+    client, auth_override, superuser_factory
+):
+    """A floor filter applies before bucketing: turns 20..25 collapse into the
+    terminal bucket, labelled 10 but honestly reporting turn_index_min=20."""
+    su = await superuser_factory("su_bt7@example.com")
+    auth_override(su.id)
+    await _seed_session_turns("bt", 25)
+
+    body = (
+        await client.get(
+            "/api/traces/analytics/by-turn"
+            "?min_turn_index=20&turn_bucket_cap=10",
+            headers=H,
+        )
+    ).json()
+    assert len(body["groups"]) == 1
+    term = body["groups"][0]
+    assert term["turn_index"] == 10
+    assert term["is_terminal"] is True
+    assert term["turn_index_min"] == 20
+    assert term["turn_index_max"] == 25
+    assert term["total_traces"] == 6
+
+
+@pytest.mark.asyncio
+async def test_by_turn_grand_total_parity_with_analytics(
+    client, auth_override, superuser_factory
+):
+    """The grand-total block must match /analytics' summary for the same filter
+    (guards the shared aggregate fragment)."""
+    su = await superuser_factory("su_bt8@example.com")
+    auth_override(su.id)
+    for ti, (lat, cost, tok) in enumerate(
+        [(1.0, 0.01, 100), (3.0, 0.03, 200), (2.0, 0.02, 50)], start=1
+    ):
+        await _seed_trace(
+            f"pty_{ti}",
+            session_id="pty",
+            turn_index=ti,
+            outcome="ANSWER",
+            latency_seconds=lat,
+            total_cost=cost,
+            turn_tokens=tok,
+            turn_tool_calls=ti,
+            tool_error_count=0,
+            trace_timestamp=_BASE + timedelta(minutes=ti),
+        )
+
+    analytics = (await client.get("/api/traces/analytics", headers=H)).json()
+    grand = (
+        await client.get("/api/traces/analytics/by-turn", headers=H)
+    ).json()["grand_total"]
+
+    assert grand["total_traces"] == analytics["total_traces"]
+    for k in ("latency", "cost", "tokens", "tool_usage"):
+        assert grand[k] == analytics[k]
+
+
+@pytest.mark.asyncio
+async def test_by_turn_requires_superuser(client, auth_override, user):
+    auth_override(user.id)
+    assert (
+        await client.get("/api/traces/analytics/by-turn", headers=H)
     ).status_code == 403
 
 

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -597,6 +597,25 @@ async def test_by_turn_requires_superuser(client, auth_override, user):
     ).status_code == 403
 
 
+@pytest.mark.asyncio
+async def test_inverted_turn_range_rejected(
+    client, auth_override, superuser_factory
+):
+    """min_turn_index > max_turn_index is a 422 on every filtered endpoint, not a
+    silently-empty result."""
+    su = await superuser_factory("su_range@example.com")
+    auth_override(su.id)
+    for path in (
+        "/api/traces",
+        "/api/traces/analytics",
+        "/api/traces/analytics/by-turn",
+    ):
+        resp = await client.get(
+            f"{path}?min_turn_index=5&max_turn_index=2", headers=H
+        )
+        assert resp.status_code == 422
+
+
 # --- sessions --------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_sessions(client, auth_override, superuser_factory):

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -4,12 +4,14 @@ from datetime import datetime, timezone
 
 import pytest
 from fastapi import Request
+from sqlalchemy import select
 
 from src.api.app import app
 from src.api.auth.dependencies import fetch_user_from_rw_api
 from src.api.auth.scopes import TRACES_READ
 from src.api.data_models import LangfuseTraceOrm
 from src.api.schemas import UserModel
+from src.api.services.langfuse.ingest import recompute_turn_positions
 from tests.conftest import async_session_maker
 
 H = {"Authorization": "Bearer test-token"}
@@ -49,6 +51,17 @@ async def _seed_trace(trace_id: str, **kw) -> None:
     async with async_session_maker() as session:
         session.add(LangfuseTraceOrm(id=trace_id, parser_version=1, **kw))
         await session.commit()
+
+
+async def _turn_fields(trace_id: str) -> tuple:
+    """Read (turn_index, is_final_turn_in_thread) straight from the DB."""
+    async with async_session_maker() as session:
+        row = (
+            await session.execute(
+                select(LangfuseTraceOrm).where(LangfuseTraceOrm.id == trace_id)
+            )
+        ).scalar_one()
+        return row.turn_index, row.is_final_turn_in_thread
 
 
 def _stub_langfuse_fetch(monkeypatch, trace):
@@ -347,3 +360,121 @@ async def test_sessions(client, auth_override, superuser_factory):
     sx = next(s for s in b["items"] if s["session_id"] == "sx")
     assert sx["turn_count"] == 2
     assert sx["first_prompt"] == "first question"  # earliest turn's prompt
+
+
+# --- turn position (Phase 0) -----------------------------------------------
+@pytest.mark.asyncio
+async def test_turn_index_surfaced_and_filtered(
+    client, auth_override, superuser_factory
+):
+    su = await superuser_factory("su_turn@example.com")
+    auth_override(su.id)
+    for ti in (1, 2, 3):
+        await _seed_trace(
+            f"ti{ti}",
+            session_id="ts",
+            turn_index=ti,
+            trace_timestamp=datetime(2026, 6, 1, ti, tzinfo=timezone.utc),
+        )
+
+    # turn_index is on the list item
+    body = (await client.get("/api/traces?session_id=ts", headers=H)).json()
+    assert {i["id"]: i["turn_index"] for i in body["items"]} == {
+        "ti1": 1,
+        "ti2": 2,
+        "ti3": 3,
+    }
+
+    ft = (
+        await client.get("/api/traces?first_turn_only=true", headers=H)
+    ).json()
+    assert [i["id"] for i in ft["items"]] == ["ti1"]
+
+    ex = (await client.get("/api/traces?turn_index=2", headers=H)).json()
+    assert [i["id"] for i in ex["items"]] == ["ti2"]
+
+    mn = (await client.get("/api/traces?min_turn_index=2", headers=H)).json()
+    assert sorted(i["id"] for i in mn["items"]) == ["ti2", "ti3"]
+
+    mx = (await client.get("/api/traces?max_turn_index=1", headers=H)).json()
+    assert [i["id"] for i in mx["items"]] == ["ti1"]
+
+
+@pytest.mark.asyncio
+async def test_turn_index_is_true_position_under_date_filter(
+    client, auth_override, superuser_factory
+):
+    """A stored turn_index is the true in-session position, so a date filter that
+    cuts a session mid-thread does NOT renumber the surviving turns (the client-
+    side-reconstruction bug this replaces)."""
+    su = await superuser_factory("su_turn_date@example.com")
+    auth_override(su.id)
+    for ti, day in ((1, 1), (2, 2), (3, 3)):
+        await _seed_trace(
+            f"d{ti}",
+            session_id="ds",
+            turn_index=ti,
+            trace_timestamp=datetime(2026, 6, day, tzinfo=timezone.utc),
+        )
+
+    body = (
+        await client.get("/api/traces?start=2026-06-02T00:00:00Z", headers=H)
+    ).json()
+    # earliest turn excluded, but survivors keep their true ordinals (2, 3)
+    assert {i["id"]: i["turn_index"] for i in body["items"]} == {
+        "d2": 2,
+        "d3": 3,
+    }
+    # first_turn_only over that same window returns nothing (turn 1 is filtered
+    # out) — not a renumbered "first of the filtered set".
+    ft = (
+        await client.get(
+            "/api/traces?start=2026-06-02T00:00:00Z&first_turn_only=true",
+            headers=H,
+        )
+    ).json()
+    assert ft["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_recompute_turn_positions_orders_flags_and_is_idempotent():
+    # three turns of one session, seeded out of order, all turn_index NULL
+    await _seed_trace(
+        "r3",
+        session_id="rs",
+        trace_timestamp=datetime(2026, 6, 1, 3, tzinfo=timezone.utc),
+    )
+    await _seed_trace(
+        "r1",
+        session_id="rs",
+        trace_timestamp=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+    )
+    await _seed_trace(
+        "r2",
+        session_id="rs",
+        trace_timestamp=datetime(2026, 6, 1, 2, tzinfo=timezone.utc),
+    )
+
+    async def _recompute():
+        async with async_session_maker() as session:
+            await recompute_turn_positions(session, {"rs"})
+            await session.commit()
+
+    await _recompute()
+    assert await _turn_fields("r1") == (1, False)
+    assert await _turn_fields("r2") == (2, False)
+    assert await _turn_fields("r3") == (3, True)
+
+    # idempotent: recomputing the same session yields identical ordinals
+    await _recompute()
+    assert await _turn_fields("r3") == (3, True)
+
+    # a late/out-of-order trace shifts the final flag and extends the numbering
+    await _seed_trace(
+        "r4",
+        session_id="rs",
+        trace_timestamp=datetime(2026, 6, 1, 4, tzinfo=timezone.utc),
+    )
+    await _recompute()
+    assert await _turn_fields("r3") == (3, False)
+    assert await _turn_fields("r4") == (4, True)

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -319,6 +319,50 @@ async def test_analytics(client, auth_override, superuser_factory):
 
 
 @pytest.mark.asyncio
+async def test_analytics_turn_position_filters(
+    client, auth_override, superuser_factory
+):
+    """The same turn-position filters as the list endpoint scope the aggregates,
+    so turn 1 and turn 3+ can be compared via two calls."""
+    su = await superuser_factory("su_an_turn@example.com")
+    auth_override(su.id)
+    # one 3-turn session: costs 0.01 / 0.02 / 0.04 across turns 1/2/3
+    for ti, cost in ((1, 0.01), (2, 0.02), (3, 0.04)):
+        await _seed_trace(
+            f"an_t{ti}",
+            outcome="ANSWER",
+            session_id="ans",
+            turn_index=ti,
+            total_cost=cost,
+            trace_timestamp=datetime(2026, 6, 1, ti, tzinfo=timezone.utc),
+        )
+
+    first = (
+        await client.get(
+            "/api/traces/analytics?first_turn_only=true", headers=H
+        )
+    ).json()
+    assert first["total_traces"] == 1
+    assert first["cost"]["total"] == 0.01
+
+    later = (
+        await client.get("/api/traces/analytics?min_turn_index=2", headers=H)
+    ).json()
+    assert later["total_traces"] == 2
+    assert later["cost"]["total"] == 0.06
+
+    exact = (
+        await client.get("/api/traces/analytics?turn_index=2", headers=H)
+    ).json()
+    assert exact["total_traces"] == 1
+
+    capped = (
+        await client.get("/api/traces/analytics?max_turn_index=2", headers=H)
+    ).json()
+    assert capped["total_traces"] == 2
+
+
+@pytest.mark.asyncio
 async def test_analytics_requires_superuser(client, auth_override, user):
     auth_override(user.id)
     assert (

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -770,6 +770,42 @@ async def test_recompute_turn_positions_orders_flags_and_is_idempotent():
     assert await _turn_fields("r4") == (4, True)
 
 
+@pytest.mark.asyncio
+async def test_recompute_skips_unchanged_rows():
+    """The no-op guard: the first recompute writes the session's rows, a second
+    identical recompute rewrites nothing (rowcount 0) so siblings aren't
+    re-versioned on every ingest. Covers a multi-element datasets_analysed_this_turn
+    array too (its order comes from EXCEPT), so the guard's array comparison is
+    exercised, not just the empty case."""
+    for i, (hour, cum) in enumerate(
+        (
+            (0, ["a"]),
+            (1, ["a", "b", "c"]),  # -> datasets_analysed_this_turn = [b, c]
+            (2, ["a", "b", "c"]),  # -> [] (nothing new)
+        ),
+        start=1,
+    ):
+        await _seed_trace(
+            f"nz{i}",
+            session_id="nz",
+            trace_timestamp=datetime(2026, 6, 1, hour, tzinfo=timezone.utc),
+            derived={"datasets_analysed_cumulative": cum},
+        )
+
+    async def _recompute() -> int:
+        async with async_session_maker() as session:
+            n = await recompute_turn_positions(session, {"nz"})
+            await session.commit()
+            return n
+
+    assert await _recompute() == 3  # all three go from NULL to their positions
+    assert await _recompute() == 0  # already current -> no rewrite
+    # the multi-element diff is stored (set diff; EXCEPT order is unspecified but
+    # stable, which is exactly why the second recompute is a no-op)
+    created, new_ds = await _diff_fields("nz2")
+    assert created is False and sorted(new_ds) == ["b", "c"]
+
+
 # --- per-turn diffs (Phase 1) ----------------------------------------------
 async def _diff_fields(trace_id: str) -> tuple:
     """Read (insight_created_this_turn, datasets_analysed_this_turn) from the DB."""

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -478,3 +478,69 @@ async def test_recompute_turn_positions_orders_flags_and_is_idempotent():
     await _recompute()
     assert await _turn_fields("r3") == (3, False)
     assert await _turn_fields("r4") == (4, True)
+
+
+# --- per-turn diffs (Phase 1) ----------------------------------------------
+async def _diff_fields(trace_id: str) -> tuple:
+    """Read (insight_created_this_turn, datasets_analysed_this_turn) from the DB."""
+    async with async_session_maker() as session:
+        row = (
+            await session.execute(
+                select(LangfuseTraceOrm).where(LangfuseTraceOrm.id == trace_id)
+            )
+        ).scalar_one()
+        return row.insight_created_this_turn, row.datasets_analysed_this_turn
+
+
+@pytest.mark.asyncio
+async def test_recompute_computes_per_turn_diffs():
+    """insight_created_this_turn is true only on the turn insight_id newly becomes
+    non-null / changes; datasets_analysed_this_turn is the per-turn delta of the
+    cumulative list, not the cumulative list itself."""
+    # (id, hour, insight_id, cumulative datasets as of this turn)
+    seeds = [
+        ("p1", 1, None, ["a"]),
+        ("p2", 2, "ins1", ["a", "b"]),
+        ("p3", 3, "ins1", ["a", "b"]),
+        ("p4", 4, "ins2", ["a", "b", "c"]),
+    ]
+    for tid, hour, ins, ds in seeds:
+        await _seed_trace(
+            tid,
+            session_id="ps",
+            insight_id=ins,
+            derived={"datasets_analysed_cumulative": ds},
+            trace_timestamp=datetime(2026, 6, 1, hour, tzinfo=timezone.utc),
+        )
+
+    async with async_session_maker() as session:
+        await recompute_turn_positions(session, {"ps"})
+        await session.commit()
+
+    assert await _diff_fields("p1") == (False, ["a"])  # first turn: all new
+    assert await _diff_fields("p2") == (True, ["b"])  # insight appears; +b
+    assert await _diff_fields("p3") == (False, [])  # unchanged: nothing new
+    assert await _diff_fields("p4") == (True, ["c"])  # insight changes; +c
+
+
+@pytest.mark.asyncio
+async def test_per_turn_diffs_surfaced_on_list_item(
+    client, auth_override, superuser_factory
+):
+    su = await superuser_factory("su_diff@example.com")
+    auth_override(su.id)
+    await _seed_trace(
+        "diff1",
+        session_id="dfs",
+        turn_index=2,
+        insight_created_this_turn=True,
+        datasets_analysed_this_turn=["b"],
+        derived={"datasets_analysed_cumulative": ["a", "b"]},
+        trace_timestamp=datetime(2026, 6, 1, 2, tzinfo=timezone.utc),
+    )
+    body = (await client.get("/api/traces?session_id=dfs", headers=H)).json()
+    item = body["items"][0]
+    assert item["insight_created_this_turn"] is True
+    assert item["datasets_analysed_this_turn"] == ["b"]
+    # the cumulative field still reflects the whole thread as of this turn
+    assert item["datasets_analysed"] == ["a", "b"]

--- a/tests/api/test_traces_endpoints.py
+++ b/tests/api/test_traces_endpoints.py
@@ -11,7 +11,10 @@ from src.api.auth.dependencies import fetch_user_from_rw_api
 from src.api.auth.scopes import TRACES_READ
 from src.api.data_models import LangfuseTraceOrm
 from src.api.schemas import UserModel
-from src.api.services.langfuse.ingest import recompute_turn_positions
+from src.api.services.langfuse.ingest import (
+    backfill_turn_fields,
+    recompute_turn_positions,
+)
 from tests.conftest import async_session_maker
 
 H = {"Authorization": "Bearer test-token"}
@@ -847,6 +850,70 @@ async def test_recompute_computes_per_turn_diffs():
     assert await _diff_fields("p2") == (True, ["b"])  # insight appears; +b
     assert await _diff_fields("p3") == (False, [])  # unchanged: nothing new
     assert await _diff_fields("p4") == (True, ["c"])  # insight changes; +c
+
+
+@pytest.mark.asyncio
+async def test_backfill_turn_fields_covers_sessions_and_singletons():
+    """The out-of-band backfill (schema-only migration + CLI) populates all turn
+    fields for pre-existing rows: multi-turn sessions get renumbered + diffed, and
+    null-session singletons are set directly. Idempotent — a re-run writes 0."""
+    # a 3-turn session, seeded out of order with all turn fields NULL
+    for tid, hour, ins, ds in [
+        ("bf1", 0, None, ["a"]),
+        ("bf3", 2, "ins1", ["a", "b"]),
+        ("bf2", 1, "ins1", ["a", "b"]),
+    ]:
+        await _seed_trace(
+            tid,
+            session_id="bf",
+            insight_id=ins,
+            derived={"datasets_analysed_cumulative": ds},
+            trace_timestamp=datetime(2026, 6, 1, hour, tzinfo=timezone.utc),
+        )
+    # two singletons (null session): one with an insight + datasets, one bare
+    await _seed_trace(
+        "solo_ins",
+        insight_id="ins9",
+        derived={"datasets_analysed_cumulative": ["x", "y"]},
+    )
+    await _seed_trace("solo_bare")
+
+    async with async_session_maker() as session:
+        first = await backfill_turn_fields(session, batch_size=500)
+    async with async_session_maker() as session:
+        second = await backfill_turn_fields(session, batch_size=500)
+
+    assert first == 5  # 3 session rows + 2 singletons
+    assert second == 0  # idempotent
+
+    # session: positions + final flag + per-turn diffs
+    assert await _turn_fields("bf1") == (1, False)
+    assert await _turn_fields("bf2") == (2, False)
+    assert await _turn_fields("bf3") == (3, True)
+    assert await _diff_fields("bf1") == (False, ["a"])
+    assert await _diff_fields("bf2") == (True, ["b"])
+    assert await _diff_fields("bf3") == (False, [])
+
+    # singletons: turn 1, final, diffs reflect the whole (predecessor-less) turn
+    assert await _turn_fields("solo_ins") == (1, True)
+    created, new_ds = await _diff_fields("solo_ins")
+    assert created is True and sorted(new_ds) == ["x", "y"]
+    assert await _turn_fields("solo_bare") == (1, True)
+    assert await _diff_fields("solo_bare") == (False, [])
+
+
+@pytest.mark.asyncio
+async def test_backfill_turn_fields_dry_run_writes_nothing():
+    """--dry-run reports the would-write count but rolls back."""
+    await _seed_trace(
+        "dr1",
+        session_id="dr",
+        trace_timestamp=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    async with async_session_maker() as session:
+        n = await backfill_turn_fields(session, dry_run=True)
+    assert n == 1
+    assert await _turn_fields("dr1") == (None, None)  # rolled back
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_langfuse_ingest.py
+++ b/tests/unit/test_langfuse_ingest.py
@@ -53,8 +53,36 @@ def test_build_row_null_session_is_singleton_turn():
 
 
 def test_build_row_session_turn_index_deferred_to_recompute():
-    # With a session, turn position is cross-row and filled by recompute; the
-    # builder leaves it None so a re-ingest doesn't assert a stale ordinal.
+    # With a session, turn position AND the per-turn diffs are cross-row and filled
+    # by recompute; the builder leaves them None so a re-ingest doesn't assert a
+    # stale ordinal/diff.
     row = build_row({"id": "t1", "sessionId": "s1"})
     assert row["turn_index"] is None
     assert row["is_final_turn_in_thread"] is None
+    assert row["insight_created_this_turn"] is None
+    assert row["datasets_analysed_this_turn"] is None
+
+
+def test_build_row_singleton_diffs_reflect_this_turn():
+    # A singleton (null-session) turn has no predecessor: any insight it carries is
+    # created this turn and every cumulative dataset is new this turn.
+    row = build_row(
+        {
+            "id": "t1",
+            "output": {
+                "messages": [],
+                "insight_id": "ins1",
+                "statistics": [{"dataset_name": "gfw"}],
+            },
+        }
+    )
+    assert row["session_id"] is None
+    assert row["insight_created_this_turn"] is True
+    assert row["datasets_analysed_this_turn"] == ["gfw"]
+
+
+def test_build_row_singleton_without_insight_has_empty_diffs():
+    # No insight, no datasets => diffs are the empty defaults (not None).
+    row = build_row({"id": "t1", "environment": "production"})
+    assert row["insight_created_this_turn"] is False
+    assert row["datasets_analysed_this_turn"] == []

--- a/tests/unit/test_langfuse_ingest.py
+++ b/tests/unit/test_langfuse_ingest.py
@@ -41,3 +41,20 @@ def test_build_row_strips_nul_from_identity_fields():
     assert "\x00" not in row["user_id"]
     assert row["user_id"] == "userid"
     assert row["id"] == "t1"
+
+
+def test_build_row_null_session_is_singleton_turn():
+    # No sessionId => singleton thread; turn position is set directly (the
+    # post-upsert recompute only touches session-scoped rows).
+    row = build_row({"id": "t1", "environment": "production"})
+    assert row["session_id"] is None
+    assert row["turn_index"] == 1
+    assert row["is_final_turn_in_thread"] is True
+
+
+def test_build_row_session_turn_index_deferred_to_recompute():
+    # With a session, turn position is cross-row and filled by recompute; the
+    # builder leaves it None so a re-ingest doesn't assert a stale ordinal.
+    row = build_row({"id": "t1", "sessionId": "s1"})
+    assert row["turn_index"] is None
+    assert row["is_final_turn_in_thread"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.15"
+version = "2026.7.16"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Based on this request from @01painadam to add turn information to the Traces API to facilitate better turn-level analytics:

# Turn-level analytics — plan for a position-independent endpoint

*2026-07-02 · Adam Pain (drafted with Claude)*

## 1. Current state: traces are already per-turn, but conversation position leaks in

A Langfuse trace **is** one agent turn — confirmed in project-zeno's
`src/api/services/langfuse/parse.py` docstring ("A Langfuse trace corresponds
to one agent turn") and `LangfuseTraceOrm` ("Derived analytics for one
Langfuse trace (= one agent turn)"). So `GET /api/traces` genuinely returns
one row per turn, not one row per conversation — there isn't literally an
endpoint that aggregates traces into conversations. Two things nonetheless
make turn-level analytics behave as if conversations were lumped together:

1. **No turn-position field.** Neither `TraceListItem` nor the
   `/api/traces/sessions` `SessionItem` carries an ordinal (`turn_index`,
   `is_first_turn`). The only way to know "is this the 1st, 2nd, 5th turn of
   its session" is to fetch every row in the session and sort by
   `trace_timestamp` client-side — which this dashboard already does, purely
   to approximate turn order:
   - `lib/analytics/outcomeRefine.ts::earliestToolTurnBySession` groups all
     rows by `sessionId` to find the earliest tool-using turn per session, so
     it can tell whether a later no-tool DEFER is really an answer served
     from earlier context.
   - `lib/analytics/outcomeRefine.ts::computeFailureFollowUps` groups by
     `sessionId`, sorts by timestamp, and walks the list to find "the next
     turn after a failure."

   Both are expensive (require the full window, not just the page being
   analyzed), silently wrong under pagination or a date range that cuts a
   session mid-thread (a session's earlier turns may simply not be in the
   fetched set), and can't be pushed down as a query filter — there's no way
   to ask the API for "just first turns" or "just turn 3+".

2. **Some "per-turn" fields are actually thread-cumulative**, exposed under
   names that don't signal this to a consumer of `/api/traces`:
   - `datasets_analysed` is sourced from
     `derived["datasets_analysed_cumulative"]` server-side — the underlying
     key literally says *cumulative*, but the public field strips that
     suffix. `CLAUDE.md` in this repo already flags this: *"`datasetsAnalysed`
     is thread-cumulative, not per-turn."*
   - `primary_dataset_name`, `has_insight`, `insight_id`, `aoi_name` reflect
     the AgentState's *current* value, which may have been set several turns
     earlier and simply persisted forward (state uses `operator.add` /
     carries prior fields). `parse_state`'s own docstring draws this
     distinction — *"Current-state fields (aoi/dataset/insight) are
     per-turn-meaningful (the selection in effect this turn). Cumulative
     fields... reflect the whole thread"* — but the API response doesn't
     surface that distinction, so a turn where the agent touched nothing new
     still reports a non-null `primary_dataset_name` / `has_insight`.

   Net effect: `/api/traces` rows are genuinely per-turn, but several of the
   interesting columns answer *"what does this conversation look like as of
   this turn"* rather than *"what happened in this turn"* — and there's no
   way to condition a query on where in the conversation a turn falls.

3. **The existing `GET /api/traces/analytics` aggregate has no turn-position
   filter either.** It SQL-aggregates `outcome_breakdown`, `daily_volume`,
   latency/cost/token percentiles, etc. over every matching row with equal
   weight. A 20-turn power-user session and a 1-turn session contribute
   equally to `outcome.p95` / `outcome_breakdown` — there's no way to ask
   "what does turn 1 look like vs. turn 5+" from that endpoint today. (Note:
   this dashboard doesn't currently call `/api/traces/analytics` at all — per
   `CLAUDE.md` it pulls raw `/api/traces` rows and aggregates client-side in
   `lib/analytics/*`, so any fix needs to keep that path viable, not just
   patch the aggregate endpoint.)

## 2. What "by turn, independent of conversation position" should mean

- A turn ordinal per trace: 1-based position within its session, ordered by
  `trace_timestamp`.
- A way to filter/segment a query by that ordinal: exact turn, turn range, or
  "first turn only" — without pulling the full session window client-side.
- Turn-scoped counterparts for the fields that are actually cumulative, so
  "did this turn produce X" and "does the thread currently have X" are two
  distinguishable answers instead of one overloaded field.
- The `/api/traces/analytics` aggregate supporting the same turn-position
  filter, so a turn-depth comparison doesn't require pulling every row.

## 3. Plan

### Phase 0 — `turn_index` on `GET /api/traces` (½–1 day, BE)

Compute at query time, no migration or backfill needed:

```sql
row_number() OVER (
  PARTITION BY session_id ORDER BY trace_timestamp ASC NULLS LAST, id ASC
) AS turn_index
```

Wrap the existing `_LIST_COLUMNS` select in a CTE (or subquery) so filters
still apply against the base table and `turn_index` is available for both
`WHERE` and the response. For rows with `session_id IS NULL` (soft reference,
no FK — machine users, dev envs, deleted threads all produce these per
`LangfuseTraceOrm`'s docstring), `turn_index` should resolve to `1` rather
than partition all of them together as one giant fake "session."

Add to `TraceListItem`: `turn_index: Optional[int]`,
`is_first_turn: Optional[bool]` (`turn_index == 1`).

Add query params to `GET /api/traces`: `turn_index` (exact), `min_turn_index`,
`max_turn_index`, `first_turn_only: bool` — applied as `WHERE` on the CTE
output, same pagination contract as today.

This alone unlocks the core ask: the FE can request e.g.
`first_turn_only=true` or `min_turn_index=2` and get turn-position-controlled
rows without any client-side session reconstruction, and `lib/analytics/*`
can add a turn-depth breakdown using the same client-aggregation pattern
already used for everything else in this dashboard.

### Phase 1 — make cumulative fields honest (1 day, BE)

Add true per-turn counterparts for the two fields most likely to be misread,
additive (existing cumulative fields stay, same non-goal as the outcome
taxonomy plan — don't break existing consumers):

- `datasets_analysed_this_turn`: cumulative list for this turn minus the
  cumulative list as of the *previous* turn in the same session (`lag(...)
  OVER (PARTITION BY session_id ORDER BY trace_timestamp)`, set-difference the
  two arrays). Distinguishes "this turn ran new analysis" from "the thread has
  analysed datasets."
- `insight_created_this_turn: bool`: true only when `insight_id` differs from
  the previous turn's `insight_id` in the same session.

Document `datasets_analysed` / `primary_dataset_name` / `has_insight` in the
OpenAPI schema as explicitly thread-cumulative-as-of-this-turn, so future
consumers don't assume otherwise (this repo's `outcomeRefine.ts`
`CONTEXT_ANSWER` logic deliberately relies on the cumulative behavior — that
usage is intentional and should keep working).

### Phase 2 — turn-position-aware `GET /api/traces/analytics` (1–2 days, BE)

Add the same `turn_index` / `min_turn_index` / `max_turn_index` /
`first_turn_only` params here, computed the same way (CTE with `row_number()`
ahead of the existing aggregate SQL). Lets one endpoint answer "how does turn
1 differ from turn 3+" via two calls instead of a full client-side pull.

Stretch: a `group_by=turn_index` mode returning one row of the existing
aggregate shape per turn-index bucket (1, 2, 3, 4, 5+) — a single response for
a turn-over-turn trend chart (outcome rate / latency / cost by conversation
depth), which is the most direct answer to "how does turn depth affect
outcome."

### Phase 3 — client integration (this repo, ½–1 day, FE)

- `lib/api/zeno.ts`: map `turn_index` / `is_first_turn` onto `TraceRow`,
  extend `TracesFilter` with `turnIndex` / `minTurnIndex` / `maxTurnIndex` /
  `firstTurnOnly`, thread them through `filterParams`.
- `lib/analytics/outcomeRefine.ts`: replace `earliestToolTurnBySession` and
  the manual sort-by-timestamp in `computeFailureFollowUps` with the
  server-provided `turn_index` — same intent, no full-window reconstruction,
  and it fixes a latent correctness gap: today's client-side grouping is
  silently wrong whenever pagination or a date-range filter excludes a
  session's earlier turns from the fetched set.
- New analytics section: outcome / latency / cost bucketed by `turn_index`
  (1, 2, 3, 4, 5+), once Phase 2 ships `group_by=turn_index`.

## 4. Non-goals

- Not changing what a "trace" means (still one row per turn) or introducing a
  new object type.
- Not deprecating `/api/traces/sessions` — that's still the right endpoint for
  the conversation browser; this plan analyzes turns *without* conversation-
  position bias, a different axis from session summaries.
- Not backfilling `turn_index` into a stored column in Phase 0 — computing it
  at query time keeps it always consistent with whatever ordering exists,
  needs no migration, and is cheap at this dashboard's current scale (25k
  trace cap, see `lib/config.ts`). Revisit only if `EXPLAIN` shows the window
  function is a bottleneck.

## 5. Effort & sequencing summary

| Phase | Where | Effort | Unlocks |
|---|---|---|---|
| 0 `turn_index` + filters on `/api/traces` | project-zeno `traces.py` | ½–1 day | position-independent turn queries, retires client-side session reconstruction |
| 1 per-turn dataset/insight diffs | project-zeno `parse.py` + `traces.py` | 1 day | honest per-turn vs. cumulative signals |
| 2 turn-position filters + `group_by` on `/api/traces/analytics` | project-zeno `traces.py` | 1–2 days | single-call turn-depth trend, apples-to-apples aggregates |
| 3 client integration | this repo | ½–1 day | dashboard consumes `turn_index`, drops reconstruction hacks, new turn-depth chart |

------------ END AI PLAN -----

I have mostly followed the plan from the above document, with one significant change:

 - We don't compute the turn index at query time view the WINDOW function, but rather just add it as a column to the db, add it to the ingestion scripts and will run a backfill: I was a bit worried about the performance implications of doing that at query time as the dataset grows - creating separate fields makes it much easier to index, etc.
 
 @01painadam here's a note back from my agent to yours :D that should document all the changes and what needs to be done on the `tracey` side:
 
 # Turn-level analytics — backend is landed

Hi Adam,

The turn-position-aware analytics from your proposal are implemented on the traces API
(branch `feat/traces-per-turn`). Summary of what you can now consume, how to try it, and
where our implementation differs slightly from the doc.

## What's new

**`turn_index`** — the 1-based position of each turn within its session, on every
`TraceListItem` / `TraceDetail`. It's a **stored column**, so it's the *true* in-session
position even when a date range or pagination cuts a thread mid-way (the client-side
reconstruction bug you flagged is gone).

**Turn-position filters** on both `GET /api/traces` and `GET /api/traces/analytics`:
- `turn_index=N` (exact), `min_turn_index`, `max_turn_index`, `first_turn_only=true`.

**Honest per-turn fields** alongside the existing cumulative ones, on the list/detail:
- `insight_created_this_turn` — true only on the turn an insight first appears.
- `datasets_analysed_this_turn` — datasets *new to this turn* (this turn's cumulative
  set minus the previous turn's).
- The cumulative fields you already use (`datasets_analysed`, `has_insight`,
  `primary_dataset_name`) are unchanged, but their OpenAPI descriptions now flag them
  explicitly as *thread-cumulative-as-of-this-turn* so the schema stops being ambiguous.

**New endpoint `GET /api/traces/analytics/by-turn`** — your `group_by=turn_index` idea,
as a first-class endpoint. One call returns the same scalar metrics (counts, latency
avg/p50/p95, cost, tokens, tool usage) **broken down per turn position**, so "how do
turns evolve within a session" is a single request. Shape:

```jsonc
GET /api/traces/analytics/by-turn?turn_bucket_cap=10
{
  "turn_bucket_cap": 10,
  "ungrouped_traces": 0,          // rows with no turn_index (reconciliation)
  "grand_total": { "total_traces": 8200, "latency": {…}, "cost": {…}, … },
  "groups": [
    { "turn_index": 1, "is_terminal": false, "turn_index_min": 1, "turn_index_max": 1,
      "sessions_reaching": 2000, "total_traces": 4200, "latency": {…}, … },
    { "turn_index": 2, "is_terminal": false, … },
    …
    { "turn_index": 10, "is_terminal": true, "turn_index_min": 10, "turn_index_max": 37,
      "sessions_reaching": 120, … }   // terminal bucket: positions >= cap collapsed here
  ]
}
```

Notes on `by-turn`:
- Positions at/above `turn_bucket_cap` (default 10, max 50) collapse into one **terminal
  bucket**, so a 40-turn outlier session doesn't produce 40 rows. `turn_index_min`/`max`
  give the true range within a bucket; `is_terminal` marks the collapsing one.
- `sessions_reaching` is a **funnel** metric (distinct sessions that reached that depth)
  — it's non-increasing and does **not** sum across buckets.
- The cumulative sums (`cost.total`, `tokens.total_turn_tokens`) are within-bucket
  totals — compare **averages/percentiles** across buckets, not the sums.
- All the turn/env/date filters compose with it (filter first, then bucket).

## How to test

- Compare turn 1 vs later turns with two analytics calls:
  - `GET /api/traces/analytics?first_turn_only=true`
  - `GET /api/traces/analytics?min_turn_index=2`
- Or in a single call: `GET /api/traces/analytics/by-turn`.
- Confirm ordinals hold under a date filter that excludes early turns:
  - `GET /api/traces?session_id=<multi-turn>&min_turn_index=2`
- Per-turn signal spot-check: `GET /api/traces/{id}` → `insight_created_this_turn` /
  `datasets_analysed_this_turn` reflect only that turn's delta.

## Docs

Everything is in the live OpenAPI schema (`/docs`, `/openapi.json`) — every new param
and field carries a description, including the cumulative-vs-per-turn distinction.

## Where we diverged from the proposal (all deliberate)

1. **`turn_index` is a stored, backfilled column populated at ingest — not a query-time
   view/CTE window.** Same correct-under-filter guarantee you wanted, but a window
   function's output can't be filtered by an index, so computing it per request would
   force a full-table sort on both hot endpoints. We pay it once at write; it's sargable
   and indexed.
2. **No `is_first_turn` field** — it's exactly `turn_index == 1`, so we dropped it. Use
   `turn_index=1` or the `first_turn_only=true` alias.
3. **Null-session traces** are singleton threads via `COALESCE(session_id, id)` →
   `turn_index=1`, rather than a special case.
4. **The per-turn diff fields are computed cross-row at ingest** (comparing against the
   previous turn), not in the per-trace parser.
5. **`group_by=turn_index` is a dedicated `/analytics/by-turn` endpoint, not a query
   param** — a param that flips the response shape is awkward for typed/OpenAPI clients.
   The endpoint also adds honest terminal-bucket semantics (`turn_index_min`/`max` +
   `is_terminal`), an `ungrouped_traces` reconciliation count, and the `sessions_reaching`
   funnel beyond the original sketch.
6. **Out of scope (yours):** the `tracey` client integration.

Let me know if any field names or semantics don't fit how `tracey` wants to consume
them — easy to adjust before this merges.

----