### PR TITLE
fix(agent): enforce skill requires: at read_skill call time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.7"
+version = "2026.7.8"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -121,6 +121,10 @@ class AgentConfigRegistry:
     def register(self, config: AgentConfig) -> None:
         self._configs[config.name] = config
 
+    def configs(self) -> tuple[AgentConfig, ...]:
+        """All registered configs, e.g. for invariant checks across profiles."""
+        return tuple(self._configs.values())
+
     def resolve(self, ff: Optional[str] = None) -> AgentConfig:
         """Return the config for ``ff``, falling back to the default."""
         if ff and ff in self._configs:

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -90,8 +90,11 @@ class AgentConfig:
                 blocks.append(category + "\n\n" + "\n".join(fragments))
         return "\n\n".join(blocks)
 
+    def tool_names(self) -> frozenset[str]:
+        return frozenset(s.tool.name for s in self.specs)
+
     def skills(self) -> list[SkillMeta]:
-        available = {s.tool.name for s in self.specs}
+        available = self.tool_names()
         return [sk for sk in all_skills() if set(sk.requires) <= available]
 
 

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -24,7 +24,7 @@ from src.agent.subagents.analyst.tool import SPEC as generate_insights_spec
 from src.agent.subagents.pick_aoi.tool import SPEC as pick_aoi_spec
 from src.agent.subagents.pick_dataset.tool import SPEC as pick_dataset_spec
 from src.agent.subagents.search.blog import SPEC as search_blogs_spec
-from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tool_spec import Availability, ToolCategory, ToolSpec
 from src.agent.tools.add_map_widget import SPEC as add_map_widget_spec
 from src.agent.tools.add_to_dashboard import SPEC as add_to_dashboard_spec
 from src.agent.tools.create_dashboard import SPEC as create_dashboard_spec
@@ -96,6 +96,16 @@ class AgentConfig:
     def skills(self) -> list[SkillMeta]:
         available = self.tool_names()
         return [sk for sk in all_skills() if set(sk.requires) <= available]
