### PR TITLE
Persist mosaic build metadata in an S3 sidecar and report observed cloud cover

### DIFF
--- a/src/agent/models.py
+++ b/src/agent/models.py
@@ -29,6 +29,13 @@ class ImageryState(BaseModel):
     )
     window_days: int = Field(..., description="Search window in days")
     max_cloud_cover: int = Field(..., description="Max cloud cover percentage")
+    mean_cloud_cover: Optional[float] = Field(
+        None,
+        description=(
+            "Observed mean cloud cover across the mosaic's scenes, percent "
+            "(None when the cached mosaic predates the metadata sidecar)"
+        ),
+    )
     aoi_names: list[str] = Field(
         ..., description="Names of selected areas of interest"
     )

--- a/src/agent/tools/add_map_widget.py
+++ b/src/agent/tools/add_map_widget.py
@@ -42,6 +42,7 @@ _IMAGERY_KEYS = (
     "target_date",
     "window_days",
     "max_cloud_cover",
+    "mean_cloud_cover",
     "aoi_names",
 )
 

--- a/src/agent/tools/show_imagery.py
+++ b/src/agent/tools/show_imagery.py
@@ -146,6 +146,7 @@ async def show_imagery(
         target_date=recipe.target_date.isoformat(),
         window_days=recipe.window_days,
         max_cloud_cover=recipe.max_cloud_cover,
+        mean_cloud_cover=result.mean_cloud_cover,
         aoi_names=aoi_names,
     )
 

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -9,11 +9,14 @@ from pydantic import BaseModel
 class MosaicCreateResponse(BaseModel):
     """Response model for mosaic creation endpoint.
 
-    item_count / date_start / date_end are absent on a cache hit, where the
-    mosaic is served from S3 without rerunning the (build-time) STAC search.
+    The build-time stats are served from the metadata sidecar on a cache
+    hit; they are absent only for mosaics written before the sidecar
+    existed. mean_cloud_cover is the observed mean across the mosaic's
+    scenes, not the search threshold.
     """
 
     mosaic_id: str
     item_count: Optional[int] = None
     date_start: Optional[date] = None
     date_end: Optional[date] = None
+    mean_cloud_cover: Optional[float] = None

--- a/src/api/routers/mosaic.py
+++ b/src/api/routers/mosaic.py
@@ -73,4 +73,5 @@ async def create_mosaic(
         item_count=result.item_count,
         date_start=result.date_start,
         date_end=result.date_end,
+        mean_cloud_cover=result.mean_cloud_cover,
     )

--- a/src/api/services/mosaic.py
+++ b/src/api/services/mosaic.py
@@ -10,9 +10,10 @@ date, search parameters). Tiles are served by the GFW tiles service at
 https://tiles.globalforestwatch.org, which reads the MosaicJSON from S3.
 
 Before building, we check S3 for the mosaic object: if it already exists we
-skip the (expensive) STAC search, build and upload. The scene count and
-acquired date range are only known at build time and are not persisted, so a
-cache hit returns without them.
+skip the (expensive) STAC search, build and upload. The build-time stats
+(scene count, acquired date range, mean cloud cover) are persisted in a
+metadata sidecar object next to the mosaic, so a cache hit serves them too;
+mosaics written before the sidecar existed serve without them.
 """
 
 import base64
@@ -85,6 +86,11 @@ def _s3_key(token: str) -> str:
     return f"{SharedSettings.mosaic_s3_prefix.strip('/')}/{token}.json"
 
 
+def _meta_key(token: str) -> str:
+    """Key of the build-metadata sidecar written next to the mosaic."""
+    return f"{SharedSettings.mosaic_s3_prefix.strip('/')}/{token}.meta.json"
+
+
 def _s3_uri(token: str) -> str:
     return f"s3://{SharedSettings.mosaic_s3_bucket}/{_s3_key(token)}"
 
@@ -138,6 +144,63 @@ def _write_mosaic(token: str, mosaic: MosaicJSON) -> None:
     logger.info("Mosaic uploaded to S3", bucket=bucket, key=_s3_key(token))
 
 
+def _write_metadata(token: str, meta: dict) -> None:
+    """Upload the build-metadata sidecar to S3. Best-effort: the mosaic is
+    already valid without it, so a failure is logged, not raised — cache hits
+    then simply serve without the build-time stats."""
+    try:
+        _s3_client().put_object(
+            Bucket=SharedSettings.mosaic_s3_bucket,
+            Key=_meta_key(token),
+            Body=json.dumps(meta).encode("utf-8"),
+            ContentType="application/json",
+        )
+    except ClientError as e:
+        logger.error(
+            "Mosaic metadata upload failed",
+            bucket=SharedSettings.mosaic_s3_bucket,
+            key=_meta_key(token),
+            error_code=e.response["Error"]["Code"],
+            error=str(e),
+        )
+
+
+def _read_metadata(token: str) -> Optional[dict]:
+    """Read and parse the build-metadata sidecar for a cached mosaic.
+
+    Returns the MosaicResult stat fields, or None when the sidecar is absent
+    (mosaics written before it existed), unreadable or malformed — a cache
+    hit then degrades to serving without the build-time stats.
+    """
+    try:
+        response = _s3_client().get_object(
+            Bucket=SharedSettings.mosaic_s3_bucket, Key=_meta_key(token)
+        )
+        raw = json.loads(response["Body"].read())
+        mean = raw.get("mean_cloud_cover")
+        return {
+            "item_count": int(raw["item_count"]),
+            "date_start": date.fromisoformat(raw["date_start"]),
+            "date_end": date.fromisoformat(raw["date_end"]),
+            "mean_cloud_cover": float(mean) if mean is not None else None,
+        }
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code not in ("NoSuchKey", "404", "NotFound"):
+            logger.warning(
+                "Mosaic metadata read failed",
+                key=_meta_key(token),
+                error_code=code,
+                error=str(e),
+            )
+        return None
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+        logger.warning(
+            "Mosaic metadata malformed", key=_meta_key(token), error=str(e)
+        )
+        return None
+
+
 @dataclass(frozen=True)
 class MosaicRecipe:
     """Everything needed to (re)build a mosaic deterministically.
