### PR TITLE
Pass code executor output to InsightTextGenerator to ground narrative in pre-computed totals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.15"
+version = "2026.7.15.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/subagents/analyst/text_generator.py
+++ b/src/agent/subagents/analyst/text_generator.py
@@ -39,6 +39,11 @@ _SYSTEM = """You write the narrative insight for one or two charts that have \
 already been produced from geospatial data. Describe what the data shows — do \
 not invent numbers, and do not redescribe the chart mechanics.
 
+If a total, sum, or other statistic appears in "Pre-computed findings from \
+code execution", cite that figure exactly — do not recompute or re-derive it \
+yourself from the chart data rows. Only compute a figure yourself if it is not \
+already present in the pre-computed findings.
+
 Write a 2-3 sentence `primary_insight` grounded in the numbers, and 1-2 \
 `follow_up_suggestions`.
 
@@ -46,6 +51,9 @@ Write a 2-3 sentence `primary_insight` grounded in the numbers, and 1-2 \
 
 _USER = """## User query
 {query}
+
+## Pre-computed findings from code execution
+{executor_context}
 
 ## Dataset cautions
 {cautions}
@@ -74,6 +82,7 @@ class InsightTextGenerator:
         charts: List[InsightChart],
         dataset: dict,
         query: str = "",
+        executor_context: Optional[str] = None,
         config: Optional[RunnableConfig] = None,
     ) -> InsightText:
         charts_block = "\n".join(
@@ -82,6 +91,7 @@ class InsightTextGenerator:
         inputs = {
             "wording_guide": WORDING_GUIDE,
             "query": query or "(none provided)",
+            "executor_context": executor_context or "(none)",
             "cautions": dataset.get(
                 "cautions", "No specific dataset cautions provided."
             ),

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -31,6 +31,11 @@ from src.shared.request_context import current_user_id
 
 logger = get_logger(__name__)
 
+# Generous cap on the executor-output text forwarded to the text-generator
+# stage — bounds prompt size against a verbose print (e.g. a full df dump)
+# without dropping the pre-computed totals we actually want it grounded in.
+MAX_EXECUTOR_CONTEXT_CHARS = 20_000
+
 
 async def _extract_inline_statistics_data(data: dict) -> dict | None:
     inline_data = data.get("data")
@@ -313,10 +318,12 @@ class Analyst:
         query: str,
         statistics: list[dict],
         dataset: dict,
-    ) -> tuple[Optional[list[InsightChart]], list[dict], Optional[str]]:
+    ) -> tuple[Optional[list[InsightChart]], list[dict], str, Optional[str]]:
         """Build charts via the LLM code executor.
 
-        Returns (charts, encoded_codeact_parts, error_message). On success
+        Returns (charts, encoded_codeact_parts, executor_context, error_message).
+        `executor_context` is the concatenated execution-output text (printed
+        totals, key statistics) for the text-generator stage. On success
         `charts` is non-empty and error is None. On failure `charts` is None and
         a user-facing error message is returned.
         """
@@ -354,12 +361,13 @@ class Analyst:
         )
         if result.error:
             logger.error(f"Code execution error: {result.error}")
-            return None, [], f"Analysis failed: {result.error}"
+            return None, [], "", f"Analysis failed: {result.error}"
         if not result.chart_data:
             logger.error("No chart data generated")
             return (
                 None,
                 [],
+                "",
                 f"Failed to generate chart data. Feedback:{text_output}",
             )
         if result.insight is None or not result.insight.charts:
@@ -367,6 +375,7 @@ class Analyst:
             return (
                 None,
                 [],
+                "",
                 f"Failed to generate chart insight. Feedback:{text_output}",
             )
 
@@ -381,7 +390,20 @@ class Analyst:
             InsightChart.from_chart_insight(chart, result.chart_data, idx)
             for idx, chart in enumerate(result.insight.charts)
         ]
-        return charts, _encode_parts(result.parts), None
+        # Collect execution-output text (printed totals, statistics) so the
+        # text-generator stage can ground its narrative in pre-computed values
+        # instead of re-deriving them from chart rows.
+        executor_context = "\n---\n".join(
+            part.content
+            for part in result.parts
+            if part.type == PartType.EXECUTION_OUTPUT
+        )
+        if len(executor_context) > MAX_EXECUTOR_CONTEXT_CHARS:
+            executor_context = (
+                executor_context[:MAX_EXECUTOR_CONTEXT_CHARS]
+                + "\n...[truncated]"
+            )
+        return charts, _encode_parts(result.parts), executor_context, None
 
     async def analyze(
         self,
@@ -399,7 +421,12 @@ class Analyst:
         )
 
         # STAGE 1: build charts from the pulled data.
