### PR TITLE
fix(pick_aoi): handle empty DB results and bad LLM src_id without crashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.22"
+version = "2026.7.22.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/subagents/pick_aoi/tool.py
+++ b/src/agent/subagents/pick_aoi/tool.py
@@ -236,7 +236,7 @@ async def query_subregion_database(
 
 async def select_best_aoi(
     question: str, candidate_aois: pd.DataFrame
-) -> AOIIndex:
+) -> Optional[AOIIndex]:
     """Select the best AOI based on the user query.
 
     Args:
@@ -244,8 +244,12 @@ async def select_best_aoi(
         candidate_aois: Candidate AOIs to select from
 
     Returns:
-        Selected AOI: AOIIndex
+        Selected AOI: AOIIndex, or None if no candidates or no match found
     """
+    if candidate_aois.empty:
+        logger.debug("No candidate AOIs to select from")
+        return None
+
     # Prompt template for selecting the best location match based on user query
     AOI_SELECTION_PROMPT = ChatPromptTemplate.from_messages(
         [
@@ -279,9 +283,16 @@ async def select_best_aoi(
         }
     )
     # Get the original data row for the selected AOI
-    selected_aoi_row = candidate_aois[
+    matched = candidate_aois[
         candidate_aois["src_id"] == selected_aoi_index.src_id
-    ].iloc[0]
+    ]
+    if matched.empty:
+        logger.warning(
+            f"LLM selected src_id '{selected_aoi_index.src_id}' "
+            f"not found in candidates. Available: {list(candidate_aois['src_id'])}"
+        )
+        return None
+    selected_aoi_row = matched.iloc[0]
     selected_aoi = AOIIndex(**selected_aoi_row.to_dict())
 
     logger.debug(f"Candidate AOIs: {candidate_aois}")
@@ -508,9 +519,25 @@ class Geocoder:
                 + (f" — {'; '.join(names[:8])}" if names else ""),
             )
 