+
+    def availability(self) -> Availability:
+        """What this profile can route to — the same rule read_skill enforces
+        at call time (a skill's ``requires`` must all be bound), so prompt
+        builders never advertise a skill or tool the model would just get
+        "not found"/refused for."""
+        return Availability(
+            skills=frozenset(sk.name for sk in self.skills()),
+            tools=self.tool_names(),
+        )
 
 
 class AgentConfigRegistry:

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -43,14 +43,77 @@ def get_prompt(
     """
     if config is None:
         config = default_registry.resolve()
+    skills = config.skills()
     skill_lines = [
         f"- {s.name}: {s.description} (use when: {s.when_to_use})"
-        for s in config.skills()
+        for s in skills
     ]
     skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
     tool_descriptions = config.tool_descriptions()
-    surface = prompt_section(page)
+    # What this profile can actually route to — same set read_skill checks
+    # requires: against, so a row is never printed for a skill/tool the
+    # model would immediately get "not found"/refused for.
+    available = {s.name for s in skills} | config.tool_names()
+    surface = prompt_section(page, frozenset(available))
     surface_block = f"\n# Current surface\n\n{surface}\n" if surface else ""
+    routing_rows = [
+        (
+            None,
+            '- Dataset-only (e.g. "pick tcl by driver"): call pick_dataset, '
+            "then stop. No AOI, pull or insights unless asked.",
+        ),
+        (
+            None,
+            '- AOI-only (e.g. "zoom to Pará"): call pick_aoi, then stop '
+            "unless asked for more.",
+        ),
+        (
+            "pull-data",
+            '- Pull-only (e.g. "pull dist alerts in Bern for last 2 '
+            'weeks"): read `pull-data`, run pick_aoi → pick_dataset → '
+            "pull_data, then stop. Do not call generate_insights unless "
+            "the user asked for a chart or analysis.",
+        ),
+        (
+            "analyze",
+            "- Full analysis (place + topic → chart/insight): read "
+            "`analyze` and follow that pipeline.",
+        ),
+        (
+            "search_insights",
+            '- Recall a past insight (e.g. "show that tree-cover insight '
+            'again", "pull up the fires analysis from before"): call '
+            "search_insights and then STOP. search_insights is terminal — "
+            "the insight already exists and is put on screen, so it is "
+            "NEVER followed by pick_aoi, pick_dataset, pull_data or "
+            'generate_insights. "Show/recall/pull up an earlier insight" '
+            "is a recall request, never a request for new analysis. After "
+            "it returns, reply with a one-line summary only.",
+        ),
+        (
+            "dashboard",
+            '- Dashboard (e.g. "add this to my dashboard", "add this '
+            'layer/imagery to my dashboard", "build a dashboard for X"): '
+            "read skill `dashboard` and follow it.",
+        ),
+        (
+            "show-imagery",
+            '- Imagery (e.g. "show satellite imagery of Bern in June"): '
+            "read `show-imagery`, run pick_aoi → show_imagery, then stop. "
+            "No dataset, pull or insights unless asked.",
+        ),
+        (
+            "capabilities",
+            "- Capabilities (what you can do, what data exists): read "
+            "`capabilities`, then answer in your own words — no analysis "
+            "tools.",
+        ),
+    ]
+    routing_block = "\n".join(
+        line
+        for required, line in routing_rows
+        if required is None or required in available
+    )
     today = datetime.now().strftime("%Y-%m-%d")
     return f"""You are Global Nature Watch's Geospatial Agent. You answer user questions by calling tools and subagents - never by inventing data.
 
@@ -72,14 +135,7 @@ Call read_skill(name) only when a skill's "use when" clause matches the request 
 
 Match the request to exactly one row; do not escalate a dataset / AOI / pull request into a full analysis.
 
-- Dataset-only (e.g. "pick tcl by driver"): call pick_dataset, then stop. No AOI, pull or insights unless asked.
-- AOI-only (e.g. "zoom to Pará"): call pick_aoi, then stop unless asked for more.
-- Pull-only (e.g. "pull dist alerts in Bern for last 2 weeks"): read `pull-data`, run pick_aoi → pick_dataset → pull_data, then stop. Do not call generate_insights unless the user asked for a chart or analysis.
-- Full analysis (place + topic → chart/insight): read `analyze` and follow that pipeline.
-- Recall a past insight (e.g. "show that tree-cover insight again", "pull up the fires analysis from before"): call search_insights and then STOP. search_insights is terminal — the insight already exists and is put on screen, so it is NEVER followed by pick_aoi, pick_dataset, pull_data or generate_insights. "Show/recall/pull up an earlier insight" is a recall request, never a request for new analysis. After it returns, reply with a one-line summary only.
-- Dashboard (e.g. "add this to my dashboard", "add this layer/imagery to my dashboard", "build a dashboard for X"): read skill `dashboard` and follow it.
-- Imagery (e.g. "show satellite imagery of Bern in June"): read `show-imagery`, run pick_aoi → show_imagery, then stop. No dataset, pull or insights unless asked.
-- Capabilities (what you can do, what data exists): read `capabilities`, then answer in your own words — no analysis tools.
+{routing_block}
 
 # Policy
 

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -23,6 +23,7 @@ from src.agent.agent_config import (
 from src.agent.llms import FALLBACK_MODELS, MODEL
 from src.agent.middleware import SessionContextMiddleware
 from src.agent.state import AgentState
+from src.agent.tool_spec import set_bound_tool_names
 from src.agent.view_pages import prompt_section
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
@@ -249,6 +250,7 @@ async def fetch_zeno(
     """
     if config is None:
         config = registry.resolve(ff)
+    set_bound_tool_names(config.tool_names())
     logger.info("Agent profile set", profile=config.name)
     if checkpointer is _CHECKPOINTER_UNSET:
         checkpointer = await fetch_checkpointer()

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -23,7 +23,7 @@ from src.agent.agent_config import (
 from src.agent.llms import FALLBACK_MODELS, MODEL
 from src.agent.middleware import SessionContextMiddleware
 from src.agent.state import AgentState
-from src.agent.tool_spec import set_bound_tool_names
+from src.agent.tool_spec import Gate, set_bound_tool_names
 from src.agent.view_pages import prompt_section
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
@@ -34,7 +34,7 @@ logger = get_logger(__name__)
 # says which namespace the row depends on — ("skill", name) or ("tool", name)
 # — or None for rows served by the core tools every profile binds. Kept
 # module-level so tests can verify every gate resolves to a real skill/tool.
-ROUTING_ROWS: tuple[tuple[Optional[tuple[str, str]], str], ...] = (
+ROUTING_ROWS: tuple[tuple[Gate, str], ...] = (
     (
         None,
         '- Dataset-only (e.g. "pick tcl by driver"): call pick_dataset, '
@@ -112,11 +112,7 @@ def get_prompt(
     surface = prompt_section(page, available)
     surface_block = f"\n# Current surface\n\n{surface}\n" if surface else ""
     routing_block = "\n".join(
-        line
-        for gate, line in ROUTING_ROWS
-        if gate is None
-        or (gate[0] == "skill" and available.has_skill(gate[1]))
-        or (gate[0] == "tool" and available.has_tool(gate[1]))
+        line for gate, line in ROUTING_ROWS if available.allows(gate)
     )
     today = datetime.now().strftime("%Y-%m-%d")
     return f"""You are Global Nature Watch's Geospatial Agent. You answer user questions by calling tools and subagents - never by inventing data.

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -30,6 +30,64 @@ from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+# The "# Routing" table, one (gate, line) pair per request shape. The gate
+# says which namespace the row depends on — ("skill", name) or ("tool", name)
+# — or None for rows served by the core tools every profile binds. Kept
+# module-level so tests can verify every gate resolves to a real skill/tool.
+ROUTING_ROWS: tuple[tuple[Optional[tuple[str, str]], str], ...] = (
+    (
+        None,
+        '- Dataset-only (e.g. "pick tcl by driver"): call pick_dataset, '
+        "then stop. No AOI, pull or insights unless asked.",
+    ),
+    (
+        None,
+        '- AOI-only (e.g. "zoom to Pará"): call pick_aoi, then stop '
+        "unless asked for more.",
+    ),
+    (
+        ("skill", "pull-data"),
+        '- Pull-only (e.g. "pull dist alerts in Bern for last 2 '
+        'weeks"): read `pull-data`, run pick_aoi → pick_dataset → '
+        "pull_data, then stop. Do not call generate_insights unless "
+        "the user asked for a chart or analysis.",
+    ),
+    (
+        ("skill", "analyze"),
+        "- Full analysis (place + topic → chart/insight): read "
+        "`analyze` and follow that pipeline.",
+    ),
+    (
+        ("tool", "search_insights"),
+        '- Recall a past insight (e.g. "show that tree-cover insight '
+        'again", "pull up the fires analysis from before"): call '
+        "search_insights and then STOP. search_insights is terminal — "
+        "the insight already exists and is put on screen, so it is "
+        "NEVER followed by pick_aoi, pick_dataset, pull_data or "
+        'generate_insights. "Show/recall/pull up an earlier insight" '
+        "is a recall request, never a request for new analysis. After "
+        "it returns, reply with a one-line summary only.",
+    ),
+    (
+        ("skill", "dashboard"),
+        '- Dashboard (e.g. "add this to my dashboard", "add this '
+        'layer/imagery to my dashboard", "build a dashboard for X"): '
+        "read skill `dashboard` and follow it.",
+    ),
+    (
+        ("skill", "show-imagery"),
+        '- Imagery (e.g. "show satellite imagery of Bern in June"): '
+        "read `show-imagery`, run pick_aoi → show_imagery, then stop. "
+        "No dataset, pull or insights unless asked.",
+    ),
+    (
+        ("skill", "capabilities"),
+        "- Capabilities (what you can do, what data exists): read "
+        "`capabilities`, then answer in your own words — no analysis "
+        "tools.",
+    ),
+)
+
 
 def get_prompt(
     config: Optional[AgentConfig] = None, page: Optional[str] = None
@@ -50,69 +108,15 @@ def get_prompt(
     ]
     skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
     tool_descriptions = config.tool_descriptions()
-    # What this profile can actually route to — same set read_skill checks
-    # requires: against, so a row is never printed for a skill/tool the
-    # model would immediately get "not found"/refused for.
-    available = {s.name for s in skills} | config.tool_names()
-    surface = prompt_section(page, frozenset(available))
+    available = config.availability()
+    surface = prompt_section(page, available)
     surface_block = f"\n# Current surface\n\n{surface}\n" if surface else ""
-    routing_rows = [
-        (
-            None,
-            '- Dataset-only (e.g. "pick tcl by driver"): call pick_dataset, '
-            "then stop. No AOI, pull or insights unless asked.",
-        ),
-        (
-            None,
-            '- AOI-only (e.g. "zoom to Pará"): call pick_aoi, then stop '
-            "unless asked for more.",
-        ),
-        (
-            "pull-data",
-            '- Pull-only (e.g. "pull dist alerts in Bern for last 2 '
-            'weeks"): read `pull-data`, run pick_aoi → pick_dataset → '
-            "pull_data, then stop. Do not call generate_insights unless "
-            "the user asked for a chart or analysis.",
-        ),
-        (
-            "analyze",
-            "- Full analysis (place + topic → chart/insight): read "
-            "`analyze` and follow that pipeline.",
-        ),
-        (
-            "search_insights",
-            '- Recall a past insight (e.g. "show that tree-cover insight '
-            'again", "pull up the fires analysis from before"): call '
-            "search_insights and then STOP. search_insights is terminal — "
-            "the insight already exists and is put on screen, so it is "
-            "NEVER followed by pick_aoi, pick_dataset, pull_data or "
-            'generate_insights. "Show/recall/pull up an earlier insight" '
-            "is a recall request, never a request for new analysis. After "
-            "it returns, reply with a one-line summary only.",
-        ),
-        (
-            "dashboard",
-            '- Dashboard (e.g. "add this to my dashboard", "add this '
-            'layer/imagery to my dashboard", "build a dashboard for X"): '
-            "read skill `dashboard` and follow it.",
-        ),
-        (
-            "show-imagery",
-            '- Imagery (e.g. "show satellite imagery of Bern in June"): '
-            "read `show-imagery`, run pick_aoi → show_imagery, then stop. "
-            "No dataset, pull or insights unless asked.",
-        ),
-        (
-            "capabilities",
-            "- Capabilities (what you can do, what data exists): read "
-            "`capabilities`, then answer in your own words — no analysis "
-            "tools.",
-        ),
-    ]
     routing_block = "\n".join(
         line
-        for required, line in routing_rows
-        if required is None or required in available
+        for gate, line in ROUTING_ROWS
+        if gate is None
+        or (gate[0] == "skill" and available.has_skill(gate[1]))
+        or (gate[0] == "tool" and available.has_tool(gate[1]))
     )
     today = datetime.now().strftime("%Y-%m-%d")
     return f"""You are Global Nature Watch's Geospatial Agent. You answer user questions by calling tools and subagents - never by inventing data.

--- a/src/agent/skills/__init__.py
+++ b/src/agent/skills/__init__.py
@@ -1,6 +1,7 @@
 from .loader import (
     SkillMeta,
     all_skills,
+    get_skill,
     get_skill_body,
     load_skills,
 )
@@ -10,6 +11,7 @@ __all__ = [
     "read_skill",
     "SkillMeta",
     "all_skills",
+    "get_skill",
     "get_skill_body",
     "load_skills",
 ]

--- a/src/agent/skills/loader.py
+++ b/src/agent/skills/loader.py
@@ -59,6 +59,10 @@ def load_skills() -> list[SkillMeta]:
 _SKILLS: dict[str, SkillMeta] = {s.name: s for s in load_skills()}
 
 
+def get_skill(name: str) -> SkillMeta | None:
+    return _SKILLS.get(name)
+
+
 def get_skill_body(name: str) -> str | None:
     s = _SKILLS.get(name)
     if s is None:

--- a/src/agent/skills/loader.py
+++ b/src/agent/skills/loader.py
@@ -63,13 +63,16 @@ def get_skill(name: str) -> SkillMeta | None:
     return _SKILLS.get(name)
 
 
+def render_body(skill: SkillMeta) -> str:
+    """A skill's body as handed to the model (capabilities is templated)."""
+    if skill.name == "capabilities":
+        return render_capabilities_body(skill.body)
+    return skill.body
+
+
 def get_skill_body(name: str) -> str | None:
     s = _SKILLS.get(name)
-    if s is None:
-        return None
-    if name == "capabilities":
-        return render_capabilities_body(s.body)
-    return s.body
+    return None if s is None else render_body(s)
 
 
 def all_skills() -> list[SkillMeta]:

--- a/src/agent/skills/tool.py
+++ b/src/agent/skills/tool.py
@@ -1,6 +1,6 @@
 from langchain_core.tools import tool
 
-from src.agent.skills.loader import get_skill, get_skill_body
+from src.agent.skills.loader import get_skill, render_body
 from src.agent.tool_spec import ToolCategory, ToolSpec, bound_tool_names
 from src.shared.logging_config import get_logger
 
@@ -22,10 +22,8 @@ def read_skill(name: str) -> str:
             missing_tools=sorted(missing),
         )
         return f"skill not found: {name}"
-    body = get_skill_body(name)
-    assert body is not None  # skill exists: confirmed by get_skill above
     logger.info("read_skill: loaded skill", skill_name=name)
-    return body
+    return render_body(skill)
 
 
 SPEC = ToolSpec(

--- a/src/agent/skills/tool.py
+++ b/src/agent/skills/tool.py
@@ -1,7 +1,7 @@
 from langchain_core.tools import tool
 
-from src.agent.skills.loader import get_skill_body
-from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.skills.loader import get_skill, get_skill_body
+from src.agent.tool_spec import ToolCategory, ToolSpec, bound_tool_names
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -10,10 +10,23 @@ logger = get_logger(__name__)
 @tool("read_skill")
 def read_skill(name: str) -> str:
     """Load the full body of a skill by name (metadata is in the system prompt)."""
-    body = get_skill_body(name)
-    if body is None:
+    skill = get_skill(name)
+    if skill is None:
         logger.warning("read_skill: skill not found", skill_name=name)
         return f"skill not found: {name}"
+    missing = set(skill.requires) - bound_tool_names()
+    if missing:
+        logger.warning(
+            "read_skill: skill not available in this profile",
+            skill_name=name,
+            missing_tools=sorted(missing),
+        )
+        return (
+            f"skill {name!r} not available in this profile "
+            f"(missing tools: {', '.join(sorted(missing))})"
+        )
+    body = get_skill_body(name)
+    assert body is not None  # skill exists: confirmed by get_skill above
     logger.info("read_skill: loaded skill", skill_name=name)
     return body
 

--- a/src/agent/skills/tool.py
+++ b/src/agent/skills/tool.py
@@ -21,10 +21,7 @@ def read_skill(name: str) -> str:
             skill_name=name,
             missing_tools=sorted(missing),
         )
-        return (
-            f"skill {name!r} not available in this profile "
-            f"(missing tools: {', '.join(sorted(missing))})"
-        )
+        return f"skill not found: {name}"
     body = get_skill_body(name)
     assert body is not None  # skill exists: confirmed by get_skill above
     logger.info("read_skill: loaded skill", skill_name=name)

--- a/src/agent/tool_spec.py
+++ b/src/agent/tool_spec.py
@@ -27,6 +27,23 @@ class ToolSpec:
     prompt_fragment: str
 
 
+@dataclass(frozen=True)
+class Availability:
+    """What one agent profile can serve, with skill and tool names kept in
+    separate namespaces — a bare ``name in available`` check can't tell a
+    skill called ``dashboard`` from a tool called ``dashboard``, and prompt
+    gating must never conflate the two."""
+
+    skills: frozenset[str]
+    tools: frozenset[str]
+
+    def has_skill(self, name: str) -> bool:
+        return name in self.skills
+
+    def has_tool(self, name: str) -> bool:
+        return name in self.tools
+
+
 # The bound tool names of the current request's agent profile. Set once per
 # request (``fetch_zeno``) and read from inside tools (``read_skill``) that
 # need to know what's actually callable, not just what's listed in the

--- a/src/agent/tool_spec.py
+++ b/src/agent/tool_spec.py
@@ -4,6 +4,7 @@ Tool files import from here to declare their SPEC; agent_config.py imports
 both ToolSpec (from here) and each tool's SPEC (from tool files).
 """
 
+from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
 
@@ -24,3 +25,23 @@ class ToolSpec:
     tool: BaseTool
     category: ToolCategory
     prompt_fragment: str
+
+
+# The bound tool names of the current request's agent profile. Set once per
+# request (``fetch_zeno``) and read from inside tools (``read_skill``) that
+# need to know what's actually callable, not just what's listed in the
+# prompt. Mirrors ``current_user_id`` in ``src.shared.request_context``.
+_bound_tool_names: ContextVar[frozenset[str]] = ContextVar(
+    "bound_tool_names", default=frozenset()
+)
+
+
+def set_bound_tool_names(names: frozenset[str]) -> None:
+    """Bind the tool names available in the current request's agent profile,
+    for the remainder of this context."""
+    _bound_tool_names.set(names)
+
+
+def bound_tool_names() -> frozenset[str]:
+    """The tool names bound by ``set_bound_tool_names``; empty when unset."""
+    return _bound_tool_names.get()

--- a/src/agent/tool_spec.py
+++ b/src/agent/tool_spec.py
@@ -7,8 +7,14 @@ both ToolSpec (from here) and each tool's SPEC (from tool files).
 from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
+from typing import Literal, Optional
 
 from langchain_core.tools import BaseTool
+
+# A prompt-content gate: which skill or tool a piece of prompt text depends
+# on, or None for text every profile can serve. The Literal kind lets mypy
+# reject a misspelled namespace at the definition site.
+Gate = Optional[tuple[Literal["skill", "tool"], str]]
 
 
 class ToolCategory(str, Enum):
@@ -42,6 +48,13 @@ class Availability:
 
     def has_tool(self, name: str) -> bool:
         return name in self.tools
+
+    def allows(self, gate: Gate) -> bool:
+        """Whether prompt text behind ``gate`` may be shown to this profile."""
+        if gate is None:
+            return True
+        kind, name = gate
+        return name in (self.skills if kind == "skill" else self.tools)
 
 
 # The bound tool names of the current request's agent profile. Set once per

--- a/src/agent/view_pages.py
+++ b/src/agent/view_pages.py
@@ -76,24 +76,35 @@ class ViewPage:
 
     name: str
     session_line: Callable[[dict], str]
-    prompt_section: str
+    # Takes the calling profile's available skill/tool names so it can drop
+    # any "read skill `x`" mention the profile can't actually serve — the
+    # same rule read_skill enforces at call time, applied here so the model
+    # is never routed toward a skill it will just be told "not found" for.
+    prompt_section: Callable[[frozenset[str]], str]
 
 
-_MAP_PROMPT = (
-    "The user is on the map explorer — free exploration of areas and "
-    "layers. 'This area', 'here' or 'what I'm looking at' refer to what is "
-    "on the map: check the session block or call inspect_view_context "
-    "before asking the user for a location."
-)
+def _map_prompt(available: frozenset[str]) -> str:
+    return (
+        "The user is on the map explorer — free exploration of areas and "
+        "layers. 'This area', 'here' or 'what I'm looking at' refer to what "
+        "is on the map: check the session block or call "
+        "inspect_view_context before asking the user for a location."
+    )
 
-_DASHBOARD_PROMPT = (
-    "The user is viewing a dashboard — a persistent collection of insight "
-    "widgets for one area. 'Add this' / 'add it to my dashboard' means "
-    "add_to_dashboard, which defaults to the dashboard on screen. New "
-    "analyses should use the dashboard's area unless the user names another "
-    "place. Call inspect_view_context to see the dashboard's area and "
-    "widgets; read skill `dashboard` for the compose workflow."
-)
+
+def _dashboard_prompt(available: frozenset[str]) -> str:
+    base = (
+        "The user is viewing a dashboard — a persistent collection of "
+        "insight widgets for one area. 'Add this' / 'add it to my "
+        "dashboard' means add_to_dashboard, which defaults to the "
+        "dashboard on screen. New analyses should use the dashboard's area "
+        "unless the user names another place. Call inspect_view_context to "
+        "see the dashboard's area and widgets"
+    )
+    if "dashboard" in available:
+        return base + "; read skill `dashboard` for the compose workflow."
+    return base + "."
+
 
 PAGES: dict[str, ViewPage] = {
     page.name: page
@@ -101,12 +112,12 @@ PAGES: dict[str, ViewPage] = {
         ViewPage(
             name="map",
             session_line=_map_session_line,
-            prompt_section=_MAP_PROMPT,
+            prompt_section=_map_prompt,
         ),
         ViewPage(
             name="dashboard",
             session_line=_dashboard_session_line,
-            prompt_section=_DASHBOARD_PROMPT,
+            prompt_section=_dashboard_prompt,
         ),
     )
 }
@@ -122,9 +133,16 @@ def get_page(view: Optional[dict]) -> Optional[ViewPage]:
     return PAGES.get(page)
 
 
-def prompt_section(page_name: Optional[str]) -> Optional[str]:
-    """System-prompt surface hints for a page name; None when unknown."""
+def prompt_section(
+    page_name: Optional[str], available: frozenset[str] = frozenset()
+) -> Optional[str]:
+    """System-prompt surface hints for a page name; None when unknown.
+
+    ``available`` is the calling profile's skill and tool names (see
+    ``AgentConfig.skills()`` / ``.tool_names()``) — pages use it to drop any
+    skill mention the profile can't actually serve.
+    """
     if not isinstance(page_name, str):
         return None
     page = PAGES.get(page_name)
-    return page.prompt_section if page else None
+    return page.prompt_section(available) if page else None

--- a/src/agent/view_pages.py
+++ b/src/agent/view_pages.py
@@ -27,6 +27,8 @@ docs/view-context-pages.md for the full design.
 from dataclasses import dataclass
 from typing import Callable, Optional
 
+from src.agent.tool_spec import Availability
+
 
 def on_screen_counts(view: dict) -> list[str]:
     """The on-screen item counts shared by the breadcrumb renderings."""
@@ -76,14 +78,14 @@ class ViewPage:
 
     name: str
     session_line: Callable[[dict], str]
-    # Takes the calling profile's available skill/tool names so it can drop
-    # any "read skill `x`" mention the profile can't actually serve — the
+    # Takes the calling profile's Availability so it can drop any
+    # "read skill `x`" mention the profile can't actually serve — the
     # same rule read_skill enforces at call time, applied here so the model
     # is never routed toward a skill it will just be told "not found" for.
-    prompt_section: Callable[[frozenset[str]], str]
+    prompt_section: Callable[[Availability], str]
 
 
-def _map_prompt(available: frozenset[str]) -> str:
+def _map_prompt(available: Availability) -> str:
     return (
         "The user is on the map explorer — free exploration of areas and "
         "layers. 'This area', 'here' or 'what I'm looking at' refer to what "
@@ -92,7 +94,7 @@ def _map_prompt(available: frozenset[str]) -> str:
     )
 
 
-def _dashboard_prompt(available: frozenset[str]) -> str:
+def _dashboard_prompt(available: Availability) -> str:
     base = (
         "The user is viewing a dashboard — a persistent collection of "
         "insight widgets for one area. 'Add this' / 'add it to my "
@@ -101,7 +103,7 @@ def _dashboard_prompt(available: frozenset[str]) -> str:
         "unless the user names another place. Call inspect_view_context to "
         "see the dashboard's area and widgets"
     )
-    if "dashboard" in available:
+    if available.has_skill("dashboard"):
         return base + "; read skill `dashboard` for the compose workflow."
     return base + "."
 
@@ -134,13 +136,14 @@ def get_page(view: Optional[dict]) -> Optional[ViewPage]:
 
 
 def prompt_section(
-    page_name: Optional[str], available: frozenset[str] = frozenset()
+    page_name: Optional[str],
+    available: Availability = Availability(frozenset(), frozenset()),
 ) -> Optional[str]:
     """System-prompt surface hints for a page name; None when unknown.
 
-    ``available`` is the calling profile's skill and tool names (see
-    ``AgentConfig.skills()`` / ``.tool_names()``) — pages use it to drop any
-    skill mention the profile can't actually serve.
+    ``available`` is the calling profile's ``Availability`` (see
+    ``AgentConfig.availability()``) — pages use it to drop any skill
+    mention the profile can't actually serve.
     """
     if not isinstance(page_name, str):
         return None

--- a/src/agent/view_pages.py
+++ b/src/agent/view_pages.py
@@ -78,34 +78,21 @@ class ViewPage:
 
     name: str
     session_line: Callable[[dict], str]
-    # Takes the calling profile's Availability so it can drop any
-    # "read skill `x`" mention the profile can't actually serve — the
-    # same rule read_skill enforces at call time, applied here so the model
-    # is never routed toward a skill it will just be told "not found" for.
-    prompt_section: Callable[[Availability], str]
+    prompt_base: str
+    # Optional (skill name, suffix sentence) appended to prompt_base only
+    # when the calling profile can serve that skill — the same rule
+    # read_skill enforces at call time, applied here so the model is never
+    # routed toward a skill it will just be told "not found" for. Kept as
+    # data (not a closure) so tests can verify the skill name resolves.
+    skill_pointer: Optional[tuple[str, str]] = None
 
-
-def _map_prompt(available: Availability) -> str:
-    return (
-        "The user is on the map explorer — free exploration of areas and "
-        "layers. 'This area', 'here' or 'what I'm looking at' refer to what "
-        "is on the map: check the session block or call "
-        "inspect_view_context before asking the user for a location."
-    )
-
-
-def _dashboard_prompt(available: Availability) -> str:
-    base = (
-        "The user is viewing a dashboard — a persistent collection of "
-        "insight widgets for one area. 'Add this' / 'add it to my "
-        "dashboard' means add_to_dashboard, which defaults to the "
-        "dashboard on screen. New analyses should use the dashboard's area "
-        "unless the user names another place. Call inspect_view_context to "
-        "see the dashboard's area and widgets"
-    )
-    if available.has_skill("dashboard"):
-        return base + "; read skill `dashboard` for the compose workflow."
-    return base + "."
+    def render_prompt(self, available: Availability) -> str:
+        if self.skill_pointer is None:
+            return self.prompt_base
+        skill, suffix = self.skill_pointer
+        if available.has_skill(skill):
+            return f"{self.prompt_base}; {suffix}"
+        return f"{self.prompt_base}."
 
 
 PAGES: dict[str, ViewPage] = {
@@ -114,12 +101,30 @@ PAGES: dict[str, ViewPage] = {
         ViewPage(
             name="map",
             session_line=_map_session_line,
-            prompt_section=_map_prompt,
+            prompt_base=(
+                "The user is on the map explorer — free exploration of "
+                "areas and layers. 'This area', 'here' or 'what I'm looking "
+                "at' refer to what is on the map: check the session block "
+                "or call inspect_view_context before asking the user for a "
+                "location."
+            ),
         ),
         ViewPage(
             name="dashboard",
             session_line=_dashboard_session_line,
-            prompt_section=_dashboard_prompt,
+            prompt_base=(
+                "The user is viewing a dashboard — a persistent collection "
+                "of insight widgets for one area. 'Add this' / 'add it to "
+                "my dashboard' means add_to_dashboard, which defaults to "
+                "the dashboard on screen. New analyses should use the "
+                "dashboard's area unless the user names another place. "
+                "Call inspect_view_context to see the dashboard's area and "
+                "widgets"
+            ),
+            skill_pointer=(
+                "dashboard",
+                "read skill `dashboard` for the compose workflow.",
+            ),
         ),
     )
 }
@@ -136,8 +141,7 @@ def get_page(view: Optional[dict]) -> Optional[ViewPage]:
 
 
 def prompt_section(
-    page_name: Optional[str],
-    available: Availability = Availability(frozenset(), frozenset()),
+    page_name: Optional[str], available: Availability
 ) -> Optional[str]:
     """System-prompt surface hints for a page name; None when unknown.
 
