### PR TITLE
Add dataset_id and aoi filters to GET /api/insights

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.8"
+version = "2026.7.9"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/routers/insights.py
+++ b/src/api/routers/insights.py
@@ -4,12 +4,12 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import String, cast, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.api.auth.dependencies import optional_auth, require_auth
-from src.api.data_models import InsightOrm, UserType
+from src.api.data_models import InsightOrm, StatisticsOrm, UserType
 from src.api.schemas import (
     InsightChartResponse,
     InsightPublicToggleRequest,
@@ -59,13 +59,59 @@ def _row_to_response(row: InsightOrm) -> InsightResponse:
     )
 
 
+def _aoi_pair_exists_clause(aoi_source: str, aoi_id: str):
+    """SQL EXISTS clause matching a (source, src_id) pair against the parallel
+    ``StatisticsOrm.aoi_sources``/``aoi_ids`` JSONB arrays.
+
+    ``src_id`` is only unique per source, so the two arrays must be zipped by
+    index (via ``WITH ORDINALITY``) rather than checked for membership
+    independently — otherwise an AOI id from one source could false-match an
+    unrelated AOI source elsewhere in the same row.
+    """
+    return text(
+        """
+        EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements_text(statistics.aoi_ids)
+                WITH ORDINALITY AS ids(val, idx)
+            JOIN jsonb_array_elements_text(statistics.aoi_sources)
+                WITH ORDINALITY AS srcs(val, idx)
+                ON ids.idx = srcs.idx
+            WHERE ids.val = :aoi_id AND srcs.val = :aoi_source
+        )
+        """
+    ).bindparams(aoi_id=aoi_id, aoi_source=aoi_source)
+
+
 @router.get("/api/insights", response_model=list[InsightResponse])
 async def list_insights(
     thread_id: Optional[str] = None,
+    dataset_id: Optional[int] = None,
+    aoi_source: Optional[str] = None,
+    aoi_id: Optional[str] = None,
     user: UserModel = Depends(require_auth),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ):
-    """List all insights belonging to the authenticated user, optionally filtered by thread."""
+    """List insights belonging to the authenticated user.
+
+    Optional filters:
+    - ``thread_id``: only insights from the given thread.
+    - ``dataset_id``: only insights derived from the given dataset id.
+    - ``aoi_source`` + ``aoi_id``: only insights derived from the AOI
+      identified by that (source, src_id) pair. Both must be given together —
+      ``src_id`` is only unique per source, so either alone is ambiguous.
+
+    ``dataset_id`` and the AOI pair are properties of the ``StatisticsOrm``
+    rows linked via ``InsightOrm.statistics_ids`` (a JSONB array of
+    stringified statistics UUIDs), so they are resolved by matching
+    statistics and keeping insights whose ``statistics_ids`` overlap.
+    """
+    if (aoi_source is None) != (aoi_id is None):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="aoi_source and aoi_id must be provided together",
+        )
+
     stmt = (
         select(InsightOrm)
         .options(selectinload(InsightOrm.charts))
@@ -73,6 +119,25 @@ async def list_insights(
     )
     if thread_id:
         stmt = stmt.where(InsightOrm.thread_id == thread_id)
+
+    if dataset_id is not None or aoi_id is not None:
+        matching_stat_ids = select(
+            func.array_agg(cast(StatisticsOrm.id, String))
+        )
+        if dataset_id is not None:
+            matching_stat_ids = matching_stat_ids.where(
+                StatisticsOrm.dataset_id == dataset_id
+            )
+        if aoi_id is not None and aoi_source is not None:
+            matching_stat_ids = matching_stat_ids.where(
+                _aoi_pair_exists_clause(aoi_source, aoi_id)
+            )
+        stmt = stmt.where(
+            InsightOrm.statistics_ids.has_any(
+                matching_stat_ids.scalar_subquery()
+            )
+        )
+
     stmt = stmt.order_by(InsightOrm.created_at.desc())
 
     result = await session.execute(stmt)

--- a/src/api/routers/insights.py
+++ b/src/api/routers/insights.py
@@ -4,7 +4,7 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import String, cast, func, select, text
+from sqlalchemy import String, cast, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -59,14 +59,13 @@ def _row_to_response(row: InsightOrm) -> InsightResponse:
     )
 
 
