### PR TITLE
Curated insights (5/5): analyze date-clamp + canopy default

### DIFF
--- a/src/api/services/analyze.py
+++ b/src/api/services/analyze.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Mapping, Optional
 
+from src.agent.datasets.dates import revise_date_range
 from src.agent.datasets.handlers.base import DataPullResult, DataSourceHandler
 from src.agent.subagents.analyst.charts import InsightChart
 from src.api.services.charts import ChartGenerator, column_to_rows
@@ -29,6 +30,13 @@ class AnalyzeService:
         start_date: str,
         end_date: str,
     ) -> AnalyzeResult:
+        # The frontend sends one global default range; clamp it to the
+        # dataset's actual coverage (fixed-content datasets force their
+        # full range) so e.g. integrated alerts is not queried from 2001.
+        start_date, end_date, _ = await revise_date_range(
+            start_date, end_date, dataset_id
+        )
+
         result = await self._handler.pull_data(
             query="",
             dataset={"dataset_id": dataset_id},

--- a/src/api/services/analyze.py
+++ b/src/api/services/analyze.py
@@ -6,6 +6,10 @@ from src.agent.datasets.handlers.base import DataPullResult, DataSourceHandler
 from src.agent.subagents.analyst.charts import InsightChart
 from src.api.services.charts import ChartGenerator, column_to_rows
 
+# The default canopy density threshold the catalog YAMLs mandate for the
+# canopy-parameterised datasets (tree cover loss/gain/extent, carbon flux).
+DEFAULT_CANOPY_COVER = 30
+
 
 @dataclass
 class AnalyzeResult:
@@ -39,7 +43,19 @@ class AnalyzeService:
 
         result = await self._handler.pull_data(
             query="",
-            dataset={"dataset_id": dataset_id},
+            # Parameters are set explicitly: the payload builder hydrates
+            # the dataset from the catalog and takes max(values) of the
+            # full canopy_cover list — 75% — when none are provided.
+            # Datasets without a canopy parameter ignore this entry.
+            dataset={
+                "dataset_id": dataset_id,
+                "parameters": [
+                    {
+                        "name": "canopy_cover",
+                        "values": [DEFAULT_CANOPY_COVER],
+                    }
+                ],
+            },
             start_date=start_date,
             end_date=end_date,
             change_over_time_query=False,

--- a/tests/unit/api/services/test_analyze_service.py
+++ b/tests/unit/api/services/test_analyze_service.py
@@ -95,6 +95,25 @@ async def test_analyze_passes_correct_args_to_handler():
 
 
 @pytest.mark.asyncio
+async def test_canopy_cover_pinned_to_catalog_default():
+    handler = FakeHandler(SUCCESS_RESULT)
+    service = make_service(handler)
+
+    await service.analyze(
+        aois=[AOI],
+        dataset_id=HANDLED_DATASET_ID,
+        start_date="2020-01-01",
+        end_date="2020-12-31",
+    )
+
+    # Without explicit parameters the payload builder would use
+    # max(catalog values) = 75% instead of the mandated 30% default.
+    assert handler.last_call["dataset"]["parameters"] == [
+        {"name": "canopy_cover", "values": [30]}
+    ]
+
+
+@pytest.mark.asyncio
 async def test_dates_clamped_to_dataset_coverage():
     handler = FakeHandler(SUCCESS_RESULT)
     service = make_service(handler)

--- a/tests/unit/api/services/test_analyze_service.py
+++ b/tests/unit/api/services/test_analyze_service.py
@@ -1,11 +1,18 @@
 import pytest
 
+from src.agent.datasets.handlers.analytics_handler import (
+    GRASSLANDS_ID,
+    NATURAL_LANDS_ID,
+    TREE_COVER_LOSS_ID,
+)
 from src.agent.datasets.handlers.base import DataPullResult, DataSourceHandler
 from src.agent.subagents.analyst.charts import InsightChart
 from src.api.services.analyze import AnalyzeService
 
-UNHANDLED_DATASET_ID = 1
-HANDLED_DATASET_ID = 99
+# Real catalog ids: analyze clamps dates against the dataset catalog, so
+# made-up ids would raise. "Unhandled" means absent from the generator map.
+HANDLED_DATASET_ID = TREE_COVER_LOSS_ID
+UNHANDLED_DATASET_ID = GRASSLANDS_ID
 
 FAKE_CHARTS = [
     InsightChart(
@@ -81,8 +88,40 @@ async def test_analyze_passes_correct_args_to_handler():
         end_date="2020-12-31",
     )
 
-    assert handler.last_call["dataset"] == {"dataset_id": HANDLED_DATASET_ID}
+    assert handler.last_call["dataset"]["dataset_id"] == HANDLED_DATASET_ID
     assert handler.last_call["aois"] == [AOI]
+    assert handler.last_call["start_date"] == "2020-01-01"
+    assert handler.last_call["end_date"] == "2020-12-31"
+
+
+@pytest.mark.asyncio
+async def test_dates_clamped_to_dataset_coverage():
+    handler = FakeHandler(SUCCESS_RESULT)
+    service = make_service(handler)
+
+    await service.analyze(
+        aois=[AOI],
+        dataset_id=TREE_COVER_LOSS_ID,  # coverage 2001-2025
+        start_date="1990-01-01",
+        end_date="2030-12-31",
+    )
+
+    assert handler.last_call["start_date"] == "2001-01-01"
+    assert handler.last_call["end_date"] == "2025-12-31"
+
+
+@pytest.mark.asyncio
+async def test_fixed_content_dataset_forces_its_full_range():
+    handler = FakeHandler(SUCCESS_RESULT)
+    service = make_service(handler)
+
+    await service.analyze(
+        aois=[AOI],
+        dataset_id=NATURAL_LANDS_ID,  # fixed 2020 snapshot
+        start_date="2001-01-01",
+        end_date="2025-12-31",
+    )
+
     assert handler.last_call["start_date"] == "2020-01-01"
     assert handler.last_call["end_date"] == "2020-12-31"
 


### PR DESCRIPTION
## What & why
_Stacked on `feat/curated-insights-alerts-sluc`. Two independent request-hygiene fixes for the analyze path._

1. **Date clamping.** The FE sends one global `2001-01-01…2025-12-31` window for every dataset. `AnalyzeService` now clamps it to each dataset's catalog coverage via the agent path's `revise_date_range`, so e.g. Integrated Alerts/DIST-ALERT query from their 2023-12 start and fixed-content snapshots use their full range.
2. **Canopy threshold.** The analytics handler hydrates the dataset from the catalog and takes `max(values)` of the `canopy_cover` list (75%) when none is passed, so analyze was querying tree-cover datasets at 75% instead of the mandated **30%** default. Now pinned explicitly.

## Tests
`test_analyze_service.py`: clamping (out-of-coverage + fixed-content) and the 30% pin. Verified end-to-end locally against the real analytics API for all 12 datasets through the actual FE analyze flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