@@ -148,4 +152,4 @@ def prompt_section(
     if not isinstance(page_name, str):
         return None
     page = PAGES.get(page_name)
-    return page.prompt_section(available) if page else None
+    return page.render_prompt(available) if page else None

--- a/tests/unit/agent/test_availability.py
+++ b/tests/unit/agent/test_availability.py
@@ -1,0 +1,61 @@
+"""Guardrails for the skill/tool availability gating.
+
+Prompt content (routing rows, surface sections) is gated on skill and tool
+names, so a rename or frontmatter typo would silently drop rows or hide
+skills from every profile. These tests turn each of those silent failure
+modes into a test failure:
+
+- skill and tool names must never collide (a flat name check would conflate
+  them — the bug the Availability split exists to prevent),
+- every ROUTING_ROWS gate must resolve to a real skill/tool,
+- every skill's ``requires:`` entry must name a tool some profile binds.
+"""
+
+from src.agent.agent_config import default_registry
+from src.agent.graph import ROUTING_ROWS
+from src.agent.skills import all_skills
+
+
+def _all_registered_tool_names() -> frozenset[str]:
+    return frozenset().union(
+        *(config.tool_names() for config in default_registry._configs.values())
+    )
+
+
+def test_skill_names_never_collide_with_tool_names():
+    """A tool named like a skill would satisfy the wrong gate; keep the
+    namespaces disjoint so has_skill/has_tool stay unambiguous."""
+    skill_names = {s.name for s in all_skills()}
+    collisions = skill_names & _all_registered_tool_names()
+    assert (
+        not collisions
+    ), f"skill names shadow tool names: {sorted(collisions)}"
+
+
+def test_routing_gates_resolve_to_real_skills_and_tools():
+    """A renamed skill/tool must fail here, not silently drop its routing
+    row from every prompt."""
+    skill_names = {s.name for s in all_skills()}
+    tool_names = _all_registered_tool_names()
+    for gate, line in ROUTING_ROWS:
+        if gate is None:
+            continue
+        kind, name = gate
+        assert kind in ("skill", "tool"), f"unknown gate kind in: {line!r}"
+        universe = skill_names if kind == "skill" else tool_names
+        assert (
+            name in universe
+        ), f"routing row gated on unknown {kind} {name!r}: {line!r}"
+
+
+def test_skill_requires_reference_registered_tools():
+    """A typo in a skill's ``requires:`` frontmatter would make the skill
+    unavailable in every profile forever, with no signal until a model
+    asks for it at runtime."""
+    tool_names = _all_registered_tool_names()
+    for skill in all_skills():
+        unknown = set(skill.requires) - tool_names
+        assert not unknown, (
+            f"skill {skill.name!r} requires unregistered tools: "
+            f"{sorted(unknown)}"
+        )

--- a/tests/unit/agent/test_availability.py
+++ b/tests/unit/agent/test_availability.py
@@ -8,17 +8,19 @@ modes into a test failure:
 - skill and tool names must never collide (a flat name check would conflate
   them — the bug the Availability split exists to prevent),
 - every ROUTING_ROWS gate must resolve to a real skill/tool,
+- every ViewPage skill_pointer must name a real skill,
 - every skill's ``requires:`` entry must name a tool some profile binds.
 """
 
 from src.agent.agent_config import default_registry
 from src.agent.graph import ROUTING_ROWS
 from src.agent.skills import all_skills
+from src.agent.view_pages import PAGES
 
 
 def _all_registered_tool_names() -> frozenset[str]:
     return frozenset().union(
-        *(config.tool_names() for config in default_registry._configs.values())
+        *(config.tool_names() for config in default_registry.configs())
     )
 
 
@@ -40,12 +42,24 @@ def test_routing_gates_resolve_to_real_skills_and_tools():
     for gate, line in ROUTING_ROWS:
         if gate is None:
             continue
-        kind, name = gate
-        assert kind in ("skill", "tool"), f"unknown gate kind in: {line!r}"
+        kind, name = gate  # kind is checked by mypy via the Gate Literal
         universe = skill_names if kind == "skill" else tool_names
         assert (
             name in universe
         ), f"routing row gated on unknown {kind} {name!r}: {line!r}"
+
+
+def test_page_skill_pointers_name_real_skills():
+    """A renamed skill must fail here, not silently strip its pointer from
+    the page's "# Current surface" section."""
+    skill_names = {s.name for s in all_skills()}
+    for page in PAGES.values():
+        if page.skill_pointer is None:
+            continue
+        skill, _ = page.skill_pointer
+        assert (
+            skill in skill_names
+        ), f"page {page.name!r} points at unknown skill {skill!r}"
 
 
 def test_skill_requires_reference_registered_tools():

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -10,7 +10,7 @@ from src.agent.agent_config import (
     default_registry,
 )
 from src.agent.skills import all_skills
-from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tool_spec import ToolCategory, ToolSpec, bound_tool_names
 
 # --- Lightweight test fixtures -----------------------------------------------
 
@@ -78,6 +78,11 @@ def test_config_tool_descriptions_excludes_unbound_tool():
     assert "_fake_tool" not in c.tool_descriptions()
 
 
+def test_config_tool_names_returns_bound_tool_names():
+    c = AgentConfig("test", specs=(FAKE_SPEC,))
+    assert c.tool_names() == frozenset({"_fake_tool"})
+
+
 # --- Structural invariants ---------------------------------------------------
 
 
@@ -122,6 +127,24 @@ def test_default_config_advertises_core_skills():
         "capabilities",
         "pull-data",
     }
