### PR TITLE
PZB-1146: chore(Middleware): add CORS headers and request_id to api errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.24.2"
+version = "2026.7.24.3"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -5,6 +5,7 @@ from typing import Optional
 import structlog
 from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from src.agent.graph import close_checkpointer_pool, get_checkpointer_pool
 from src.agent.utils.sgrep import data_status
@@ -31,6 +32,20 @@ from src.shared.logging_config import get_logger
 from src.shared.version import get_version
 
 logger = get_logger(__name__)
+
+
+def _add_cors_headers_for_error(request: Request, response: Response) -> None:
+    origin = request.headers.get("origin")
+    if not origin:
+        return
+    response.headers["Access-Control-Allow-Origin"] = origin
+    response.headers["Access-Control-Allow-Credentials"] = "true"
+    vary = response.headers.get("Vary")
+    if vary:
+        if "Origin" not in vary:
+            response.headers["Vary"] = f"{vary}, Origin"
+    else:
+        response.headers["Vary"] = "Origin"
 
 
 @asynccontextmanager
@@ -94,6 +109,7 @@ async def mosaic_cache_headers(request: Request, call_next) -> Response:
 async def logging_middleware(request: Request, call_next) -> Response:
     """Middleware to log requests and bind request ID to context."""
     req_id = uuid.uuid4().hex
+    request.state.request_id = req_id
 
     structlog.contextvars.clear_contextvars()
     structlog.contextvars.bind_contextvars(request_id=req_id)
@@ -118,8 +134,19 @@ async def logging_middleware(request: Request, call_next) -> Response:
             error=str(e),
             request_id=req_id,
         )
+        # TODO: Add explicit APM error capture here.
+        # We swallow the exception to return a CORS-friendly JSON error.
+        # The error is still logged (visible in Grafana), but the APM
+        # won't alert on it unless we explicitly report it.
         response_code = 500
-        raise e
+        response = JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={
+                "detail": "Internal Server Error",
+                "request_id": req_id,
+            },
+        )
+        _add_cors_headers_for_error(request, response)
     finally:
         if not response:
             response = Response(

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -12,6 +12,7 @@ from src.api.data_models import (
     StatisticsOrm,
     UserOrm,
 )
+from src.api.routers import insights as insights_router
 from tests.conftest import async_session_maker
 
 
@@ -404,6 +405,34 @@ async def test_get_insight_with_null_thread_id(client, auth_override):
     )
     assert response.status_code == 200
     assert response.json()["thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_insight_internal_error_keeps_cors_headers(
+    client, auth_override, monkeypatch
+):
+    user = await _create_user("cors-error-owner")
+    auth_override(user.id)
+    insight = await _create_insight(user_id=user.id)
+
+    def _raise_runtime_error(_row):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        insights_router, "_row_to_response", _raise_runtime_error
+    )
+
+    response = await client.get(
+        f"/api/insights/{insight.id}",
+        headers={
+            "Authorization": "Bearer t",
+            "Origin": "https://example.org",
+        },
+    )
+    assert response.status_code == 500
+    assert response.headers.get("access-control-allow-origin") is not None
+    assert response.json()["detail"] == "Internal Server Error"
+    assert isinstance(response.json().get("request_id"), str)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR: Improve API error responses for CORS + observability

## Existing behavior

When an unhandled exception occurs (for example, response-model validation failure), the request path can bypass normal CORS header injection.  
Result: the browser reports a CORS error, and the real 500 response body is not visible to frontend code.

The response also does not reliably include a correlation identifier the client can pass back for debugging.

## Behavior after this PR

Unhandled exceptions are converted into a structured JSON `500` response in middleware:

- `detail: "Internal Server Error"`
- `request_id: "<uuid>"`

For cross-origin requests (`Origin` header present), the middleware explicitly adds:

- `Access-Control-Allow-Origin: <origin>`
- `Access-Control-Allow-Credentials: true`
- `Vary: Origin`

This ensures browsers can read the error response instead of masking it as a CORS failure.

## Why `request_id` helps investigations

The same `request_id` is already bound in server logs. Returning it in the error payload lets frontend, QA, or support report one ID that backend engineers can search to quickly reconstruct:

1. request start
2. exception details
3. final error response

That shortens triage time and removes ambiguity when multiple failures happen concurrently.

## Example browser-visible error response

Example `fetch` response payload/body:

```json
{
  "detail": "Internal Server Error",
  "request_id": "2bb17a20af5442b69dad7e78e351c1f7"
}
```

Example response headers:

```http
HTTP/1.1 500 Internal Server Error
Content-Type: application/json
Access-Control-Allow-Origin: https://horizon.globalnaturewatch.org
Access-Control-Allow-Credentials: true
Vary: Origin
```

## How this accelerates investigation

1. Frontend logs `request_id` from the response body and includes it in Sentry/user-facing error details.
2. Backend engineer searches logs for that exact `request_id`.
3. They immediately get the full request timeline (start log, stack trace, response log) without guessing by timestamp, user, or endpoint.

## Sequence diagram (error path with CORS headers)

```mermaid
sequenceDiagram
    autonumber
    participant B as Browser
    participant API as FastAPI app
    participant LM as logging_middleware
    participant H as Route handler

    B->>API: GET /api/insights/{id}<br/>Origin: https://horizon.globalnaturewatch.org
    API->>LM: Enter middleware
    LM->>LM: Generate request_id + bind log context
    LM->>H: call_next(request)
    H-->>LM: Raise unhandled exception
    LM->>LM: Log exception with request_id
    LM-->>B: 500 JSON<br/>{detail, request_id}<br/>Access-Control-Allow-Origin: https://horizon.globalnaturewatch.org<br/>Access-Control-Allow-Credentials: true<br/>Vary: Origin
    B->>B: JS can read response body and request_id
```