@@ -157,12 +220,16 @@ class MosaicRecipe:
 
 @dataclass
 class MosaicResult:
-    # item_count / date_start / date_end are only known when the mosaic is
-    # built; on a cache hit (mosaic already in S3) they are None.
+    # The build-time stats are computed when the mosaic is built and served
+    # from the metadata sidecar on a cache hit; they are None only for
+    # mosaics written before the sidecar existed (or when it is unreadable).
+    # mean_cloud_cover is the observed mean across the mosaic's scenes —
+    # distinct from the recipe's max_cloud_cover search filter.
     mosaic_id: str
     item_count: Optional[int] = None
     date_start: Optional[date] = None
     date_end: Optional[date] = None
+    mean_cloud_cover: Optional[float] = None
 
     @property
     def tile_url(self) -> str:
@@ -239,8 +306,9 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
     """Build the mosaic for a recipe and persist it to S3.
 
     If a mosaic for this recipe already exists in S3, the STAC search, build
-    and upload are skipped; the returned result then carries no item_count or
-    date range (those are only known at build time and are not persisted).
+    and upload are skipped; the build-time stats (item_count, date range,
+    mean cloud cover) are then served from the metadata sidecar — or omitted
+    for mosaics written before the sidecar existed.
 
     Raises MosaicNotFoundError (AOI geometry gone), AoiTooLargeError,
     StacSearchError or NoScenesFoundError.
@@ -254,10 +322,10 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
     token = encode_recipe(recipe)
 
     # S3-based lookup: if the mosaic already exists, serve it without
-    # rebuilding. The scene count and date range are not persisted, so a
-    # cache hit returns without them.
+    # rebuilding, with the build-time stats from the metadata sidecar.
     if await run_in_threadpool(_mosaic_exists, token):
-        return MosaicResult(mosaic_id=token)
+        meta = await run_in_threadpool(_read_metadata, token)
+        return MosaicResult(mosaic_id=token, **(meta or {}))
 
     geometry = await _load_geometry(recipe)
     check_aoi_area(geometry)
@@ -330,7 +398,32 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
     date_start = min(item_dates)
     date_end = max(item_dates)
 
+    # Observed cloud cover across the mosaic's scenes — what the imagery
+    # actually looks like, as opposed to the recipe's search threshold.
+    cloud_values = [
+        cover
+        for cover in (item.properties.get("eo:cloud_cover") for item in items)
+        if isinstance(cover, (int, float))
+    ]
+    mean_cloud_cover = (
+        round(sum(cloud_values) / len(cloud_values), 1)
+        if cloud_values
+        else None
+    )
+
     await run_in_threadpool(_write_mosaic, token, mosaic)
+    # Sidecar written after the mosaic (the mosaic object is the cache
+    # marker); a concurrent hit in that window degrades to a bare result.
+    await run_in_threadpool(
+        _write_metadata,
+        token,
+        {
+            "item_count": len(items),
+            "date_start": date_start.isoformat(),
+            "date_end": date_end.isoformat(),
+            "mean_cloud_cover": mean_cloud_cover,
+        },
+    )
     logger.info(
         "Mosaic created",
         item_count=len(items),
@@ -342,4 +435,5 @@ async def create_sentinel2_mosaic(recipe: MosaicRecipe) -> MosaicResult:
         item_count=len(items),
         date_start=date_start,
         date_end=date_end,
+        mean_cloud_cover=mean_cloud_cover,
     )

--- a/tests/agent/test_add_map_widget.py
+++ b/tests/agent/test_add_map_widget.py
@@ -64,6 +64,7 @@ def _imagery_state():
         "target_date": "2024-06-01",
         "window_days": 7,
         "max_cloud_cover": 20,
+        "mean_cloud_cover": 8.5,
         "aoi_names": ["Paraná"],
     }
 

--- a/tests/agent/test_show_imagery.py
+++ b/tests/agent/test_show_imagery.py
@@ -50,6 +50,7 @@ async def test_show_imagery_success():
         item_count=4,
         date_start=date(2025, 5, 20),
         date_end=date(2025, 6, 10),
+        mean_cloud_cover=7.5,
     )
 
     with _patch_create(return_value=result) as mock_create:
@@ -70,6 +71,7 @@ async def test_show_imagery_success():
     assert imagery["target_date"] == "2025-06-01"
     assert imagery["window_days"] == 7
     assert imagery["max_cloud_cover"] == 20
+    assert imagery["mean_cloud_cover"] == 7.5
     assert imagery["aoi_names"] == ["Zurich"]
     assert "4 scenes" in _messages(command)[0].content
 

--- a/tests/api/test_mosaic.py
+++ b/tests/api/test_mosaic.py
@@ -17,6 +17,7 @@ from src.api.services.mosaic import (
     MosaicRecipe,
     MosaicResult,
     NoScenesFoundError,
+    _meta_key,
     _s3_key,
     _s3_uri,
     check_aoi_area,
@@ -209,6 +210,7 @@ async def test_create_mosaic_orders_scenes_by_date_proximity(fake_s3):
     assert result.item_count == 2
     assert result.date_start == date(2025, 5, 1)
     assert result.date_end == date(2025, 6, 14)
+    assert result.mean_cloud_cover == 7.5
 
     # The mosaic is persisted to S3.
     assert _s3_key(result.mosaic_id) in fake_s3.store
@@ -223,26 +225,77 @@ async def test_create_mosaic_orders_scenes_by_date_proximity(fake_s3):
 @pytest.mark.asyncio
 async def test_create_mosaic_skips_when_exists(fake_s3):
     """A second build for the same recipe finds the mosaic in S3 and skips
