### PR TITLE
PZB-1095: Add agent tools to create and edit dashboard text widgets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.9"
+version = "2026.7.13"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -49,8 +49,10 @@ from src.agent.subagents.pick_dataset.tool import SPEC as pick_dataset_spec
 from src.agent.subagents.search.blog import SPEC as search_blogs_spec
 from src.agent.tool_spec import Availability, ToolCategory, ToolSpec
 from src.agent.tools.add_map_widget import SPEC as add_map_widget_spec
+from src.agent.tools.add_text_widget import SPEC as add_text_widget_spec
 from src.agent.tools.add_to_dashboard import SPEC as add_to_dashboard_spec
 from src.agent.tools.create_dashboard import SPEC as create_dashboard_spec
+from src.agent.tools.edit_text_widget import SPEC as edit_text_widget_spec
 from src.agent.tools.inspect_view_context import (
     SPEC as inspect_view_context_spec,
 )
@@ -81,6 +83,8 @@ ALL_SPECS = (
     create_dashboard_spec,
     add_to_dashboard_spec,
     add_map_widget_spec,
+    add_text_widget_spec,
+    edit_text_widget_spec,
 )
 _SPEC_BY_NAME = {s.tool.name: s for s in ALL_SPECS}
 

--- a/src/agent/skills/skills_md/dashboard.md
+++ b/src/agent/skills/skills_md/dashboard.md
@@ -1,14 +1,14 @@
 ---
 name: dashboard
-description: Create a dashboard for an area and fill it with insights (new or recalled) and map widgets.
+description: Create a dashboard for an area and fill it with insights (new or recalled), map widgets, and text notes.
 when_to_use: User asks to build/create a dashboard for a place, to add an insight/analysis to a dashboard, or to add a map layer / satellite imagery to a dashboard. Not for one-off analysis without a dashboard — use `analyze`.
-requires: create_dashboard, add_to_dashboard, add_map_widget
+requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget
 ---
 
 # Dashboards
 
 A dashboard is a persistent collection of widgets for ONE area (a country, a
-state, a protected area). Widgets are insights or map layers. Widgets
+state, a protected area). Widgets are insights, map layers, or free-form text notes. Widgets
 reference or snapshot work that already exists — adding to a dashboard never
 recomputes anything.
 
@@ -48,6 +48,15 @@ layer — run `pick_dataset` first if none is selected.
 `add_map_widget(layer="imagery")` snapshots the Sentinel-2 mosaic — run
 `show_imagery` first. Build the layer/imagery for the dashboard's area. Map
 widgets render focused on the dashboard's area automatically.
+
+# Adding a text note ("add a note / summary / explanation to my dashboard")
+
+`add_text_widget(text)` puts a markdown note on the dashboard — use it when
+the user wants to add a summary, section intro, caveat or explanation. The
+text is markdown; compose it yourself (concise, no raw data). To rewrite a
+note, use `edit_text_widget(text)` — it defaults to the dashboard's only text
+widget; if several exist the tool lists their ids so you can retry with
+`widget_id`.
 
 # Stop conditions
 

