### PR TITLE
Feat/unified aoi table

### DIFF
--- a/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
+++ b/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
@@ -44,11 +44,16 @@ def upgrade() -> None:
         sa.Column("source_id", sa.String(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("subtype", sa.String(), nullable=False),
+        # Typed MULTIPOLYGON: every AOI is one areal shape, so the typmod
+        # rejects any non-MultiPolygon / non-4326 insert. build-aois normalizes
+        # source geometry (ST_MakeValid + dissolve + ST_Multi) to satisfy this.
         # spatial_index=False: the GiST index is created explicitly below so
         # its name is controlled and not auto-emitted by geoalchemy2.
         sa.Column(
             "geometry",
-            Geometry(geometry_type="GEOMETRY", srid=4326, spatial_index=False),
+            Geometry(
+                geometry_type="MULTIPOLYGON", srid=4326, spatial_index=False
+            ),
             nullable=False,
         ),
         # [west, south, east, north]; precomputed, antimeridian-aware.

--- a/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
+++ b/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
@@ -136,8 +136,6 @@ def upgrade() -> None:
             "relationship",
             sa.Enum(
                 "owner",
-                "shared_edit",
-                "shared_view",
                 "saved",
                 name="aoi_relationship",
                 native_enum=False,

--- a/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
+++ b/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
@@ -1,7 +1,7 @@
 """create unified aoi tables
 
 Revision ID: ceea2a027738
-Revises: a1b2c3d4e5f6
+Revises: 98638da8f348
 Create Date: 2026-07-08 14:34:50.155560
 
 Schema only. The unified ``aois`` table and the ``user_aois`` relationship
@@ -21,7 +21,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "ceea2a027738"
-down_revision: Union[str, None] = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "98638da8f348"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
+++ b/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
@@ -17,6 +17,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 from geoalchemy2 import Geometry
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "ceea2a027738"
@@ -68,6 +69,11 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("created_by", sa.String(), nullable=True),
+        # Arbitrary/source-specific key-values: an escape hatch for
+        # user-uploaded custom-AOI attributes and source columns that don't map
+        # to the typed columns above. Left NULL by build-aois for now; anything
+        # we filter/facet/sort on gets promoted to a real column instead.
+        sa.Column("properties", postgresql.JSONB(), nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(),

--- a/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
+++ b/db/alembic/versions/ceea2a027738_create_unified_aoi_tables.py
@@ -1,0 +1,185 @@
+"""create unified aoi tables
+
+Revision ID: ceea2a027738
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-08 14:34:50.155560
+
+Schema only. The unified ``aois`` table and the ``user_aois`` relationship
+join are created empty here; data is populated out-of-band by the idempotent
+``build-aois`` CLI command (heavy work must not run in the blocking migrate
+Job). No existing tables are touched -- this is purely additive, so the live
+API keeps serving from ``geometries_*`` / ``custom_areas`` until the API PR.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from geoalchemy2 import Geometry
+
+# revision identifiers, used by Alembic.
+revision: str = "ceea2a027738"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS postgis")
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    # --- aois: unified AOI table -------------------------------------------
+    op.create_table(
+        "aois",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column("source_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("subtype", sa.String(), nullable=False),
+        # spatial_index=False: the GiST index is created explicitly below so
+        # its name is controlled and not auto-emitted by geoalchemy2.
+        sa.Column(
+            "geometry",
+            Geometry(geometry_type="GEOMETRY", srid=4326, spatial_index=False),
+            nullable=False,
+        ),
+        # [west, south, east, north]; precomputed, antimeridian-aware.
+        sa.Column("bbox", sa.ARRAY(sa.Float()), nullable=True),
+        sa.Column("area_km2", sa.Float(), nullable=True),
+        sa.Column("iso3", sa.ARRAY(sa.String()), nullable=True),
+        sa.Column("admin_level", sa.SmallInteger(), nullable=True),
+        sa.Column(
+            "is_disputed",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "is_deprecated",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # One *live* version per logical id. Identical to a full unique today;
+    # partial-on-not-deprecated leaves room for future versioning with no
+    # constraint surgery. Also backs INSERT ... ON CONFLICT in build-aois.
+    op.create_index(
+        "uq_aois_source_source_id_live",
+        "aois",
+        ["source", "source_id"],
+        unique=True,
+        postgresql_where=sa.text("NOT is_deprecated"),
+    )
+    op.create_index(
+        "idx_aois_geometry_gist",
+        "aois",
+        ["geometry"],
+        postgresql_using="gist",
+    )
+    # Partial: disputed/deprecated rows are absent from the search index, so
+    # excluding them from results costs nothing, yet they stay resolvable by
+    # (source, source_id) / id for geometry fetches and analytics linkage.
+    op.create_index(
+        "idx_aois_name_trgm",
+        "aois",
+        ["name"],
+        postgresql_using="gin",
+        postgresql_ops={"name": "gin_trgm_ops"},
+        postgresql_where=sa.text("NOT is_disputed AND NOT is_deprecated"),
+    )
+    op.create_index(
+        "idx_aois_iso3",
+        "aois",
+        ["iso3"],
+        postgresql_using="gin",
+    )
+    op.create_index("idx_aois_source", "aois", ["source"])
+    op.create_index("idx_aois_admin_level", "aois", ["admin_level"])
+    op.create_index("idx_aois_created_by", "aois", ["created_by"])
+
+    # --- user_aois: user<->AOI relationships -------------------------------
+    op.create_table(
+        "user_aois",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("aoi_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "relationship",
+            sa.Enum(
+                "owner",
+                "shared_edit",
+                "shared_view",
+                "saved",
+                name="aoi_relationship",
+                native_enum=False,
+                create_constraint=True,
+            ),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["aoi_id"], ["aois.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "aoi_id",
+            "relationship",
+            name="uq_user_aoi_relationship",
+        ),
+    )
+    # Powers the custom-visibility semi-join and the saved-first sort.
+    op.create_index(
+        "idx_user_aois_user_rel_aoi",
+        "user_aois",
+        ["user_id", "relationship", "aoi_id"],
+    )
+    op.create_index("idx_user_aois_aoi_id", "user_aois", ["aoi_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop the child (FK -> aois) first; indexes drop with their tables.
+    op.drop_table("user_aois")
+    op.drop_table("aois")
+    # Extensions are left in place -- they may be used by other tables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.21.1"
+version = "2026.7.21.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -825,6 +825,22 @@ _ISO3_SOURCE_COLUMNS = {
 }
 
 
+def _multipolygon_sql(geom_expr: str) -> str:
+    """Normalize *geom_expr* to a valid 2D MultiPolygon (for the typed column).
+
+    ``ST_MakeValid`` repairs self-intersections / ring errors;
+    ``ST_CollectionExtract(..., 3)`` keeps only polygonal parts (dropping the
+    line/point slivers ``ST_MakeValid`` can emit); ``ST_Multi`` guarantees the
+    ``MULTIPOLYGON`` type the ``aois.geometry`` column enforces. Callers filter
+    out an empty result (a geometry with no areal component) with
+    ``NOT ST_IsEmpty(...)`` so such rows are skipped, not stored empty.
+    """
+    return (
+        "ST_Multi(ST_CollectionExtract("
+        f"ST_MakeValid(ST_Force2D({geom_expr})), 3))"
+    )
+
+
 def _bbox_float_array_sql(geom_expr: str) -> str:
     """A ``float8[]`` ``[west, south, east, north]`` for *geom_expr*.
 
@@ -895,24 +911,39 @@ async def _build_reference_aois(session: AsyncSession, source: str) -> int:
         admin_expr = "NULL::smallint"
         disputed_expr = "false"
 
+    # Normalize source geometry to a valid MultiPolygon once, then derive
+    # geometry / bbox / area_km2 from the same shape.
+    norm_geom = _multipolygon_sql("geometry")
     sql = f"""
+        WITH normalized AS (
+            SELECT
+                CAST("{id_col}" AS TEXT) AS source_id,
+                name,
+                subtype,
+                {norm_geom} AS geom,
+                {iso3_expr} AS iso3,
+                {admin_expr} AS admin_level,
+                {disputed_expr} AS is_disputed
+            FROM {table}
+            WHERE name IS NOT NULL AND geometry IS NOT NULL
+        )
         INSERT INTO aois (
             source, source_id, name, subtype, geometry,
             bbox, area_km2, iso3, admin_level, is_disputed
         )
         SELECT
             '{source}',
-            CAST("{id_col}" AS TEXT),
+            source_id,
             name,
             subtype,
-            geometry,
-            {_bbox_float_array_sql("geometry")},
-            ST_Area(geometry::geography) / 1e6,
-            {iso3_expr},
-            {admin_expr},
-            {disputed_expr}
-        FROM {table}
-        WHERE name IS NOT NULL AND geometry IS NOT NULL
+            geom,
+            {_bbox_float_array_sql("geom")},
+            ST_Area(geom::geography) / 1e6,
+            iso3,
+            admin_level,
+            is_disputed
+        FROM normalized
+        WHERE geom IS NOT NULL AND NOT ST_IsEmpty(geom)
         ON CONFLICT (source, source_id) WHERE NOT is_deprecated
         DO UPDATE SET
             name = EXCLUDED.name,
@@ -926,16 +957,40 @@ async def _build_reference_aois(session: AsyncSession, source: str) -> int:
             updated_at = now()
     """
     result = await session.execute(text(sql))
+
+    # Surface (don't silently drop) rows whose geometry couldn't be coerced to
+    # a non-empty MultiPolygon.
+    skipped = await session.scalar(
+        text(
+            f"SELECT count(*) FROM {table} "
+            f"WHERE name IS NOT NULL AND geometry IS NOT NULL "
+            f"AND ({norm_geom} IS NULL OR ST_IsEmpty({norm_geom}))"
+        )
+    )
+    if skipped:
+        click.echo(
+            f"⚠️  {source}: {skipped} row(s) skipped "
+            f"(geometry not coercible to a non-empty MultiPolygon)."
+        )
     return result.rowcount
 
 
 async def _build_custom_aois(session: AsyncSession) -> int:
     """Transform ``custom_areas`` into ``aois`` + one ``owner`` link each.
 
-    Geometry is the ``ST_Collect`` of the stored GeoJSON-string list (same
-    shape ``CUSTOM_BBOX_SQL`` reads). Each area gets exactly one ``owner`` row
-    in ``user_aois`` for its ``user_id``. Returns the owner-link upsert count.
+    Geometry is the dissolved union of the stored GeoJSON-string list, coerced
+    to a valid MultiPolygon: overlapping user-drawn parts merge (so ``area_km2``
+    is not double-counted) and the result satisfies the typed column. Each area
+    gets exactly one ``owner`` row in ``user_aois`` for its ``user_id``. Returns
+    the owner-link upsert count.
     """
+    # Union dissolves overlapping parts; _multipolygon_sql makes it a valid
+    # MultiPolygon. ST_MakeValid per element guards invalid input polygons.
+    geom_sql = _multipolygon_sql(
+        "(SELECT ST_Union("
+        "ST_MakeValid(ST_Force2D(ST_SetSRID(ST_GeomFromGeoJSON(g), 4326)))"
+        ") FROM jsonb_array_elements_text(ca.geometries) AS g)"
+    )
     sql = f"""
         WITH collected AS (
             SELECT
@@ -944,10 +999,7 @@ async def _build_custom_aois(session: AsyncSession) -> int:
                 ca.name,
                 ca.created_at,
                 ca.updated_at,
-                (
-                    SELECT ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON(g), 4326))
-                    FROM jsonb_array_elements_text(ca.geometries) AS g
-                ) AS geom
+                {geom_sql} AS geom
             FROM custom_areas ca
         ),
         ins AS (
@@ -967,7 +1019,7 @@ async def _build_custom_aois(session: AsyncSession) -> int:
                 created_at,
                 updated_at
             FROM collected
-            WHERE name IS NOT NULL AND geom IS NOT NULL
+            WHERE name IS NOT NULL AND geom IS NOT NULL AND NOT ST_IsEmpty(geom)
             ON CONFLICT (source, source_id) WHERE NOT is_deprecated
             DO UPDATE SET
                 name = EXCLUDED.name,
@@ -982,6 +1034,21 @@ async def _build_custom_aois(session: AsyncSession) -> int:
         ON CONFLICT (user_id, aoi_id, relationship) DO NOTHING
     """
     result = await session.execute(text(sql))
+
+    # Surface (don't silently drop) custom areas whose geometries couldn't be
+    # coerced to a non-empty MultiPolygon.
+    skipped = await session.scalar(
+        text(
+            f"SELECT count(*) FROM custom_areas ca "
+            f"WHERE ca.name IS NOT NULL "
+            f"AND ({geom_sql} IS NULL OR ST_IsEmpty({geom_sql}))"
+        )
+    )
+    if skipped:
+        click.echo(
+            f"⚠️  custom: {skipped} area(s) skipped "
+            f"(geometries not coercible to a non-empty MultiPolygon)."
+        )
     return result.rowcount
 
 

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -25,7 +25,7 @@ from typing import Optional
 
 import bcrypt
 import click
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -37,6 +37,12 @@ from src.api.data_models import (
     UserType,
 )
 from src.shared.config import SharedSettings
+from src.shared.geocoding_helpers import (
+    GADM_LEVELS,
+    GADM_STANDARD_ID_RE,
+    SOURCE_ID_MAPPING,
+    _antimeridian_bbox_sql,
+)
 
 
 class DatabaseManager:
@@ -790,6 +796,261 @@ def backfill_turn_fields_command(batch_size: int, dry_run: bool):
                 )
                 verb = "would update" if dry_run else "updated"
                 click.echo(f"backfill-turn-fields: {verb} {written} row(s)")
+        finally:
+            await db.close()
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# build-aois: populate the unified `aois` / `user_aois` tables
+# ---------------------------------------------------------------------------
+
+# Reference sources first, custom last (custom depends only on custom_areas).
+_BUILD_SOURCES = ["gadm", "kba", "wdpa", "landmark", "custom"]
+
+# Which source column carries the ISO3 country code(s), per reference source.
+# Resolved case-insensitively at runtime: geometries_* are built by GeoPandas
+# `to_postgis` and preserve the source file's (often upper-case) column casing.
+_ISO3_SOURCE_COLUMNS = {
+    "gadm": ["GID_0"],
+    "kba": ["ISO3"],
+    "wdpa": ["iso3"],
+    "landmark": ["iso_code"],
+}
+
+
+def _bbox_float_array_sql(geom_expr: str) -> str:
+    """A ``float8[]`` ``[west, south, east, north]`` for *geom_expr*.
+
+    Wraps the shared antimeridian-aware bbox (which yields a JSON array) and
+    turns it into a real Postgres array so it lands in ``aois.bbox`` directly.
+    ``WITH ORDINALITY`` pins the element order.
+    """
+    return (
+        "(SELECT array_agg(e::double precision ORDER BY ord) "
+        f"FROM json_array_elements_text({_antimeridian_bbox_sql(geom_expr)}) "
+        "WITH ORDINALITY AS t(e, ord))"
+    )
+
+
+async def _table_exists(session: AsyncSession, table: str) -> bool:
+    result = await session.execute(
+        text("SELECT to_regclass(:t) IS NOT NULL"), {"t": f"public.{table}"}
+    )
+    return bool(result.scalar())
+
+
+async def _resolve_column(
+    session: AsyncSession, table: str, candidates: list[str]
+) -> Optional[str]:
+    """Return the real (correctly-cased) name of the first present candidate."""
+    for cand in candidates:
+        result = await session.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = :table AND lower(column_name) = lower(:c) "
+                "LIMIT 1"
+            ),
+            {"table": table, "c": cand},
+        )
+        found = result.scalar()
+        if found:
+            return found
+    return None
+
+
+async def _build_reference_aois(session: AsyncSession, source: str) -> int:
+    """Transform one ``geometries_<source>`` table into ``aois`` (idempotent)."""
+    cfg = SOURCE_ID_MAPPING[source]
+    table, id_col = cfg["table"], cfg["id_column"]
+
+    iso3_col = await _resolve_column(
+        session, table, _ISO3_SOURCE_COLUMNS[source]
+    )
+    iso3_expr = (
+        f"string_to_array(NULLIF(btrim(\"{iso3_col}\"::text), ''), ';')"
+        if iso3_col
+        else "NULL::text[]"
+    )
+
+    if source == "gadm":
+        # subtype -> GADM admin level (0..5), in GADM_LEVELS declaration order.
+        admin_expr = (
+            "CASE subtype "
+            + " ".join(
+                f"WHEN '{st}' THEN {lvl}" for lvl, st in enumerate(GADM_LEVELS)
+            )
+            + " ELSE NULL END"
+        )
+        # Disputed territories (e.g. "Z01") lack a 3-letter ISO prefix; keep
+        # the rows but flag them so search can exclude via its partial index.
+        disputed_expr = f"NOT (\"{id_col}\" ~ '{GADM_STANDARD_ID_RE}')"
+    else:
+        admin_expr = "NULL::smallint"
+        disputed_expr = "false"
+
+    sql = f"""
+        INSERT INTO aois (
+            source, source_id, name, subtype, geometry,
+            bbox, area_km2, iso3, admin_level, is_disputed
+        )
+        SELECT
+            '{source}',
+            CAST("{id_col}" AS TEXT),
+            name,
+            subtype,
+            geometry,
+            {_bbox_float_array_sql("geometry")},
+            ST_Area(geometry::geography) / 1e6,
+            {iso3_expr},
+            {admin_expr},
+            {disputed_expr}
+        FROM {table}
+        WHERE name IS NOT NULL AND geometry IS NOT NULL
+        ON CONFLICT (source, source_id) WHERE NOT is_deprecated
+        DO UPDATE SET
+            name = EXCLUDED.name,
+            subtype = EXCLUDED.subtype,
+            geometry = EXCLUDED.geometry,
+            bbox = EXCLUDED.bbox,
+            area_km2 = EXCLUDED.area_km2,
+            iso3 = EXCLUDED.iso3,
+            admin_level = EXCLUDED.admin_level,
+            is_disputed = EXCLUDED.is_disputed,
+            updated_at = now()
+    """
+    result = await session.execute(text(sql))
+    return result.rowcount
+
+
+async def _build_custom_aois(session: AsyncSession) -> int:
+    """Transform ``custom_areas`` into ``aois`` + one ``owner`` link each.
+
+    Geometry is the ``ST_Collect`` of the stored GeoJSON-string list (same
+    shape ``CUSTOM_BBOX_SQL`` reads). Each area gets exactly one ``owner`` row
+    in ``user_aois`` for its ``user_id``. Returns the owner-link upsert count.
+    """
+    sql = f"""
+        WITH collected AS (
+            SELECT
+                ca.id,
+                ca.user_id,
+                ca.name,
+                ca.created_at,
+                ca.updated_at,
+                (
+                    SELECT ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON(g), 4326))
+                    FROM jsonb_array_elements_text(ca.geometries) AS g
+                ) AS geom
+            FROM custom_areas ca
+        ),
+        ins AS (
+            INSERT INTO aois (
+                source, source_id, name, subtype, geometry,
+                bbox, area_km2, created_by, created_at, updated_at
+            )
+            SELECT
+                'custom',
+                id::text,
+                name,
+                'custom-area',
+                geom,
+                {_bbox_float_array_sql("geom")},
+                ST_Area(geom::geography) / 1e6,
+                user_id,
+                created_at,
+                updated_at
+            FROM collected
+            WHERE name IS NOT NULL AND geom IS NOT NULL
+            ON CONFLICT (source, source_id) WHERE NOT is_deprecated
+            DO UPDATE SET
+                name = EXCLUDED.name,
+                geometry = EXCLUDED.geometry,
+                bbox = EXCLUDED.bbox,
+                area_km2 = EXCLUDED.area_km2,
+                updated_at = now()
+            RETURNING id AS aoi_id, created_by AS user_id
+        )
+        INSERT INTO user_aois (user_id, aoi_id, relationship)
+        SELECT user_id, aoi_id, 'owner' FROM ins
+        ON CONFLICT (user_id, aoi_id, relationship) DO NOTHING
+    """
+    result = await session.execute(text(sql))
+    return result.rowcount
+
+
+@cli.command("build-aois")
+@click.option(
+    "--source",
+    "sources",
+    multiple=True,
+    type=click.Choice(_BUILD_SOURCES),
+    help="Limit to source(s); repeatable. Default: all.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Run the transform in a transaction, report counts, then roll back.",
+)
+def build_aois_command(sources: tuple, dry_run: bool):
+    """Populate the unified aois/user_aois tables from already-loaded data.
+
+    Idempotent, set-based, in-DB transform of the reference geometries_*
+    tables and custom_areas into the unified schema. Run post-deploy (heavy
+    work must not run in the blocking migrate Job). Purely additive: the live
+    API keeps serving from geometries_* / custom_areas until the API PR.
+    """
+    selected = list(sources) or _BUILD_SOURCES
+
+    async def _run():
+        db = DatabaseManager()
+        try:
+            async with db.async_session() as session:
+                for source in selected:
+                    table = (
+                        "custom_areas"
+                        if source == "custom"
+                        else SOURCE_ID_MAPPING[source]["table"]
+                    )
+                    if not await _table_exists(session, table):
+                        click.echo(
+                            f"⏭️  {source}: {table} not found, skipping."
+                        )
+                        continue
+
+                    if source == "custom":
+                        links = await _build_custom_aois(session)
+                        click.echo(
+                            f"✅ custom: {links} owner link(s) upserted."
+                        )
+                    else:
+                        n = await _build_reference_aois(session, source)
+                        click.echo(f"✅ {source}: {n} aoi row(s) upserted.")
+
+                # Summary from the tables (visible within this transaction).
+                summary = await session.execute(
+                    text(
+                        "SELECT source, count(*) FROM aois "
+                        "GROUP BY source ORDER BY source"
+                    )
+                )
+                click.echo("\n📊 aois by source:")
+                for src, cnt in summary.all():
+                    click.echo(f"   {src}: {cnt}")
+                links_total = await session.execute(
+                    text("SELECT count(*) FROM user_aois")
+                )
+                click.echo(f"   user_aois: {links_total.scalar()}")
+
+                if dry_run:
+                    await session.rollback()
+                    click.echo(
+                        "\n🔎 --dry-run: rolled back, no changes saved."
+                    )
+                else:
+                    await session.commit()
+                    click.echo("\n💾 Committed.")
         finally:
             await db.close()
 

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -809,6 +809,11 @@ def backfill_turn_fields_command(batch_size: int, dry_run: bool):
 # Reference sources first, custom last (custom depends only on custom_areas).
 _BUILD_SOURCES = ["gadm", "kba", "wdpa", "landmark", "custom"]
 
+# Note: `aois.properties` (JSONB) is intentionally left NULL by this transform.
+# It exists as an escape hatch for user-uploaded custom-AOI attributes (needs
+# the PR2 API change to accept them) and source-specific reference columns
+# (a deliberate follow-up); neither is populated in PR1.
+
 # Which source column carries the ISO3 country code(s), per reference source.
 # Resolved case-insensitively at runtime: geometries_* are built by GeoPandas
 # `to_postgis` and preserve the source file's (often upper-case) column casing.

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -1074,12 +1074,19 @@ def build_aois_command(sources: tuple, dry_run: bool):
     API keeps serving from geometries_* / custom_areas until the API PR.
     """
     selected = list(sources) or _BUILD_SOURCES
+    outcome = "would be upserted" if dry_run else "upserted"
 
     async def _run():
         db = DatabaseManager()
+        committed: list[str] = []
         try:
-            async with db.async_session() as session:
-                for source in selected:
+            for source in selected:
+                # One transaction per source. Each build is independently
+                # idempotent, so committing as we go keeps a late failure
+                # from discarding sources that already succeeded -- GADM
+                # alone is far too large to hold in an open transaction
+                # while the remaining sources run.
+                async with db.async_session() as session:
                     table = (
                         "custom_areas"
                         if source == "custom"
@@ -1094,35 +1101,52 @@ def build_aois_command(sources: tuple, dry_run: bool):
                     if source == "custom":
                         links = await _build_custom_aois(session)
                         click.echo(
-                            f"✅ custom: {links} owner link(s) upserted."
+                            f"✅ custom: {links} owner link(s) {outcome}."
                         )
                     else:
                         n = await _build_reference_aois(session, source)
-                        click.echo(f"✅ {source}: {n} aoi row(s) upserted.")
+                        click.echo(f"✅ {source}: {n} aoi row(s) {outcome}.")
 
-                # Summary from the tables (visible within this transaction).
+                    if dry_run:
+                        await session.rollback()
+                    else:
+                        await session.commit()
+                        committed.append(source)
+
+            if dry_run:
+                click.echo(
+                    "\n🔎 --dry-run: each source rolled back, nothing saved."
+                )
+            else:
+                done = ", ".join(committed) if committed else "nothing"
+                click.echo(f"\n💾 Committed: {done}.")
+
+            # Fresh session, so this reports *committed* state only. Under
+            # --dry-run that is the pre-existing table contents, not this
+            # run's rolled-back work -- the per-source counts above are the
+            # authoritative dry-run output.
+            async with db.async_session() as session:
                 summary = await session.execute(
                     text(
                         "SELECT source, count(*) FROM aois "
                         "GROUP BY source ORDER BY source"
                     )
                 )
-                click.echo("\n📊 aois by source:")
+                click.echo("\n📊 aois by source (committed):")
                 for src, cnt in summary.all():
                     click.echo(f"   {src}: {cnt}")
                 links_total = await session.execute(
                     text("SELECT count(*) FROM user_aois")
                 )
                 click.echo(f"   user_aois: {links_total.scalar()}")
-
-                if dry_run:
-                    await session.rollback()
-                    click.echo(
-                        "\n🔎 --dry-run: rolled back, no changes saved."
-                    )
-                else:
-                    await session.commit()
-                    click.echo("\n💾 Committed.")
+        except Exception:
+            if committed:
+                click.echo(
+                    "\n⚠️  Committed before the failure: "
+                    f"{', '.join(committed)}. build-aois is idempotent -- "
+                    "re-run to resume."
+                )
+            raise
         finally:
             await db.close()
 

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -171,13 +171,12 @@ class CustomAreaOrm(Base):
 class AoiRelationship(str, enum.Enum):
     """A user's relationship to an AOI in ``user_aois``.
 
-    ``owner``/``shared_edit`` may edit the AOI; ``saved``/``shared_view`` are
-    read-only. Having any row means the AOI is in the user's list.
+    ``owner`` may edit the AOI; ``saved`` is read-only. Having any row means the
+    AOI is in the user's list. Shared/collaborator relationships will be added
+    when those use-cases are built.
     """
 
     OWNER = "owner"
-    SHARED_EDIT = "shared_edit"
-    SHARED_VIEW = "shared_view"
     SAVED = "saved"
 
 
@@ -234,7 +233,7 @@ class AoiOrm(Base):
 
 
 class UserAoiOrm(Base):
-    """User<->AOI relationships: owner / shared / saved.
+    """User<->AOI relationships: owner / saved.
 
     A single join carrying the whole permission model. ``aoi_id`` is a clean
     single-column FK to ``aois.id`` (the payoff of unifying storage). "In my

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -217,6 +217,11 @@ class AoiOrm(Base):
     is_deprecated = Column(Boolean, nullable=False, default=False)
     # Provenance / "uploaded_by": set for custom areas, null for reference.
     created_by = Column(String, ForeignKey("users.id"), nullable=True)
+    # Arbitrary/source-specific key-values: escape hatch for user-uploaded
+    # custom-AOI attributes and source columns that don't map to the typed
+    # columns above. Left NULL by build-aois for now; anything we
+    # filter/facet/sort on gets promoted to a real column instead.
+    properties = Column(JSONB, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(
         DateTime,

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -11,10 +11,12 @@ from sqlalchemy import (
     Column,
     Date,
     DateTime,
+    Enum,
     Float,
     ForeignKey,
     Index,
     Integer,
+    SmallInteger,
     String,
     UniqueConstraint,
     text,
@@ -79,6 +81,7 @@ class UserOrm(Base):
     machine_user_keys = relationship(
         "MachineUserKeyOrm", back_populates="user"
     )
+    user_aois = relationship("UserAoiOrm", back_populates="user")
 
 
 class ThreadOrm(Base):
@@ -163,6 +166,135 @@ class CustomAreaOrm(Base):
     )
 
     user = relationship("UserOrm", back_populates="custom_areas")
+
+
+class AoiRelationship(str, enum.Enum):
+    """A user's relationship to an AOI in ``user_aois``.
+
+    ``owner``/``shared_edit`` may edit the AOI; ``saved``/``shared_view`` are
+    read-only. Having any row means the AOI is in the user's list.
+    """
+
+    OWNER = "owner"
+    SHARED_EDIT = "shared_edit"
+    SHARED_VIEW = "shared_view"
+    SAVED = "saved"
+
+
+class AoiOrm(Base):
+    """Unified AOI table: one row per live ``(source, source_id)``.
+
+    Holds every kind of area -- reference sources (gadm/kba/wdpa/landmark) and
+    custom drawn areas -- addressed by a stable UUID ``id`` and by the logical
+    ``(source, source_id)`` key.
+
+    Deliberately PostGIS-free at the ORM layer, like the rest of this module:
+    the real ``geometry geometry(GEOMETRY, 4326)`` column plus the GiST,
+    partial trigram, and partial-unique indexes live in the Alembic migration
+    only. The test DB is built from this metadata via ``create_all`` and has no
+    PostGIS/pg_trgm; geometry is read/written through raw SQL (see
+    ``src/shared/geocoding_helpers.py``).
+    """
+
+    __tablename__ = "aois"
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    source = Column(String, nullable=False)
+    source_id = Column(String, nullable=False)
+    name = Column(String, nullable=False)
+    subtype = Column(String, nullable=False)
+    # bbox as [west, south, east, north]; precomputed, antimeridian-aware.
+    bbox = Column(ARRAY(Float), nullable=True)
+    area_km2 = Column(Float, nullable=True)
+    iso3 = Column(ARRAY(String), nullable=True)
+    admin_level = Column(SmallInteger, nullable=True)
+    # Kept in the table but excluded from search via a partial index.
+    is_disputed = Column(Boolean, nullable=False, default=False)
+    # Inert today; reserved for future versioning (deprecate-old on update).
+    is_deprecated = Column(Boolean, nullable=False, default=False)
+    # Provenance / "uploaded_by": set for custom areas, null for reference.
+    created_by = Column(String, ForeignKey("users.id"), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=datetime.now,
+        onupdate=datetime.now,
+    )
+
+    user_links = relationship(
+        "UserAoiOrm",
+        back_populates="aoi",
+        cascade="all, delete-orphan",
+    )
+
+
+class UserAoiOrm(Base):
+    """User<->AOI relationships: owner / shared / saved.
+
+    A single join carrying the whole permission model. ``aoi_id`` is a clean
+    single-column FK to ``aois.id`` (the payoff of unifying storage). "In my
+    list" == any row for the user; ``relationship`` says what they may do.
+    """
+
+    __tablename__ = "user_aois"
+
+    id = Column(
+        PostgresUUID,
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    aoi_id = Column(
+        PostgresUUID,
+        ForeignKey("aois.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # native_enum=False -> VARCHAR + CHECK, so create_all needs no PG type.
+    relationship_type = Column(
+        "relationship",
+        Enum(
+            AoiRelationship,
+            native_enum=False,
+            create_constraint=True,
+            values_callable=lambda e: [m.value for m in e],
+            name="aoi_relationship",
+        ),
+        nullable=False,
+    )
+    # User's per-list label; null falls back to aois.name.
+    name = Column(String, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=datetime.now,
+        onupdate=datetime.now,
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "aoi_id",
+            "relationship",
+            name="uq_user_aoi_relationship",
+        ),
+        # Powers custom-visibility semi-join and saved-first sort.
+        Index(
+            "idx_user_aois_user_rel_aoi",
+            "user_id",
+            "relationship",
+            "aoi_id",
+        ),
+        Index("idx_user_aois_aoi_id", "aoi_id"),
+    )
+
+    user = relationship("UserOrm", back_populates="user_aois")
+    aoi = relationship("AoiOrm", back_populates="user_links")
 
 
 class MachineUserKeyOrm(Base):

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.21"
+version = "2026.7.21.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Refs #735 

Creates schema for a new unified AOIs table that brings together AOIs from KBA, GADM, etc. + Custom AOIs into a single AOIs table.

The scope of this PR is:

 - Create new unified AOI table
 - Write script to copy data from current AOI tables to new AOI table

It is purely additive in the database and does not touch APIs. The goal would be to merge this, run the schema and data migration and verify that all data has been copied over to the unified table correctly. Then we follow up with a PR to move the APIs, etc. to use the new table and deprecate the old tables.

cc @yellowcap @01painadam 