-        charts, codeact_parts, error = await self._resolve_charts(
+        (
+            charts,
+            codeact_parts,
+            executor_context,
+            error,
+        ) = await self._resolve_charts(
             query,
             statistics,
             dataset,
@@ -410,7 +437,9 @@ class Analyst:
             )
 
         # STAGE 2: generate insight text from the resolved charts.
-        text = await InsightTextGenerator().generate(charts, dataset, query)
+        text = await InsightTextGenerator().generate(
+            charts, dataset, query, executor_context=executor_context
+        )
         insight = Insight(
             charts=charts,
             primary_insight=text.primary_insight,

--- a/tests/tools/test_generate_insights.py
+++ b/tests/tools/test_generate_insights.py
@@ -77,7 +77,9 @@ def mock_insight_text():
         primary_insight = "Synthetic insight text for tests."
         follow_up_suggestions = ["Follow-up one."]
 
-    async def fake_generate(self, charts, dataset, query="", config=None):
+    async def fake_generate(
+        self, charts, dataset, query="", executor_context=None, config=None
+    ):
         return _Text()
 
     with patch(

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -526,7 +526,9 @@ async def test_generate_insights_persists_statistics_provenance(monkeypatch):
         primary_insight = "Brazil has one unit."
         follow_up_suggestions = ["Compare another area."]
 
-    async def fake_generate(self, charts, dataset, query="", config=None):
+    async def fake_generate(
+        self, charts, dataset, query="", executor_context=None, config=None
+    ):
         return _Text()
 
     monkeypatch.setattr(

--- a/tests/unit/agent/tools/test_insight_text_generator.py
+++ b/tests/unit/agent/tools/test_insight_text_generator.py
@@ -66,6 +66,23 @@ async def test_generate_returns_structured_text(generator):
 
 
 @pytest.mark.asyncio
+async def test_generate_passes_executor_context(generator):
+    gen, fake = generator
+    context = "High total: 1306617.82 ha\nHighest total: 12982.53 ha"
+    await gen.generate(
+        CHARTS, DATASET, query="Loss?", executor_context=context
+    )
+    assert fake.last_inputs["executor_context"] == context
+
+
+@pytest.mark.asyncio
+async def test_generate_defaults_executor_context(generator):
+    gen, fake = generator
+    await gen.generate(CHARTS, DATASET, query="Loss?")
+    assert fake.last_inputs["executor_context"] == "(none)"
+
+
+@pytest.mark.asyncio
 async def test_prompt_includes_cautions_and_presentation(generator):
     gen, fake = generator
     await gen.generate(CHARTS, DATASET, query="Loss in Brazil?")


### PR DESCRIPTION
## Summary

Thread the code executor's printed totals (e.g. `High total: 1306617.82 ha`) into the text generator so the narrative LLM can reference actual pre-computed statistics instead of trying to sum monthly CSV rows itself.

This is a classic "summarization drift" bug: the code executor computed correct totals, the monthly table was correct, but the prose narrative hallucinated `1,147,547.83` instead of `1,306,617.83` because it was forced to do arithmetic on raw chart data it couldn't reliably aggregate.

**Regression likely introduced by #724** (which decoupled narrative generation from the code executor stage).

## Root cause

The pipeline has two independent LLM stages:

| Stage | Model | Input | Output |
|---|---|---|---|
| 1. Code Executor | gemini-3.1-pro | CSV data | Correct totals in stdout (`High total: 1306617.82 ha`) |
| 2. InsightTextGenerator | gemini-3-flash | Chart CSV rows (6 rows) only | Hallucinates total |

The executor's `EXECUTION_OUTPUT` parts (printed totals, statistics) were stored as `codeact_parts` for debugging/trace export but never forwarded to any downstream LLM. `InsightTextGenerator` only saw the 6 rows of monthly chart data and the user query, forcing it to derive totals itself.

## Changes

- **`src/agent/subagents/analyst/text_generator.py`**: Add `executor_context` param and `## Executor findings` section to prompt template. Defaults to `"(none)"` when no context.
- **`src/agent/subagents/analyst/tool.py`**: Collect `EXECUTION_OUTPUT` parts in `_resolve_charts()` and pass them through to the text generator.
- **`tests/unit/agent/tools/test_insight_text_generator.py`**: Add unit tests for executor_context passthrough and default.
- **Integration test mocks**: Update signatures to accept the new kwarg (no behavior change).
