### PR TITLE
Make explicit profile creation by extending base & adding skills + tools

### DIFF
--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -1,23 +1,42 @@
-"""Agent configurations: which skills (and prompt) load per feature flag.
+"""Agent configurations: which skills and tools (and prompt) load per feature flag.
 
-An ``AgentConfig`` declares its capability surface as a tuple of *skill
-names*; the tools those skills ``require:`` are derived from ``ALL_SPECS``,
-so a profile can never advertise a skill whose tools aren't bound — and,
-conversely, adding a tool can never silently activate an unintended skill.
-Tools useful on their own (not part of any skill's workflow) go in
-``extra_tools``. An optional ``system_prompt`` override replaces the
-generated prompt entirely — useful for testing or bespoke agents.
+Profiles form a chain, each one a small delta on its parent:
 
-Configs are held in an ``AgentConfigRegistry``. The module-level
-``default_registry`` is used in production; tests create isolated instances
-and inject them, keeping global state clean.
+    base         — the core toolbox (pick_aoi, pick_dataset, pull_data,
+                   generate_insights), no skills. Ships on its own so raw
+                   tool-calling can be evaluated without recipe guidance.
+    default      — base + the core skills (analyze, pull-data, capabilities).
+    experimental — default + opt-in skills and standalone tools.
+
+An ``AgentConfig`` declares three things:
+
+- ``extends`` — the parent profile whose skills and tools it inherits.
+- ``skills`` — skill names this profile adds. The tools those skills
+  ``require:`` are derived from ``ALL_SPECS``, so a profile can never
+  advertise a skill whose tools aren't bound — and, conversely, adding a
+  tool can never silently activate an unintended skill.
+- ``tools`` — specs bound directly, independent of any skill: the base
+  profile's core toolbox, or standalone extras no skill's workflow owns.
+
+A skill's ``requires:`` stays a complete list of what its workflow calls,
+even when the parent profile already binds those tools — the overlap
+dedupes, and the skill stays portable to profiles built on a leaner base.
+
+An optional ``system_prompt`` override replaces the generated prompt
+entirely — useful for testing or bespoke agents.
+
+Configs are held in an ``AgentConfigRegistry``, which flattens ``extends``
+at registration time. The module-level ``default_registry`` is used in
+production; tests create isolated instances and inject them, keeping global
+state clean.
 
 To expose a new skill behind a feature flag, register a new ``AgentConfig``
-in ``default_registry`` with the flag name (and add any new tools' specs to
-``ALL_SPECS``).
+in ``default_registry`` that extends an existing profile (and add any new
+tools' specs to ``ALL_SPECS``). Each production profile's full derived
+surface is snapshot-tested in ``tests/unit/agent/test_profile_manifest.py``.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Optional
 
 from langchain_core.tools import BaseTool
@@ -65,34 +84,48 @@ ALL_SPECS = (
 )
 _SPEC_BY_NAME = {s.tool.name: s for s in ALL_SPECS}
 
+# The core toolbox every profile builds on: resolve an AOI, pick a dataset,
+# pull data, generate insights.
+BASE_PROFILE = "base"
+CORE_TOOLS = (
+    pick_aoi_spec,
+    pick_dataset_spec,
+    pull_data_spec,
+    generate_insights_spec,
+)
+
+# The core skills layered on the base toolbox.
 DEFAULT_PROFILE = "default"
 DEFAULT_SKILLS = ("analyze", "pull-data", "capabilities")
 
-# Experimental, opt-in skills/tools layered on top of the default set.
+# Experimental, opt-in additions over the default profile.
 EXPERIMENTAL_PROFILE = "experimental"
-EXPERIMENTAL_SKILLS = (
-    *DEFAULT_SKILLS,
-    "dashboard",
-    "show-imagery",
-    "wri-insights",
-    "explore",
+EXPERIMENTAL_SKILLS = ("dashboard", "show-imagery", "wri-insights", "explore")
+EXPERIMENTAL_TOOLS = (
+    inspect_view_context_spec,
+    update_insight_display_spec,
+    search_insights_spec,
 )
 
 
 @dataclass(frozen=True)
 class AgentConfig:
-    """A named agent configuration: declared skills and an optional prompt.
+    """A named agent configuration: a parent to extend, declared skills,
+    directly-bound tools, and an optional prompt.
 
-    ``skills`` is the capability surface; the tools those skills require are
-    derived (see ``specs``). ``extra_tools`` holds specs not tied to any
-    skill's workflow. ``system_prompt`` overrides the generated prompt when
-    set — useful for testing or bespoke agents with a fixed persona and no
-    tools.
+    ``extends`` names a parent profile; the registry merges the parent's
+    skills and tools into this config at registration time. ``skills`` is
+    the capability surface this profile adds; the tools those skills require
+    are derived (see ``specs``). ``tools`` holds specs bound directly,
+    independent of any skill. ``system_prompt`` overrides the generated
+    prompt when set — useful for testing or bespoke agents with a fixed
+    persona and no tools.
     """
 
     name: str
+    extends: Optional[str] = None
     skills: tuple[str, ...] = ()
-    extra_tools: tuple[ToolSpec, ...] = ()
+    tools: tuple[ToolSpec, ...] = ()
     system_prompt: Optional[str] = field(default=None)
 
     def __post_init__(self) -> None:
@@ -113,9 +146,9 @@ class AgentConfig:
 
     @property
     def specs(self) -> tuple[ToolSpec, ...]:
-        """The profile's tool specs: the union of its skills' ``requires``
-        (plus ``read_skill`` when any skill is declared) and ``extra_tools``,
-        in canonical ``ALL_SPECS`` order."""
+        """The profile's tool specs: the directly-bound ``tools`` plus the
+        union of its skills' ``requires`` (and ``read_skill`` when any skill
+        is declared), in canonical ``ALL_SPECS`` order."""
         names = {
             tool_name
             for skill_name in self.skills
@@ -123,14 +156,14 @@ class AgentConfig:
         }
         if self.skills:
             names.add(read_skill_spec.tool.name)
-        names.update(s.tool.name for s in self.extra_tools)
+        names.update(s.tool.name for s in self.tools)
         derived = tuple(s for s in ALL_SPECS if s.tool.name in names)
         unregistered = tuple(
-            s for s in self.extra_tools if s.tool.name not in _SPEC_BY_NAME
+            s for s in self.tools if s.tool.name not in _SPEC_BY_NAME
         )
         return derived + unregistered
 
-    def tools(self) -> list[BaseTool]:
+    def bound_tools(self) -> list[BaseTool]:
         return [s.tool for s in self.specs]
 
     def tool_descriptions(self) -> str:
@@ -159,6 +192,78 @@ class AgentConfig:
             tools=self.tool_names(),
         )
 
+    def describe(self) -> str:
+        """A plain-text manifest of everything this profile can do, grouped
+        by layer: skills (recipes loaded on demand), subagents (tools that
+        run their own reasoning), and primitive tools.
+
+        Profiles declare deltas (``extends`` plus their own skills/tools),
+        so the full bound surface is not visible at the declaration site —
+        this renders it in one place. Snapshot-tested per production profile
+        in ``tests/unit/agent/test_profile_manifest.py``.
+        """
+        lines = [f"profile: {self.name}"]
+        if self.extends is not None:
+            lines.append(f"extends: {self.extends}")
+
+        def section(title: str, entries: list[str]) -> None:
+            lines.append(f"{title}:")
+            if entries:
+                lines.extend(f"  - {entry}" for entry in entries)
+            else:
+                lines.append("  (none)")
+
+        skill_entries = []
+        for skill in self.skill_metas():
+            if skill.requires:
+                skill_entries.append(
+                    f"{skill.name} (requires: {', '.join(skill.requires)})"
+                )
+            else:
+                skill_entries.append(skill.name)
+        section("skills", skill_entries)
+        section(
+            "subagents",
+            [
+                s.tool.name
+                for s in self.specs
+                if s.category is ToolCategory.SUBAGENT
+            ],
+        )
+        section(
+            "tools",
+            [
+                s.tool.name
+                for s in self.specs
+                if s.category is ToolCategory.PRIMITIVE
+            ],
+        )
+        return "\n".join(lines)
+
+
+def _merge_skills(
+    parent: tuple[str, ...], child: tuple[str, ...]
+) -> tuple[str, ...]:
+    """Parent's skills first, then the child's new ones; no duplicates."""
+    merged = list(parent)
+    for name in child:
+        if name not in merged:
+            merged.append(name)
+    return tuple(merged)
+
+
+def _merge_tools(
+    parent: tuple[ToolSpec, ...], child: tuple[ToolSpec, ...]
+) -> tuple[ToolSpec, ...]:
+    """Parent's tools first, then the child's new ones; deduped by name."""
+    merged = list(parent)
+    seen = {s.tool.name for s in parent}
+    for spec in child:
+        if spec.tool.name not in seen:
+            merged.append(spec)
+            seen.add(spec.tool.name)
+    return tuple(merged)
+
 
 class AgentConfigRegistry:
     """Holds named configs and resolves feature flags to them.
@@ -171,6 +276,25 @@ class AgentConfigRegistry:
         self._configs: dict[str, AgentConfig] = {}
 
     def register(self, config: AgentConfig) -> None:
+        """Store ``config``, flattening its ``extends`` chain first.
+
+        A config that extends another inherits the parent's skills and tools
+        and adds its own; the parent must already be registered. The stored
+        config is fully flattened (the parent it names was flattened when it
+        registered), so lookups never walk the chain.
+        """
+        if config.extends is not None:
+            parent = self._configs.get(config.extends)
+            if parent is None:
+                raise ValueError(
+                    f"profile {config.name!r} extends unknown profile "
+                    f"{config.extends!r}; register the parent first"
+                )
+            config = replace(
+                config,
+                skills=_merge_skills(parent.skills, config.skills),
+                tools=_merge_tools(parent.tools, config.tools),
+            )
         self._configs[config.name] = config
 
     def configs(self) -> tuple[AgentConfig, ...]:
@@ -190,17 +314,22 @@ class AgentConfigRegistry:
         return self._configs[DEFAULT_PROFILE]
 
 
-# Production registry — register new flag configs here.
+# Production registry — register new flag configs here. Each profile is a
+# delta on its parent; parents must be registered before children.
 default_registry = AgentConfigRegistry()
-default_registry.register(AgentConfig(DEFAULT_PROFILE, skills=DEFAULT_SKILLS))
+default_registry.register(AgentConfig(BASE_PROFILE, tools=CORE_TOOLS))
+default_registry.register(
+    AgentConfig(
+        DEFAULT_PROFILE,
+        extends=BASE_PROFILE,
+        skills=DEFAULT_SKILLS,
+    )
+)
 default_registry.register(
     AgentConfig(
         EXPERIMENTAL_PROFILE,
+        extends=DEFAULT_PROFILE,
         skills=EXPERIMENTAL_SKILLS,
-        extra_tools=(
-            inspect_view_context_spec,
-            update_insight_display_spec,
-            search_insights_spec,
-        ),
+        tools=EXPERIMENTAL_TOOLS,
     )
 )

--- a/src/agent/cli.py
+++ b/src/agent/cli.py
@@ -16,6 +16,7 @@ import re
 import sys
 import uuid
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
@@ -30,12 +31,7 @@ from langchain_core.messages import (
 from langgraph.checkpoint.memory import InMemorySaver
 from sqlalchemy import select
 
-from src.agent.agent_config import (
-    DEFAULT_PROFILE,
-    DEFAULT_SKILLS,
-    AgentConfig,
-    default_registry,
-)
+from src.agent.agent_config import default_registry
 from src.agent.graph import (
     close_checkpointer_pool,
     fetch_zeno,
@@ -623,10 +619,10 @@ async def _fetch_agent(
     if ff:
         config = default_registry.resolve(ff)
     else:
-        config = AgentConfig(
-            DEFAULT_PROFILE,
-            skills=DEFAULT_SKILLS,
-            system_prompt=system_prompt,
+        # The production default profile, with only the prompt overridden —
+        # so the CLI always binds the same surface as the server.
+        config = replace(
+            default_registry.resolve(), system_prompt=system_prompt
         )
     if use_postgres:
         return await fetch_zeno(config=config)

--- a/src/agent/docs/feature-flags.md
+++ b/src/agent/docs/feature-flags.md
@@ -2,6 +2,19 @@
 
 Feature flags let you swap the agent's capability surface (skills, and the tools derived from them) and system prompt on a per-request basis without touching the database. A client passes `"ff": "<flag-name>"` in the `POST /api/chat` request body; the server resolves this to a named `AgentConfig` and builds the agent from it.
 
+## The profile chain
+
+Profiles form a chain, each one a small delta on its parent:
+
+```
+base         core toolbox (pick_aoi, pick_dataset, pull_data, generate_insights), no skills
+  └─ default       base + core skills (analyze, pull-data, capabilities)
+       └─ experimental  default + opt-in skills (dashboard, show-imagery, wri-insights, explore)
+                        + standalone tools (inspect_view_context, update_insight_display, search_insights)
+```
+
+`base` ships as its own flag so raw tool-calling can be evaluated without recipe guidance. `default` is what unknown or absent `ff` values fall back to. Each production profile's full derived surface (skills, subagents, tools) is snapshot-tested in `tests/unit/agent/test_profile_manifest.py` — run `config.describe()` to see it, and update the snapshot when you change a profile on purpose.
+
 ## How it works
 
 ```mermaid
@@ -13,8 +26,8 @@ flowchart TD
 
     Registry["AgentConfigRegistry\n.resolve(ff)"]
 
-    DefaultConfig["AgentConfig 'default'\nDEFAULT_SKILLS\nget_prompt(config)"]
-    FlagConfig["AgentConfig 'my-flag'\nDEFAULT_SKILLS + 'my-skill'\nget_prompt(config)"]
+    DefaultConfig["AgentConfig 'default'\nextends 'base' + core skills\nget_prompt(config)"]
+    FlagConfig["AgentConfig 'my-flag'\nextends 'default' + 'my-skill'\nget_prompt(config)"]
 
     Agent["LangGraph agent\ntools + system prompt\nfrom resolved config"]
 
@@ -23,12 +36,15 @@ flowchart TD
     Registry -->|"flag unknown\nor absent"| DefaultConfig --> Agent
 ```
 
-Each `AgentConfig` bundles:
-- **`skills`** — a tuple of skill names (files in `src/agent/skills/skills_md/`); the profile's tools are *derived* from each skill's `requires:` frontmatter (plus `read_skill` itself), so a skill can never be declared without its tools, and adding a tool can never silently activate a skill
-- **`extra_tools`** — a tuple of `ToolSpec` objects for tools that aren't part of any skill's workflow (e.g. `inspect_view_context`)
+Each `AgentConfig` declares:
+- **`extends`** — the parent profile whose skills and tools it inherits; the registry flattens the chain at registration time (parents must be registered first)
+- **`skills`** — skill names this profile adds (files in `src/agent/skills/skills_md/`); the tools those skills require are *derived* from each skill's `requires:` frontmatter (plus `read_skill` itself), so a skill can never be declared without its tools, and adding a tool can never silently activate a skill
+- **`tools`** — `ToolSpec` objects bound directly, independent of any skill: the base profile's core toolbox, or standalone tools no skill's workflow owns (e.g. `inspect_view_context`)
 - **`system_prompt`** — an optional override that replaces the generated prompt entirely (useful for test personas like "say only the word cat")
 
-Declaring an unknown skill name, or a skill whose `requires:` names a tool missing from `ALL_SPECS`, raises at construction time. The system prompt is always `config.system_prompt or get_prompt(config)`. `get_prompt` renders the tools and skills sections from the config automatically, so the prompt can never describe a skill or tool that isn't bound.
+A skill's `requires:` stays a complete list of what its workflow calls, even when the parent profile already binds those tools — the overlap dedupes, and the skill stays portable to profiles built on a leaner base.
+
+Declaring an unknown skill name, a skill whose `requires:` names a tool missing from `ALL_SPECS`, or an `extends` naming an unregistered profile raises at registration time. The system prompt is always `config.system_prompt or get_prompt(config)`. `get_prompt` renders the tools and skills sections from the config automatically, so the prompt can never describe a skill or tool that isn't bound.
 
 ## Adding a new feature flag
 
@@ -56,20 +72,25 @@ Add the spec to `ALL_SPECS` in `agent_config.py` — its position there is its p
 
 ### 2. Wrap it in a skill (usually) and register an `AgentConfig`
 
-If the tool is part of a workflow, write a skill file in `src/agent/skills/skills_md/` that lists it under `requires:`, then declare the skill. Use `extra_tools` only for standalone tools:
+If the tool is part of a workflow, write a skill file in `src/agent/skills/skills_md/` that lists it under `requires:`, then declare the skill in a profile that extends an existing one. Use `tools` only for standalone tools:
 
 ```python
 # src/agent/agent_config.py
 default_registry.register(AgentConfig(
     "my-flag",
-    skills=(*DEFAULT_SKILLS, "my-skill"),
-    extra_tools=(my_standalone_tool_spec,),
+    extends=DEFAULT_PROFILE,
+    skills=("my-skill",),
+    tools=(my_standalone_tool_spec,),
 ))
 ```
 
 The config's `name` is the exact string the client passes as `ff`.
 
-### 3. Use the flag from a client
+### 3. Snapshot the new profile's surface
+
+Add the profile's `describe()` output to `tests/unit/agent/test_profile_manifest.py` — the test suite fails on any registered profile without a snapshot, so the full derived surface is always visible in review.
+
+### 4. Use the flag from a client
 
 ```json
 POST /api/chat
@@ -94,7 +115,7 @@ from langgraph.checkpoint.memory import InMemorySaver
 async def test_my_flag():
     registry = AgentConfigRegistry()
     registry.register(AgentConfig(DEFAULT_PROFILE, skills=DEFAULT_SKILLS))
-    registry.register(AgentConfig("my-flag", skills=(*DEFAULT_SKILLS, "my-skill")))
+    registry.register(AgentConfig("my-flag", extends=DEFAULT_PROFILE, skills=("my-skill",)))
 
     agent = await fetch_zeno(ff="my-flag", registry=registry, checkpointer=InMemorySaver())
     result = await agent.ainvoke(...)

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -78,7 +78,23 @@ def get_prompt(
         f"- {s.name}: {s.description} (use when: {s.when_to_use})"
         for s in config.skill_metas()
     ]
-    skills_block = "\n".join(skill_lines) if skill_lines else "(none)"
+    # A profile without skills (base) binds no read_skill, so the whole
+    # skills section — including the read_skill instruction — is omitted.
+    if skill_lines:
+        skills_section = (
+            "# Skills (multi-step recipes)\n"
+            "\n"
+            'Call read_skill(name) only when a skill\'s "use when" clause '
+            "matches the request — usually one skill, not the whole list.\n"
+            "\n" + "\n".join(skill_lines) + "\n"
+            "\n"
+        )
+        routing_intro = (
+            "Match the request to exactly one skill (above) or one row (below)"
+        )
+    else:
+        skills_section = ""
+        routing_intro = "Match the request to exactly one row below"
     tool_descriptions = config.tool_descriptions()
     available = config.availability()
     surface = prompt_section(page, available)
@@ -97,15 +113,9 @@ Call tools one at a time, never in parallel.
 
 {tool_descriptions}
 
-# Skills (multi-step recipes)
+{skills_section}# Routing
 
-Call read_skill(name) only when a skill's "use when" clause matches the request — usually one skill, not the whole list.
-
-{skills_block}
-
-# Routing
-
-Match the request to exactly one skill (above) or one row (below); do not escalate a dataset / AOI / pull request into a full analysis.
+{routing_intro}; do not escalate a dataset / AOI / pull request into a full analysis.
 
 {routing_block}
 
@@ -284,7 +294,7 @@ async def fetch_zeno(
         checkpointer = await fetch_checkpointer()
     zeno_agent = create_agent(
         model=MODEL,
-        tools=config.tools(),
+        tools=config.bound_tools(),
         state_schema=AgentState,
         system_prompt=config.system_prompt or get_prompt(config, page=page),
         middleware=_build_middleware(),

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -4,6 +4,7 @@ import pytest
 from langchain_core.tools import tool
 
 from src.agent.agent_config import (
+    BASE_PROFILE,
     DEFAULT_PROFILE,
     DEFAULT_SKILLS,
     EXPERIMENTAL_PROFILE,
@@ -34,7 +35,7 @@ FAKE_SPEC = ToolSpec(
 def test_registry_resolves_known_ff():
     registry = AgentConfigRegistry()
     registry.register(AgentConfig("default"))
-    registry.register(AgentConfig("blog", extra_tools=(FAKE_SPEC,)))
+    registry.register(AgentConfig("blog", tools=(FAKE_SPEC,)))
     assert registry.resolve("blog").name == "blog"
 
 
@@ -60,6 +61,62 @@ def test_registry_instances_are_isolated():
 
     assert registry_a.resolve("cat").name == "cat"
     assert registry_b.resolve("cat").name == DEFAULT_PROFILE
+
+
+# --- AgentConfigRegistry: extends --------------------------------------------
+
+
+def test_extends_merges_parent_skills_and_tools():
+    """A child profile is its parent plus its own additions — parent's
+    entries first, duplicates removed."""
+    registry = AgentConfigRegistry()
+    registry.register(AgentConfig("default", tools=(FAKE_SPEC,)))
+    registry.register(
+        AgentConfig("child", extends="default", skills=("capabilities",))
+    )
+    child = registry.resolve("child")
+    assert child.skills == ("capabilities",)
+    assert child.tools == (FAKE_SPEC,)
+
+
+def test_extends_chain_flattens_through_grandparent():
+    registry = AgentConfigRegistry()
+    registry.register(AgentConfig("default", tools=(FAKE_SPEC,)))
+    registry.register(
+        AgentConfig("child", extends="default", skills=("capabilities",))
+    )
+    registry.register(
+        AgentConfig("grandchild", extends="child", skills=("analyze",))
+    )
+    grandchild = registry.resolve("grandchild")
+    assert grandchild.skills == ("capabilities", "analyze")
+    assert grandchild.tools == (FAKE_SPEC,)
+
+
+def test_extends_deduplicates_reinherited_entries():
+    registry = AgentConfigRegistry()
+    registry.register(
+        AgentConfig("default", skills=("capabilities",), tools=(FAKE_SPEC,))
+    )
+    registry.register(
+        AgentConfig(
+            "child",
+            extends="default",
+            skills=("capabilities", "analyze"),
+            tools=(FAKE_SPEC,),
+        )
+    )
+    child = registry.resolve("child")
+    assert child.skills == ("capabilities", "analyze")
+    assert child.tools == (FAKE_SPEC,)
+
+
+def test_extends_unknown_parent_raises():
+    """A child registered before (or without) its parent is a wiring bug —
+    fail loudly instead of silently dropping the inherited surface."""
+    registry = AgentConfigRegistry()
+    with pytest.raises(ValueError, match="extends unknown profile"):
+        registry.register(AgentConfig("child", extends="nope"))
 
 
 # --- AgentConfig: skills-first construction ----------------------------------
@@ -105,11 +162,11 @@ def test_config_derives_tools_from_declared_skills():
 
 def test_config_without_skills_has_no_read_skill():
     """read_skill only rides along when there are skills to read."""
-    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
+    c = AgentConfig("test", tools=(FAKE_SPEC,))
     assert c.tool_names() == frozenset({"_fake_tool"})
 
 
-def test_extra_tools_do_not_activate_skills():
+def test_directly_bound_tools_do_not_activate_skills():
     """The bug this design kills: under tools-first profiles, adding a tool
     could silently activate any skill whose ``requires`` it completed. Now
     the capability surface is exactly what's declared."""
@@ -119,7 +176,7 @@ def test_extra_tools_do_not_activate_skills():
     c = AgentConfig(
         "test",
         skills=("capabilities",),
-        extra_tools=(pick_aoi_spec, show_imagery_spec),
+        tools=(pick_aoi_spec, show_imagery_spec),
     )
     # pick_aoi + show_imagery satisfy show-imagery's requires, but it was
     # never declared — it must not be advertised or counted available.
@@ -127,13 +184,13 @@ def test_extra_tools_do_not_activate_skills():
     assert not c.availability().has_skill("show-imagery")
 
 
-def test_config_tools_returns_bound_tools():
-    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
-    assert _fake_tool in c.tools()
+def test_config_bound_tools_returns_bound_tools():
+    c = AgentConfig("test", tools=(FAKE_SPEC,))
+    assert _fake_tool in c.bound_tools()
 
 
 def test_config_tool_descriptions_includes_bound_tool():
-    c = AgentConfig("test", extra_tools=(FAKE_SPEC,))
+    c = AgentConfig("test", tools=(FAKE_SPEC,))
     assert "_fake_tool" in c.tool_descriptions()
 
 
@@ -166,6 +223,21 @@ def test_declared_skills_always_have_their_tools_bound():
 def test_default_config_advertises_core_skills():
     config = default_registry.resolve(None)
     assert {s.name for s in config.skill_metas()} == set(DEFAULT_SKILLS)
+
+
+def test_base_profile_binds_the_core_toolbox_and_no_skills():
+    """The base profile is the floor every other profile builds on: the four
+    core tools, no skills — and therefore no read_skill."""
+    config = default_registry.resolve(BASE_PROFILE)
+    assert config.skills == ()
+    assert config.tool_names() == frozenset(
+        {
+            "pick_aoi",
+            "pick_dataset",
+            "pull_data",
+            "generate_insights",
+        }
+    )
 
 
 def test_default_profile_derives_exactly_the_core_tools():
@@ -215,7 +287,7 @@ async def test_fetch_zeno_binds_the_resolved_configs_availability():
     registry = AgentConfigRegistry()
     registry.register(AgentConfig("default"))
     registry.register(
-        AgentConfig("fake", skills=("capabilities",), extra_tools=(FAKE_SPEC,))
+        AgentConfig("fake", skills=("capabilities",), tools=(FAKE_SPEC,))
     )
 
     await fetch_zeno(
@@ -233,8 +305,8 @@ def test_experimental_config_adds_experimental_tools_and_skills():
     default = default_registry.resolve(DEFAULT_PROFILE)
     experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
 
-    default_tools = {t.name for t in default.tools()}
-    experimental_tools = {t.name for t in experimental.tools()}
+    default_tools = {t.name for t in default.bound_tools()}
+    experimental_tools = {t.name for t in experimental.bound_tools()}
     assert {"show_imagery", "search_blogs"} & default_tools == set()
     assert {"show_imagery", "search_blogs"} <= experimental_tools
 

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -1,0 +1,98 @@
+"""Snapshot the full derived surface of every production profile.
+
+Profiles declare deltas (``extends`` plus their own skills and tools), so
+the complete bound surface — which subagents and tools a skill pulled in —
+is never visible at the declaration site. These snapshots make it visible
+and reviewable: adding a skill to a profile shows up in the diff as exactly
+the subagents/tools it brought along.
+
+When one of these fails after an intentional change, update the expected
+manifest to the new ``describe()`` output — the point is that the change is
+seen, not that the surface is frozen forever.
+"""
+
+from src.agent.agent_config import (
+    BASE_PROFILE,
+    DEFAULT_PROFILE,
+    EXPERIMENTAL_PROFILE,
+    default_registry,
+)
+
+BASE_MANIFEST = """\
+profile: base
+skills:
+  (none)
+subagents:
+  - pick_aoi
+  - pick_dataset
+  - generate_insights
+tools:
+  - pull_data"""
+
+DEFAULT_MANIFEST = """\
+profile: default
+extends: base
+skills:
+  - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
+  - capabilities
+  - pull-data (requires: pick_aoi, pick_dataset, pull_data)
+subagents:
+  - pick_aoi
+  - pick_dataset
+  - generate_insights
+tools:
+  - pull_data
+  - read_skill"""
+
+EXPERIMENTAL_MANIFEST = """\
+profile: experimental
+extends: default
+skills:
+  - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
+  - capabilities
+  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget)
+  - explore (requires: search_blogs)
+  - pull-data (requires: pick_aoi, pick_dataset, pull_data)
+  - show-imagery (requires: pick_aoi, show_imagery)
+  - wri-insights (requires: search_blogs)
+subagents:
+  - pick_aoi
+  - pick_dataset
+  - generate_insights
+  - search_blogs
+  - update_insight_display
+tools:
+  - pull_data
+  - read_skill
+  - inspect_view_context
+  - show_imagery
+  - search_insights
+  - create_dashboard
+  - add_to_dashboard
+  - add_map_widget"""
+
+
+def test_base_profile_manifest():
+    assert default_registry.resolve(BASE_PROFILE).describe() == BASE_MANIFEST
+
+
+def test_default_profile_manifest():
+    assert (
+        default_registry.resolve(DEFAULT_PROFILE).describe()
+        == DEFAULT_MANIFEST
+    )
+
+
+def test_experimental_profile_manifest():
+    assert (
+        default_registry.resolve(EXPERIMENTAL_PROFILE).describe()
+        == EXPERIMENTAL_MANIFEST
+    )
+
+
+def test_every_production_profile_has_a_manifest_snapshot():
+    """A new profile registered without a snapshot here would ship with an
+    unreviewed surface."""
+    snapshotted = {BASE_PROFILE, DEFAULT_PROFILE, EXPERIMENTAL_PROFILE}
+    registered = {config.name for config in default_registry.configs()}
+    assert registered == snapshotted


### PR DESCRIPTION
Inverts profile definition from tools-first to skills-first, then organizes profiles into an explicit inheritance chain:
```bash
base         → core toolbox (pick_aoi, pick_dataset, pull_data, generate_insights), no skills
default      → base + core skills (analyze, pull-data, capabilities)
experimental → default + opt-in skills (dashboard, show-imagery, wri-insights, explore) + standalone tools
```

- Skills are the source of truth - a profile declares skill names; the tools those skills require: are derived. A skill can never ship without its tools, and adding a tool can never silently activate a skill.
- extends - profiles declare deltas on a parent; the registry flattens the chain at registration time. Unknown parent/skill raises at startup, not at request time.

Notes for reviewers
- `extra_tools` → `tools` (directly-bound, skill-independent); `AgentConfig.tools()` → `bound_tools()`.