+
+
+async def test_fetch_zeno_binds_the_resolved_configs_tool_names():
+    """read_skill relies on bound_tool_names() reflecting the profile that
+    was actually resolved for this request, not just what's listed in the
+    prompt (see AgentConfig.skills())."""
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from src.agent.graph import fetch_zeno
+
+    registry = AgentConfigRegistry()
+    registry.register(AgentConfig("default", specs=()))
+    registry.register(AgentConfig("fake", specs=(FAKE_SPEC,)))
+
+    await fetch_zeno(
+        ff="fake", registry=registry, checkpointer=InMemorySaver()
+    )
+    assert bound_tool_names() == frozenset({"_fake_tool"})
 
 
 def test_experimental_config_adds_experimental_tools_and_skills():

--- a/tests/unit/agent/test_tool_spec.py
+++ b/tests/unit/agent/test_tool_spec.py
@@ -1,0 +1,26 @@
+"""Unit tests for the request-scoped bound-tool-names ContextVar."""
+
+import pytest
+
+from src.agent.tool_spec import bound_tool_names, set_bound_tool_names
+
+
+@pytest.fixture(autouse=True)
+def _reset_bound_tool_names():
+    yield
+    set_bound_tool_names(frozenset())
+
+
+def test_bound_tool_names_defaults_to_empty():
+    assert bound_tool_names() == frozenset()
+
+
+def test_set_bound_tool_names_round_trips():
+    set_bound_tool_names(frozenset({"pick_aoi", "pull_data"}))
+    assert bound_tool_names() == frozenset({"pick_aoi", "pull_data"})
+
+
+def test_set_bound_tool_names_overwrites_previous_value():
+    set_bound_tool_names(frozenset({"pick_aoi"}))
+    set_bound_tool_names(frozenset({"pull_data"}))
+    assert bound_tool_names() == frozenset({"pull_data"})