-        selected_aois = await asyncio.gather(
+        selected_aois_raw = await asyncio.gather(
             *[select_best_aoi(question, result) for result in all_results]
         )
+        selected_aois = [aoi for aoi in selected_aois_raw if aoi is not None]
+        if not selected_aois:
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(
+                            "No matching location was found for your request. "
+                            "Try a broader place name (e.g., the country or region) "
+                            "or rephrase the location.",
+                            tool_call_id=tool_call_id,
+                            status="success",
+                            response_metadata={"msg_type": "human_feedback"},
+                        )
+                    ],
+                },
+            )
 
         duplicate_check = await check_duplicate_aois(
             selected_aois, all_results

--- a/src/agent/subagents/pick_aoi/tool.py
+++ b/src/agent/subagents/pick_aoi/tool.py
@@ -522,15 +522,21 @@ class Geocoder:
         selected_aois_raw = await asyncio.gather(
             *[select_best_aoi(question, result) for result in all_results]
         )
+        unmatched_places = [
+            place
+            for place, aoi in zip(places, selected_aois_raw)
+            if aoi is None
+        ]
         selected_aois = [aoi for aoi in selected_aois_raw if aoi is not None]
         if not selected_aois:
             return Command(
                 update={
                     "messages": [
                         ToolMessage(
-                            "No matching location was found for your request. "
-                            "Try a broader place name (e.g., the country or region) "
-                            "or rephrase the location.",
+                            "No matching location was found for: "
+                            f"{', '.join(unmatched_places)}. Try a broader "
+                            "place name (e.g., the country or region) or "
+                            "rephrase the location.",
                             tool_call_id=tool_call_id,
                             status="success",
                             response_metadata={"msg_type": "human_feedback"},
@@ -597,6 +603,11 @@ class Geocoder:
         tool_message = "Selected AOIs:"
         for selected_aoi in final_aois:
             tool_message += f"\n- {selected_aoi.name}"
+        if unmatched_places:
+            tool_message += (
+                "\n\nNo match found for: "
+                f"{', '.join(unmatched_places)}. These were skipped."
+            )
 
         logger.debug(f"Pick AOI tool message: {tool_message}")
 

--- a/src/agent/tools/add_text_widget.py
+++ b/src/agent/tools/add_text_widget.py
@@ -107,6 +107,7 @@ async def add_text_widget(
 
     return dashboard_updated_command(
         dashboard.id,
+        dashboard.name,
         (
             f"Added text widget {widget_id} to dashboard "
             f"'{dashboard.name}' ({dashboard.id}). Use this widget id with "

--- a/src/agent/tools/edit_text_widget.py
+++ b/src/agent/tools/edit_text_widget.py
@@ -172,6 +172,7 @@ async def edit_text_widget(
 
     return dashboard_updated_command(
         dashboard.id,
+        dashboard.name,
         (
             f"Updated text widget {widget.id} on dashboard "
             f"'{dashboard.name}' ({dashboard.id})."

--- a/tests/unit/agent/tools/pick_aoi/test_tool.py
+++ b/tests/unit/agent/tools/pick_aoi/test_tool.py
@@ -200,6 +200,35 @@ async def test_select_best_aoi_empty_candidates_returns_none():
 
 
 @pytest.mark.asyncio
+async def test_select_best_aoi_bad_src_id_returns_none(monkeypatch):
+    """When the LLM picks a src_id that isn't among the candidates,
+    select_best_aoi should return None instead of crashing on .iloc[0]."""
+    tool_module = import_module("src.agent.subagents.pick_aoi.tool")
+
+    async def fake_structured_output(_input):
+        return tool_module.AOIId(src_id="does-not-exist")
+
+    class _FakeSmallModel:
+        def with_structured_output(self, schema):
+            return fake_structured_output
+
+    monkeypatch.setattr(tool_module, "SMALL_MODEL", _FakeSmallModel())
+
+    candidates = pd.DataFrame(
+        [
+            {
+                "src_id": "BRA.14_1",
+                "name": "Para, Brazil",
+                "subtype": "state-province",
+                "source": "gadm",
+            }
+        ]
+    )
+    result = await tool_module.select_best_aoi("some question", candidates)
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_pick_aoi_returns_no_match_when_db_search_empty(monkeypatch):
     """When the DB returns no candidates, pick_aoi should return a helpful
     message instead of crashing."""
@@ -232,3 +261,65 @@ async def test_pick_aoi_returns_no_match_when_db_search_empty(monkeypatch):
         "no matching location"
         in str(command.update["messages"][0].content).lower()
     )
+
+
+@pytest.mark.asyncio
+async def test_pick_aoi_reports_unmatched_places_alongside_matches(
+    monkeypatch,
+):
+    """When some places match and others don't, pick_aoi should still return
+    the matches but name the place(s) it couldn't find rather than silently
+    dropping them."""
+    tool_module = import_module("src.agent.subagents.pick_aoi.tool")
+
+    async def fake_extract(self, question, aoi_type):
+        return PlaceQuery(
+            places=["Para, Brazil", "Nonexistent Place"], subregion=None
+        )
+
+    async def fake_query_aoi_database(place_name, aoi_type, result_limit=10):
+        if place_name == "Para, Brazil":
+            return pd.DataFrame(
+                [
+                    {
+                        "src_id": "BRA.14_1",
+                        "name": "Para, Brazil",
+                        "subtype": "state-province",
+                        "source": "gadm",
+                    }
+                ]
+            )
+        return pd.DataFrame()
+
+    async def fake_select_best_aoi(question, candidate_aois):
+        if candidate_aois.empty:
+            return None
+        return AOIIndex(
+            src_id="BRA.14_1",
+            name="Para, Brazil",
+            subtype="state-province",
+            source="gadm",
+        )
+
+    monkeypatch.setattr(Geocoder, "extract", fake_extract)
+    monkeypatch.setattr(
+        tool_module, "query_aoi_database", fake_query_aoi_database
+    )
+    monkeypatch.setattr(tool_module, "select_best_aoi", fake_select_best_aoi)
+
+    command = await pick_aoi.ainvoke(
+        {
+            "args": {
+                "question": (
+                    "tree cover loss in Para, Brazil and Nonexistent Place"
+                ),
+                "area_of_interest": None,
+            },
+            "id": "tc-4",
+            "type": "tool_call",
+        }
+    )
+
+    selection = command.update["aoi_selection"]
+    assert selection["aois"][0]["src_id"] == "BRA.14_1"
+    assert "Nonexistent Place" in str(command.update["messages"][0].content)

--- a/tests/unit/agent/tools/pick_aoi/test_tool.py
+++ b/tests/unit/agent/tools/pick_aoi/test_tool.py
@@ -187,3 +187,48 @@ async def test_pick_aoi_tool_asks_for_clarification_when_no_place(
     assert "couldn't identify a place" in str(
         command.update["messages"][0].content
     )
+
+
+@pytest.mark.asyncio
+async def test_select_best_aoi_empty_candidates_returns_none():
+    """When DB search returns zero rows, select_best_aoi should return None
+    instead of crashing with 'single positional indexer is out-of-bounds'."""
+    from src.agent.subagents.pick_aoi.tool import select_best_aoi
+
+    result = await select_best_aoi("some question", pd.DataFrame())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pick_aoi_returns_no_match_when_db_search_empty(monkeypatch):
+    """When the DB returns no candidates, pick_aoi should return a helpful
+    message instead of crashing."""
+    tool_module = import_module("src.agent.subagents.pick_aoi.tool")
+
+    async def fake_extract(self, question, aoi_type):
+        return PlaceQuery(places=["Nonexistent Place"], subregion=None)
+
+    async def fake_query_aoi_database(place_name, aoi_type, result_limit=10):
+        return pd.DataFrame()  # empty results
+
+    monkeypatch.setattr(Geocoder, "extract", fake_extract)
+    monkeypatch.setattr(
+        tool_module, "query_aoi_database", fake_query_aoi_database
+    )
+
+    command = await pick_aoi.ainvoke(
+        {
+            "args": {
+                "question": "trees around Nonexistent Place",
+                "area_of_interest": None,
+            },
+            "id": "tc-3",
+            "type": "tool_call",
+        }
+    )
+
+    assert "aoi_selection" not in command.update
+    assert (
+        "no matching location"
+        in str(command.update["messages"][0].content).lower()
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.22"
+version = "2026.7.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -3031,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.21.3"
+version = "2026.7.22"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Problem

`pick_aoi` crashed with `single positional indexer is out-of-bounds` when the DB search returned zero candidates or when the LLM returned a `src_id` not present in the candidates DataFrame.

Seen in trace `c5ffb1be`: the model called `pick_aoi` with `area_of_interest: 'protected area, park, or reserve'` (WDPA table) for a beach in Indonesia that doesn't exist in WDPA. The crash was recovered by the model on retry, but cost an unnecessary tool invocation.

## Fix

- `select_best_aoi` returns `None` early when candidates are empty or when the matched row is missing
- `Geocoder.lookup` filters `None` results and returns a user-facing clarification message instead of crashing

## Testing

- All 45 existing pick_aoi tests pass
- Added 2 new tests: empty candidates guard and end-to-end no-match behavior