### PR TITLE
Use bundled sgrep model from S3 instead of Hugging Face Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,23 @@ RUN --mount=type=secret,id=aws_access_key_id \
 # image fails at build time rather than on the first search query. The data
 # check is enforced only when a snapshot was pulled (WRI_INSIGHTS_S3_URI set);
 # local builds without it rely on the bind-mounted ./data at runtime.
+#
+# build_index() bundles its own copy of the model into
+# data/insights_index/model/ (see sgrep.py), which travels with the
+# wri-insights S3 snapshot pulled above -- so _index_model() below normally
+# loads it from disk and never touches the Hugging Face Hub. Local builds
+# without a pulled snapshot (and any snapshot predating the bundled model)
+# fall back to the Hub, so a short retry stays as a safety net for that path.
 ENV HF_HOME=/app/.hf-cache
-RUN uv run --no-sync python -c "\
+RUN for i in 1 2 3; do \
+    uv run --no-sync python -c "\
 import os, sys; \
-from src.agent.utils.sgrep import data_status, get_model; \
-get_model(); \
+from src.agent.utils.sgrep import DEFAULT_INDEX_DIR, _index_model, data_status; \
+_index_model(DEFAULT_INDEX_DIR); \
 ok, detail = data_status(min_articles=2000); \
 print(detail); \
-sys.exit(0)"
+sys.exit(0)" && exit 0; \
+    echo "Embedding model check failed (attempt $i/3), retrying in 15s..." >&2; \
+    sleep 15; \
+    done; \
+    exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.15.1"
+version = "2026.7.16"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"


### PR DESCRIPTION
## Summary
- The Docker build's embedding-model verification step called `get_model()` directly, which always fetches `minishlab/potion-retrieval-32M` from the Hugging Face Hub — even though `build_index()` already bundles a copy of the model into `data/insights_index/model/`, which ships as part of the `wri-insights` S3 snapshot the build already pulls.
- Switch to `_index_model()`, the existing helper that prefers the local bundled copy and only falls back to the Hub when it's missing (e.g. local builds without a pulled snapshot). Keeps a short 3-attempt retry as a safety net for that fallback path.
- This removes an unnecessary runtime dependency on huggingface.co availability during CI builds, since the model was already self-hosted in our own S3 bucket.

Fixes https://github.com/wri/project-zeno/actions/runs/29482035395, which failed because huggingface.co was returning 504s at the time.

## Test plan
- [x] Verified `s3://zeno-static-data/wri-insights/latest.tar.gz` already contains `insights_index/model/{config.json,model.safetensors,tokenizer.json,...}`
- [x] Ran a full local `docker build` with the real `WRI_INSIGHTS_S3_URI` snapshot pull + AWS secrets — build succeeds, and the model-check step completes in ~1.9s (vs. 30s+ before hanging/timing out against HF), confirming it loads from the bundled snapshot copy and never contacts Hugging Face