-    geometry load, STAC search and upload."""
+    geometry load, STAC search and upload; the build-time stats are served
+    from the metadata sidecar written next to the mosaic."""
     item = FakeItem(date(2025, 6, 1), 3.0, "https://example.com/a.tif")
     with _patch_geometry(), _patch_search([item]):
         first = await create_sentinel2_mosaic(RECIPE)
 
-    # The mosaic object itself is the cache marker (S3 puts are atomic).
+    # The mosaic object itself is the cache marker (S3 puts are atomic);
+    # the sidecar carries the build-time stats.
     assert _s3_key(first.mosaic_id) in fake_s3.store
+    assert _meta_key(first.mosaic_id) in fake_s3.store
 
     with _patch_geometry() as geo, _patch_search([item]) as search:
         second = await create_sentinel2_mosaic(RECIPE)
 
     assert second.mosaic_id == first.mosaic_id
-    # The scene count and date range are only known at build time, so a cache
-    # hit returns without them.
-    assert second.item_count is None
-    assert second.date_start is None
-    assert second.date_end is None
+    assert second.item_count == 1
+    assert second.date_start == date(2025, 6, 1)
+    assert second.date_end == date(2025, 6, 1)
+    assert second.mean_cloud_cover == 3.0
     # On a hit we return without loading geometry, searching STAC or uploading.
     geo.assert_not_called()
     search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_without_sidecar_returns_bare_result(fake_s3):
