### PR TITLE
Move wri-insights skill (blog search) into default profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.9"
+version = "2026.7.15"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -5,7 +5,8 @@ Profiles form a chain, each one a small delta on its parent:
     base         — the core toolbox (pick_aoi, pick_dataset, pull_data,
                    generate_insights), no skills. Ships on its own so raw
                    tool-calling can be evaluated without recipe guidance.
-    default      — base + the core skills (analyze, pull-data, capabilities).
+    default      — base + the core skills (analyze, pull-data, capabilities,
+                   wri-insights).
     experimental — default + opt-in skills and standalone tools.
 
 An ``AgentConfig`` declares three things:
@@ -96,11 +97,11 @@ CORE_TOOLS = (
 
 # The core skills layered on the base toolbox.
 DEFAULT_PROFILE = "default"
-DEFAULT_SKILLS = ("analyze", "pull-data", "capabilities")
+DEFAULT_SKILLS = ("analyze", "pull-data", "capabilities", "wri-insights")
 
 # Experimental, opt-in additions over the default profile.
 EXPERIMENTAL_PROFILE = "experimental"
-EXPERIMENTAL_SKILLS = ("dashboard", "show-imagery", "wri-insights", "explore")
+EXPERIMENTAL_SKILLS = ("dashboard", "show-imagery", "explore")
 EXPERIMENTAL_TOOLS = (
     inspect_view_context_spec,
     update_insight_display_spec,

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -251,6 +251,7 @@ def test_default_profile_derives_exactly_the_core_tools():
             "pull_data",
             "generate_insights",
             "read_skill",
+            "search_blogs",
         }
     )
 
@@ -299,22 +300,18 @@ async def test_fetch_zeno_binds_the_resolved_configs_availability():
 
 
 def test_experimental_config_adds_experimental_tools_and_skills():
-    """The experimental profile layers show_imagery and search_blogs (and
-    their skills) on top of the default set; the default profile exposes
-    none."""
+    """The experimental profile layers show_imagery (and its skill, plus
+    explore) on top of the default set; the default profile exposes
+    neither."""
     default = default_registry.resolve(DEFAULT_PROFILE)
     experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
 
     default_tools = {t.name for t in default.bound_tools()}
     experimental_tools = {t.name for t in experimental.bound_tools()}
-    assert {"show_imagery", "search_blogs"} & default_tools == set()
+    assert "show_imagery" not in default_tools
     assert {"show_imagery", "search_blogs"} <= experimental_tools
 
     default_skills = {s.name for s in default.skill_metas()}
     experimental_skills = {s.name for s in experimental.skill_metas()}
-    assert {
-        "show-imagery",
-        "explore",
-        "wri-insights",
-    } & default_skills == set()
+    assert {"show-imagery", "explore"} & default_skills == set()
     assert {"show-imagery", "explore", "wri-insights"} <= experimental_skills

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -36,10 +36,12 @@ skills:
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
   - pull-data (requires: pick_aoi, pick_dataset, pull_data)
+  - wri-insights (requires: search_blogs)
 subagents:
   - pick_aoi
   - pick_dataset
   - generate_insights
+  - search_blogs
 tools:
   - pull_data
   - read_skill"""

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.8"
+version = "2026.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Moves the `wri-insights` skill from the experimental profile to the default profile, making blog-post search available to all users.

- The `wri-insights` skill carries the `search_blogs` tool via its `requires:` frontmatter, so the profile machinery derives `search_blogs` into the default profile automatically.
- The `analyze` skill already references `search_blogs` as an optional step ("call after pull, before generate") — that step now actually works in the default profile.
- The experimental profile keeps the same surface via `extends: default`; its manifest snapshot is unchanged.
- The `explore` skill also uses `search_blogs` but is a separate discovery workflow, so it stays experimental.

## Test plan

- Updated the default-profile manifest snapshot (`test_profile_manifest.py`) to include `wri-insights` and the `search_blogs` subagent.
- Updated the pinned default tool set and experimental-delta assertions in `test_feature_flag.py`.
- Full unit suite passes (366 passed).