--- a/src/agent/tools/add_text_widget.py
+++ b/src/agent/tools/add_text_widget.py
@@ -1,0 +1,130 @@
+"""add_text_widget — put a composed markdown note onto a dashboard.
+
+The fourth dashboard primitive next to create_dashboard, add_to_dashboard
+and add_map_widget. The agent composes the markdown itself (a summary of
+findings, a section intro, a caveat) and it lands in the widget's config
+under the ``text`` key — the same shape the REST path validates
+(``validate_text_config`` in src/api/schemas.py). The dashboard defaults to
+the one in state or the one the user is looking at (view_context).
+Owner-only, like the other primitives.
+"""
+
+from typing import Annotated, Dict, Optional
+
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import (
+    dashboard_updated_command,
+    error_command,
+    load_editable_dashboard,
+    resolve_dashboard_id,
+)
+from src.api.repositories import dashboard_writer
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+EMPTY_TEXT_MESSAGE = (
+    "text is empty. Compose the markdown note first, then call "
+    "add_text_widget with it."
+)
+
+
+def _normalize_text(text: Optional[str]) -> Optional[str]:
+    """Strip surrounding whitespace; None when nothing remains."""
+    if not text:
+        return None
+    return text.strip() or None
+
+
+def _widget_config(text: str) -> dict:
+    """The text-widget config contract: exactly ``{"text": markdown}``."""
+    return {"text": text}
+
+
+@tool("add_text_widget")
+async def add_text_widget(
+    text: str,
+    dashboard_id: Optional[str] = None,
+    position: Optional[int] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Add a text widget (a markdown note) to a dashboard.
+
+    `text` is the widget's markdown body — compose it yourself: a concise
+    note, summary or section intro; headings go in the markdown (there is
+    no separate title). `dashboard_id` defaults to the dashboard in state
+    or the one the user is currently viewing; `position` optionally places
+    the widget (default: appended at the end). Only dashboards the user
+    owns can be edited.
+    """
+    state = state or {}
+
+    body = _normalize_text(text)
+    if body is None:
+        return error_command(EMPTY_TEXT_MESSAGE, tool_call_id)
+
+    target_dashboard = resolve_dashboard_id(state, dashboard_id)
+    if not target_dashboard:
+        return error_command(
+            "No dashboard to add to. Create one with create_dashboard, or "
+            "pass a dashboard_id.",
+            tool_call_id,
+        )
+
+    logger.info(
+        "add_text_widget tool called",
+        dashboard_id=str(target_dashboard),
+        text_chars=len(body),
+    )
+
+    dashboard = await load_editable_dashboard(
+        target_dashboard, "add_text_widget"
+    )
+    if dashboard is None:
+        return error_command(
+            f"Dashboard {target_dashboard} not found or not editable.",
+            tool_call_id,
+        )
+
+    widget_id = await dashboard_writer.add_widget(
+        str(target_dashboard),
+        widget_type="text",
+        config=_widget_config(body),
+        position=position,
+    )
+    if widget_id is None:
+        return error_command(
+            f"Dashboard {target_dashboard} disappeared before the text "
+            "widget could be added.",
+            tool_call_id,
+        )
+
+    return dashboard_updated_command(
+        dashboard.id,
+        (
+            f"Added text widget {widget_id} to dashboard "
+            f"'{dashboard.name}' ({dashboard.id}). Use this widget id with "
+            "edit_text_widget to change the note later."
+        ),
+        tool_call_id,
+    )
+
+
+SPEC = ToolSpec(
+    tool=add_text_widget,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- add_text_widget(text, dashboard_id?, position?): add a markdown "
+        "text widget to a dashboard. Compose the markdown yourself — a "
+        "concise note, summary of findings from this conversation, or "
+        "section intro; do not paste raw data. Dashboard defaults to the "
+        "one in state or on screen. Use when the user asks to add a note, "
+        "description, summary or explanation to their dashboard."
+    ),
+)

--- a/src/agent/tools/edit_text_widget.py
+++ b/src/agent/tools/edit_text_widget.py
@@ -1,0 +1,194 @@
+"""edit_text_widget — replace the markdown of an existing text widget.
+
+The companion to add_text_widget. When no widget_id is given the tool
+targets the resolved dashboard's only text widget; with several text
+widgets it refuses and lists the candidates (id + excerpt) so the model
+can retry with an explicit id. With a widget_id the ownership check runs
+against the widget's own dashboard, so a widget on someone else's
+dashboard reads the same as a missing one. Owner-only, like the other
+dashboard primitives.
+"""
+
+from typing import Annotated, Dict, Optional
+
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.add_text_widget import (
+    EMPTY_TEXT_MESSAGE,
+    _normalize_text,
+    _widget_config,
+)
+from src.agent.tools.common import (
+    dashboard_updated_command,
+    error_command,
+    load_editable_dashboard,
+    resolve_dashboard_id,
+)
+from src.api.repositories import dashboard_writer
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_EXCERPT_CHARS = 60
+
+
+def _excerpt(text: str, max_chars: int = _EXCERPT_CHARS) -> str:
+    """A short single-purpose preview of a widget's markdown body."""
+    text = (text or "").strip()
+    if len(text) > max_chars:
+        return text[:max_chars] + "…"
+    return text
+
+
+def _select_text_widget(widgets) -> tuple[Optional[object], Optional[str]]:
+    """The dashboard's single text widget, or an error message explaining
+    why one cannot be chosen (none exist, or several do — listing each
+    candidate's id and an excerpt so the model can retry with widget_id).
+    """
+    text_widgets = [w for w in widgets if w.widget_type == "text"]
+    if not text_widgets:
+        return None, (
+            "No text widget on this dashboard. Add one with "
+            "add_text_widget instead."
+        )
+    if len(text_widgets) > 1:
+        listing = "; ".join(
+            f'{w.id}: "{_excerpt((w.config or {}).get("text", ""))}"'
+            for w in text_widgets
+        )
+        return None, (
+            "Multiple text widgets on this dashboard — pass widget_id to "
+            f"pick one. Candidates: {listing}"
+        )
+    return text_widgets[0], None
+
+
+async def _resolve_by_widget_id(widget_id: str):
+    """The (widget, dashboard) pair for an explicit widget_id, or an error
+    message. Widgets on dashboards the user cannot edit, non-text widgets
+    and unknown/malformed ids all resolve to an error."""
+    widget = await dashboard_writer.get_widget(widget_id)
+    if widget is None:
+        return None, None, f"Widget {widget_id} not found."
+    if widget.widget_type != "text":
+        return (
+            None,
+            None,
+            (
+                f"Widget {widget_id} is a {widget.widget_type} widget, not a "
+                "text widget."
+            ),
+        )
+    dashboard = await load_editable_dashboard(
+        widget.dashboard_id, "edit_text_widget"
+    )
+    if dashboard is None:
+        return (
+            None,
+            None,
+            (
+                f"Widget {widget_id} not found or its dashboard is not "
+                "editable."
+            ),
+        )
+    return widget, dashboard, None
+
+
+async def _resolve_by_dashboard(state: dict, dashboard_id: Optional[str]):
+    """The (widget, dashboard) pair for the resolved dashboard's only text
+    widget, or an error message."""
+    target_dashboard = resolve_dashboard_id(state, dashboard_id)
+    if not target_dashboard:
+        return (
+            None,
+            None,
+            ("No dashboard to edit. Pass a dashboard_id or a widget_id."),
+        )
+    dashboard = await load_editable_dashboard(
+        target_dashboard, "edit_text_widget"
+    )
+    if dashboard is None:
+        return (
+            None,
+            None,
+            (f"Dashboard {target_dashboard} not found or not editable."),
+        )
+    widget, message = _select_text_widget(dashboard.widgets)
+    if widget is None:
+        return None, None, message
+    return widget, dashboard, None
+
+
+@tool("edit_text_widget")
+async def edit_text_widget(
+    text: str,
+    widget_id: Optional[str] = None,
+    dashboard_id: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Replace the markdown body of an existing text widget.
+
+    `text` is the full new markdown body (a replacement, not an append).
+    `widget_id` defaults to the dashboard's only text widget — when the
+    dashboard has several, the error lists their ids so you can retry with
+    one. `dashboard_id` defaults to the dashboard in state or the one the
+    user is currently viewing. Only dashboards the user owns can be edited.
+    """
+    state = state or {}
+
+    body = _normalize_text(text)
+    if body is None:
+        return error_command(EMPTY_TEXT_MESSAGE, tool_call_id)
+
+    if widget_id:
+        widget, dashboard, message = await _resolve_by_widget_id(widget_id)
+    else:
+        widget, dashboard, message = await _resolve_by_dashboard(
+            state, dashboard_id
+        )
+    if widget is None:
+        return error_command(message, tool_call_id)
+
+    logger.info(
+        "edit_text_widget tool called",
+        widget_id=str(widget.id),
+        dashboard_id=str(dashboard.id),
+        text_chars=len(body),
+    )
+
+    updated = await dashboard_writer.update_widget(
+        widget.id, config=_widget_config(body)
+    )
+    if not updated:
+        return error_command(
+            f"Widget {widget.id} disappeared before it could be edited.",
+            tool_call_id,
+        )
+
+    return dashboard_updated_command(
+        dashboard.id,
+        (
+            f"Updated text widget {widget.id} on dashboard "
+            f"'{dashboard.name}' ({dashboard.id})."
+        ),
+        tool_call_id,
+    )
+
+
+SPEC = ToolSpec(
+    tool=edit_text_widget,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- edit_text_widget(text, widget_id?, dashboard_id?): replace the "
+        "markdown of an existing text widget with `text` (full "
+        "replacement). Defaults to the dashboard's only text widget; when "
+        "several exist the error lists their ids — retry with widget_id. "
+        "Use when the user asks to change, rewrite or update a note on "
+        "their dashboard."
+    ),
+)

--- a/src/api/repositories/dashboard_writer.py
+++ b/src/api/repositories/dashboard_writer.py
@@ -113,6 +113,16 @@ async def get_dashboard(dashboard_id) -> Optional[DashboardOrm]:
         return result.scalar_one_or_none()
 
 
+async def get_widget(widget_id) -> Optional[DashboardWidgetOrm]:
+    """Load a single widget by id; the caller applies access checks via the
+    owning dashboard. Malformed ids are not-found (None), never an error."""
+    target = _parse_uuid(widget_id)
+    if target is None:
+        return None
+    async with get_session_from_pool() as session:
+        return await session.get(DashboardWidgetOrm, target)
+
+
 async def add_widget(
     dashboard_id,
     *,

--- a/tests/agent/test_add_text_widget.py
+++ b/tests/agent/test_add_text_widget.py
@@ -1,0 +1,171 @@
+"""Tests for the add_text_widget agent tool."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from src.agent.tools.add_text_widget import add_text_widget
+from src.shared.request_context import bound_user_id
+
+NOTE = "# Deforestation summary\n\nTree cover loss rose 12% in 2024."
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _dashboard(user_id="user-1", name="Paraná"):
+    return SimpleNamespace(
+        id=uuid4(), user_id=user_id, name=name, is_public=False
+    )
+
+
+def _patches(dashboard, widget_id="widget-1"):
+    return (
+        patch(
+            "src.api.repositories.dashboard_writer.get_dashboard",
+            new=AsyncMock(return_value=dashboard),
+        ),
+        patch(
+            "src.api.repositories.dashboard_writer.add_widget",
+            new=AsyncMock(return_value=widget_id),
+        ),
+    )
+
+
+async def test_add_text_widget_happy_path():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard, widget_id="widget-42")
+    state = {"dashboard_id": str(dashboard.id)}
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await add_text_widget.coroutine(
+            text=NOTE, state=state, tool_call_id="t1"
+        )
+
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata == {
+        "msg_type": "dashboard_updated",
+        "dashboard_id": str(dashboard.id),
+    }
+    assert command.update["dashboard_id"] == str(dashboard.id)
+    # The widget id is surfaced so the agent can edit the note later.
+    assert "widget-42" in message.content
+
+    add_widget_mock.assert_awaited_once()
+    kwargs = add_widget_mock.await_args.kwargs
+    assert kwargs["widget_type"] == "text"
+    assert kwargs["config"] == {"text": NOTE}
+    assert kwargs["position"] is None
+
+
+async def test_add_text_widget_strips_whitespace():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard)
+    state = {"dashboard_id": str(dashboard.id)}
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        bound_user_id("user-1"),
+    ):
+        await add_text_widget.coroutine(
+            text=f"  {NOTE}\n", state=state, tool_call_id="t1"
+        )
+    assert add_widget_mock.await_args.kwargs["config"] == {"text": NOTE}
+
+
+async def test_add_text_widget_position_passthrough():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard)
+    state = {"dashboard_id": str(dashboard.id)}
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        bound_user_id("user-1"),
+    ):
+        await add_text_widget.coroutine(
+            text=NOTE, position=0, state=state, tool_call_id="t1"
+        )
+    assert add_widget_mock.await_args.kwargs["position"] == 0
+
+
+async def test_add_text_widget_falls_back_to_view_context():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard)
+    state = {
+        "view_context": {
+            "page": "dashboard",
+            "dashboard_id": str(dashboard.id),
+        },
+    }
+    with (
+        get_dash,
+        add_widget,
+        bound_user_id("user-1"),
+    ):
+        command = await add_text_widget.coroutine(
+            text=NOTE, state=state, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "success"
+    assert command.update["dashboard_id"] == str(dashboard.id)
+
+
+async def test_add_text_widget_rejects_empty_text():
+    with bound_user_id("user-1"):
+        command = await add_text_widget.coroutine(
+            text="   \n", state={}, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "text is empty" in _content(command)
+
+
+async def test_add_text_widget_requires_dashboard():
+    with bound_user_id("user-1"):
+        command = await add_text_widget.coroutine(
+            text=NOTE, state={}, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No dashboard to add to" in _content(command)
+
+
+async def test_add_text_widget_owner_only():
+    # A public dashboard someone else owns is readable but not editable.
+    dashboard = _dashboard(user_id="someone-else")
+    dashboard.is_public = True
+    get_dash, add_widget = _patches(dashboard)
+    with (
+        get_dash,
+        add_widget as add_widget_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await add_text_widget.coroutine(
+            text=NOTE,
+            dashboard_id=str(dashboard.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not found or not editable" in _content(command)
+    add_widget_mock.assert_not_awaited()
+
+
+async def test_add_text_widget_dashboard_vanishes_mid_write():
+    dashboard = _dashboard()
+    get_dash, add_widget = _patches(dashboard, widget_id=None)
+    with (
+        get_dash,
+        add_widget,
+        bound_user_id("user-1"),
+    ):
+        command = await add_text_widget.coroutine(
+            text=NOTE,
+            dashboard_id=str(dashboard.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "disappeared" in _content(command)

--- a/tests/agent/test_dashboards_db.py
+++ b/tests/agent/test_dashboards_db.py
@@ -145,6 +145,24 @@ async def test_widget_add_reorder_remove(user):
     )
 
 
+async def test_get_widget(user):
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user.id, name="Paraná", aois=[PARANA]
+    )
+    widget_id = await dashboard_writer.add_widget(
+        dashboard_id, widget_type="text", config={"text": "# A note"}
+    )
+
+    widget = await dashboard_writer.get_widget(widget_id)
+    assert str(widget.id) == widget_id
+    assert str(widget.dashboard_id) == dashboard_id
+    assert widget.widget_type == "text"
+    assert widget.config == {"text": "# A note"}
+
+    assert await dashboard_writer.get_widget(str(uuid4())) is None
+    assert await dashboard_writer.get_widget("not-a-uuid") is None
+
+
 async def test_map_widget_persists_config(user):
     # A map widget's config is a self-contained layer snapshot (nested dicts,
     # lists, nulls) that must round-trip through JSONB unchanged.

--- a/tests/agent/test_edit_text_widget.py
+++ b/tests/agent/test_edit_text_widget.py
@@ -1,0 +1,239 @@
+"""Tests for the edit_text_widget agent tool."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from src.agent.tools.edit_text_widget import edit_text_widget
+from src.shared.request_context import bound_user_id
+
+NEW_TEXT = "# Updated note\n\nRevised after the 2024 data pull."
+
+
+def _content(command):
+    return command.update["messages"][0].content
+
+
+def _dashboard(user_id="user-1", name="Paraná", widgets=()):
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=user_id,
+        name=name,
+        is_public=False,
+        widgets=list(widgets),
+    )
+
+
+def _widget(widget_type="text", text="Old note.", dashboard_id=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        widget_type=widget_type,
+        config={"text": text} if widget_type == "text" else {},
+        dashboard_id=dashboard_id or uuid4(),
+    )
+
+
+def _patch_get_dashboard(dashboard):
+    return patch(
+        "src.api.repositories.dashboard_writer.get_dashboard",
+        new=AsyncMock(return_value=dashboard),
+    )
+
+
+def _patch_get_widget(widget):
+    return patch(
+        "src.api.repositories.dashboard_writer.get_widget",
+        new=AsyncMock(return_value=widget),
+    )
+
+
+def _patch_update_widget(result=True):
+    return patch(
+        "src.api.repositories.dashboard_writer.update_widget",
+        new=AsyncMock(return_value=result),
+    )
+
+
+async def test_edit_text_widget_single_widget_on_dashboard():
+    dashboard = _dashboard()
+    widget = _widget(dashboard_id=dashboard.id)
+    dashboard.widgets = [_widget("insight"), widget, _widget("map")]
+    state = {"dashboard_id": str(dashboard.id)}
+    with (
+        _patch_get_dashboard(dashboard),
+        _patch_update_widget() as update_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT, state=state, tool_call_id="t1"
+        )
+
+    message = command.update["messages"][0]
+    assert message.status == "success"
+    assert message.response_metadata == {
+        "msg_type": "dashboard_updated",
+        "dashboard_id": str(dashboard.id),
+    }
+    assert command.update["dashboard_id"] == str(dashboard.id)
+    assert str(widget.id) in message.content
+
+    update_mock.assert_awaited_once()
+    args, kwargs = update_mock.await_args
+    assert args == (widget.id,)
+    assert kwargs["config"] == {"text": NEW_TEXT}
+
+
+async def test_edit_text_widget_explicit_widget_id():
+    dashboard = _dashboard()
+    widget = _widget(dashboard_id=dashboard.id)
+    with (
+        _patch_get_widget(widget),
+        _patch_get_dashboard(dashboard),
+        _patch_update_widget() as update_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT,
+            widget_id=str(widget.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "success"
+    update_mock.assert_awaited_once()
+
+
+async def test_edit_text_widget_rejects_empty_text():
+    with bound_user_id("user-1"):
+        command = await edit_text_widget.coroutine(
+            text="  \n ", state={}, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "text is empty" in _content(command)
+
+
+async def test_edit_text_widget_requires_dashboard_or_widget():
+    with bound_user_id("user-1"):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT, state={}, tool_call_id="t1"
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No dashboard to edit" in _content(command)
+
+
+async def test_edit_text_widget_ambiguous_lists_candidates():
+    dashboard = _dashboard()
+    first = _widget(text="First note.", dashboard_id=dashboard.id)
+    second = _widget(text="Second note.", dashboard_id=dashboard.id)
+    dashboard.widgets = [first, second]
+    with (
+        _patch_get_dashboard(dashboard),
+        _patch_update_widget() as update_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT,
+            dashboard_id=str(dashboard.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    content = _content(command)
+    assert "pass widget_id" in content
+    assert str(first.id) in content
+    assert str(second.id) in content
+    update_mock.assert_not_awaited()
+
+
+async def test_edit_text_widget_no_text_widget_on_dashboard():
+    dashboard = _dashboard(widgets=[_widget("insight"), _widget("map")])
+    with (
+        _patch_get_dashboard(dashboard),
+        _patch_update_widget() as update_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT,
+            dashboard_id=str(dashboard.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "No text widget" in _content(command)
+    update_mock.assert_not_awaited()
+
+
+async def test_edit_text_widget_unknown_widget_id():
+    with (
+        _patch_get_widget(None),
+        _patch_update_widget() as update_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT,
+            widget_id=str(uuid4()),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not found" in _content(command)
+    update_mock.assert_not_awaited()
+
+
+async def test_edit_text_widget_rejects_non_text_widget():
+    widget = _widget("map")
+    with (
+        _patch_get_widget(widget),
+        _patch_update_widget() as update_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT,
+            widget_id=str(widget.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not a text widget" in _content(command)
+    update_mock.assert_not_awaited()
+
+
+async def test_edit_text_widget_owner_only():
+    # The widget exists but lives on someone else's (public) dashboard:
+    # same reply as a missing widget, and no write happens.
+    dashboard = _dashboard(user_id="someone-else")
+    dashboard.is_public = True
+    widget = _widget(dashboard_id=dashboard.id)
+    with (
+        _patch_get_widget(widget),
+        _patch_get_dashboard(dashboard),
+        _patch_update_widget() as update_mock,
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT,
+            widget_id=str(widget.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "not editable" in _content(command)
+    update_mock.assert_not_awaited()
+
+
+async def test_edit_text_widget_vanishes_mid_write():
+    dashboard = _dashboard()
+    widget = _widget(dashboard_id=dashboard.id)
+    dashboard.widgets = [widget]
+    with (
+        _patch_get_dashboard(dashboard),
+        _patch_update_widget(result=False),
+        bound_user_id("user-1"),
+    ):
+        command = await edit_text_widget.coroutine(
+            text=NEW_TEXT,
+            dashboard_id=str(dashboard.id),
+            state={},
+            tool_call_id="t1",
+        )
+    assert command.update["messages"][0].status == "error"
+    assert "disappeared" in _content(command)

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -272,6 +272,8 @@ def test_experimental_profile_derives_exactly_the_experimental_tools():
             "create_dashboard",
             "add_to_dashboard",
             "add_map_widget",
+            "add_text_widget",
+            "edit_text_widget",
         }
     )
 

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -50,7 +50,7 @@ extends: default
 skills:
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
-  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget)
+  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget)
   - explore (requires: search_blogs)
   - pull-data (requires: pick_aoi, pick_dataset, pull_data)
   - show-imagery (requires: pick_aoi, show_imagery)
@@ -69,7 +69,9 @@ tools:
   - search_insights
   - create_dashboard
   - add_to_dashboard
-  - add_map_widget"""
+  - add_map_widget
+  - add_text_widget
+  - edit_text_widget"""
 
 
 def test_base_profile_manifest():

--- a/tests/unit/agent/tools/test_add_text_widget.py
+++ b/tests/unit/agent/tools/test_add_text_widget.py
@@ -1,0 +1,31 @@
+"""Unit tests for add_text_widget's pure helpers."""
+
+from src.agent.tools.add_text_widget import _normalize_text, _widget_config
+
+
+class TestNormalizeText:
+    def test_plain_text_passes_through(self):
+        assert _normalize_text("A note.") == "A note."
+
+    def test_surrounding_whitespace_stripped(self):
+        assert _normalize_text("  A note. \n") == "A note."
+
+    def test_empty_string_is_none(self):
+        assert _normalize_text("") is None
+
+    def test_none_is_none(self):
+        assert _normalize_text(None) is None
+
+    def test_whitespace_only_is_none(self):
+        assert _normalize_text("   \n\t ") is None
+
+    def test_multiline_markdown_preserved(self):
+        markdown = "# Title\n\n- one\n- two"
+        assert _normalize_text(f"\n{markdown}\n") == markdown
+
+
+class TestWidgetConfig:
+    def test_exact_shape(self):
+        # The REST validator (validate_text_config) requires config.text to
+        # be a string; the agent path must produce exactly that shape.
+        assert _widget_config("# Note") == {"text": "# Note"}

--- a/tests/unit/agent/tools/test_edit_text_widget.py
+++ b/tests/unit/agent/tools/test_edit_text_widget.py
@@ -1,0 +1,76 @@
+"""Unit tests for edit_text_widget's pure helpers."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from src.agent.tools.edit_text_widget import _excerpt, _select_text_widget
+
+
+def _widget(widget_type="text", text="A note."):
+    config = {"text": text} if widget_type == "text" else {}
+    return SimpleNamespace(id=uuid4(), widget_type=widget_type, config=config)
+
+
+class TestSelectTextWidget:
+    def test_empty_list_is_error(self):
+        widget, message = _select_text_widget([])
+        assert widget is None
+        assert "No text widget" in message
+
+    def test_only_non_text_widgets_is_error(self):
+        widgets = [_widget("insight"), _widget("map")]
+        widget, message = _select_text_widget(widgets)
+        assert widget is None
+        assert "No text widget" in message
+
+    def test_single_text_widget_returned(self):
+        only = _widget()
+        widget, message = _select_text_widget([only])
+        assert widget is only
+        assert message is None
+
+    def test_multiple_text_widgets_lists_all_candidates(self):
+        first = _widget(text="First note.")
+        second = _widget(text="Second note.")
+        widget, message = _select_text_widget([first, second])
+        assert widget is None
+        assert "pass widget_id" in message
+        for candidate in (first, second):
+            assert str(candidate.id) in message
+            assert candidate.config["text"] in message
+
+    def test_mixed_list_picks_the_text_widget(self):
+        note = _widget()
+        widgets = [_widget("insight"), note, _widget("map")]
+        widget, message = _select_text_widget(widgets)
+        assert widget is note
+        assert message is None
+
+    def test_text_widget_without_config_still_selectable(self):
+        # Defensive: a text widget whose config lost its body should still
+        # be the edit target (the edit replaces the body anyway).
+        bare = SimpleNamespace(id=uuid4(), widget_type="text", config=None)
+        widget, message = _select_text_widget([bare])
+        assert widget is bare
+        assert message is None
+
+
+class TestExcerpt:
+    def test_short_text_unchanged(self):
+        assert _excerpt("A short note.") == "A short note."
+
+    def test_long_text_truncated_with_ellipsis(self):
+        long_text = "x" * 100
+        result = _excerpt(long_text, max_chars=60)
+        assert result == "x" * 60 + "…"
+
+    def test_exact_limit_not_truncated(self):
+        text = "x" * 60
+        assert _excerpt(text, max_chars=60) == text
+
+    def test_whitespace_stripped_before_truncation(self):
+        assert _excerpt("  padded  ") == "padded"
+
+    def test_empty_and_none_are_empty(self):
+        assert _excerpt("") == ""
+        assert _excerpt(None) == ""

--- a/tests/unit/api/repositories/test_dashboard_writer.py
+++ b/tests/unit/api/repositories/test_dashboard_writer.py
@@ -49,6 +49,9 @@ class TestMalformedIdsAreNotFound:
             is None
         )
 
+    async def test_get_widget(self, bad):
+        assert await dashboard_writer.get_widget(bad) is None
+
     async def test_update_widget(self, bad):
         assert await dashboard_writer.update_widget(bad, position=1) is False
 

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.8"
+version = "2026.7.13"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Text widgets (`widget_type="text"`, markdown in `config.text`) already exist end-to-end via REST, but the agent had no way to create them. This adds the agent path with two new experimental primitives, following the same pattern as the other dashboard tools (resolve dashboard → owner check → write → `dashboard_updated` signal):

- **`add_text_widget(text, dashboard_id?, position?)`** — composes a markdown note onto a dashboard. Config is exactly `{"text": ...}`, the shape `validate_text_config` enforces on the REST path. The success reply surfaces the new widget id so the agent can reference it for later edits. No `title` parameter — headings go in the markdown, per the frontend contract.
- **`edit_text_widget(text, widget_id?, dashboard_id?)`** — replaces the full markdown body of an existing text widget. Without a `widget_id` it targets the resolved dashboard's only text widget; with several, the error lists each candidate's id plus an excerpt so the model can retry with an explicit id. With a `widget_id`, ownership is checked against the widget's own dashboard, and non-text widgets are rejected.

Supporting changes:

- New `dashboard_writer.get_widget(widget_id)` lookup (malformed id → `None`, matching module conventions), needed for the ownership check on explicit widget ids.
- Both SPECs registered in `EXPERIMENTAL_SPECS`, so the tools ship behind the `experimental` feature flag like the other dashboard primitives.

## Test plan

- [x] Unit tests per helper (no DB): `_normalize_text`, `_widget_config`, `_select_text_widget`, `_excerpt` in `tests/unit/agent/tools/`
- [x] `get_widget`: malformed-id contract in the writer unit tests; found/unknown-UUID round-trip in `tests/agent/test_dashboards_db.py`
- [x] Tool-level tests (`tests/agent/test_add_text_widget.py`, `test_edit_text_widget.py`): happy paths, empty text, dashboard resolution fallbacks (state / view_context), owner-only denial, ambiguity, non-text widget, mid-write disappearance
- [x] `ruff check` / `ruff format` clean; full unit suite (375 tests) passes
- [x] Manual smoke test via CLI: `uv run python src/agent/cli.py -i --ff experimental` — create dashboard, add note, edit note
