### PR TITLE
Add dashboard_name to the dashboard_updated frontend signal

### DIFF
--- a/src/agent/tools/add_map_widget.py
+++ b/src/agent/tools/add_map_widget.py
@@ -204,6 +204,7 @@ async def add_map_widget(
 
     return dashboard_updated_command(
         dashboard.id,
+        dashboard.name,
         (
             f"Added {layer_type.summary(snapshot)} to dashboard "
             f"'{dashboard.name}' ({dashboard.id})."

--- a/src/agent/tools/add_to_dashboard.py
+++ b/src/agent/tools/add_to_dashboard.py
@@ -139,6 +139,7 @@ async def add_to_dashboard(
 
     return dashboard_updated_command(
         dashboard.id,
+        dashboard.name,
         (
             f"Added insight {target_insight} to dashboard "
             f"'{dashboard.name}' ({dashboard.id}).\n"

--- a/src/agent/tools/common.py
+++ b/src/agent/tools/common.py
@@ -91,10 +91,15 @@ async def load_editable_dashboard(
 
 
 def dashboard_updated_command(
-    dashboard_id, content: str, tool_call_id: Optional[str]
+    dashboard_id,
+    dashboard_name: str,
+    content: str,
+    tool_call_id: Optional[str],
 ) -> Command:
     """Success reply for a dashboard write: pins the dashboard in state and
-    signals the frontend to re-fetch /api/dashboards/{id}."""
+    signals the frontend to re-fetch /api/dashboards/{id}. The name rides
+    along so the frontend can render a link to the dashboard without an
+    extra fetch."""
     return Command(
         update={
             "dashboard_id": str(dashboard_id),
@@ -106,6 +111,7 @@ def dashboard_updated_command(
                     response_metadata={
                         "msg_type": "dashboard_updated",
                         "dashboard_id": str(dashboard_id),
+                        "dashboard_name": dashboard_name,
                     },
                 )
             ],

--- a/src/agent/tools/create_dashboard.py
+++ b/src/agent/tools/create_dashboard.py
@@ -86,6 +86,7 @@ async def create_dashboard(
 
     return dashboard_updated_command(
         dashboard_id,
+        dashboard_name,
         (
             f"Created dashboard '{dashboard_name}' ({dashboard_id}) for "
             f"{aois[0]['name']}. It is empty — use add_to_dashboard to "

--- a/tests/agent/test_add_map_widget.py
+++ b/tests/agent/test_add_map_widget.py
@@ -99,6 +99,7 @@ async def test_add_map_widget_dataset_from_state():
     assert message.response_metadata == {
         "msg_type": "dashboard_updated",
         "dashboard_id": str(dashboard.id),
+        "dashboard_name": dashboard.name,
     }
     assert command.update["dashboard_id"] == str(dashboard.id)
     add_widget_mock.assert_awaited_once()

--- a/tests/agent/test_add_to_dashboard.py
+++ b/tests/agent/test_add_to_dashboard.py
@@ -67,6 +67,7 @@ async def test_add_to_dashboard_defaults_from_state():
     assert message.response_metadata == {
         "msg_type": "dashboard_updated",
         "dashboard_id": str(dashboard.id),
+        "dashboard_name": dashboard.name,
     }
     assert command.update["dashboard_id"] == str(dashboard.id)
     add_widget_mock.assert_awaited_once_with(

--- a/tests/agent/test_create_dashboard.py
+++ b/tests/agent/test_create_dashboard.py
@@ -45,6 +45,7 @@ async def test_create_dashboard_from_state_aoi():
     assert message.response_metadata == {
         "msg_type": "dashboard_updated",
         "dashboard_id": "dash-1",
+        "dashboard_name": "Paraná",
     }
     assert "Paraná" in message.content
 


### PR DESCRIPTION
## What

Adds `dashboard_name` to the `response_metadata` of the `dashboard_updated` ToolMessage emitted by `create_dashboard`, `add_to_dashboard`, and `add_map_widget` (via the shared `dashboard_updated_command` helper).

## Why

The frontend is adding a dashboard navigation card to the chat thread, surfaced when the agent creates or updates a dashboard. The stream already carries `dashboard_id` in `response_metadata`, but the dashboard's name only appears embedded in the tool-message prose. Carrying the name as a structured field lets the FE render the card title without an extra `GET /api/dashboards/{id}` round-trip. Companion FE PR in project-zeno-next.

All three call sites already had the name in hand, so this is metadata-only — no behaviour change for the agent, no new DB reads.

## Testing

- `tests/agent/test_create_dashboard.py`, `test_add_to_dashboard.py`, `test_add_map_widget.py`, `test_dashboards_db.py` — 35 passed (exact `response_metadata` assertions updated to pin the new field)
- `tests/unit` — 352 passed; `tests/api` — 264 passed (the handful of intermittent `InsufficientPrivilegeError` teardown errors are the known local test-db volume-ownership issue, unrelated; affected files pass in isolation)
- `pre-commit` (ruff, ruff-format, mypy) clean

Note: no Jira ticket for this one — happy to retitle with a `PZB-NNN` prefix if one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)