-def _aoi_pair_exists_clause(aoi_source: str, aoi_id: str):
-    """SQL EXISTS clause matching a (source, src_id) pair against the parallel
+def _aoi_pair_match(aoi_source: str, aoi_id: str):
+    """Match a (source, src_id) pair against the parallel
     ``StatisticsOrm.aoi_sources``/``aoi_ids`` JSONB arrays.
 
-    ``src_id`` is only unique per source, so the two arrays must be zipped by
-    index (via ``WITH ORDINALITY``) rather than checked for membership
-    independently — otherwise an AOI id from one source could false-match an
-    unrelated AOI source elsewhere in the same row.
+    ``src_id`` is only unique per source, so the arrays are matched pairwise
+    by index — independent membership checks would let an id from one source
+    false-match a different source elsewhere in the same row.
     """
     return text(
         """
@@ -74,10 +73,8 @@ def _aoi_pair_exists_clause(aoi_source: str, aoi_id: str):
             SELECT 1
             FROM jsonb_array_elements_text(statistics.aoi_ids)
                 WITH ORDINALITY AS ids(val, idx)
-            JOIN jsonb_array_elements_text(statistics.aoi_sources)
-                WITH ORDINALITY AS srcs(val, idx)
-                ON ids.idx = srcs.idx
-            WHERE ids.val = :aoi_id AND srcs.val = :aoi_source
+            WHERE ids.val = :aoi_id
+                AND statistics.aoi_sources ->> (ids.idx - 1)::int = :aoi_source
         )
         """
     ).bindparams(aoi_id=aoi_id, aoi_source=aoi_source)
@@ -103,8 +100,8 @@ async def list_insights(
 
     ``dataset_id`` and the AOI pair are properties of the ``StatisticsOrm``
     rows linked via ``InsightOrm.statistics_ids`` (a JSONB array of
-    stringified statistics UUIDs), so they are resolved by matching
-    statistics and keeping insights whose ``statistics_ids`` overlap.
+    stringified statistics UUIDs), so an insight matches when a statistics
+    row satisfying the filters appears in its ``statistics_ids``.
     """
     if (aoi_source is None) != (aoi_id is None):
         raise HTTPException(
@@ -121,22 +118,16 @@ async def list_insights(
         stmt = stmt.where(InsightOrm.thread_id == thread_id)
 
     if dataset_id is not None or aoi_id is not None:
-        matching_stat_ids = select(
-            func.array_agg(cast(StatisticsOrm.id, String))
+        stat_match = select(StatisticsOrm.id).where(
+            InsightOrm.statistics_ids.has_key(cast(StatisticsOrm.id, String))
         )
         if dataset_id is not None:
-            matching_stat_ids = matching_stat_ids.where(
+            stat_match = stat_match.where(
                 StatisticsOrm.dataset_id == dataset_id
             )
         if aoi_id is not None and aoi_source is not None:
-            matching_stat_ids = matching_stat_ids.where(
-                _aoi_pair_exists_clause(aoi_source, aoi_id)
-            )
-        stmt = stmt.where(
-            InsightOrm.statistics_ids.has_any(
-                matching_stat_ids.scalar_subquery()
-            )
-        )
+            stat_match = stat_match.where(_aoi_pair_match(aoi_source, aoi_id))
+        stmt = stmt.where(stat_match.exists())
 
     stmt = stmt.order_by(InsightOrm.created_at.desc())
 

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -6,7 +6,12 @@ import pytest
 
 from src.api.app import app
 from src.api.auth.dependencies import fetch_user_from_rw_api
-from src.api.data_models import InsightChartOrm, InsightOrm, UserOrm
+from src.api.data_models import (
+    InsightChartOrm,
+    InsightOrm,
+    StatisticsOrm,
+    UserOrm,
+)
 from tests.conftest import async_session_maker
 
 
@@ -31,6 +36,7 @@ async def _create_insight(
     thread_id: str | None = "thread-1",
     title: str = "Test Insight",
     is_public: bool = False,
+    statistics_ids: list[str] | None = None,
 ) -> InsightOrm:
     async with async_session_maker() as session:
         row = InsightOrm(
@@ -38,6 +44,7 @@ async def _create_insight(
             thread_id=thread_id,
             insight_text="Sample insight text",
             follow_up_suggestions=["Try a different area"],
+            statistics_ids=statistics_ids or [],
             codeact_types=["code_block"],
             codeact_contents=["print('hi')"],
             is_public=is_public,
@@ -54,6 +61,30 @@ async def _create_insight(
             chart_data=[{"x": 1, "y": 2}],
         )
         session.add(chart)
+        await session.commit()
+        await session.refresh(row)
+        return row
+
+
+async def _create_statistics(
+    *,
+    dataset_id: int | None = None,
+    dataset_name: str = "tree_cover_loss",
+    aoi_ids: list[str] | None = None,
+    aoi_sources: list[str] | None = None,
+    aoi_names: list[str] | None = None,
+) -> StatisticsOrm:
+    async with async_session_maker() as session:
+        row = StatisticsOrm(
+            dataset_name=dataset_name,
+            dataset_id=dataset_id,
+            start_date="2020-01-01",
+            end_date="2020-12-31",
+            aoi_names=aoi_names or [],
+            aoi_ids=aoi_ids or [],
+            aoi_sources=aoi_sources or [],
+        )
+        session.add(row)
         await session.commit()
         await session.refresh(row)
         return row
@@ -106,6 +137,217 @@ async def test_list_insights_filter_by_thread(client, auth_override):
     data = response.json()
     assert len(data) == 1
     assert data[0]["id"] == str(i2.id)
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_by_dataset_id(client, auth_override):
+    user = await _create_user("dataset-filter-owner")
+    auth_override(user.id)
+
+    stat_match = await _create_statistics(dataset_id=42)
+    stat_other = await _create_statistics(dataset_id=99)
+
+    i_match = await _create_insight(
+        user_id=user.id, statistics_ids=[str(stat_match.id)]
+    )
+    await _create_insight(user_id=user.id, statistics_ids=[str(stat_other.id)])
+
+    response = await client.get(
+        "/api/insights",
+        params={"dataset_id": 42},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["id"] == str(i_match.id)
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_by_dataset_id_no_match(
+    client, auth_override
+):
+    user = await _create_user("dataset-filter-no-match")
+    auth_override(user.id)
+
+    stat = await _create_statistics(dataset_id=1)
+    await _create_insight(user_id=user.id, statistics_ids=[str(stat.id)])
+
+    response = await client.get(
+        "/api/insights",
+        params={"dataset_id": 999},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_by_aoi_pair(client, auth_override):
+    user = await _create_user("aoi-filter-owner")
+    auth_override(user.id)
+
+    stat_match = await _create_statistics(
+        aoi_ids=["IDN.24_1"], aoi_sources=["gadm"]
+    )
+    stat_other = await _create_statistics(
+        aoi_ids=["BRA.1_1"], aoi_sources=["gadm"]
+    )
+
+    i_match = await _create_insight(
+        user_id=user.id, statistics_ids=[str(stat_match.id)]
+    )
+    await _create_insight(user_id=user.id, statistics_ids=[str(stat_other.id)])
+
+    response = await client.get(
+        "/api/insights",
+        params={"aoi_source": "gadm", "aoi_id": "IDN.24_1"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["id"] == str(i_match.id)
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_by_aoi_pair_does_not_cross_match(
+    client, auth_override
+):
+    """A stats row analysing (gadm, X) and (wdpa, Y) must not match a query
+    for (gadm, Y) or (wdpa, X) — the id and source arrays are parallel and
+    must be matched pairwise by index, not as independent membership checks.
+    """
+    user = await _create_user("aoi-filter-crossmatch")
+    auth_override(user.id)
+
+    stat = await _create_statistics(
+        aoi_ids=["X", "Y"], aoi_sources=["gadm", "wdpa"]
+    )
+    await _create_insight(user_id=user.id, statistics_ids=[str(stat.id)])
+
+    response = await client.get(
+        "/api/insights",
+        params={"aoi_source": "gadm", "aoi_id": "Y"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+    response = await client.get(
+        "/api/insights",
+        params={"aoi_source": "wdpa", "aoi_id": "X"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+    # Sanity check: the true pairs do match.
+    response = await client.get(
+        "/api/insights",
+        params={"aoi_source": "gadm", "aoi_id": "X"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert len(response.json()) == 1
+
+    response = await client.get(
+        "/api/insights",
+        params={"aoi_source": "wdpa", "aoi_id": "Y"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert len(response.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_aoi_id_without_source_returns_400(
+    client, auth_override
+):
+    user = await _create_user("aoi-filter-missing-source")
+    auth_override(user.id)
+
+    response = await client.get(
+        "/api/insights",
+        params={"aoi_id": "IDN.24_1"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_aoi_source_without_id_returns_400(
+    client, auth_override
+):
+    user = await _create_user("aoi-filter-missing-id")
+    auth_override(user.id)
+
+    response = await client.get(
+        "/api/insights",
+        params={"aoi_source": "gadm"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_by_dataset_id_and_aoi_pair_combined(
+    client, auth_override
+):
+    """Combining dataset_id and the AOI pair filters narrows results with
+    AND semantics — an insight must match both to be returned."""
+    user = await _create_user("combined-filter-owner")
+    auth_override(user.id)
+
+    stat_both = await _create_statistics(
+        dataset_id=1, aoi_ids=["IDN.24_1"], aoi_sources=["gadm"]
+    )
+    stat_dataset_only = await _create_statistics(
+        dataset_id=1, aoi_ids=["BRA.1_1"], aoi_sources=["gadm"]
+    )
+    stat_aoi_only = await _create_statistics(
+        dataset_id=2, aoi_ids=["IDN.24_1"], aoi_sources=["gadm"]
+    )
+
+    i_both = await _create_insight(
+        user_id=user.id, statistics_ids=[str(stat_both.id)]
+    )
+    await _create_insight(
+        user_id=user.id, statistics_ids=[str(stat_dataset_only.id)]
+    )
+    await _create_insight(
+        user_id=user.id, statistics_ids=[str(stat_aoi_only.id)]
+    )
+
+    response = await client.get(
+        "/api/insights",
+        params={"dataset_id": 1, "aoi_source": "gadm", "aoi_id": "IDN.24_1"},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["id"] == str(i_both.id)
+
+
+@pytest.mark.asyncio
+async def test_list_insights_filter_by_dataset_id_scoped_to_own_insights(
+    client, auth_override
+):
+    """Filters narrow within the caller's own insights; they never leak
+    another user's insights even on a dataset_id match."""
+    owner = await _create_user("scoped-filter-owner")
+    other = await _create_user("scoped-filter-other")
+
+    stat = await _create_statistics(dataset_id=7)
+    await _create_insight(user_id=other.id, statistics_ids=[str(stat.id)])
+
+    auth_override(owner.id)
+    response = await client.get(
+        "/api/insights",
+        params={"dataset_id": 7},
+        headers={"Authorization": "Bearer t"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds `dataset_id` and `aoi_source` + `aoi_id` query filters to `GET /api/insights`, alongside the existing `thread_id` filter.
- Filters resolve against `StatisticsOrm` rows linked via `InsightOrm.statistics_ids`, matching on the `dataset_id` and parallel `aoi_ids`/`aoi_sources` JSONB arrays added in #729.

## Details
- `aoi_source` and `aoi_id` must be passed together (400 if only one is given) — `src_id` is only unique per source.
- The AOI pair is matched pairwise by index (unnest `aoi_ids` `WITH ORDINALITY`, index into `aoi_sources`), not via independent membership checks — this avoids cross-matching an id from one source against an unrelated source in the same stats row.
- The statistics linkage is a correlated `EXISTS` against `statistics_ids`; `dataset_id` and the AOI pair combine with AND semantics and narrow within the caller's own insights.

Example:
```
GET /api/insights?dataset_id=42
GET /api/insights?aoi_source=gadm&aoi_id=IDN.24_1
GET /api/insights?dataset_id=42&aoi_source=gadm&aoi_id=IDN.24_1
```

## Test plan
- [x] `pytest tests/api/test_insights.py` — 29 passed, including 8 new tests covering: dataset_id match/no-match, aoi pair match, pairwise cross-match regression (index-zipping correctness), missing-half-of-pair 400s, combined AND filtering, and per-user scoping.
- [x] `ruff check` / `ruff format --check` / `mypy` clean (no new mypy errors vs. baseline).
