### PR TITLE
chore: add Horizon Production Lag Report for better visibility of our delivery cadence.

### DIFF
--- a/.github/workflows/production-lag-report.yaml
+++ b/.github/workflows/production-lag-report.yaml
@@ -1,0 +1,233 @@
+name: 'Production Lag Report'
+
+on:
+  schedule:
+    - cron: '0 8 * * 4'   # Every Thursday at 08:00 UTC
+  workflow_dispatch:        # Allow manual runs
+
+jobs:
+  report:
+    name: 'Generate and post production lag report'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Get deploy repo token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: project-zeno-deploy
+
+      - name: Extract production image tag from deploy repo
+        id: prod
+        env:
+          DEPLOY_REPO_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Read values.yaml from the main branch of the deploy repo using
+          # a GitHub App installation token with read-only contents access to project-zeno-deploy.
+          TAG=$(curl -s \
+            -H "Authorization: Bearer ${DEPLOY_REPO_TOKEN}" \
+            -H "Accept: application/vnd.github.v3.raw" \
+            "https://api.github.com/repos/wri/project-zeno-deploy/contents/helm/zeno/values.yaml?ref=main" \
+            | grep -E '^\s+tag:' | head -1 | awk '{print $2}')
+          echo "sha=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Production SHA: ${TAG}"
+
+      - name: Compare and score commits
+        id: compare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PROD_SHA="${{ steps.prod.outputs.sha }}"
+          RESPONSE=$(gh api "repos/wri/project-zeno/compare/${PROD_SHA}...main")
+
+          PROD_DATE=$(gh api "repos/wri/project-zeno/commits/${PROD_SHA}" --jq '.commit.author.date')
+          PROD_MSG=$(gh api  "repos/wri/project-zeno/commits/${PROD_SHA}" --jq '.commit.message | split("\n")[0]')
+          LATEST_SHA=$(echo "$RESPONSE"  | jq -r '.commits[-1].sha[0:8]')
+          LATEST_MSG=$(echo "$RESPONSE"  | jq -r '.commits[-1].commit.message | split("\n")[0]')
+          LATEST_DATE=$(echo "$RESPONSE" | jq -r '.commits[-1].commit.author.date')
+
+          # Filtered commits as JSON array, newest first
+          FILTERED=$(echo "$RESPONSE" | jq '[
+            .commits[]
+            | select(.commit.message | test("^Merge ";  "i") | not)
+            | select(.commit.message | test("^Merged "; "i") | not)
+            | select(.commit.message | test("^Bump version"; "i") | not)
+            | select(.commit.message | test("^chore: sync uv"; "i") | not)
+            | {sha: .sha, msg: (.commit.message | split("\n")[0])}
+          ] | reverse')
+
+          AHEAD=$(echo "$FILTERED" | jq 'length')
+
+          # Score each commit via the GitHub API
+          TOTAL_RISK=0
+          BULLETS=""
+
+          while IFS= read -r COMMIT; do
+            SHA=$(echo "$COMMIT" | jq -r '.sha')
+            MSG=$(echo "$COMMIT" | jq -r '.msg')
+
+            STATS=$(gh api "repos/wri/project-zeno/commits/$SHA" --jq '{
+              total: (.stats.total // 0),
+              high_risk: ([.files[].filename] | map(test("alembic|migration|\\.sql|schema|model|auth"; "i")) | any)
+            }')
+
+            TOTAL=$(echo "$STATS" | jq '.total')
+            HIGH_RISK=$(echo "$STATS" | jq '.high_risk')
+
+            if   [ "$TOTAL" -lt 20  ]; then LSCORE=1
+            elif [ "$TOTAL" -lt 100 ]; then LSCORE=2
+            elif [ "$TOTAL" -lt 300 ]; then LSCORE=3
+            elif [ "$TOTAL" -lt 500 ]; then LSCORE=4
+            else LSCORE=5; fi
+
+            SCORE=$LSCORE
+            [ "$HIGH_RISK" = "true" ] && SCORE=$((SCORE + 1))
+            [ "$SCORE" -gt 5 ] && SCORE=5
+
+            TOTAL_RISK=$((TOTAL_RISK + SCORE))
+
+            case $SCORE in
+              1) BADGE=":white_circle:[1]" ;;
+              2) BADGE=":large_yellow_circle:[2]" ;;
+              3) BADGE=":large_orange_circle:[3]" ;;
+              4) BADGE=":large_orange_circle:[4]" ;;
+              5) BADGE=":red_circle:[5]" ;;
+            esac
+            BULLETS="${BULLETS}• ${BADGE} \`${SHA:0:8}\` ${MSG}"$'\n'
+          done < <(echo "$FILTERED" | jq -c '.[]')
+
+          # Aggregate risk rating (integer math, no bc needed)
+          if [ "$AHEAD" -gt 0 ]; then
+            AVG_TIMES10=$(( (TOTAL_RISK * 10) / AHEAD ))
+            AVG_INT=$(( AVG_TIMES10 / 10 ))
+            AVG_FRAC=$(( AVG_TIMES10 % 10 ))
+            AVG_RISK="${AVG_INT}.${AVG_FRAC}"
+          else
+            AVG_RISK="0.0"
+            AVG_INT=0
+          fi
+
+          if   [ "$AVG_INT" -le 1 ]; then RISK_LABEL=":large_green_circle: *Low*"
+          elif [ "$AVG_INT" -le 2 ]; then RISK_LABEL=":large_yellow_circle: *Medium*"
+          elif [ "$AVG_INT" -le 3 ]; then RISK_LABEL=":large_orange_circle: *High*"
+          else                             RISK_LABEL=":red_circle: *Critical*"
+          fi
+
+          RISK_SUMMARY="${RISK_LABEL} — total score ${TOTAL_RISK} across ${AHEAD} commits (avg ${AVG_RISK}/commit)"
+
+          echo "ahead=${AHEAD}"               >> "$GITHUB_OUTPUT"
+          echo "prod_sha=${PROD_SHA:0:8}"     >> "$GITHUB_OUTPUT"
+          echo "prod_date=${PROD_DATE}"       >> "$GITHUB_OUTPUT"
+          echo "prod_msg=${PROD_MSG}"         >> "$GITHUB_OUTPUT"
+          echo "latest_sha=${LATEST_SHA}"     >> "$GITHUB_OUTPUT"
+          echo "latest_msg=${LATEST_MSG}"     >> "$GITHUB_OUTPUT"
+          echo "latest_date=${LATEST_DATE}"   >> "$GITHUB_OUTPUT"
+          {
+            echo "bullets<<EOF"
+            printf '%s' "$BULLETS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "risk_summary<<EOF"
+            echo "$RISK_SUMMARY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and post Slack message
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          AHEAD: ${{ steps.compare.outputs.ahead }}
+          PROD_SHA: ${{ steps.compare.outputs.prod_sha }}
+          PROD_DATE: ${{ steps.compare.outputs.prod_date }}
+          PROD_MSG: ${{ steps.compare.outputs.prod_msg }}
+          LATEST_SHA: ${{ steps.compare.outputs.latest_sha }}
+          LATEST_MSG: ${{ steps.compare.outputs.latest_msg }}
+          LATEST_DATE: ${{ steps.compare.outputs.latest_date }}
+          BULLETS: ${{ steps.compare.outputs.bullets }}
+          RISK_SUMMARY: ${{ steps.compare.outputs.risk_summary }}
+        run: |
+
+          PROD_DATE_FMT=$(echo "$PROD_DATE"     | cut -c1-10)
+          LATEST_DATE_FMT=$(echo "$LATEST_DATE" | cut -c1-10)
+
+          PROD_TS=$(date -d "$PROD_DATE_FMT" +%s)
+          LATEST_TS=$(date -d "$LATEST_DATE_FMT" +%s)
+          DAYS=$(( (LATEST_TS - PROD_TS) / 86400 ))
+
+          if [ "$AHEAD" -eq 0 ]; then
+            HEADER=":white_check_mark: *Zeno production is up to date* — no unreleased commits on \`main\`."
+            COLOR="good"
+          elif [ "$AHEAD" -lt 10 ]; then
+            HEADER=":large_yellow_circle: *Zeno production lag report* — *${AHEAD} commits* unreleased (~${DAYS} days)"
+            COLOR="warning"
+          else
+            HEADER=":red_circle: *Zeno production lag report* — *${AHEAD} commits* unreleased (~${DAYS} days)"
+            COLOR="danger"
+          fi
+
+          COMPARE_URL="https://github.com/wri/project-zeno/compare/${PROD_SHA}...main"
+
+          LEGEND=":white_check_mark: 0 commits — up to date    :large_yellow_circle: 1–9 commits — mild lag    :red_circle: 10+ commits — significant lag"
+          LEGEND="${LEGEND}"$'\n'"*Commit risk score (1–5):* :white_circle: 1 trivial (<20 lines)  :large_yellow_circle: 2 small (<100)  :large_orange_circle: 3–4 medium/large (<500)  :red_circle: 5 critical (500+ lines or touches migrations/schema/auth)"
+          LEGEND="${LEGEND}"$'\n'"_Merge commits, version bumps, and lockfile syncs are excluded._"
+
+          PAYLOAD=$(jq -n \
+            --arg header       "$HEADER" \
+            --arg prod_sha     "$PROD_SHA" \
+            --arg prod_msg     "$PROD_MSG" \
+            --arg prod_date    "$PROD_DATE_FMT" \
+            --arg latest_sha   "$LATEST_SHA" \
+            --arg latest_msg   "$LATEST_MSG" \
+            --arg latest_date  "$LATEST_DATE_FMT" \
+            --arg bullets      "$BULLETS" \
+            --arg risk_summary "$RISK_SUMMARY" \
+            --arg legend       "$LEGEND" \
+            --arg compare_url  "$COMPARE_URL" \
+            --arg color        "$COLOR" \
+            '{
+              attachments: [{
+                color: $color,
+                blocks: [
+                  {
+                    type: "section",
+                    text: { type: "mrkdwn", text: $header }
+                  },
+                  {
+                    type: "section",
+                    fields: [
+                      { type: "mrkdwn", text: ("*Production commit*\n`" + $prod_sha + "` " + $prod_msg + "\n_" + $prod_date + "_") },
+                      { type: "mrkdwn", text: ("*Latest on main*\n`"    + $latest_sha + "` " + $latest_msg + "\n_" + $latest_date + "_") }
+                    ]
+                  },
+                  {
+                    type: "section",
+                    text: { type: "mrkdwn", text: ("*Deployment risk*\n" + $risk_summary) }
+                  },
+                  {
+                    type: "section",
+                    text: { type: "mrkdwn", text: ("*Unreleased commits (newest first)*\n" + $bullets) }
+                  },
+                  { type: "divider" },
+                  {
+                    type: "section",
+                    text: { type: "mrkdwn", text: $legend }
+                  },
+                  {
+                    type: "actions",
+                    elements: [{
+                      type: "button",
+                      text: { type: "plain_text", text: "View full diff on GitHub" },
+                      url: $compare_url
+                    }]
+                  }
+                ]
+              }]
+            }')
+
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            "$SLACK_WEBHOOK_URL" | grep -q "200" && echo "Slack message posted." || echo "::error::Slack webhook returned non-200"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.22.1"
+version = "2026.7.23"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"


### PR DESCRIPTION
# Add weekly Production Lag Report workflow

## Summary

Adds a scheduled GitHub Actions workflow that generates a **weekly production lag report** and posts it to Slack. The report compares what's currently deployed in production against the `main` branch, scores each unreleased commit by risk, and gives the team clear visibility into deployment lag.

Runs every **Thursday at 08:00 UTC** (and can be triggered manually via `workflow_dispatch`).

## How it works

### Cross-repo access via GitHub App

The production image tag lives in a **separate private deploy repo** (`wri/project-zeno-deploy`), not in this repo. To read it securely, the workflow uses a **GitHub App installation token** rather than a personal access token (PAT).

**Why a GitHub App instead of a PAT:**
- PATs are tied to a personal account — if the person leaves, the token breaks.
- GitHub App tokens are scoped to specific repositories and permissions, following the principle of least privilege.
- App tokens are short-lived (1 hour), automatically rotated, and never stored in workflow logs.

**How the GitHub App token is created:**
1. A GitHub App is registered in the `wri` organization with **read-only Contents** permission.
2. The App is installed on the `project-zeno-deploy` repository only.
3. The App's `APP_ID` and `APP_PRIVATE_KEY` are stored as repository secrets in `project-zeno`.
4. At runtime, `actions/create-github-app-token@v1` exchanges the private key for a short-lived installation token scoped to `project-zeno-deploy`.
5. That token is used in a single `curl` call to read `helm/zeno/values.yaml` and extract the currently deployed image tag (a git SHA).

### Workflow pipeline

1. **Authenticate** — mint a GitHub App token scoped to the deploy repo.
2. **Extract production SHA** — read `values.yaml` from `project-zeno-deploy` to find the deployed commit.
3. **Compare** — use the GitHub API to diff the production SHA against `main`, filtering out merge commits, version bumps, and lockfile syncs.
4. **Score** — each commit gets a risk score (1–5) based on lines changed and whether it touches high-risk paths (migrations, schema, auth).
5. **Post to Slack** — build a rich Slack message with commit list, risk summary, and a link to the full diff.

### Sequence diagram

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions<br/>(project-zeno)
    participant App as GitHub App<br/>(actions/create-github-app-token)
    participant Deploy as wri/project-zeno-deploy<br/>(deploy repo)
    participant Zeno as wri/project-zeno<br/>(source repo)
    participant Slack as Slack Webhook

    Note over GHA: Triggered: Thursday 08:00 UTC<br/>or manual workflow_dispatch

    GHA->>App: Request installation token<br/>(APP_ID + APP_PRIVATE_KEY)
    App-->>GHA: Short-lived token<br/>(scoped to project-zeno-deploy, read-only)

    GHA->>Deploy: GET /contents/helm/zeno/values.yaml<br/>(Bearer token)
    Deploy-->>GHA: values.yaml content
    Note over GHA: Parse image tag → production SHA

    GHA->>Zeno: GET /compare/{prod_sha}...main<br/>(GITHUB_TOKEN)
    Zeno-->>GHA: Commit list + diff stats

    loop For each non-merge commit
        GHA->>Zeno: GET /commits/{sha}<br/>(file stats)
        Zeno-->>GHA: Lines changed + file paths
        Note over GHA: Score 1-5 based on size<br/>+1 if touches migrations/auth
    end

    Note over GHA: Build risk summary<br/>aggregate scores

    GHA->>Slack: POST webhook<br/>(formatted message with<br/>commit list, risk scores,<br/>diff link)
    Slack-->>GHA: 200 OK
```

## Security considerations

- **Minimal permissions**: Job has `contents: read` only — no write access to any repo.
- **GitHub App token**: Short-lived (~1 hour), scoped to a single repo (`project-zeno-deploy`), read-only Contents. Cannot push, create branches, or modify anything.
- **Script injection prevention**: All step outputs (which may contain attacker-controllable commit messages) are passed via `env:` blocks rather than inline `${{ }}` expressions in shell scripts. This prevents shell metacharacter injection.
- **Secrets**: `APP_ID`, `APP_PRIVATE_KEY`, and `SLACK_WEBHOOK_URL` are stored as GitHub repository secrets and never logged.
- **No checkout**: The workflow never checks out source code — it only makes API calls.

## Slack message example

The report posts a color-coded Slack message showing:
- 🟢 / 🟡 / 🔴 header based on number of unreleased commits
- Production commit vs. latest on `main` (SHA, message, date)
- Deployment risk score (aggregate + per-commit)
- All unreleased commits with individual risk badges
- Button linking to the full GitHub compare view

## Testing

- Use `workflow_dispatch` to trigger a manual run and verify the Slack message.
- The workflow is read-only and has no side effects beyond posting to Slack.