--- a/tests/unit/agent/test_view_pages.py
+++ b/tests/unit/agent/test_view_pages.py
@@ -6,6 +6,7 @@ the graceful fallback for unknown/absent pages.
 """
 
 from src.agent.middleware import format_session_block
+from src.agent.tool_spec import Availability
 from src.agent.view_pages import get_page, prompt_section
 
 MAP_STATE = {
@@ -90,7 +91,10 @@ def test_unregistered_page_falls_back_to_generic_breadcrumb():
 # ---------------------------------------------------------------------------
 def test_prompt_section_for_registered_pages():
     assert "map explorer" in prompt_section("map")
-    dashboard = prompt_section("dashboard", frozenset({"dashboard"}))
+    dashboard = prompt_section(
+        "dashboard",
+        Availability(skills=frozenset({"dashboard"}), tools=frozenset()),
+    )
     assert "add_to_dashboard" in dashboard
     assert "dashboard's area" in dashboard
     assert "skill `dashboard`" in dashboard
@@ -105,11 +109,23 @@ def test_prompt_section_unknown_is_none():
 def test_prompt_section_drops_skill_mention_when_unavailable():
     """A profile without the dashboard skill (its required tools aren't all
     bound) must not be told to read it — read_skill would just refuse."""
-    dashboard = prompt_section("dashboard", frozenset())
+    dashboard = prompt_section(
+        "dashboard", Availability(skills=frozenset(), tools=frozenset())
+    )
     # The page-level orientation stays; only the skill pointer is gated.
     assert "add_to_dashboard" in dashboard
     assert "dashboard's area" in dashboard
     assert "skill `dashboard`" not in dashboard
+
+
+def test_prompt_section_ignores_tools_that_shadow_a_skill_name():
+    """A *tool* named like a skill must not satisfy a skill gate — the two
+    namespaces are separate (this is what the flat-set version got wrong)."""
+    shadowed = prompt_section(
+        "dashboard",
+        Availability(skills=frozenset(), tools=frozenset({"dashboard"})),
+    )
+    assert "skill `dashboard`" not in shadowed
 
 
 def test_prompt_section_defaults_to_no_available_skills():

--- a/tests/unit/agent/test_view_pages.py
+++ b/tests/unit/agent/test_view_pages.py
@@ -90,7 +90,7 @@ def test_unregistered_page_falls_back_to_generic_breadcrumb():
 # ---------------------------------------------------------------------------
 def test_prompt_section_for_registered_pages():
     assert "map explorer" in prompt_section("map")
-    dashboard = prompt_section("dashboard")
+    dashboard = prompt_section("dashboard", frozenset({"dashboard"}))
     assert "add_to_dashboard" in dashboard
     assert "dashboard's area" in dashboard
     assert "skill `dashboard`" in dashboard
@@ -100,6 +100,20 @@ def test_prompt_section_unknown_is_none():
     assert prompt_section(None) is None
     assert prompt_section("report") is None
     assert prompt_section("") is None
+
+
+def test_prompt_section_drops_skill_mention_when_unavailable():
+    """A profile without the dashboard skill (its required tools aren't all
+    bound) must not be told to read it — read_skill would just refuse."""
+    dashboard = prompt_section("dashboard", frozenset())
+    # The page-level orientation stays; only the skill pointer is gated.
+    assert "add_to_dashboard" in dashboard
+    assert "dashboard's area" in dashboard
+    assert "skill `dashboard`" not in dashboard
+
+
+def test_prompt_section_defaults_to_no_available_skills():
+    assert "skill `dashboard`" not in prompt_section("dashboard")
 
 
 def test_get_prompt_includes_surface_section_only_for_known_pages():
@@ -113,5 +127,17 @@ def test_get_prompt_includes_surface_section_only_for_known_pages():
     assert "add_to_dashboard, which defaults to the dashboard" in dashboard
     # The rest of the prompt is unchanged.
     assert "# Routing" in dashboard
+    # The default profile has no dashboard tools, so the dashboard skill
+    # is unavailable — the surface section must not point at it.
+    assert "skill `dashboard`" not in dashboard
 
     assert "# Current surface" not in get_prompt(page="report")
+
+
+def test_get_prompt_dashboard_surface_names_the_skill_when_available():
+    from src.agent.agent_config import EXPERIMENTAL_PROFILE, default_registry
+    from src.agent.graph import get_prompt
+
+    config = default_registry.resolve(EXPERIMENTAL_PROFILE)
+    dashboard = get_prompt(config=config, page="dashboard")
+    assert "skill `dashboard`" in dashboard

--- a/tests/unit/agent/test_view_pages.py
+++ b/tests/unit/agent/test_view_pages.py
@@ -89,8 +89,11 @@ def test_unregistered_page_falls_back_to_generic_breadcrumb():
 # ---------------------------------------------------------------------------
 # Layer 2: system-prompt surface section
 # ---------------------------------------------------------------------------
+NOTHING_AVAILABLE = Availability(skills=frozenset(), tools=frozenset())
+
+
 def test_prompt_section_for_registered_pages():
-    assert "map explorer" in prompt_section("map")
+    assert "map explorer" in prompt_section("map", NOTHING_AVAILABLE)
     dashboard = prompt_section(
         "dashboard",
         Availability(skills=frozenset({"dashboard"}), tools=frozenset()),
@@ -101,17 +104,15 @@ def test_prompt_section_for_registered_pages():
 
 
 def test_prompt_section_unknown_is_none():
-    assert prompt_section(None) is None
-    assert prompt_section("report") is None
-    assert prompt_section("") is None
+    assert prompt_section(None, NOTHING_AVAILABLE) is None
+    assert prompt_section("report", NOTHING_AVAILABLE) is None
+    assert prompt_section("", NOTHING_AVAILABLE) is None
 
 
 def test_prompt_section_drops_skill_mention_when_unavailable():
     """A profile without the dashboard skill (its required tools aren't all
     bound) must not be told to read it — read_skill would just refuse."""
-    dashboard = prompt_section(
-        "dashboard", Availability(skills=frozenset(), tools=frozenset())
-    )
+    dashboard = prompt_section("dashboard", NOTHING_AVAILABLE)
     # The page-level orientation stays; only the skill pointer is gated.
     assert "add_to_dashboard" in dashboard
     assert "dashboard's area" in dashboard
@@ -126,10 +127,6 @@ def test_prompt_section_ignores_tools_that_shadow_a_skill_name():
         Availability(skills=frozenset(), tools=frozenset({"dashboard"})),
     )
     assert "skill `dashboard`" not in shadowed
-
-
-def test_prompt_section_defaults_to_no_available_skills():
-    assert "skill `dashboard`" not in prompt_section("dashboard")
 
 
 def test_get_prompt_includes_surface_section_only_for_known_pages():

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -251,3 +251,31 @@ def test_get_prompt_scope_and_policy():
     # only the three recipe skills are advertised
     assert "pick-aoi" not in prompt
     assert "pick-dataset" not in prompt
+
+
+def test_get_prompt_routing_excludes_rows_for_unbound_profiles():
+    """The default profile has no dashboard/show-imagery/search_insights
+    tools bound, so the Routing table must not route to them — it would
+    just send the model into a read_skill/tool call that fails."""
+    from src.agent.graph import get_prompt
+
+    prompt = get_prompt()
+    assert "Dashboard (" not in prompt
+    assert "read skill `dashboard`" not in prompt
+    assert "Imagery (" not in prompt
+    assert "read `show-imagery`" not in prompt
+    assert "Recall a past insight" not in prompt
+    assert "search_insights" not in prompt
+
+
+def test_get_prompt_routing_includes_rows_when_tools_bound():
+    from src.agent.agent_config import EXPERIMENTAL_PROFILE, default_registry
+    from src.agent.graph import get_prompt
+
+    config = default_registry.resolve(EXPERIMENTAL_PROFILE)
+    prompt = get_prompt(config=config)
+    assert "Dashboard (" in prompt
+    assert "read skill `dashboard`" in prompt
+    assert "Imagery (" in prompt
+    assert "read `show-imagery`" in prompt
+    assert "Recall a past insight" in prompt

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -1,8 +1,20 @@
+import pytest
+
 from src.agent.skills import (
     all_skills,
+    get_skill,
     get_skill_body,
     load_skills,
 )
+from src.agent.skills.tool import read_skill
+from src.agent.tool_spec import set_bound_tool_names
+
+
+@pytest.fixture(autouse=True)
+def _reset_bound_tool_names():
+    """``bound_tool_names`` is a ContextVar; tests must not leak state."""
+    yield
+    set_bound_tool_names(frozenset())
 
 
 def test_load_skills():
@@ -67,6 +79,93 @@ def test_get_skill_body():
     body = get_skill_body("analyze")
     assert body is not None
     assert "pick_aoi" in body
+
+
+def test_get_skill_returns_meta_with_requires():
+    skill = get_skill("analyze")
+    assert skill is not None
+    assert set(skill.requires) == {
+        "pick_aoi",
+        "pick_dataset",
+        "pull_data",
+        "generate_insights",
+    }
+
+
+def test_get_skill_returns_none_for_unknown_name():
+    assert get_skill("does-not-exist") is None
+
+
+def test_get_skill_capabilities_has_no_requires():
+    """Informational skills with no tool dependencies must always pass the
+    read_skill gate, bound tools or not."""
+    skill = get_skill("capabilities")
+    assert skill is not None
+    assert skill.requires == ()
+
+
+def test_read_skill_refuses_when_a_required_tool_is_unbound():
+    """analyze requires pick_aoi, pick_dataset, pull_data, generate_insights;
+    binding only some of them must not hand back the skill body."""
+    set_bound_tool_names(frozenset({"pick_aoi", "pick_dataset"}))
+    result = read_skill.invoke({"name": "analyze"})
+    assert "not available in this profile" in result
+    assert "pull_data" in result
+    assert "generate_insights" in result
+
+
+def test_read_skill_refuses_when_no_tools_are_bound():
+    set_bound_tool_names(frozenset())
+    result = read_skill.invoke({"name": "analyze"})
+    assert "not available in this profile" in result
+
+
+def test_read_skill_lists_every_missing_tool_sorted():
+    set_bound_tool_names(frozenset())
+    result = read_skill.invoke({"name": "analyze"})
+    missing_clause = result.split("missing tools: ")[1].rstrip(")")
+    assert missing_clause.split(", ") == sorted(
+        ["pick_aoi", "pick_dataset", "pull_data", "generate_insights"]
+    )
+
+
+def test_read_skill_serves_body_when_all_required_tools_bound():
+    set_bound_tool_names(
+        frozenset(
+            {"pick_aoi", "pick_dataset", "pull_data", "generate_insights"}
+        )
+    )
+    result = read_skill.invoke({"name": "analyze"})
+    assert result == get_skill_body("analyze")
+
+
+def test_read_skill_serves_body_when_bound_tools_are_a_superset():
+    """Extra bound tools beyond what the skill requires must not matter."""
+    set_bound_tool_names(
+        frozenset(
+            {
+                "pick_aoi",
+                "pick_dataset",
+                "pull_data",
+                "generate_insights",
+                "show_imagery",
+            }
+        )
+    )
+    result = read_skill.invoke({"name": "analyze"})
+    assert result == get_skill_body("analyze")
+
+
+def test_read_skill_serves_no_requires_skill_even_with_no_tools_bound():
+    set_bound_tool_names(frozenset())
+    result = read_skill.invoke({"name": "capabilities"})
+    assert result == get_skill_body("capabilities")
+
+
+def test_read_skill_unknown_name_still_reports_not_found():
+    set_bound_tool_names(frozenset())
+    result = read_skill.invoke({"name": "does-not-exist"})
+    assert "skill not found" in result
 
 
 def test_pick_dataset_is_a_thin_subagent_tool():

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -106,25 +106,44 @@ def test_get_skill_capabilities_has_no_requires():
 
 def test_read_skill_refuses_when_a_required_tool_is_unbound():
     """analyze requires pick_aoi, pick_dataset, pull_data, generate_insights;
