### PR TITLE
refactor(agent): define profiles by skills, derive tools from them

### DIFF
--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -1,16 +1,20 @@
-"""Agent configurations: which tools (and prompt) load per feature flag.
+"""Agent configurations: which skills (and prompt) load per feature flag.
 
-An ``AgentConfig`` bundles a set of ``ToolSpec`` objects together so the
-system prompt can never describe a tool that isn't bound. An optional
-``system_prompt`` override replaces the generated prompt entirely — useful
-for testing or bespoke agents.
+An ``AgentConfig`` declares its capability surface as a tuple of *skill
+names*; the tools those skills ``require:`` are derived from ``ALL_SPECS``,
+so a profile can never advertise a skill whose tools aren't bound — and,
+conversely, adding a tool can never silently activate an unintended skill.
+Tools useful on their own (not part of any skill's workflow) go in
+``extra_tools``. An optional ``system_prompt`` override replaces the
+generated prompt entirely — useful for testing or bespoke agents.
 
 Configs are held in an ``AgentConfigRegistry``. The module-level
 ``default_registry`` is used in production; tests create isolated instances
 and inject them, keeping global state clean.
 
-To expose a new tool behind a feature flag, register a new ``AgentConfig``
-in ``default_registry`` with the flag name.
+To expose a new skill behind a feature flag, register a new ``AgentConfig``
+in ``default_registry`` with the flag name (and add any new tools' specs to
+``ALL_SPECS``).
 """
 
 from dataclasses import dataclass, field
@@ -18,7 +22,7 @@ from typing import Optional
 
 from langchain_core.tools import BaseTool
 
-from src.agent.skills import SkillMeta, all_skills
+from src.agent.skills import SkillMeta, all_skills, get_skill
 from src.agent.skills.tool import SPEC as read_skill_spec
 from src.agent.subagents.analyst.tool import SPEC as generate_insights_spec
 from src.agent.subagents.pick_aoi.tool import SPEC as pick_aoi_spec
@@ -41,19 +45,15 @@ from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-DEFAULT_PROFILE = "default"
-CORE_SPECS = (
+# Every registered tool spec, in canonical system-prompt order. Profiles
+# derive their spec tuples from this, so a tool's position here is its
+# position in every profile's prompt.
+ALL_SPECS = (
     pick_aoi_spec,
     pick_dataset_spec,
     pull_data_spec,
     generate_insights_spec,
     read_skill_spec,
-)
-
-# Experimental, opt-in tools layered on top of the core set.
-EXPERIMENTAL_PROFILE = "experimental"
-EXPERIMENTAL_SPECS = (
-    *CORE_SPECS,
     inspect_view_context_spec,
     show_imagery_spec,
     search_blogs_spec,
@@ -63,19 +63,72 @@ EXPERIMENTAL_SPECS = (
     add_to_dashboard_spec,
     add_map_widget_spec,
 )
+_SPEC_BY_NAME = {s.tool.name: s for s in ALL_SPECS}
+
+DEFAULT_PROFILE = "default"
+DEFAULT_SKILLS = ("analyze", "pull-data", "capabilities")
+
+# Experimental, opt-in skills/tools layered on top of the default set.
+EXPERIMENTAL_PROFILE = "experimental"
+EXPERIMENTAL_SKILLS = (
+    *DEFAULT_SKILLS,
+    "dashboard",
+    "show-imagery",
+    "wri-insights",
+    "explore",
+)
 
 
 @dataclass(frozen=True)
 class AgentConfig:
-    """A named agent configuration: a set of tools and an optional prompt.
+    """A named agent configuration: declared skills and an optional prompt.
 
-    ``system_prompt`` overrides the generated prompt when set — useful for
-    testing or bespoke agents with a fixed persona and no tools.
+    ``skills`` is the capability surface; the tools those skills require are
+    derived (see ``specs``). ``extra_tools`` holds specs not tied to any
+    skill's workflow. ``system_prompt`` overrides the generated prompt when
+    set — useful for testing or bespoke agents with a fixed persona and no
+    tools.
     """
 
     name: str
-    specs: tuple[ToolSpec, ...]
+    skills: tuple[str, ...] = ()
+    extra_tools: tuple[ToolSpec, ...] = ()
     system_prompt: Optional[str] = field(default=None)
+
+    def __post_init__(self) -> None:
+        for skill_name in self.skills:
+            skill = get_skill(skill_name)
+            if skill is None:
+                raise ValueError(
+                    f"profile {self.name!r} declares unknown skill "
+                    f"{skill_name!r}"
+                )
+            unknown = [t for t in skill.requires if t not in _SPEC_BY_NAME]
+            if unknown:
+                raise ValueError(
+                    f"skill {skill_name!r} (declared by profile "
+                    f"{self.name!r}) requires tools missing from ALL_SPECS: "
+                    f"{unknown}"
+                )
+
+    @property
+    def specs(self) -> tuple[ToolSpec, ...]:
+        """The profile's tool specs: the union of its skills' ``requires``
+        (plus ``read_skill`` when any skill is declared) and ``extra_tools``,
+        in canonical ``ALL_SPECS`` order."""
+        names = {
+            tool_name
+            for skill_name in self.skills
+            for tool_name in get_skill(skill_name).requires  # type: ignore[union-attr]
+        }
+        if self.skills:
+            names.add(read_skill_spec.tool.name)
+        names.update(s.tool.name for s in self.extra_tools)
+        derived = tuple(s for s in ALL_SPECS if s.tool.name in names)
+        unregistered = tuple(
+            s for s in self.extra_tools if s.tool.name not in _SPEC_BY_NAME
+        )
+        return derived + unregistered
 
     def tools(self) -> list[BaseTool]:
         return [s.tool for s in self.specs]
@@ -93,17 +146,16 @@ class AgentConfig:
     def tool_names(self) -> frozenset[str]:
         return frozenset(s.tool.name for s in self.specs)
 
-    def skills(self) -> list[SkillMeta]:
-        available = self.tool_names()
-        return [sk for sk in all_skills() if set(sk.requires) <= available]
+    def skill_metas(self) -> list[SkillMeta]:
+        declared = set(self.skills)
+        return [sk for sk in all_skills() if sk.name in declared]
 
     def availability(self) -> Availability:
-        """What this profile can route to — the same rule read_skill enforces
-        at call time (a skill's ``requires`` must all be bound), so prompt
-        builders never advertise a skill or tool the model would just get
-        "not found"/refused for."""
+        """What this profile can route to — the declared skills and the tools
+        derived from them, so prompt builders and ``read_skill`` never serve
+        a skill or tool the profile doesn't declare."""
         return Availability(
-            skills=frozenset(sk.name for sk in self.skills()),
+            skills=frozenset(self.skills),
             tools=self.tool_names(),
         )
 
@@ -140,7 +192,15 @@ class AgentConfigRegistry:
 
 # Production registry — register new flag configs here.
 default_registry = AgentConfigRegistry()
-default_registry.register(AgentConfig(DEFAULT_PROFILE, specs=CORE_SPECS))
+default_registry.register(AgentConfig(DEFAULT_PROFILE, skills=DEFAULT_SKILLS))
 default_registry.register(
-    AgentConfig(EXPERIMENTAL_PROFILE, specs=EXPERIMENTAL_SPECS)
+    AgentConfig(
+        EXPERIMENTAL_PROFILE,
+        skills=EXPERIMENTAL_SKILLS,
+        extra_tools=(
+            inspect_view_context_spec,
+            update_insight_display_spec,
+            search_insights_spec,
+        ),
+    )
 )

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -1,23 +1,42 @@
-"""Agent configurations: which skills (and prompt) load per feature flag.
+"""Agent configurations: which skills and tools (and prompt) load per feature flag.
 
-An ``AgentConfig`` declares its capability surface as a tuple of *skill
-names*; the tools those skills ``require:`` are derived from ``ALL_SPECS``,
-so a profile can never advertise a skill whose tools aren't bound — and,
-conversely, adding a tool can never silently activate an unintended skill.
-Tools useful on their own (not part of any skill's workflow) go in
-``extra_tools``. An optional ``system_prompt`` override replaces the
-generated prompt entirely — useful for testing or bespoke agents.
+Profiles form a chain, each one a small delta on its parent:
 
-Configs are held in an ``AgentConfigRegistry``. The module-level
-``default_registry`` is used in production; tests create isolated instances
-and inject them, keeping global state clean.
+    base         — the core toolbox (pick_aoi, pick_dataset, pull_data,
+                   generate_insights), no skills. Ships on its own so raw
+                   tool-calling can be evaluated without recipe guidance.
+    default      — base + the core skills (analyze, pull-data, capabilities).
+    experimental — default + opt-in skills and standalone tools.
+
+An ``AgentConfig`` declares three things:
+
+- ``extends`` — the parent profile whose skills and tools it inherits.
+- ``skills`` — skill names this profile adds. The tools those skills
+  ``require:`` are derived from ``ALL_SPECS``, so a profile can never
+  advertise a skill whose tools aren't bound — and, conversely, adding a
+  tool can never silently activate an unintended skill.
+- ``tools`` — specs bound directly, independent of any skill: the base
+  profile's core toolbox, or standalone extras no skill's workflow owns.
+
+A skill's ``requires:`` stays a complete list of what its workflow calls,
+even when the parent profile already binds those tools — the overlap
+dedupes, and the skill stays portable to profiles built on a leaner base.
+
+An optional ``system_prompt`` override replaces the generated prompt
+entirely — useful for testing or bespoke agents.
+
+Configs are held in an ``AgentConfigRegistry``, which flattens ``extends``
+at registration time. The module-level ``default_registry`` is used in
+production; tests create isolated instances and inject them, keeping global
+state clean.
 
 To expose a new skill behind a feature flag, register a new ``AgentConfig``
-in ``default_registry`` with the flag name (and add any new tools' specs to
-``ALL_SPECS``).
+in ``default_registry`` that extends an existing profile (and add any new
+tools' specs to ``ALL_SPECS``). Each production profile's full derived
+surface is snapshot-tested in ``tests/unit/agent/test_profile_manifest.py``.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Optional
 
 from langchain_core.tools import BaseTool
@@ -65,34 +84,48 @@ ALL_SPECS = (
 )
 _SPEC_BY_NAME = {s.tool.name: s for s in ALL_SPECS}
 
+# The core toolbox every profile builds on: resolve an AOI, pick a dataset,
+# pull data, generate insights.
+BASE_PROFILE = "base"
+CORE_TOOLS = (
+    pick_aoi_spec,
+    pick_dataset_spec,
+    pull_data_spec,
+    generate_insights_spec,
+)
+
+# The core skills layered on the base toolbox.
 DEFAULT_PROFILE = "default"
 DEFAULT_SKILLS = ("analyze", "pull-data", "capabilities")
 
-# Experimental, opt-in skills/tools layered on top of the default set.
+# Experimental, opt-in additions over the default profile.
 EXPERIMENTAL_PROFILE = "experimental"
-EXPERIMENTAL_SKILLS = (
-    *DEFAULT_SKILLS,
-    "dashboard",
-    "show-imagery",
-    "wri-insights",
-    "explore",
+EXPERIMENTAL_SKILLS = ("dashboard", "show-imagery", "wri-insights", "explore")
+EXPERIMENTAL_TOOLS = (
+    inspect_view_context_spec,
+    update_insight_display_spec,
+    search_insights_spec,
 )
 
 
 @dataclass(frozen=True)
 class AgentConfig:
-    """A named agent configuration: declared skills and an optional prompt.
+    """A named agent configuration: a parent to extend, declared skills,
+    directly-bound tools, and an optional prompt.
 
-    ``skills`` is the capability surface; the tools those skills require are
-    derived (see ``specs``). ``extra_tools`` holds specs not tied to any
-    skill's workflow. ``system_prompt`` overrides the generated prompt when
-    set — useful for testing or bespoke agents with a fixed persona and no
-    tools.
+    ``extends`` names a parent profile; the registry merges the parent's
+    skills and tools into this config at registration time. ``skills`` is
+    the capability surface this profile adds; the tools those skills require
+    are derived (see ``specs``). ``tools`` holds specs bound directly,
+    independent of any skill. ``system_prompt`` overrides the generated
+    prompt when set — useful for testing or bespoke agents with a fixed
+    persona and no tools.
     """
 
     name: str
+    extends: Optional[str] = None
     skills: tuple[str, ...] = ()
-    extra_tools: tuple[ToolSpec, ...] = ()
+    tools: tuple[ToolSpec, ...] = ()
     system_prompt: Optional[str] = field(default=None)
 
     def __post_init__(self) -> None:
@@ -113,9 +146,9 @@ class AgentConfig:
 
     @property
     def specs(self) -> tuple[ToolSpec, ...]:
-        """The profile's tool specs: the union of its skills' ``requires``
-        (plus ``read_skill`` when any skill is declared) and ``extra_tools``,
-        in canonical ``ALL_SPECS`` order."""
+        """The profile's tool specs: the directly-bound ``tools`` plus the
+        union of its skills' ``requires`` (and ``read_skill`` when any skill
+        is declared), in canonical ``ALL_SPECS`` order."""
         names = {
             tool_name
             for skill_name in self.skills
@@ -123,14 +156,14 @@ class AgentConfig:
         }
         if self.skills:
             names.add(read_skill_spec.tool.name)
-        names.update(s.tool.name for s in self.extra_tools)
+        names.update(s.tool.name for s in self.tools)
         derived = tuple(s for s in ALL_SPECS if s.tool.name in names)
         unregistered = tuple(
-            s for s in self.extra_tools if s.tool.name not in _SPEC_BY_NAME
+            s for s in self.tools if s.tool.name not in _SPEC_BY_NAME
         )
         return derived + unregistered
 
-    def tools(self) -> list[BaseTool]:
+    def bound_tools(self) -> list[BaseTool]:
         return [s.tool for s in self.specs]
 
     def tool_descriptions(self) -> str:
@@ -159,6 +192,78 @@ class AgentConfig:
             tools=self.tool_names(),
         )
 
+    def describe(self) -> str:
+        """A plain-text manifest of everything this profile can do, grouped
+        by layer: skills (recipes loaded on demand), subagents (tools that
+        run their own reasoning), and primitive tools.
+
+        Profiles declare deltas (``extends`` plus their own skills/tools),
+        so the full bound surface is not visible at the declaration site —
+        this renders it in one place. Snapshot-tested per production profile
+        in ``tests/unit/agent/test_profile_manifest.py``.
+        """
+        lines = [f"profile: {self.name}"]
+        if self.extends is not None:
+            lines.append(f"extends: {self.extends}")
+
+        def section(title: str, entries: list[str]) -> None:
+            lines.append(f"{title}:")
+            if entries:
+                lines.extend(f"  - {entry}" for entry in entries)
+            else:
+                lines.append("  (none)")
+
+        skill_entries = []
+        for skill in self.skill_metas():
+            if skill.requires:
+                skill_entries.append(
+                    f"{skill.name} (requires: {', '.join(skill.requires)})"
+                )
+            else:
+                skill_entries.append(skill.name)
+        section("skills", skill_entries)
+        section(
+            "subagents",
+            [
+                s.tool.name
+                for s in self.specs
+                if s.category is ToolCategory.SUBAGENT
+            ],
+        )
+        section(
+            "tools",
+            [
+                s.tool.name
+                for s in self.specs
+                if s.category is ToolCategory.PRIMITIVE
+            ],
+        )
+        return "\n".join(lines)
+
+
+def _merge_skills(
+    parent: tuple[str, ...], child: tuple[str, ...]
+) -> tuple[str, ...]:
+    """Parent's skills first, then the child's new ones; no duplicates."""
+    merged = list(parent)
+    for name in child:
+        if name not in merged:
+            merged.append(name)
+    return tuple(merged)
+
+
+def _merge_tools(
+    parent: tuple[ToolSpec, ...], child: tuple[ToolSpec, ...]
+) -> tuple[ToolSpec, ...]:
+    """Parent's tools first, then the child's new ones; deduped by name."""
+    merged = list(parent)
+    seen = {s.tool.name for s in parent}
+    for spec in child:
+        if spec.tool.name not in seen:
+            merged.append(spec)
+            seen.add(spec.tool.name)
+    return tuple(merged)
+
 
 class AgentConfigRegistry:
     """Holds named configs and resolves feature flags to them.
@@ -171,6 +276,25 @@ class AgentConfigRegistry:
         self._configs: dict[str, AgentConfig] = {}
 
     def register(self, config: AgentConfig) -> None:
+        """Store ``config``, flattening its ``extends`` chain first.
+
+        A config that extends another inherits the parent's skills and tools
+        and adds its own; the parent must already be registered. The stored
+        config is fully flattened (the parent it names was flattened when it
+        registered), so lookups never walk the chain.
+        """
+        if config.extends is not None:
+            parent = self._configs.get(config.extends)
+            if parent is None:
+                raise ValueError(
+                    f"profile {config.name!r} extends unknown profile "
+                    f"{config.extends!r}; register the parent first"
+                )
+            config = replace(
+                config,
+                skills=_merge_skills(parent.skills, config.skills),
+                tools=_merge_tools(parent.tools, config.tools),
+            )
         self._configs[config.name] = config
 
     def configs(self) -> tuple[AgentConfig, ...]:
@@ -190,17 +314,22 @@ class AgentConfigRegistry:
         return self._configs[DEFAULT_PROFILE]
 
 
-# Production registry — register new flag configs here.
+# Production registry — register new flag configs here. Each profile is a
+# delta on its parent; parents must be registered before children.
 default_registry = AgentConfigRegistry()
-default_registry.register(AgentConfig(DEFAULT_PROFILE, skills=DEFAULT_SKILLS))
+default_registry.register(AgentConfig(BASE_PROFILE, tools=CORE_TOOLS))
+default_registry.register(
+    AgentConfig(
+        DEFAULT_PROFILE,
+        extends=BASE_PROFILE,
+        skills=DEFAULT_SKILLS,
+    )
+)
 default_registry.register(
     AgentConfig(
         EXPERIMENTAL_PROFILE,
+        extends=DEFAULT_PROFILE,
         skills=EXPERIMENTAL_SKILLS,
-        extra_tools=(
-            inspect_view_context_spec,
-            update_insight_display_spec,
-            search_insights_spec,
-        ),
+        tools=EXPERIMENTAL_TOOLS,
     )
 )

--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -31,8 +31,8 @@ from langgraph.checkpoint.memory import InMemorySaver
 from sqlalchemy import select
 
 from src.agent.agent_config import (
-    CORE_SPECS,
     DEFAULT_PROFILE,
+    DEFAULT_SKILLS,
     AgentConfig,
     default_registry,
 )
@@ -625,7 +625,7 @@ async def _fetch_agent(
     else:
         config = AgentConfig(
             DEFAULT_PROFILE,
-            specs=CORE_SPECS,
+            skills=DEFAULT_SKILLS,
             system_prompt=system_prompt,
         )
     if use_postgres:

--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -16,6 +16,7 @@ import re
 import sys
 import uuid
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
@@ -30,12 +31,7 @@ from langchain_core.messages import (
 from langgraph.checkpoint.memory import InMemorySaver
 from sqlalchemy import select
 
-from src.agent.agent_config import (
-    DEFAULT_PROFILE,
-    DEFAULT_SKILLS,
-    AgentConfig,
-    default_registry,
-)
+from src.agent.agent_config import default_registry
 from src.agent.graph import (
     close_checkpointer_pool,
     fetch_zeno,
@@ -623,10 +619,10 @@ async def _fetch_agent(
     if ff:
         config = default_registry.resolve(ff)
     else:
-        config = AgentConfig(
-            DEFAULT_PROFILE,
-            skills=DEFAULT_SKILLS,
-            system_prompt=system_prompt,
+        # The production default profile, with only the prompt overridden —
+        # so the CLI always binds the same surface as the server.
+        config = replace(
+            default_registry.resolve(), system_prompt=system_prompt
         )
     if use_postgres:
         return await fetch_zeno(config=config)

--- a/src/agent/docs/feature-flags.md
+++ b/src/agent/docs/feature-flags.md
@@ -2,6 +2,19 @@
 
 Feature flags let you swap the agent's capability surface (skills, and the tools derived from them) and system prompt on a per-request basis without touching the database. A client passes `"ff": "<flag-name>"` in the `POST /api/chat` request body; the server resolves this to a named `AgentConfig` and builds the agent from it.
 
+## The profile chain
+
+Profiles form a chain, each one a small delta on its parent:
+
+```
+base         core toolbox (pick_aoi, pick_dataset, pull_data, generate_insights), no skills
+  └─ default       base + core skills (analyze, pull-data, capabilities)
+       └─ experimental  default + opt-in skills (dashboard, show-imagery, wri-insights, explore)
+                        + standalone tools (inspect_view_context, update_insight_display, search_insights)
+```
+
+`base` ships as its own flag so raw tool-calling can be evaluated without recipe guidance. `default` is what unknown or absent `ff` values fall back to. Each production profile's full derived surface (skills, subagents, tools) is snapshot-tested in `tests/unit/agent/test_profile_manifest.py` — run `config.describe()` to see it, and update the snapshot when you change a profile on purpose.
+
 ## How it works
 
 ```mermaid
@@ -13,8 +26,8 @@ flowchart TD
 
     Registry["AgentConfigRegistry\n.resolve(ff)"]
 
-    DefaultConfig["AgentConfig 'default'\nDEFAULT_SKILLS\nget_prompt(config)"]
-    FlagConfig["AgentConfig 'my-flag'\nDEFAULT_SKILLS + 'my-skill'\nget_prompt(config)"]
+    DefaultConfig["AgentConfig 'default'\nextends 'base' + core skills\nget_prompt(config)"]
+    FlagConfig["AgentConfig 'my-flag'\nextends 'default' + 'my-skill'\nget_prompt(config)"]
 
     Agent["LangGraph agent\ntools + system prompt\nfrom resolved config"]
 
@@ -23,12 +36,15 @@ flowchart TD
     Registry -->|"flag unknown\nor absent"| DefaultConfig --> Agent
 ```
 
-Each `AgentConfig` bundles:
-- **`skills`** — a tuple of skill names (files in `src/agent/skills/skills_md/`); the profile's tools are *derived* from each skill's `requires:` frontmatter (plus `read_skill` itself), so a skill can never be declared without its tools, and adding a tool can never silently activate a skill
-- **`extra_tools`** — a tuple of `ToolSpec` objects for tools that aren't part of any skill's workflow (e.g. `inspect_view_context`)
+Each `AgentConfig` declares:
+- **`extends`** — the parent profile whose skills and tools it inherits; the registry flattens the chain at registration time (parents must be registered first)
+- **`skills`** — skill names this profile adds (files in `src/agent/skills/skills_md/`); the tools those skills require are *derived* from each skill's `requires:` frontmatter (plus `read_skill` itself), so a skill can never be declared without its tools, and adding a tool can never silently activate a skill
+- **`tools`** — `ToolSpec` objects bound directly, independent of any skill: the base profile's core toolbox, or standalone tools no skill's workflow owns (e.g. `inspect_view_context`)
 - **`system_prompt`** — an optional override that replaces the generated prompt entirely (useful for test personas like "say only the word cat")
 
-Declaring an unknown skill name, or a skill whose `requires:` names a tool missing from `ALL_SPECS`, raises at construction time. The system prompt is always `config.system_prompt or get_prompt(config)`. `get_prompt` renders the tools and skills sections from the config automatically, so the prompt can never describe a skill or tool that isn't bound.
+A skill's `requires:` stays a complete list of what its workflow calls, even when the parent profile already binds those tools — the overlap dedupes, and the skill stays portable to profiles built on a leaner base.
+
+Declaring an unknown skill name, a skill whose `requires:` names a tool missing from `ALL_SPECS`, or an `extends` naming an unregistered profile raises at registration time. The system prompt is always `config.system_prompt or get_prompt(config)`. `get_prompt` renders the tools and skills sections from the config automatically, so the prompt can never describe a skill or tool that isn't bound.
 
 ## Adding a new feature flag
 
@@ -56,20 +72,25 @@ Add the spec to `ALL_SPECS` in `agent_config.py` — its position there is its p
 
 ### 2. Wrap it in a skill (usually) and register an `AgentConfig`
 
-If the tool is part of a workflow, write a skill file in `src/agent/skills/skills_md/` that lists it under `requires:`, then declare the skill. Use `extra_tools` only for standalone tools:
+If the tool is part of a workflow, write a skill file in `src/agent/skills/skills_md/` that lists it under `requires:`, then declare the skill in a profile that extends an existing one. Use `tools` only for standalone tools:
 
 ```python
 # src/agent/agent_config.py
 default_registry.register(AgentConfig(
     "my-flag",
-    skills=(*DEFAULT_SKILLS, "my-skill"),
-    extra_tools=(my_standalone_tool_spec,),
+    extends=DEFAULT_PROFILE,
+    skills=("my-skill",),
+    tools=(my_standalone_tool_spec,),
 ))
 ```
 
 The config's `name` is the exact string the client passes as `ff`.
 
-### 3. Use the flag from a client
+### 3. Snapshot the new profile's surface
+
+Add the profile's `describe()` output to `tests/unit/agent/test_profile_manifest.py` — the test suite fails on any registered profile without a snapshot, so the full derived surface is always visible in review.
+
+### 4. Use the flag from a client
 
 ```json
 POST /api/chat
@@ -94,7 +115,7 @@ from langgraph.checkpoint.memory import InMemorySaver
 async def test_my_flag():
     registry = AgentConfigRegistry()
     registry.register(AgentConfig(DEFAULT_PROFILE, skills=DEFAULT_SKILLS))
-    registry.register(AgentConfig("my-flag", skills=(*DEFAULT_SKILLS, "my-skill")))
+    registry.register(AgentConfig("my-flag", extends=DEFAULT_PROFILE, skills=("my-skill",)))
 
     agent = await fetch_zeno(ff="my-flag", registry=registry, checkpointer=InMemorySaver())
     result = await agent.ainvoke(...)

--- a/src/agent/docs/feature-flags.md
+++ b/src/agent/docs/feature-flags.md
@@ -1,6 +1,6 @@
 # Agent Feature Flags
 
-Feature flags let you swap the agent's tool set and system prompt on a per-request basis without touching the database. A client passes `"ff": "<flag-name>"` in the `POST /api/chat` request body; the server resolves this to a named `AgentConfig` and builds the agent from it.
+Feature flags let you swap the agent's capability surface (skills, and the tools derived from them) and system prompt on a per-request basis without touching the database. A client passes `"ff": "<flag-name>"` in the `POST /api/chat` request body; the server resolves this to a named `AgentConfig` and builds the agent from it.
 
 ## How it works
 
@@ -13,8 +13,8 @@ flowchart TD
 
     Registry["AgentConfigRegistry\n.resolve(ff)"]
 
-    DefaultConfig["AgentConfig 'default'\nCORE_SPECS\nget_prompt(config)"]
-    FlagConfig["AgentConfig 'my-flag'\nCORE_SPECS + new_tool_spec\nget_prompt(config)"]
+    DefaultConfig["AgentConfig 'default'\nDEFAULT_SKILLS\nget_prompt(config)"]
+    FlagConfig["AgentConfig 'my-flag'\nDEFAULT_SKILLS + 'my-skill'\nget_prompt(config)"]
 
     Agent["LangGraph agent\ntools + system prompt\nfrom resolved config"]
 
@@ -24,10 +24,11 @@ flowchart TD
 ```
 
 Each `AgentConfig` bundles:
-- **`specs`** — a tuple of `ToolSpec` objects; each spec carries the tool object, its category, and the prompt fragment that describes it
+- **`skills`** — a tuple of skill names (files in `src/agent/skills/skills_md/`); the profile's tools are *derived* from each skill's `requires:` frontmatter (plus `read_skill` itself), so a skill can never be declared without its tools, and adding a tool can never silently activate a skill
+- **`extra_tools`** — a tuple of `ToolSpec` objects for tools that aren't part of any skill's workflow (e.g. `inspect_view_context`)
 - **`system_prompt`** — an optional override that replaces the generated prompt entirely (useful for test personas like "say only the word cat")
 
-The system prompt is always `config.system_prompt or get_prompt(config)`. `get_prompt` renders the tools and skills sections from the config's specs automatically, so the prompt can never describe a tool that isn't bound.
+Declaring an unknown skill name, or a skill whose `requires:` names a tool missing from `ALL_SPECS`, raises at construction time. The system prompt is always `config.system_prompt or get_prompt(config)`. `get_prompt` renders the tools and skills sections from the config automatically, so the prompt can never describe a skill or tool that isn't bound.
 
 ## Adding a new feature flag
 
@@ -51,17 +52,18 @@ SPEC = ToolSpec(
 )
 ```
 
-### 2. Register an `AgentConfig` in `agent_config.py`
+Add the spec to `ALL_SPECS` in `agent_config.py` — its position there is its position in every profile's prompt.
 
-Import the spec and register a new config on `default_registry`:
+### 2. Wrap it in a skill (usually) and register an `AgentConfig`
+
+If the tool is part of a workflow, write a skill file in `src/agent/skills/skills_md/` that lists it under `requires:`, then declare the skill. Use `extra_tools` only for standalone tools:
 
 ```python
 # src/agent/agent_config.py
-from src.agent.subagents.my_tool.tool import SPEC as my_tool_spec
-
 default_registry.register(AgentConfig(
     "my-flag",
-    specs=(*CORE_SPECS, my_tool_spec),
+    skills=(*DEFAULT_SKILLS, "my-skill"),
+    extra_tools=(my_standalone_tool_spec,),
 ))
 ```
 
@@ -85,26 +87,25 @@ Unknown or absent `ff` values silently fall back to the default config — no er
 Because `AgentConfigRegistry` is injected as a dependency, tests create isolated instances without touching global state:
 
 ```python
-from src.agent.agent_config import AgentConfig, AgentConfigRegistry, DEFAULT_PROFILE
+from src.agent.agent_config import AgentConfig, AgentConfigRegistry, DEFAULT_PROFILE, DEFAULT_SKILLS
 from src.agent.graph import fetch_zeno
 from langgraph.checkpoint.memory import InMemorySaver
 
 async def test_my_flag():
     registry = AgentConfigRegistry()
-    registry.register(AgentConfig(DEFAULT_PROFILE, specs=CORE_SPECS))
-    registry.register(AgentConfig("my-flag", specs=(*CORE_SPECS, my_tool_spec)))
+    registry.register(AgentConfig(DEFAULT_PROFILE, skills=DEFAULT_SKILLS))
+    registry.register(AgentConfig("my-flag", skills=(*DEFAULT_SKILLS, "my-skill")))
 
     agent = await fetch_zeno(ff="my-flag", registry=registry, checkpointer=InMemorySaver())
     result = await agent.ainvoke(...)
     # assert my_tool was called, others were not
 ```
 
-For a bespoke test persona with no tools:
+For a bespoke test persona with no skills or tools:
 
 ```python
 registry.register(AgentConfig(
     "cat",
-    specs=(),
     system_prompt="Say only the word 'cat' in response to everything.",
 ))
 ```

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -78,7 +78,23 @@ def get_prompt(
         f"- {s.name}: {s.description} (use when: {s.when_to_use})"
         for s in config.skill_metas()
     ]
-    skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
+    # A profile without skills (base) binds no read_skill, so the whole
+    # skills section — including the read_skill instruction — is omitted.
+    if skill_lines:
+        skills_section = (
+            "# Skills (multi-step recipes)\n"
+            "\n"
+            'Call read_skill(name) only when a skill\'s "use when" clause '
+            "matches the request — usually one skill, not the whole list.\n"
+            "\n" + "\n".join(skill_lines) + "\n"
+            "\n"
+        )
+        routing_intro = (
+            "Match the request to exactly one skill (above) or one row (below)"
+        )
+    else:
+        skills_section = ""
+        routing_intro = "Match the request to exactly one row below"
     tool_descriptions = config.tool_descriptions()
     available = config.availability()
     surface = prompt_section(page, available)
@@ -97,15 +113,9 @@ Call tools one at a time, never in parallel.
 
 {tool_descriptions}
 
-# Skills (multi-step recipes)
+{skills_section}# Routing
 
-Call read_skill(name) only when a skill's "use when" clause matches the request — usually one skill, not the whole list.
-
-{skills_block}
-
-# Routing
-
-Match the request to exactly one skill (above) or one row (below); do not escalate a dataset / AOI / pull request into a full analysis.
+{routing_intro}; do not escalate a dataset / AOI / pull request into a full analysis.
 
 {routing_block}
 
@@ -284,7 +294,7 @@ async def fetch_zeno(
         checkpointer = await fetch_checkpointer()
     zeno_agent = create_agent(
         model=MODEL,
-        tools=config.tools(),
+        tools=config.bound_tools(),
         state_schema=AgentState,
         system_prompt=config.system_prompt or get_prompt(config, page=page),
         middleware=_build_middleware(),

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -23,17 +23,20 @@ from src.agent.agent_config import (
 from src.agent.llms import FALLBACK_MODELS, MODEL
 from src.agent.middleware import SessionContextMiddleware
 from src.agent.state import AgentState
-from src.agent.tool_spec import Gate, set_bound_tool_names
+from src.agent.tool_spec import Gate, set_bound_availability
 from src.agent.view_pages import prompt_section
 from src.shared.config import SharedSettings
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# The "# Routing" table, one (gate, line) pair per request shape. The gate
-# says which namespace the row depends on — ("skill", name) or ("tool", name)
-# — or None for rows served by the core tools every profile binds. Kept
-# module-level so tests can verify every gate resolves to a real skill/tool.
+# The "# Routing" table — only the request shapes the skills block can't
+# carry: the no-skill shapes (dataset-only, AOI-only) and the recall stop
+# semantics. Per-skill routing lives in each skill's ``when_to_use`` and
+# body, not here. The gate says which namespace a row depends on —
+# ("skill", name) or ("tool", name) — or None for rows served by the core
+# tools every profile binds. Kept module-level so tests can verify every
+# gate resolves to a real skill/tool.
 ROUTING_ROWS: tuple[tuple[Gate, str], ...] = (
     (
         None,
@@ -46,18 +49,6 @@ ROUTING_ROWS: tuple[tuple[Gate, str], ...] = (
         "unless asked for more.",
     ),
     (
-        ("skill", "pull-data"),
-        '- Pull-only (e.g. "pull dist alerts in Bern for last 2 '
-        'weeks"): read `pull-data`, run pick_aoi → pick_dataset → '
-        "pull_data, then stop. Do not call generate_insights unless "
-        "the user asked for a chart or analysis.",
-    ),
-    (
-        ("skill", "analyze"),
-        "- Full analysis (place + topic → chart/insight): read "
-        "`analyze` and follow that pipeline.",
-    ),
-    (
         ("tool", "search_insights"),
         '- Recall a past insight (e.g. "show that tree-cover insight '
         'again", "pull up the fires analysis from before"): call '
@@ -67,24 +58,6 @@ ROUTING_ROWS: tuple[tuple[Gate, str], ...] = (
         'generate_insights. "Show/recall/pull up an earlier insight" '
         "is a recall request, never a request for new analysis. After "
         "it returns, reply with a one-line summary only.",
-    ),
-    (
-        ("skill", "dashboard"),
-        '- Dashboard (e.g. "add this to my dashboard", "add this '
-        'layer/imagery to my dashboard", "build a dashboard for X"): '
-        "read skill `dashboard` and follow it.",
-    ),
-    (
-        ("skill", "show-imagery"),
-        '- Imagery (e.g. "show satellite imagery of Bern in June"): '
-        "read `show-imagery`, run pick_aoi → show_imagery, then stop. "
-        "No dataset, pull or insights unless asked.",
-    ),
-    (
-        ("skill", "capabilities"),
-        "- Capabilities (what you can do, what data exists): read "
-        "`capabilities`, then answer in your own words — no analysis "
-        "tools.",
     ),
 )
 
@@ -101,10 +74,9 @@ def get_prompt(
     """
     if config is None:
         config = default_registry.resolve()
-    skills = config.skills()
     skill_lines = [
         f"- {s.name}: {s.description} (use when: {s.when_to_use})"
-        for s in skills
+        for s in config.skill_metas()
     ]
     skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
     tool_descriptions = config.tool_descriptions()
@@ -133,7 +105,7 @@ Call read_skill(name) only when a skill's "use when" clause matches the request 
 
 # Routing
 
-Match the request to exactly one row; do not escalate a dataset / AOI / pull request into a full analysis.
+Match the request to exactly one skill (above) or one row (below); do not escalate a dataset / AOI / pull request into a full analysis.
 
 {routing_block}
 
@@ -306,7 +278,7 @@ async def fetch_zeno(
     """
     if config is None:
         config = registry.resolve(ff)
-    set_bound_tool_names(config.tool_names())
+    set_bound_availability(config.availability())
     logger.info("Agent profile set", profile=config.name)
     if checkpointer is _CHECKPOINTER_UNSET:
         checkpointer = await fetch_checkpointer()

--- a/src/agent/skills/tool.py
+++ b/src/agent/skills/tool.py
@@ -1,7 +1,7 @@
 from langchain_core.tools import tool
 
 from src.agent.skills.loader import get_skill, render_body
-from src.agent.tool_spec import ToolCategory, ToolSpec, bound_tool_names
+from src.agent.tool_spec import ToolCategory, ToolSpec, bound_availability
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -14,12 +14,10 @@ def read_skill(name: str) -> str:
     if skill is None:
         logger.warning("read_skill: skill not found", skill_name=name)
         return f"skill not found: {name}"
-    missing = set(skill.requires) - bound_tool_names()
-    if missing:
+    if not bound_availability().has_skill(name):
         logger.warning(
-            "read_skill: skill not available in this profile",
+            "read_skill: skill not declared by this profile",
             skill_name=name,
-            missing_tools=sorted(missing),
         )
         return f"skill not found: {name}"
     logger.info("read_skill: loaded skill", skill_name=name)

--- a/src/agent/tool_spec.py
+++ b/src/agent/tool_spec.py
@@ -57,21 +57,23 @@ class Availability:
         return name in (self.skills if kind == "skill" else self.tools)
 
 
-# The bound tool names of the current request's agent profile. Set once per
+# The availability of the current request's agent profile. Set once per
 # request (``fetch_zeno``) and read from inside tools (``read_skill``) that
-# need to know what's actually callable, not just what's listed in the
+# need to know what this profile declares, not just what's listed in the
 # prompt. Mirrors ``current_user_id`` in ``src.shared.request_context``.
-_bound_tool_names: ContextVar[frozenset[str]] = ContextVar(
-    "bound_tool_names", default=frozenset()
+_bound_availability: ContextVar[Availability] = ContextVar(
+    "bound_availability",
+    default=Availability(skills=frozenset(), tools=frozenset()),
 )
 
 
-def set_bound_tool_names(names: frozenset[str]) -> None:
-    """Bind the tool names available in the current request's agent profile,
-    for the remainder of this context."""
-    _bound_tool_names.set(names)
+def set_bound_availability(available: Availability) -> None:
+    """Bind the current request's agent-profile availability, for the
+    remainder of this context."""
+    _bound_availability.set(available)
 
 
-def bound_tool_names() -> frozenset[str]:
-    """The tool names bound by ``set_bound_tool_names``; empty when unset."""
-    return _bound_tool_names.get()
+def bound_availability() -> Availability:
+    """The availability bound by ``set_bound_availability``; empty when
+    unset."""
+    return _bound_availability.get()

--- a/tests/agent/test_feature_flag.py
+++ b/tests/agent/test_feature_flag.py
@@ -17,11 +17,10 @@ async def test_cat_profile_responds_with_only_cat():
     """A profile with a custom system prompt and no tools should make the
     agent respond with only the word 'cat'."""
     registry = AgentConfigRegistry()
-    registry.register(AgentConfig(DEFAULT_PROFILE, specs=()))
+    registry.register(AgentConfig(DEFAULT_PROFILE))
     registry.register(
         AgentConfig(
             "cat",
-            specs=(),
             system_prompt=(
                 "Say only the word 'cat' in response to everything. "
                 "Do not say anything else."

--- a/tests/unit/agent/test_availability.py
+++ b/tests/unit/agent/test_availability.py
@@ -9,10 +9,11 @@ modes into a test failure:
   them — the bug the Availability split exists to prevent),
 - every ROUTING_ROWS gate must resolve to a real skill/tool,
 - every ViewPage skill_pointer must name a real skill,
-- every skill's ``requires:`` entry must name a tool some profile binds.
+- every skill's ``requires:`` entry must name a spec in ALL_SPECS,
+- every skill file must be declared by some profile (else it's dead content).
 """
 
-from src.agent.agent_config import default_registry
+from src.agent.agent_config import ALL_SPECS, default_registry
 from src.agent.graph import ROUTING_ROWS
 from src.agent.skills import all_skills
 from src.agent.view_pages import PAGES
@@ -62,14 +63,28 @@ def test_page_skill_pointers_name_real_skills():
         ), f"page {page.name!r} points at unknown skill {skill!r}"
 
 
-def test_skill_requires_reference_registered_tools():
-    """A typo in a skill's ``requires:`` frontmatter would make the skill
-    unavailable in every profile forever, with no signal until a model
-    asks for it at runtime."""
-    tool_names = _all_registered_tool_names()
+def test_skill_requires_reference_known_specs():
+    """A typo in a skill's ``requires:`` frontmatter would blow up any
+    profile that declares the skill (AgentConfig.__post_init__) — and a
+    skill nobody declares yet would hide the typo entirely. Check every
+    skill file against the full spec catalogue."""
+    spec_names = {s.tool.name for s in ALL_SPECS}
     for skill in all_skills():
-        unknown = set(skill.requires) - tool_names
+        unknown = set(skill.requires) - spec_names
         assert not unknown, (
-            f"skill {skill.name!r} requires unregistered tools: "
+            f"skill {skill.name!r} requires tools missing from ALL_SPECS: "
             f"{sorted(unknown)}"
         )
+
+
+def test_every_skill_is_declared_by_some_profile():
+    """Profiles declare skills explicitly now, so a skill file nobody
+    declares is dead content the model can never reach — the drift this
+    refactor exists to make visible."""
+    declared = set().union(
+        *(config.skills for config in default_registry.configs())
+    )
+    undeclared = {s.name for s in all_skills()} - declared
+    assert (
+        not undeclared
+    ), f"skills not declared by any profile: {sorted(undeclared)}"

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -1,16 +1,18 @@
 """Tests for AgentConfig, AgentConfigRegistry, and feature flags."""
 
+import pytest
 from langchain_core.tools import tool
 
 from src.agent.agent_config import (
     DEFAULT_PROFILE,
+    DEFAULT_SKILLS,
     EXPERIMENTAL_PROFILE,
     AgentConfig,
     AgentConfigRegistry,
     default_registry,
 )
-from src.agent.skills import all_skills
-from src.agent.tool_spec import ToolCategory, ToolSpec, bound_tool_names
+from src.agent.skills import SkillMeta
+from src.agent.tool_spec import ToolCategory, ToolSpec, bound_availability
 
 # --- Lightweight test fixtures -----------------------------------------------
 
@@ -31,56 +33,113 @@ FAKE_SPEC = ToolSpec(
 
 def test_registry_resolves_known_ff():
     registry = AgentConfigRegistry()
-    registry.register(AgentConfig("default", specs=()))
-    registry.register(AgentConfig("blog", specs=(FAKE_SPEC,)))
+    registry.register(AgentConfig("default"))
+    registry.register(AgentConfig("blog", extra_tools=(FAKE_SPEC,)))
     assert registry.resolve("blog").name == "blog"
 
 
 def test_registry_falls_back_to_default_for_unknown_ff():
     registry = AgentConfigRegistry()
-    registry.register(AgentConfig("default", specs=()))
+    registry.register(AgentConfig("default"))
     assert registry.resolve("bogus").name == DEFAULT_PROFILE
 
 
 def test_registry_falls_back_to_default_for_none():
     registry = AgentConfigRegistry()
-    registry.register(AgentConfig("default", specs=()))
+    registry.register(AgentConfig("default"))
     assert registry.resolve(None).name == DEFAULT_PROFILE
 
 
 def test_registry_instances_are_isolated():
     registry_a = AgentConfigRegistry()
-    registry_a.register(AgentConfig("default", specs=()))
-    registry_a.register(AgentConfig("cat", specs=(), system_prompt="Say cat."))
+    registry_a.register(AgentConfig("default"))
+    registry_a.register(AgentConfig("cat", system_prompt="Say cat."))
 
     registry_b = AgentConfigRegistry()
-    registry_b.register(AgentConfig("default", specs=()))
+    registry_b.register(AgentConfig("default"))
 
     assert registry_a.resolve("cat").name == "cat"
     assert registry_b.resolve("cat").name == DEFAULT_PROFILE
 
 
-# --- AgentConfig -------------------------------------------------------------
+# --- AgentConfig: skills-first construction ----------------------------------
+
+
+def test_config_rejects_unknown_skill_name():
+    """A typo'd skill declaration must fail at registration time, not
+    surface as a runtime "skill not found" the model can't act on."""
+    with pytest.raises(ValueError, match="unknown skill 'does-not-exist'"):
+        AgentConfig("test", skills=("does-not-exist",))
+
+
+def test_config_rejects_skill_requiring_unregistered_tool(monkeypatch):
+    """A skill whose ``requires:`` names a tool missing from ALL_SPECS could
+    never bind its workflow — refuse the profile outright."""
+    fake = SkillMeta(
+        name="broken",
+        description="",
+        when_to_use="",
+        body="",
+        requires=("no_such_tool",),
+    )
+    monkeypatch.setattr(
+        "src.agent.agent_config.get_skill",
+        lambda name: fake if name == "broken" else None,
+    )
+    with pytest.raises(ValueError, match="no_such_tool"):
+        AgentConfig("test", skills=("broken",))
+
+
+def test_config_derives_tools_from_declared_skills():
+    c = AgentConfig("test", skills=("analyze",))
+    assert c.tool_names() == frozenset(
+        {
+            "pick_aoi",
+            "pick_dataset",
+            "pull_data",
+            "generate_insights",
+            "read_skill",
+        }
+    )
+
+
+def test_config_without_skills_has_no_read_skill():
+    """read_skill only rides along when there are skills to read."""
+    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
+    assert c.tool_names() == frozenset({"_fake_tool"})
+
+
+def test_extra_tools_do_not_activate_skills():
+    """The bug this design kills: under tools-first profiles, adding a tool
+    could silently activate any skill whose ``requires`` it completed. Now
+    the capability surface is exactly what's declared."""
+    from src.agent.subagents.pick_aoi.tool import SPEC as pick_aoi_spec
+    from src.agent.tools.show_imagery import SPEC as show_imagery_spec
+
+    c = AgentConfig(
+        "test",
+        skills=("capabilities",),
+        extra_tools=(pick_aoi_spec, show_imagery_spec),
+    )
+    # pick_aoi + show_imagery satisfy show-imagery's requires, but it was
+    # never declared — it must not be advertised or counted available.
+    assert {s.name for s in c.skill_metas()} == {"capabilities"}
+    assert not c.availability().has_skill("show-imagery")
 
 
 def test_config_tools_returns_bound_tools():
-    c = AgentConfig("test", specs=(FAKE_SPEC,))
+    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
     assert _fake_tool in c.tools()
 
 
 def test_config_tool_descriptions_includes_bound_tool():
-    c = AgentConfig("test", specs=(FAKE_SPEC,))
+    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
     assert "_fake_tool" in c.tool_descriptions()
 
 
 def test_config_tool_descriptions_excludes_unbound_tool():
-    c = AgentConfig("test", specs=())
+    c = AgentConfig("test")
     assert "_fake_tool" not in c.tool_descriptions()
-
-
-def test_config_tool_names_returns_bound_tool_names():
-    c = AgentConfig("test", specs=(FAKE_SPEC,))
-    assert c.tool_names() == frozenset({"_fake_tool"})
 
 
 # --- Structural invariants ---------------------------------------------------
@@ -95,61 +154,82 @@ def test_prompt_describes_exactly_bound_tools():
     assert "_fake_tool" not in descriptions
 
 
-def test_skill_dependencies_satisfiable_by_some_profile():
-    """Every tool a skill requires must be bound by at least one profile.
-
-    A skill may legitimately require a tool that only an experimental profile
-    binds (e.g. show-imagery needs show_imagery). What must never happen is a
-    skill requiring a tool no profile binds — it could never be advertised.
-    """
-    bound = set()
-    for profile in (DEFAULT_PROFILE, EXPERIMENTAL_PROFILE):
-        bound |= {s.tool.name for s in default_registry.resolve(profile).specs}
-    for skill in all_skills():
-        for tool_name in skill.requires:
-            assert tool_name in bound, (
-                f"skill {skill.name!r} requires {tool_name!r} "
-                "which no registered profile binds"
-            )
-
-
-def test_skills_only_advertised_when_tools_bound():
-    config = default_registry.resolve(None)
-    available = {s.tool.name for s in config.specs}
-    for skill in config.skills():
-        assert set(skill.requires) <= available
+def test_declared_skills_always_have_their_tools_bound():
+    """Correct-by-construction: a declared skill's requires are derived
+    into the profile's tool set, never filtered against it."""
+    for config in default_registry.configs():
+        available = config.tool_names()
+        for skill in config.skill_metas():
+            assert set(skill.requires) <= available
 
 
 def test_default_config_advertises_core_skills():
     config = default_registry.resolve(None)
-    assert {s.name for s in config.skills()} == {
-        "analyze",
-        "capabilities",
-        "pull-data",
-    }
+    assert {s.name for s in config.skill_metas()} == set(DEFAULT_SKILLS)
 
 
-async def test_fetch_zeno_binds_the_resolved_configs_tool_names():
-    """read_skill relies on bound_tool_names() reflecting the profile that
+def test_default_profile_derives_exactly_the_core_tools():
+    """Pin the derived tool set so a skill frontmatter change that would
+    alter production bindings is a visible test failure."""
+    config = default_registry.resolve(DEFAULT_PROFILE)
+    assert config.tool_names() == frozenset(
+        {
+            "pick_aoi",
+            "pick_dataset",
+            "pull_data",
+            "generate_insights",
+            "read_skill",
+        }
+    )
+
+
+def test_experimental_profile_derives_exactly_the_experimental_tools():
+    config = default_registry.resolve(EXPERIMENTAL_PROFILE)
+    assert config.tool_names() == frozenset(
+        {
+            "pick_aoi",
+            "pick_dataset",
+            "pull_data",
+            "generate_insights",
+            "read_skill",
+            "inspect_view_context",
+            "show_imagery",
+            "search_blogs",
+            "update_insight_display",
+            "search_insights",
+            "create_dashboard",
+            "add_to_dashboard",
+            "add_map_widget",
+        }
+    )
+
+
+async def test_fetch_zeno_binds_the_resolved_configs_availability():
+    """read_skill relies on bound_availability() reflecting the profile that
     was actually resolved for this request, not just what's listed in the
-    prompt (see AgentConfig.skills())."""
+    prompt."""
     from langgraph.checkpoint.memory import InMemorySaver
 
     from src.agent.graph import fetch_zeno
 
     registry = AgentConfigRegistry()
-    registry.register(AgentConfig("default", specs=()))
-    registry.register(AgentConfig("fake", specs=(FAKE_SPEC,)))
+    registry.register(AgentConfig("default"))
+    registry.register(
+        AgentConfig("fake", skills=("capabilities",), extra_tools=(FAKE_SPEC,))
+    )
 
     await fetch_zeno(
         ff="fake", registry=registry, checkpointer=InMemorySaver()
     )
-    assert bound_tool_names() == frozenset({"_fake_tool"})
+    available = bound_availability()
+    assert available.skills == frozenset({"capabilities"})
+    assert available.tools == frozenset({"_fake_tool", "read_skill"})
 
 
 def test_experimental_config_adds_experimental_tools_and_skills():
-    """The experimental profile layers show_imagery and search_blogs (and their
-    skills) on top of the default set; the default profile exposes none."""
+    """The experimental profile layers show_imagery and search_blogs (and
+    their skills) on top of the default set; the default profile exposes
+    none."""
     default = default_registry.resolve(DEFAULT_PROFILE)
     experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
 
@@ -158,8 +238,8 @@ def test_experimental_config_adds_experimental_tools_and_skills():
     assert {"show_imagery", "search_blogs"} & default_tools == set()
     assert {"show_imagery", "search_blogs"} <= experimental_tools
 
-    default_skills = {s.name for s in default.skills()}
-    experimental_skills = {s.name for s in experimental.skills()}
+    default_skills = {s.name for s in default.skill_metas()}
+    experimental_skills = {s.name for s in experimental.skill_metas()}
     assert {
         "show-imagery",
         "explore",

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -4,6 +4,7 @@ import pytest
 from langchain_core.tools import tool
 
 from src.agent.agent_config import (
+    BASE_PROFILE,
     DEFAULT_PROFILE,
     DEFAULT_SKILLS,
     EXPERIMENTAL_PROFILE,
@@ -34,7 +35,7 @@ FAKE_SPEC = ToolSpec(
 def test_registry_resolves_known_ff():
     registry = AgentConfigRegistry()
     registry.register(AgentConfig("default"))
-    registry.register(AgentConfig("blog", extra_tools=(FAKE_SPEC,)))
+    registry.register(AgentConfig("blog", tools=(FAKE_SPEC,)))
     assert registry.resolve("blog").name == "blog"
 
 
@@ -60,6 +61,62 @@ def test_registry_instances_are_isolated():
 
     assert registry_a.resolve("cat").name == "cat"
     assert registry_b.resolve("cat").name == DEFAULT_PROFILE
+
+
+# --- AgentConfigRegistry: extends --------------------------------------------
+
+
+def test_extends_merges_parent_skills_and_tools():
+    """A child profile is its parent plus its own additions — parent's
+    entries first, duplicates removed."""
+    registry = AgentConfigRegistry()
+    registry.register(AgentConfig("default", tools=(FAKE_SPEC,)))
+    registry.register(
+        AgentConfig("child", extends="default", skills=("capabilities",))
+    )
+    child = registry.resolve("child")
+    assert child.skills == ("capabilities",)
+    assert child.tools == (FAKE_SPEC,)
+
+
+def test_extends_chain_flattens_through_grandparent():
+    registry = AgentConfigRegistry()
+    registry.register(AgentConfig("default", tools=(FAKE_SPEC,)))
+    registry.register(
+        AgentConfig("child", extends="default", skills=("capabilities",))
+    )
+    registry.register(
+        AgentConfig("grandchild", extends="child", skills=("analyze",))
+    )
+    grandchild = registry.resolve("grandchild")
+    assert grandchild.skills == ("capabilities", "analyze")
+    assert grandchild.tools == (FAKE_SPEC,)
+
+
+def test_extends_deduplicates_reinherited_entries():
+    registry = AgentConfigRegistry()
+    registry.register(
+        AgentConfig("default", skills=("capabilities",), tools=(FAKE_SPEC,))
+    )
+    registry.register(
+        AgentConfig(
+            "child",
+            extends="default",
+            skills=("capabilities", "analyze"),
+            tools=(FAKE_SPEC,),
+        )
+    )
+    child = registry.resolve("child")
+    assert child.skills == ("capabilities", "analyze")
+    assert child.tools == (FAKE_SPEC,)
+
+
+def test_extends_unknown_parent_raises():
+    """A child registered before (or without) its parent is a wiring bug —
+    fail loudly instead of silently dropping the inherited surface."""
+    registry = AgentConfigRegistry()
+    with pytest.raises(ValueError, match="extends unknown profile"):
+        registry.register(AgentConfig("child", extends="nope"))
 
 
 # --- AgentConfig: skills-first construction ----------------------------------
@@ -105,11 +162,11 @@ def test_config_derives_tools_from_declared_skills():
 
 def test_config_without_skills_has_no_read_skill():
     """read_skill only rides along when there are skills to read."""
-    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
+    c = AgentConfig("test", tools=(FAKE_SPEC,))
     assert c.tool_names() == frozenset({"_fake_tool"})
 
 
-def test_extra_tools_do_not_activate_skills():
+def test_directly_bound_tools_do_not_activate_skills():
     """The bug this design kills: under tools-first profiles, adding a tool
     could silently activate any skill whose ``requires`` it completed. Now
     the capability surface is exactly what's declared."""
@@ -119,7 +176,7 @@ def test_extra_tools_do_not_activate_skills():
     c = AgentConfig(
         "test",
         skills=("capabilities",),
-        extra_tools=(pick_aoi_spec, show_imagery_spec),
+        tools=(pick_aoi_spec, show_imagery_spec),
     )
     # pick_aoi + show_imagery satisfy show-imagery's requires, but it was
     # never declared — it must not be advertised or counted available.
@@ -127,13 +184,13 @@ def test_extra_tools_do_not_activate_skills():
     assert not c.availability().has_skill("show-imagery")
 
 
-def test_config_tools_returns_bound_tools():
-    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
-    assert _fake_tool in c.tools()
+def test_config_bound_tools_returns_bound_tools():
+    c = AgentConfig("test", tools=(FAKE_SPEC,))
+    assert _fake_tool in c.bound_tools()
 
 
 def test_config_tool_descriptions_includes_bound_tool():
-    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
+    c = AgentConfig("test", tools=(FAKE_SPEC,))
     assert "_fake_tool" in c.tool_descriptions()
 
 
@@ -166,6 +223,21 @@ def test_declared_skills_always_have_their_tools_bound():
 def test_default_config_advertises_core_skills():
     config = default_registry.resolve(None)
     assert {s.name for s in config.skill_metas()} == set(DEFAULT_SKILLS)
+
+
+def test_base_profile_binds_the_core_toolbox_and_no_skills():
+    """The base profile is the floor every other profile builds on: the four
+    core tools, no skills — and therefore no read_skill."""
+    config = default_registry.resolve(BASE_PROFILE)
+    assert config.skills == ()
+    assert config.tool_names() == frozenset(
+        {
+            "pick_aoi",
+            "pick_dataset",
+            "pull_data",
+            "generate_insights",
+        }
+    )
 
 
 def test_default_profile_derives_exactly_the_core_tools():
@@ -215,7 +287,7 @@ async def test_fetch_zeno_binds_the_resolved_configs_availability():
     registry = AgentConfigRegistry()
     registry.register(AgentConfig("default"))
     registry.register(
-        AgentConfig("fake", skills=("capabilities",), extra_tools=(FAKE_SPEC,))
+        AgentConfig("fake", skills=("capabilities",), tools=(FAKE_SPEC,))
     )
 
     await fetch_zeno(
@@ -233,8 +305,8 @@ def test_experimental_config_adds_experimental_tools_and_skills():
     default = default_registry.resolve(DEFAULT_PROFILE)
     experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
 
-    default_tools = {t.name for t in default.tools()}
-    experimental_tools = {t.name for t in experimental.tools()}
+    default_tools = {t.name for t in default.bound_tools()}
+    experimental_tools = {t.name for t in experimental.bound_tools()}
     assert {"show_imagery", "search_blogs"} & default_tools == set()
     assert {"show_imagery", "search_blogs"} <= experimental_tools
 

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -1,0 +1,98 @@
+"""Snapshot the full derived surface of every production profile.
+
+Profiles declare deltas (``extends`` plus their own skills and tools), so
+the complete bound surface — which subagents and tools a skill pulled in —
+is never visible at the declaration site. These snapshots make it visible
+and reviewable: adding a skill to a profile shows up in the diff as exactly
+the subagents/tools it brought along.
+
+When one of these fails after an intentional change, update the expected
+manifest to the new ``describe()`` output — the point is that the change is
+seen, not that the surface is frozen forever.
+"""
+
+from src.agent.agent_config import (
+    BASE_PROFILE,
+    DEFAULT_PROFILE,
+    EXPERIMENTAL_PROFILE,
+    default_registry,
+)
+
+BASE_MANIFEST = """\
+profile: base
+skills:
+  (none)
+subagents:
+  - pick_aoi
+  - pick_dataset
+  - generate_insights
+tools:
+  - pull_data"""
+
+DEFAULT_MANIFEST = """\
+profile: default
+extends: base
+skills:
+  - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
+  - capabilities
+  - pull-data (requires: pick_aoi, pick_dataset, pull_data)
+subagents:
+  - pick_aoi
+  - pick_dataset
+  - generate_insights
+tools:
+  - pull_data
+  - read_skill"""
+
+EXPERIMENTAL_MANIFEST = """\
+profile: experimental
+extends: default
+skills:
+  - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
+  - capabilities
+  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget)
+  - explore (requires: search_blogs)
+  - pull-data (requires: pick_aoi, pick_dataset, pull_data)
+  - show-imagery (requires: pick_aoi, show_imagery)
+  - wri-insights (requires: search_blogs)
+subagents:
+  - pick_aoi
+  - pick_dataset
+  - generate_insights
+  - search_blogs
+  - update_insight_display
+tools:
+  - pull_data
+  - read_skill
+  - inspect_view_context
+  - show_imagery
+  - search_insights
+  - create_dashboard
+  - add_to_dashboard
+  - add_map_widget"""
+
+
+def test_base_profile_manifest():
+    assert default_registry.resolve(BASE_PROFILE).describe() == BASE_MANIFEST
+
+
+def test_default_profile_manifest():
+    assert (
+        default_registry.resolve(DEFAULT_PROFILE).describe()
+        == DEFAULT_MANIFEST
+    )
+
+
+def test_experimental_profile_manifest():
+    assert (
+        default_registry.resolve(EXPERIMENTAL_PROFILE).describe()
+        == EXPERIMENTAL_MANIFEST
+    )
+
+
+def test_every_production_profile_has_a_manifest_snapshot():
+    """A new profile registered without a snapshot here would ship with an
+    unreviewed surface."""
+    snapshotted = {BASE_PROFILE, DEFAULT_PROFILE, EXPERIMENTAL_PROFILE}
+    registered = {config.name for config in default_registry.configs()}
+    assert registered == snapshotted

--- a/tests/unit/agent/test_tool_spec.py
+++ b/tests/unit/agent/test_tool_spec.py
@@ -1,26 +1,40 @@
-"""Unit tests for the request-scoped bound-tool-names ContextVar."""
+"""Unit tests for the request-scoped bound-availability ContextVar."""
 
 import pytest
 
-from src.agent.tool_spec import bound_tool_names, set_bound_tool_names
+from src.agent.tool_spec import (
+    Availability,
+    bound_availability,
+    set_bound_availability,
+)
+
+_EMPTY = Availability(skills=frozenset(), tools=frozenset())
 
 
 @pytest.fixture(autouse=True)
-def _reset_bound_tool_names():
+def _reset_bound_availability():
     yield
-    set_bound_tool_names(frozenset())
+    set_bound_availability(_EMPTY)
 
 
-def test_bound_tool_names_defaults_to_empty():
-    assert bound_tool_names() == frozenset()
+def test_bound_availability_defaults_to_empty():
+    assert bound_availability() == _EMPTY
 
 
-def test_set_bound_tool_names_round_trips():
-    set_bound_tool_names(frozenset({"pick_aoi", "pull_data"}))
-    assert bound_tool_names() == frozenset({"pick_aoi", "pull_data"})
+def test_set_bound_availability_round_trips():
+    available = Availability(
+        skills=frozenset({"analyze"}),
+        tools=frozenset({"pick_aoi", "pull_data"}),
+    )
+    set_bound_availability(available)
+    assert bound_availability() == available
 
 
-def test_set_bound_tool_names_overwrites_previous_value():
-    set_bound_tool_names(frozenset({"pick_aoi"}))
-    set_bound_tool_names(frozenset({"pull_data"}))
-    assert bound_tool_names() == frozenset({"pull_data"})
+def test_set_bound_availability_overwrites_previous_value():
+    set_bound_availability(
+        Availability(skills=frozenset({"analyze"}), tools=frozenset())
+    )
+    set_bound_availability(
+        Availability(skills=frozenset({"pull-data"}), tools=frozenset())
+    )
+    assert bound_availability().skills == frozenset({"pull-data"})

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -7,14 +7,20 @@ from src.agent.skills import (
     load_skills,
 )
 from src.agent.skills.tool import read_skill
-from src.agent.tool_spec import set_bound_tool_names
+from src.agent.tool_spec import Availability, set_bound_availability
+
+_EMPTY = Availability(skills=frozenset(), tools=frozenset())
+
+
+def _availability(*skills: str) -> Availability:
+    return Availability(skills=frozenset(skills), tools=frozenset())
 
 
 @pytest.fixture(autouse=True)
-def _reset_bound_tool_names():
-    """``bound_tool_names`` is a ContextVar; tests must not leak state."""
+def _reset_bound_availability():
+    """``bound_availability`` is a ContextVar; tests must not leak state."""
     yield
-    set_bound_tool_names(frozenset())
+    set_bound_availability(_EMPTY)
 
 
 def test_load_skills():
@@ -97,34 +103,36 @@ def test_get_skill_returns_none_for_unknown_name():
 
 
 def test_get_skill_capabilities_has_no_requires():
-    """Informational skills with no tool dependencies must always pass the
-    read_skill gate, bound tools or not."""
+    """Informational skills contribute no tools to the profiles that
+    declare them."""
     skill = get_skill("capabilities")
     assert skill is not None
     assert skill.requires == ()
 
 
-def test_read_skill_refuses_when_a_required_tool_is_unbound():
-    """analyze requires pick_aoi, pick_dataset, pull_data, generate_insights;
-    binding only some of them must not hand back the skill body. To the
-    model this must read exactly like an unknown skill name — it's already
-    excluded from what this profile advertises (AgentConfig.skills())."""
-    set_bound_tool_names(frozenset({"pick_aoi", "pick_dataset"}))
+def test_read_skill_refuses_a_skill_the_profile_does_not_declare():
+    """The profile's declared skills are the capability surface; anything
+    else must read exactly like an unknown skill name to the model — it's
+    already excluded from what this profile advertises
+    (AgentConfig.skill_metas())."""
+    set_bound_availability(_availability("pull-data", "capabilities"))
     result = read_skill.invoke({"name": "analyze"})
     assert result == "skill not found: analyze"
 
 
-def test_read_skill_refuses_when_no_tools_are_bound():
-    set_bound_tool_names(frozenset())
-    result = read_skill.invoke({"name": "analyze"})
-    assert result == "skill not found: analyze"
+def test_read_skill_refuses_everything_when_nothing_is_bound():
+    """Outside fetch_zeno no profile is bound, so no skill is served — even
+    ones with no tool requirements."""
+    for name in ("analyze", "capabilities"):
+        result = read_skill.invoke({"name": name})
+        assert result == f"skill not found: {name}"
 
 
-def test_read_skill_logs_every_missing_tool_sorted_without_exposing_them(
+def test_read_skill_logs_the_refusal_without_exposing_profile_details(
     monkeypatch,
 ):
-    """The model-facing message stays a generic "not found"; the specifics
-    are only for our own logs."""
+    """The model-facing message stays a generic "not found"; the reason is
+    only for our own logs."""
     warnings = []
 
     class _FakeLogger:
@@ -135,54 +143,32 @@ def test_read_skill_logs_every_missing_tool_sorted_without_exposing_them(
             pass
 
     monkeypatch.setattr("src.agent.skills.tool.logger", _FakeLogger())
-    set_bound_tool_names(frozenset())
+    set_bound_availability(_availability("capabilities"))
     result = read_skill.invoke({"name": "analyze"})
 
-    assert "pull_data" not in result
-    assert "generate_insights" not in result
+    assert result == "skill not found: analyze"
     [(event, kwargs)] = warnings
-    assert event == "read_skill: skill not available in this profile"
+    assert event == "read_skill: skill not declared by this profile"
     assert kwargs["skill_name"] == "analyze"
-    assert kwargs["missing_tools"] == sorted(
-        ["pick_aoi", "pick_dataset", "pull_data", "generate_insights"]
-    )
 
 
-def test_read_skill_serves_body_when_all_required_tools_bound():
-    set_bound_tool_names(
-        frozenset(
-            {"pick_aoi", "pick_dataset", "pull_data", "generate_insights"}
-        )
-    )
+def test_read_skill_serves_a_declared_skill():
+    set_bound_availability(_availability("analyze"))
     result = read_skill.invoke({"name": "analyze"})
     assert result == get_skill_body("analyze")
 
 
-def test_read_skill_serves_body_when_bound_tools_are_a_superset():
-    """Extra bound tools beyond what the skill requires must not matter."""
-    set_bound_tool_names(
-        frozenset(
-            {
-                "pick_aoi",
-                "pick_dataset",
-                "pull_data",
-                "generate_insights",
-                "show_imagery",
-            }
-        )
+def test_read_skill_serves_each_skill_a_profile_declares():
+    """Declaring more skills must not interfere with serving any of them."""
+    set_bound_availability(_availability("analyze", "capabilities"))
+    assert read_skill.invoke({"name": "capabilities"}) == get_skill_body(
+        "capabilities"
     )
-    result = read_skill.invoke({"name": "analyze"})
-    assert result == get_skill_body("analyze")
-
-
-def test_read_skill_serves_no_requires_skill_even_with_no_tools_bound():
-    set_bound_tool_names(frozenset())
-    result = read_skill.invoke({"name": "capabilities"})
-    assert result == get_skill_body("capabilities")
+    assert read_skill.invoke({"name": "analyze"}) == get_skill_body("analyze")
 
 
 def test_read_skill_unknown_name_still_reports_not_found():
-    set_bound_tool_names(frozenset())
+    set_bound_availability(_availability("analyze"))
     result = read_skill.invoke({"name": "does-not-exist"})
     assert "skill not found" in result
 
@@ -237,13 +223,14 @@ def test_get_prompt_scope_and_policy():
     from src.agent.graph import get_prompt
 
     prompt = get_prompt()
-    assert "pull-data" in prompt
-    assert "Pull-only" in prompt
-    assert "Capabilities (what you can do" in prompt
-    assert "read `capabilities`" in prompt
-    assert "capabilities" in prompt
+    # per-skill routing lives in the skills block, not the Routing table
+    assert "- pull-data:" in prompt
+    assert "- capabilities:" in prompt
+    assert "- analyze:" in prompt
     assert "get_capabilities" not in prompt
-    assert "read `analyze`" in prompt
+    # the no-skill request shapes stay in Routing
+    assert "Dataset-only" in prompt
+    assert "AOI-only" in prompt
     # always-on policy folded in
     assert "# Policy" in prompt
     assert "same language" in prompt
@@ -253,29 +240,30 @@ def test_get_prompt_scope_and_policy():
     assert "pick-dataset" not in prompt
 
 
-def test_get_prompt_routing_excludes_rows_for_unbound_profiles():
-    """The default profile has no dashboard/show-imagery/search_insights
-    tools bound, so the Routing table must not route to them — it would
-    just send the model into a read_skill/tool call that fails."""
-    from src.agent.graph import get_prompt
-
-    prompt = get_prompt()
-    assert "Dashboard (" not in prompt
-    assert "read skill `dashboard`" not in prompt
-    assert "Imagery (" not in prompt
-    assert "read `show-imagery`" not in prompt
-    assert "Recall a past insight" not in prompt
-    assert "search_insights" not in prompt
-
-
-def test_get_prompt_routing_includes_rows_when_tools_bound():
+def test_get_prompt_has_no_per_skill_routing_rows():
+    """Per-skill routing restated each skill's when_to_use; it must stay
+    dropped for every profile so the skills block is the single source."""
     from src.agent.agent_config import EXPERIMENTAL_PROFILE, default_registry
     from src.agent.graph import get_prompt
 
-    config = default_registry.resolve(EXPERIMENTAL_PROFILE)
-    prompt = get_prompt(config=config)
-    assert "Dashboard (" in prompt
-    assert "read skill `dashboard`" in prompt
-    assert "Imagery (" in prompt
-    assert "read `show-imagery`" in prompt
-    assert "Recall a past insight" in prompt
+    for config in (None, default_registry.resolve(EXPERIMENTAL_PROFILE)):
+        prompt = get_prompt(config=config)
+        assert "Pull-only" not in prompt
+        assert "Full analysis (place + topic" not in prompt
+        assert "Dashboard (" not in prompt
+        assert "Imagery (" not in prompt
+        assert "Capabilities (what you can do" not in prompt
+
+
+def test_get_prompt_routing_gates_recall_row_on_search_insights():
+    """The recall row routes to the search_insights tool; a profile that
+    doesn't bind it must not see the row."""
+    from src.agent.agent_config import EXPERIMENTAL_PROFILE, default_registry
+    from src.agent.graph import get_prompt
+
+    default_prompt = get_prompt()
+    assert "Recall a past insight" not in default_prompt
+    assert "search_insights" not in default_prompt
+
+    experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
+    assert "Recall a past insight" in get_prompt(config=experimental)


### PR DESCRIPTION
## Summary
A profile now *declares its skills* and derives its tools from them (plus an `extra_tools` bag), instead of being a tool tuple with skills inferred — so adding a tool can no longer silently activate a skill, and `read_skill` gating becomes a simple declared-membership check. The prompt's `# Routing` table drops the five per-skill rows that restated each skill's `when_to_use`. Implements srmsoumya's suggestion in https://github.com/wri/project-zeno/pull/744#issuecomment-4924390861; follow-up to #744.

## Skills-first profiles

- `AgentConfig` is now `(name, skills, extra_tools, system_prompt)`. Tools are derived from each declared skill's `requires:` frontmatter via a canonical `ALL_SPECS` catalogue (+ `read_skill` whenever any skill is declared); `extra_tools` carries standalone tools (`inspect_view_context`, `update_insight_display`, `search_insights`).
  ```python
  AgentConfig(DEFAULT_PROFILE, skills=("analyze", "pull-data", "capabilities"))
  AgentConfig(EXPERIMENTAL_PROFILE,
              skills=(*DEFAULT_SKILLS, "dashboard", "show-imagery", "wri-insights", "explore"),
              extra_tools=(inspect_view_context_spec, update_insight_display_spec, search_insights_spec))
  ```
- Correct-by-construction: declaring an unknown skill name, or a skill whose `requires:` names a tool missing from `ALL_SPECS`, raises `ValueError` at registration — not a runtime "skill not found".
- Derived specs are ordered by `ALL_SPECS` position, so both profiles resolve to **exactly the same tool sets and prompt blocks as before** (pinned by new tests).

## Skill-focused gating

- `fetch_zeno` binds the profile's full `Availability` (skills + tools namespaces) to the per-request ContextVar; `read_skill` refuses any skill the profile doesn't *declare*, replacing the `requires ⊆ bound tools` re-derivation from #744. Refusal message stays the generic `skill not found: {name}`.
- Edge behavior change: with no profile bound (outside `fetch_zeno`), all skills are refused — previously no-`requires` skills like `capabilities` were served.

## Routing trim

- The five per-skill routing rows (pull-data, analyze, dashboard, show-imagery, capabilities) are dropped — their content already lives in each skill's `when_to_use` and body. Kept: the don't-escalate preamble (now pointing at the skills block), dataset-only, AOI-only, and the recall-is-terminal row (still gated on `search_insights`).
- Deferred (per the comment's "over time"): dropping `# Routing` entirely in favor of skills + tool descriptions.

## Guardrails added

- Derived tool sets pinned per profile (a `requires:` change that alters production bindings fails a test)
- `extra_tools` provably cannot activate an undeclared skill
- Every skill's `requires:` must resolve against `ALL_SPECS`
- Every skill file must be declared by some profile — an undeclared skill is dead content (the explore/wri-insights drift class)

## Test plan

- [x] `uv run pytest tests/unit -q` — 357 passed (rerun after rebase onto main)
- [x] Rendered prompts diffed against pre-refactor output across both profiles × (no page, map, dashboard, unknown page): byte-identical except exactly the Routing trim
- [x] Runtime probe: default profile serves `analyze`/`capabilities`, refuses `dashboard` with the generic message; experimental serves all; unknown names unchanged
- [x] ruff / ruff-format / mypy clean via pre-commit (two pre-existing `graph.py` mypy errors already on main)
- [x] `src/agent/docs/feature-flags.md` updated to the skills-first API