+    """Mosaics written before the sidecar existed still serve — without the
+    build-time stats, as before."""
+    item = FakeItem(date(2025, 6, 1), 3.0, "https://example.com/a.tif")
+    with _patch_geometry(), _patch_search([item]):
+        first = await create_sentinel2_mosaic(RECIPE)
+
+    del fake_s3.store[_meta_key(first.mosaic_id)]
+
+    with _patch_geometry(), _patch_search([item]):
+        second = await create_sentinel2_mosaic(RECIPE)
+
+    assert second.mosaic_id == first.mosaic_id
+    assert second.item_count is None
+    assert second.date_start is None
+    assert second.date_end is None
+    assert second.mean_cloud_cover is None
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_with_corrupt_sidecar_returns_bare_result(fake_s3):
+    item = FakeItem(date(2025, 6, 1), 3.0, "https://example.com/a.tif")
+    with _patch_geometry(), _patch_search([item]):
+        first = await create_sentinel2_mosaic(RECIPE)
+
+    fake_s3.store[_meta_key(first.mosaic_id)] = b"not json"
+
+    with _patch_geometry(), _patch_search([item]):
+        second = await create_sentinel2_mosaic(RECIPE)
+
+    assert second.mosaic_id == first.mosaic_id
+    assert second.item_count is None
+    assert second.mean_cloud_cover is None
+
+
+@pytest.mark.asyncio
+async def test_mean_cloud_cover_ignores_items_without_the_property():
+    with_cover = FakeItem(date(2025, 6, 1), 8.0, "https://example.com/a.tif")
+    without = FakeItem(date(2025, 6, 2), 0.0, "https://example.com/b.tif")
+    del without.properties["eo:cloud_cover"]
+
+    with _patch_geometry(), _patch_search([with_cover, without]):
+        result = await create_sentinel2_mosaic(RECIPE)
+
+    assert result.item_count == 2
+    assert result.mean_cloud_cover == 8.0
 
 
 def test_mosaic_result_urls():
@@ -321,6 +374,7 @@ async def test_create_mosaic_success_and_idempotent(
     body = response.json()
     assert body["item_count"] == 1
     assert body["date_start"] == "2025-06-01"
+    assert body["mean_cloud_cover"] == 3.0
 
     # The mosaic is persisted to S3, where the tiler reads it from.
     assert _s3_key(body["mosaic_id"]) in fake_s3.store
@@ -335,9 +389,10 @@ async def test_create_mosaic_success_and_idempotent(
     assert response.status_code == 200
     cached = response.json()
     assert cached["mosaic_id"] == body["mosaic_id"]
-    # The cache hit serves the mosaic without the build-time stats.
-    assert cached["item_count"] is None
-    assert cached["date_start"] is None
-    assert cached["date_end"] is None
+    # The cache hit serves the build-time stats from the metadata sidecar.
+    assert cached["item_count"] == 1
+    assert cached["date_start"] == "2025-06-01"
+    assert cached["date_end"] == "2025-06-01"
+    assert cached["mean_cloud_cover"] == 3.0
     geo.assert_not_called()
     search.assert_not_called()


### PR DESCRIPTION
## Summary

A few changes to support the FE. `create_sentinel2_mosaic` computes the scene count and acquired date range at build time but never persists them, so any cache hit (mosaic already in S3) returns a bare `MosaicResult`. Downstream that means:

- `show_imagery` reports "imagery layer created" without scene/date context on reruns of the same recipe, and
- `add_map_widget` snapshots an `ImageryState` with `item_count` / `date_start` / `date_end` as `null` **permanently** into the dashboard widget config — the frontend's imagery legend (wri/project-zeno-next#593) then has nothing to show for the most useful fields.

### Changes

1. **Metadata sidecar** — the build now writes `{token}.meta.json` next to the MosaicJSON with `item_count`, `date_start`, `date_end` and `mean_cloud_cover`. Cache hits read it back, so the build-time stats survive. Degradation is explicit and safe:
   - sidecar absent (mosaics written before this change) → bare result, exactly as today
   - sidecar unreadable or malformed → bare result + warning log, never an error
   - sidecar write failure → logged, not raised (the mosaic itself is unaffected)
   - The mosaic object remains the cache marker; the sidecar is written after it, so a concurrent hit in that window just degrades to a bare result.

2. **Observed cloud cover** — the mean `eo:cloud_cover` across the mosaic's scenes is now computed at build time and threaded through `MosaicResult`, the `/mosaic/create` response, `ImageryState` and `_IMAGERY_KEYS`. This is what the imagery *actually looks like*, as opposed to the recipe's `max_cloud_cover` search threshold, which is all the frontend can currently display ("< 20%").

No changes to recipe tokens, S3 keys of existing mosaics, or the tiler contract.

## Test plan

- [x] `tests/api/test_mosaic.py`: cache hit serves sidecar metadata; missing sidecar → bare result (backwards compat); corrupt sidecar → bare result; mean cloud cover computed and items without `eo:cloud_cover` ignored; endpoint returns metadata on both build and cache hit
- [x] `tests/agent/test_show_imagery.py` / `test_add_map_widget.py`: `mean_cloud_cover` carried in `ImageryState` and the widget config snapshot
- [x] Full `tests/api tests/cli tests/unit tests/agent` run locally: 723 passed; the 7 failures are pre-existing on `main` (agent LLM tests needing API keys, and PostGIS-dependent `test_aois` in my local DB) — verified by running them on a clean `main` checkout
- [x] `ruff check` / `ruff format --check` clean on touched files
- [ ] Verify on staging that a `show_imagery` rerun of a cached recipe now reports scene count/date range