-    binding only some of them must not hand back the skill body."""
+    binding only some of them must not hand back the skill body. To the
+    model this must read exactly like an unknown skill name — it's already
+    excluded from what this profile advertises (AgentConfig.skills())."""
     set_bound_tool_names(frozenset({"pick_aoi", "pick_dataset"}))
     result = read_skill.invoke({"name": "analyze"})
-    assert "not available in this profile" in result
-    assert "pull_data" in result
-    assert "generate_insights" in result
+    assert result == "skill not found: analyze"
 
 
 def test_read_skill_refuses_when_no_tools_are_bound():
     set_bound_tool_names(frozenset())
     result = read_skill.invoke({"name": "analyze"})
-    assert "not available in this profile" in result
+    assert result == "skill not found: analyze"
 
 
-def test_read_skill_lists_every_missing_tool_sorted():
+def test_read_skill_logs_every_missing_tool_sorted_without_exposing_them(
+    monkeypatch,
+):
+    """The model-facing message stays a generic "not found"; the specifics
+    are only for our own logs."""
+    warnings = []
+
+    class _FakeLogger:
+        def warning(self, event, **kwargs):
+            warnings.append((event, kwargs))
+
+        def info(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("src.agent.skills.tool.logger", _FakeLogger())
     set_bound_tool_names(frozenset())
     result = read_skill.invoke({"name": "analyze"})
-    missing_clause = result.split("missing tools: ")[1].rstrip(")")
-    assert missing_clause.split(", ") == sorted(
+
+    assert "pull_data" not in result
+    assert "generate_insights" not in result
+    [(event, kwargs)] = warnings
+    assert event == "read_skill: skill not available in this profile"
+    assert kwargs["skill_name"] == "analyze"
+    assert kwargs["missing_tools"] == sorted(
         ["pick_aoi", "pick_dataset", "pull_data", "generate_insights"]
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.7"
+version = "2026.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- `read_skill` was a plain `name -> body` lookup with no check against the calling agent's actually-bound tools, unlike `AgentConfig.skills()` which already filters what gets *advertised* in the system prompt (#743).
- Bind the resolved profile's tool names to a per-request `ContextVar` in `fetch_zeno` (mirroring the existing `current_user_id` pattern in `src/shared/request_context.py`), and have `read_skill` refuse when a skill's `requires:` aren't all bound. The refusal message is identical to the "unknown skill name" case (`"skill not found: {name}"`) — a skill excluded from this profile's advertised list is, from the model's perspective, indistinguishable from one that doesn't exist; the specific missing tools are only logged, not surfaced to the model.
- **Follow-up caught in review**: two prompt-building paths still named skills unconditionally, so the model could be routed straight into a `read_skill` call that gets refused — reproducing exactly this in a production trace where the agent asked for the `dashboard` skill immediately on a profile that doesn't bind its required tools:
  - `get_prompt()`'s `# Routing` table (`graph.py`) was a hardcoded string naming `dashboard`, `show-imagery`, `pull-data`, `analyze`, `capabilities`, and `search_insights` regardless of the active profile.
  - `view_pages.py`'s dashboard `# Current surface` section had the same `read skill \`dashboard\`` pointer, gated only by which frontend page the user is on, not by the bound profile.
- **Hardening pass**: the first cut of that prompt gating checked names against a single flat set mixing skill and tool names — correct only by the accident that skills are hyphenated (`show-imagery`) and tools snake_case (`show_imagery`). Availability is now a typed, two-namespace concept, gates declare which namespace they mean, and new guardrail tests turn every silent failure mode (name collision, renamed skill/tool dropping prompt content, typo'd `requires:` hiding a skill forever) into a test failure.

No behavior change for any currently-registered profile beyond the routing text: `create_dashboard`/`add_to_dashboard`/`add_map_widget` are only ever bound together today, so this closes a latent hole plus the prompt-side symptom of it, rather than fixing a different live bug. Rendered system prompts were verified **byte-identical** across both profiles and all registered pages before/after the hardening and simplification commits.

Closes #743

## Changes

### Call-time enforcement (`read_skill`)
- `src/agent/tool_spec.py` — `ContextVar[frozenset[str]]` + `set_bound_tool_names()` / `bound_tool_names()` accessors
- `src/agent/graph.py` (`fetch_zeno`) — binds `set_bound_tool_names(config.tool_names())` once per request
- `src/agent/skills/loader.py` / `__init__.py` — added `get_skill(name)` to expose `SkillMeta` (including `requires`); `render_body(skill)` factored out and shared by `get_skill_body` and `read_skill` (single lookup, no assert)
- `src/agent/skills/tool.py` (`read_skill`) — checks `requires` against `bound_tool_names()`; returns the generic "not found" message when something's missing

### Prompt-side gating, typed namespaces
- `src/agent/tool_spec.py` — `Availability(skills, tools)` frozen dataclass with `has_skill` / `has_tool` / `allows(gate)`, and a `Gate` type alias (`tuple[Literal["skill", "tool"], str] | None`) so a misspelled gate kind is a **mypy error at the definition site**, not a silently-dropped prompt row
- `src/agent/agent_config.py` — `AgentConfig.tool_names()` (reused by `.skills()`) and `AgentConfig.availability()`, the one place the availability set is computed; `AgentConfigRegistry.configs()` public accessor for cross-profile invariant checks
- `src/agent/graph.py` — the `# Routing` table is a module-level `ROUTING_ROWS` constant of `(Gate, line)` pairs; `get_prompt()` renders only rows the profile's `Availability.allows()`
- `src/agent/view_pages.py` — `ViewPage` carries `prompt_base` plus a declarative `skill_pointer: (skill, suffix)` instead of prompt-section closures; a generic `render_prompt(available)` appends the pointer only when `has_skill` passes. `prompt_section(page, available)` now requires the availability argument (the empty default existed only for tests)

### Guardrail tests (`tests/unit/agent/test_availability.py`, new)
- skill names never collide with tool names across all registered profiles
- every `ROUTING_ROWS` gate resolves to a real skill/tool
- every `ViewPage.skill_pointer` names a real skill
- every skill's `requires:` frontmatter entry names a registered tool

Each was proven to bite by injecting a typo and watching the test fail.

## Test plan

- [x] `read_skill` refuses (with the generic "not found" message) when a required tool is unbound, when no tools are bound, and when the skill name is simply unknown — all indistinguishable to the model
- [x] `read_skill` serves the body when all required tools are bound, and when bound tools are a strict superset; skills with no `requires:` (e.g. `capabilities`) are always served
- [x] The missing-tools detail is captured in the warning log but not in the returned string (verified via a log-capturing test)
- [x] `AgentConfig.tool_names()`, the `bound_tool_names` ContextVar accessors, and `fetch_zeno` binding the resolved profile's tool names
- [x] `get_prompt()`'s Routing table excludes rows for skills/tools the profile doesn't bind (default profile) and includes them when it does (experimental profile)
- [x] `view_pages.py`'s dashboard surface section drops the `dashboard` skill pointer when unavailable, keeps it when available; a *tool* named like a skill does **not** satisfy a skill gate
- [x] The four availability guardrail tests pass, and each fails when its invariant is deliberately broken
- [x] Rendered prompts byte-identical to the pre-refactor output across (default, experimental) × (no page, map, dashboard, unknown page)
- [x] `uv run pytest tests/unit -q` — 352 passed
- [x] `ruff check` / `ruff format --check` clean; `mypy` clean on touched files (two pre-existing, unrelated errors on `graph.py` confirmed present on `main` too)
