### PR TITLE
Add backend-owned color registry for insight charts and map legends (phase 1)

### DIFF
--- a/docs/insight-chart-colors-plan.md
+++ b/docs/insight-chart-colors-plan.md
@@ -1,0 +1,258 @@
+# Insight chart colors — implementation plan
+
+*Status: agreed design, phase 1 in progress. Written 2026-07-24. This document
+is self-contained: a fresh session can pick up any phase from here without
+prior conversation context.*
+
+## Problem
+
+Chart and category colors for insights (land cover classes, tree-cover-loss
+drivers, dataset series colors, divergent GHG colors) are currently defined
+**only in the frontend** (`project-zeno-next`), keyed by literal English
+strings, and applied client-side when rendering `ChartWidget`. Two independent
+frontend files hold overlapping-but-unsynced color data:
+
+- `app/config/chartColorMappings.ts` — `CHART_COLOR_MAPPING` (category → hex,
+  per chart field), `DATASET_SERIES_COLORS` (dataset name → hex),
+  `DATASET_DIVERGENT_COLORS` (dataset name → {positive, negative})
+- `app/constants/datasets.ts` — map-legend `legend.items` (label → hex), same
+  categories, different casing, at least one confirmed drift bug (GHG dataset
+  keyed `2001-2024` here vs `2001-2025` in `chartColorMappings.ts`)
+
+This breaks once the agent translates category labels for non-English users:
+the frontend's color lookup is an exact string match against the (now
+translated) category value, so the same bucket gets a different color per
+language, or falls back to the generic cycling palette.
+
+The backend today has **no color values anywhere** in the chart pipeline —
+`InsightChart.color_field` only names *which column* drives color grouping,
+not an actual color. `chart_data` is a flat `List[dict]` with no schema
+enforcing a stable, language-independent key: once the code-executor LLM
+writes a translated string into a row, the English category identity is gone.
+
+## Decisions already made (don't re-litigate)
+
+1. **Colors reach the frontend via a sibling `color_map` field**, not inlined
+   per-row. `InsightChart` gains `color_map: Dict[str, str]` (category slug →
+   hex) alongside the existing `chart_data` rows, plus `series_color` and
+   `divergent_colors` for non-categorical single-series/diverging charts.
+2. **Stable category key = English slug, uniformly.** Verified by calling the
+   live analytics API directly (not just the test fixtures, which turned out
+   to be synthetic/inconsistent placeholders): **none** of the three
+   categorical datasets (Global Land Cover, Tree Cover Loss by Dominant
+   Driver, SBTN Natural Lands Map) return a numeric class code — only string
+   labels (`natural_lands_class`, `driver`, `land_cover_class`), with no
+   `class_id` field in the real response at all. (An earlier draft of this
+   doc incorrectly claimed SBTN Natural Lands returns a numeric `class_id`
+   alongside the label — that was an artifact of a synthetic test fixture,
+   not real API behavior; corrected 2026-07-24.) So a numeric-first design
+   isn't viable for any of them — uniform English slugs, defined by us in
+   the catalog YAML (where the grouping rules already live), is the only
+   option and is simpler anyway.
+   Also verified: the SBTN Natural Lands API returns a **variable** number of
+   classes per AOI (18 for Colombia, 19 for Brazil in live tests) — up to
+   the ~20 in the tile colormap — never a collapsed 2-row "Natural"/
+   "Non-natural" response. That grouping is purely an LLM/code-executor
+   post-processing step per the catalog's `code_instructions`, not something
+   the API does.
+3. **Unify chart colors and map-legend colors** on one backend-owned registry,
+   not two independently-maintained frontend files. This also fixes the
+   existing GHG dataset-name drift bug as a side effect.
+4. **No existing metadata channel to extend** — verified there is no
+   `datasets`/`catalog`/`legend` router in `src/api/routers/`, and the
+   frontend's `constants/datasets.ts` is 100% static, never fetched from the
+   backend for anything. `GET /api/metadata` is unrelated (geocoding/model
+   info). Unifying means building a **new** endpoint from scratch.
+5. **Color resolution is deterministic Python, not LLM output.** The
+   code-executor LLM must never be asked to invent/emit hex codes — it only
+   needs to emit a stable slug column. A plain Python post-processing step
+   looks up colors from the registry. Any slug not found in the registry
+   (a genuinely novel LLM-invented grouping, e.g. combining "Cropland" +
+   "Cultivated grasslands" into "Agriculture") falls back to a deterministic
+   hash/index-based pick from a generic palette — consistent across
+   regenerations of the same insight, never random.
+
+## Architecture
+
+### A. Canonical palette registry (backend, single source of truth)
+
+Extend the existing dataset catalog YAMLs
+(`src/agent/datasets/catalog/*.yml`) with new top-level keys:
+
+```yaml
+categories:        # only on datasets with categorical breakdowns
+  - slug: tree_cover
+    label_en: "Tree cover"
+    color: "#246E24"
+  - slug: cropland
+    label_en: "Cropland"
+    color: "#fff183"
+  ...
+series_color: "#DC6C9A"          # only on single-series datasets
+divergent_colors:                # only on datasets with pos/neg semantics
+  positive: "#9a65c0"
+  negative: "#137375"
+```
+
+This sits in the same file as the existing numeric `colormap` (embedded in
+`tile_url`, used for raster tile rendering — untouched, still numeric because
+that's a hard technical constraint of pixel rendering, not a design choice).
+One file, one edit point, so a human editing colors for a dataset sees both
+representations together and can't let them drift apart.
+
+Verified safe to add: `src/agent/datasets/config.py::_load_datasets()` only
+checks for **required** columns (`dataset_id, dataset_name, description,
+selection_hints, content_date, context_layers, parameters`) — it does not
+reject unknown keys, so `categories`/`series_color`/`divergent_colors` are
+inert additions until explicitly read by new code.
+
+### B. New endpoint: `GET /api/datasets/catalog`
+
+Reads `DATASETS` (from `src/agent/datasets/config.py`) and returns structured
+JSON per dataset: `dataset_id`, `dataset_name`, `categories`, `series_color`,
+`divergent_colors`. This becomes the frontend's source for map-legend colors,
+replacing the hardcoded `legend.items` in `constants/datasets.ts`. Ships
+independently of the agent-pipeline work below — zero risk to chart
+generation, and fixes the existing GHG drift bug on its own.
+
+### C. Stable slug threaded through chart generation (not yet built — phase 2)
+
+Today `dataset_id` is available on `state["dataset"]`
+(`DatasetSelectionResult.model_dump()`, see `src/agent/subagents/pick_dataset/`)
+at the point `generate_insights` runs, but is **dropped** before reaching the
+code-executor prompt or `InsightChart` — verified in
+`src/agent/subagents/analyst/tool.py::Analyst._resolve_charts()` (lines
+365-381), which only forwards `code_instructions`, `prompt_instructions`,
+`cautions`, `context_layer`.
+
+Phase 2 must:
+- Thread `dataset_id` through `_resolve_charts` → `InsightChart`.
+- Update the `EXECUTOR_WORKFLOW` prompt (`src/agent/subagents/analyst/prompts.py`)
+  so that when the code-executor groups/renames raw API category strings
+  (e.g. "combine cropland + cultivated grassland into Agriculture", per each
+  catalog's `code_instructions`), it emits a stable English slug column
+  alongside the translated display label it writes today. Naming convention
+  TBD (e.g. every categorical column `X` gets a sibling `X__slug` column).
+
+### D. Deterministic color resolution step (not yet built — phase 2)
+
+After `chart_data` is produced, a plain Python function looks up the registry
+(same YAML data from A, via the loader from B) by `dataset_id` + slug column,
+and attaches `color_map` / `series_color` / `divergent_colors` onto
+`InsightChart`. Unrecognized slugs get a deterministic fallback color (hash of
+the slug, or index-based cycling), never random.
+
+### E. Schema/DB/API plumbing (not yet built — phase 2)
+
+- `InsightChart` (`src/agent/subagents/analyst/charts/model.py`): add
+  `color_map: Dict[str, str] = {}`, `series_color: Optional[str] = None`,
+  `divergent_colors: Optional[dict] = None`.
+- `InsightChartOrm` (`src/api/data_models.py`): new JSONB column(s) + alembic
+  migration in `db/alembic/versions/`.
+- `to_orm_kwargs()` / `to_frontend_dict()`, `InsightChartResponse`
+  (`src/api/schemas.py`) updated to match.
+- `update_insight_display` / `DisplayReviser`
+  (`src/agent/subagents/analyst/display_reviser.py`) re-runs color resolution
+  when chart type/fields are revised.
+
+### F. Frontend cutover (partially phase 1, rest phase 2)
+
+- **Phase 1**: legend components (`app/components/legend/useLegendHook.tsx`
+  etc.) and `constants/datasets.ts` fetch categories/colors from the new
+  `/api/datasets/catalog` endpoint instead of hardcoded `legend.items`.
+- **Phase 2**: `ChartWidget.tsx` / `formatCharts.tsx` prefer backend-supplied
+  `colorMap`/`seriesColor`/`divergentColors` on the insight response; local
+  `chartColorMappings.ts` demotes to fallback-only (pre-migration insights,
+  genuinely unmapped slugs), then gets deleted once verified.
+
+## Concrete color data to port (phase 1 source of truth)
+
+Ported verbatim from `chartColorMappings.ts` / `constants/datasets.ts` — no
+new color design, just consolidation. Slugs are new (snake_case of the
+English label), everything else is an existing hex value.
+
+| dataset_id | dataset_name | color data |
+|---|---|---|
+| 0 | Global all ecosystem disturbance alerts (DIST-ALERT) | series_color `#f69` |
+| 1 | Global land cover | categories: see below |
+| 2 | Global natural/semi-natural grassland extent | series_color `#ff9916` |
+| 3 | SBTN Natural Lands Map | categories: see below |
+| 4 | Tree cover loss | series_color `#DC6C9A` |
+| 5 | Tree cover gain | series_color `#3F08F5` |
+| 6 | Forest greenhouse gas net flux | divergent_colors: positive `#9a65c0`, negative `#137375` |
+| 7 | Tree cover | series_color `#97BD3D` |
+| 8 | Tree cover loss by dominant driver | categories: see below; series_color `#DC6C9A` (used for non-pie chart types) |
+
+**dataset_id 1 — Global land cover categories:**
+`tree_cover` #246E24, `short_vegetation` #B9B91E, `wetland_short_vegetation`
+#74D6B4 ("Wetland – short vegetation"), `bare_and_sparse_vegetation` #FEFECC
+("Bare and sparse vegetation"), `water` #6BAED6, `snow_ice` #ACD1E8
+("Snow/ice"), `cropland` #fff183, `cultivated_grasslands` #FFCD73, `built_up`
+#e8765d ("Built-up").
+
+**dataset_id 3 — SBTN Natural Lands Map categories (21):**
+`natural_forests` #246E24, `natural_peat_forests` #093D09,
+`natural_peat_short_vegetation` #99991A, `mangroves` #06A285,
+`wet_natural_forests` #589558, `wet_natural_short_vegetation` #DBDB7B,
+`natural_short_vegetation` #B9B91E, `natural_water` #6BAED6, `bare` #FEFECC,
+`snow` #ACD1E8, `crop` #D3D3D3, `built` #D3D3D3, `non_natural_tree_cover`
+#D3D3D3, `non_natural_short_vegetation` #D3D3D3, `wet_non_natural_tree_cover`
+#D3D3D3, `non_natural_peat_tree_cover` #D3D3D3,
+`wet_non_natural_short_vegetation` #D3D3D3, `non_natural_peat_short_vegetation`
+#D3D3D3, `non_natural_water` #D3D3D3, `non_natural_bare` #D3D3D3, `other`
+#D3D3D3.
+
+Note: this dataset's API returns **only** the string `natural_lands_class`
+label, no numeric code (see decision 2) — the numeric class codes only exist
+in the raster tile colormap in `sbtn_natural_lands_map.yml`, unrelated to
+this registry. The API also returns a variable subset of these 21 classes
+per AOI (never all of them at once, never a collapsed 2-row response), so
+the code-executor/frontend must expect partial coverage, not assume every
+category always appears.
+
+**Map legend exception**: this dataset's map legend (`constants/datasets.ts`
+in project-zeno-next) intentionally curates the 21 fine-grained classes down
+to 11 display rows (grouping all non-natural classes, which share the same
+grey `#D3D3D3`, into a single "non-natural" row) — a deliberate simplification
+because the fine-grained non-natural breakdown is less relevant there. The
+catalog YAML marks this with `legend_categories: false`
+(`src/agent/datasets/palette.py` → `DatasetPalette.legend_categories`), which
+tells the frontend's `applyPaletteOverride`
+(`app/components/legend/useLegendHook.tsx`) to leave this dataset's
+hand-curated legend `items` untouched rather than expanding it to the full
+category list. Chart colors are unaffected — this flag only controls legend
+*display grouping*, not the color values themselves, which still come from
+this same registry.
+
+**dataset_id 8 — Tree cover loss by dominant driver categories:**
+`logging` #52A44E, `shifting_cultivation` #E9D700, `wildfire` #885128,
+`other_natural_disturbances` #3B209A, `settlements_infrastructure` #A354A0
+("Settlements & Infrastructure"), `hard_commodities` #E58074,
+`permanent_agriculture` #E39D29, `unknown` #D3D3D3.
+
+## Known gaps (pre-existing, not fixed by this plan)
+
+- When the code-executor groups raw categories per a catalog's
+  `code_instructions` (e.g. "Agriculture" = cropland + cultivated grasslands;
+  "Natural"/"Non-natural" for SBTN natural lands), the resulting bucket name
+  has **no registry entry** — this is already true of today's frontend maps
+  and isn't a regression. These fall through to the deterministic fallback
+  palette (decision 5). A future pass could add these grouped-bucket slugs to
+  the registry explicitly if they turn out to be common.
+
+## Build order
+
+1. **Phase 1 (this pass)**: registry data (A) + loader + new endpoint (B) +
+   frontend legend fetch (part of F). Ships independently, fixes the GHG
+   drift bug, zero risk to the agent/LLM pipeline.
+2. **Phase 2**: slug threading (C) + resolver (D) + schema/DB (E) + chart-side
+   frontend cutover (rest of F) — the harder LLM-prompt/schema work.
+3. **Phase 3 (cleanup)**: delete dead frontend color code once phase 2 is
+   verified in production for a while.
+
+## Out of scope (deliberately)
+
+- Redesigning any color values — this is pure consolidation.
+- Backfilling colors onto already-persisted insights — the frontend fallback
+  covers old data, no migration script planned.
+- Solving the "grouped bucket has no color" gap above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.24"
+version = "2026.7.24.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/datasets/catalog/forest_greenhouse_gas_net_flux.yml
+++ b/src/agent/datasets/catalog/forest_greenhouse_gas_net_flux.yml
@@ -110,3 +110,6 @@ providers: 'Harris, N.L., D.A. Gibbs, A. Baccini, R.A. Birdsey, S. de Bruin, M. 
 citation: 'Harris et al. (2021). Global maps of 21st century forest carbon fluxes. Accessed on <date> from Global Forest Watch.
 
   '
+divergent_colors:
+  positive: "#9a65c0"
+  negative: "#137375"

--- a/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -157,3 +157,4 @@ citation: 'Hansen, M.. OPERA Land Surface Disturbance Alert from Harmonized Land
   distributed by NASA EOSDIS Land Processes Distributed Active Archive Center, LP DAAC - OPERA_L3_DIST-ALERT-HLS_V1
 
   '
+series_color: "#f69"

--- a/src/agent/datasets/catalog/global_land_cover.yml
+++ b/src/agent/datasets/catalog/global_land_cover.yml
@@ -158,3 +158,31 @@ citation: 'Annual 30-m maps of Global Land Cover and Land Use 2015-2024 based on
   Data, 11(1), 1303. [doi:10.1038/s41597-024-04139-6](https://doi.org/10.1038/s41597-024-04139-6)
 
   '
+categories:
+- slug: tree_cover
+  label_en: Tree cover
+  color: "#246E24"
+- slug: short_vegetation
+  label_en: Short vegetation
+  color: "#B9B91E"
+- slug: wetland_short_vegetation
+  label_en: Wetland – short vegetation
+  color: "#74D6B4"
+- slug: bare_and_sparse_vegetation
+  label_en: Bare and sparse vegetation
+  color: "#FEFECC"
+- slug: water
+  label_en: Water
+  color: "#6BAED6"
+- slug: snow_ice
+  label_en: Snow/ice
+  color: "#ACD1E8"
+- slug: cropland
+  label_en: Cropland
+  color: "#fff183"
+- slug: cultivated_grasslands
+  label_en: Cultivated grasslands
+  color: "#FFCD73"
+- slug: built_up
+  label_en: Built-up
+  color: "#e8765d"

--- a/src/agent/datasets/catalog/global_natural_semi_natural_grassland_extent.yml
+++ b/src/agent/datasets/catalog/global_natural_semi_natural_grassland_extent.yml
@@ -155,3 +155,4 @@ citation: 'Parente, L., Sloat, L., Mesquita, V., Consoli, D., Stanimirova, R., H
   Learning. Scientific Data, 11(1), 1303. [doi:10.1038/s41597-024-04139-6](https://doi.org/10.1038/s41597-024-04139-6)
 
   '
+series_color: "#ff9916"

--- a/src/agent/datasets/catalog/sbtn_natural_lands_map.yml
+++ b/src/agent/datasets/catalog/sbtn_natural_lands_map.yml
@@ -104,3 +104,68 @@ citation: 'Mazur, E., M. Sims, E. Goldman, M. Schneider, M.D. Pirri, C.R. Beatty
   Targets Network. [SBTN Natural Lands Map Technical Documentation](https://sciencebasedtargetsnetwork.org/wp-content/uploads/2025/02/Technical-Guidance-2025-Step3-Land-v1_1-Natural-Lands-Map.pdf)
 
   '
+categories:
+- slug: natural_forests
+  label_en: Natural forests
+  color: "#246E24"
+- slug: natural_peat_forests
+  label_en: Natural peat forests
+  color: "#093D09"
+- slug: natural_peat_short_vegetation
+  label_en: Natural peat short vegetation
+  color: "#99991A"
+- slug: mangroves
+  label_en: Mangroves
+  color: "#06A285"
+- slug: wet_natural_forests
+  label_en: Wet natural forests
+  color: "#589558"
+- slug: wet_natural_short_vegetation
+  label_en: Wet natural short vegetation
+  color: "#DBDB7B"
+- slug: natural_short_vegetation
+  label_en: Natural short vegetation
+  color: "#B9B91E"
+- slug: natural_water
+  label_en: Natural water
+  color: "#6BAED6"
+- slug: bare
+  label_en: Bare
+  color: "#FEFECC"
+- slug: snow
+  label_en: Snow
+  color: "#ACD1E8"
+- slug: crop
+  label_en: Crop
+  color: "#D3D3D3"
+- slug: built
+  label_en: Built
+  color: "#D3D3D3"
+- slug: non_natural_tree_cover
+  label_en: Non-natural tree cover
+  color: "#D3D3D3"
+- slug: non_natural_short_vegetation
+  label_en: Non-natural short vegetation
+  color: "#D3D3D3"
+- slug: wet_non_natural_tree_cover
+  label_en: Wet non-natural tree cover
+  color: "#D3D3D3"
+- slug: non_natural_peat_tree_cover
+  label_en: Non-natural peat tree cover
+  color: "#D3D3D3"
+- slug: wet_non_natural_short_vegetation
+  label_en: Wet non-natural short vegetation
+  color: "#D3D3D3"
+- slug: non_natural_peat_short_vegetation
+  label_en: Non-natural peat short vegetation
+  color: "#D3D3D3"
+- slug: non_natural_water
+  label_en: Non-natural water
+  color: "#D3D3D3"
+- slug: non_natural_bare
+  label_en: Non-natural bare
+  color: "#D3D3D3"
+- slug: other
+  label_en: Other
+  color: "#D3D3D3"
+legend_categories: false

--- a/src/agent/datasets/catalog/tree_cover.yml
+++ b/src/agent/datasets/catalog/tree_cover.yml
@@ -85,3 +85,4 @@ citation: 'Use the following credit when these data are displayed: Source: Hanse
   Accessed through Global Forest Watch on <date>. [www.globalforestwatch.org](https://www.globalforestwatch.org)
 
   '
+series_color: "#97BD3D"

--- a/src/agent/datasets/catalog/tree_cover_gain.yml
+++ b/src/agent/datasets/catalog/tree_cover_gain.yml
@@ -98,3 +98,4 @@ citation: 'Use the following credit when this data is displayed: Accessed throug
   in Remote Sensing, 13, April 2022. [doi:10.3389/frsen.2022.856903](https://doi.org/10.3389/frsen.2022.856903)
 
   '
+series_color: "#3F08F5"

--- a/src/agent/datasets/catalog/tree_cover_loss.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss.yml
@@ -150,3 +150,4 @@ citation: 'Hansen et al., 2013. "High-Resolution Global Maps of 21st-Century For
   Learn more: https://storage.googleapis.com/earthenginepartners-hansen/GFC-2025-v1.13/download.html
 
   '
+series_color: "#DC6C9A"

--- a/src/agent/datasets/catalog/tree_cover_loss_by_dominant_driver.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss_by_dominant_driver.yml
@@ -128,3 +128,29 @@ citation: 'Use the following credit when these data are displayed: "Tree cover l
   "Global Drivers of Forest Loss at 1 Km Resolution." Environmental Research Letters 20 (7): 074027. [doi:10.1088/1748-9326/add606](https://doi.org/10.1088/1748-9326/add606).
 
   '
+categories:
+- slug: logging
+  label_en: Logging
+  color: "#52A44E"
+- slug: shifting_cultivation
+  label_en: Shifting cultivation
+  color: "#E9D700"
+- slug: wildfire
+  label_en: Wildfire
+  color: "#885128"
+- slug: other_natural_disturbances
+  label_en: Other natural disturbances
+  color: "#3B209A"
+- slug: settlements_infrastructure
+  label_en: Settlements & Infrastructure
+  color: "#A354A0"
+- slug: hard_commodities
+  label_en: Hard commodities
+  color: "#E58074"
+- slug: permanent_agriculture
+  label_en: Permanent agriculture
+  color: "#E39D29"
+- slug: unknown
+  label_en: Unknown
+  color: "#D3D3D3"
+series_color: "#DC6C9A"

--- a/src/agent/datasets/palette.py
+++ b/src/agent/datasets/palette.py
@@ -1,0 +1,107 @@
+"""
+Canonical color registry for dataset categories, series colors, and divergent
+colors, derived from the `categories` / `series_color` / `divergent_colors`
+keys in the catalog YAMLs (`src/agent/datasets/catalog/*.yml`).
+
+This is the single source of truth chart and map-legend colors are resolved
+from — see docs/insight-chart-colors-plan.md. Colors are keyed by a stable
+English slug (defined here, in the catalog), never by a translated display
+label, so the same category gets the same color regardless of the user's
+language.
+"""
+
+import re
+from typing import Optional, TypedDict
+
+from src.agent.datasets.config import DATASETS
+
+_HEX_COLOR_RE = re.compile(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+
+class PaletteCategory(TypedDict):
+    slug: str
+    label_en: str
+    color: str
+
+
+class DivergentColors(TypedDict):
+    positive: str
+    negative: str
+
+
+class DatasetPalette(TypedDict):
+    dataset_id: int
+    dataset_name: str
+    categories: list[PaletteCategory]
+    series_color: Optional[str]
+    divergent_colors: Optional[DivergentColors]
+    # Whether a map legend should render `categories` verbatim. False for
+    # datasets whose legend intentionally curates/collapses categories that
+    # are less relevant at a glance (e.g. SBTN Natural Lands groups all
+    # non-natural classes into one legend row) — chart colors are unaffected
+    # either way, this only controls map legend display grouping.
+    legend_categories: bool
+
+
+def _validate_hex(color: str, context: str) -> str:
+    if not _HEX_COLOR_RE.match(color):
+        raise ValueError(f"invalid hex color {color!r} in {context}")
+    return color
+
+
+def _build_palettes() -> dict[int, DatasetPalette]:
+    palettes: dict[int, DatasetPalette] = {}
+    for dataset in DATASETS:
+        raw_categories = dataset.get("categories") or []
+        series_color = dataset.get("series_color")
+        raw_divergent = dataset.get("divergent_colors")
+        if not raw_categories and not series_color and not raw_divergent:
+            continue
+
+        dataset_id = dataset["dataset_id"]
+        context = f"dataset_id={dataset_id} ({dataset['dataset_name']})"
+
+        categories: list[PaletteCategory] = []
+        seen_slugs: set[str] = set()
+        for category in raw_categories:
+            slug = category["slug"]
+            if slug in seen_slugs:
+                raise ValueError(
+                    f"duplicate category slug {slug!r} in {context}"
+                )
+            seen_slugs.add(slug)
+            categories.append(
+                PaletteCategory(
+                    slug=slug,
+                    label_en=category["label_en"],
+                    color=_validate_hex(category["color"], context),
+                )
+            )
+
+        if series_color is not None:
+            series_color = _validate_hex(series_color, context)
+
+        divergent_colors: Optional[DivergentColors] = None
+        if raw_divergent is not None:
+            divergent_colors = DivergentColors(
+                positive=_validate_hex(raw_divergent["positive"], context),
+                negative=_validate_hex(raw_divergent["negative"], context),
+            )
+
+        palettes[dataset_id] = DatasetPalette(
+            dataset_id=dataset_id,
+            dataset_name=dataset["dataset_name"],
+            categories=categories,
+            series_color=series_color,
+            divergent_colors=divergent_colors,
+            legend_categories=dataset.get("legend_categories", True),
+        )
+    return palettes
+
+
+PALETTES: dict[int, DatasetPalette] = _build_palettes()
+
+
+def get_dataset_palette(dataset_id: int) -> Optional[DatasetPalette]:
+    """Return the color registry entry for a dataset, or None if it has no colors defined."""
+    return PALETTES.get(dataset_id)

--- a/src/api/routers/metadata.py
+++ b/src/api/routers/metadata.py
@@ -3,7 +3,9 @@
 from fastapi import APIRouter
 
 from src.agent.config import AgentSettings
+from src.agent.datasets.palette import PALETTES
 from src.agent.llms import get_model, get_small_model
+from src.api.schemas import DatasetCatalogResponse
 from src.shared.geocoding_helpers import (
     GADM_SUBTYPE_MAP,
     SOURCE_ID_MAPPING,
@@ -41,3 +43,18 @@ async def api_metadata() -> dict:
             "small_model_class": small_model.__class__.__name__,
         },
     }
+
+
+@router.get("/api/datasets/catalog")
+async def datasets_catalog() -> DatasetCatalogResponse:
+    """
+    Returns the canonical color registry for each dataset: category colors
+    (keyed by a stable English slug, not a translated label), single-series
+    colors, and divergent (positive/negative) colors.
+
+    This is the single source of truth for chart and map-legend colors —
+    see docs/insight-chart-colors-plan.md. Only datasets with color data
+    defined in their catalog YAML are included.
+    """
+    ordered = sorted(PALETTES.values(), key=lambda p: p["dataset_id"])
+    return DatasetCatalogResponse.model_validate({"datasets": ordered})

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -692,3 +692,27 @@ class DashboardPublicToggleResponse(DashboardResponse):
             "Insights flipped to public because this dashboard was published."
         ),
     )
+
+
+class DatasetPaletteCategoryResponse(BaseModel):
+    slug: str
+    label_en: str
+    color: str
+
+
+class DatasetDivergentColorsResponse(BaseModel):
+    positive: str
+    negative: str
+
+
+class DatasetPaletteResponse(BaseModel):
+    dataset_id: int
+    dataset_name: str
+    categories: List[DatasetPaletteCategoryResponse] = []
+    series_color: Optional[str] = None
+    divergent_colors: Optional[DatasetDivergentColorsResponse] = None
+    legend_categories: bool = True
+
+
+class DatasetCatalogResponse(BaseModel):
+    datasets: List[DatasetPaletteResponse]

--- a/tests/api/test_metadata.py
+++ b/tests/api/test_metadata.py
@@ -63,3 +63,70 @@ async def test_metadata_layer_id_mapping_has_known_sources(client):
     # These sources are expected to be present based on geocoding_helpers
     assert isinstance(layer_id_mapping, dict)
     assert len(layer_id_mapping) > 0
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_no_auth_required(client):
+    """Dataset catalog endpoint is public - no authentication needed."""
+    response = await client.get("/api/datasets/catalog")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_includes_global_land_cover(client):
+    """Global land cover (dataset_id=1) exposes its category color mapping."""
+    response = await client.get("/api/datasets/catalog")
+    datasets = response.json()["datasets"]
+
+    land_cover = next(d for d in datasets if d["dataset_id"] == 1)
+    assert land_cover["dataset_name"] == "Global land cover"
+    assert land_cover["series_color"] is None
+    assert land_cover["divergent_colors"] is None
+    assert land_cover["legend_categories"] is True
+    slugs = [c["slug"] for c in land_cover["categories"]]
+    assert "tree_cover" in slugs
+    assert "cropland" in slugs
+    tree_cover = next(
+        c for c in land_cover["categories"] if c["slug"] == "tree_cover"
+    )
+    assert tree_cover["label_en"] == "Tree cover"
+    assert tree_cover["color"] == "#246E24"
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_natural_lands_opts_out_of_legend_categories(
+    client,
+):
+    """SBTN Natural Lands (dataset_id=3) curates its map legend down to fewer
+    rows — chart colors still cover all categories, but legend_categories=False
+    tells the frontend not to expand its legend to the full category list."""
+    response = await client.get("/api/datasets/catalog")
+    datasets = response.json()["datasets"]
+
+    natural_lands = next(d for d in datasets if d["dataset_id"] == 3)
+    assert len(natural_lands["categories"]) == 21
+    assert natural_lands["legend_categories"] is False
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_includes_divergent_colors(client):
+    """Forest GHG net flux (dataset_id=6) exposes divergent positive/negative colors."""
+    response = await client.get("/api/datasets/catalog")
+    datasets = response.json()["datasets"]
+
+    ghg = next(d for d in datasets if d["dataset_id"] == 6)
+    assert ghg["categories"] == []
+    assert ghg["divergent_colors"] == {
+        "positive": "#9a65c0",
+        "negative": "#137375",
+    }
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_only_includes_datasets_with_colors(client):
+    """Datasets without any category/series/divergent colors are omitted."""
+    response = await client.get("/api/datasets/catalog")
+    datasets = response.json()["datasets"]
+
+    dataset_ids = {d["dataset_id"] for d in datasets}
+    assert dataset_ids == {0, 1, 2, 3, 4, 5, 6, 7, 8}

--- a/tests/tools/test_dataset_palette.py
+++ b/tests/tools/test_dataset_palette.py
@@ -1,0 +1,114 @@
+import re
+
+import pytest
+
+from src.agent.datasets.palette import PALETTES, get_dataset_palette
+
+
+# This module only exercises pure in-memory catalog parsing and needs no
+# database, so override the global autouse DB fixtures with no-ops.
+@pytest.fixture(scope="function", autouse=True)
+def test_db():
+    """Override the global test_db fixture to avoid database connections."""
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_session():
+    """Override the global test_db_session fixture to avoid database connections."""
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def test_db_pool():
+    """Override the global test_db_pool fixture to avoid database pool operations."""
+    pass
+
+
+EXPECTED_DATASET_IDS = {0, 1, 2, 3, 4, 5, 6, 7, 8}
+
+
+def test_all_expected_datasets_have_palettes():
+    assert set(PALETTES.keys()) == EXPECTED_DATASET_IDS
+
+
+def test_get_dataset_palette_unknown_returns_none():
+    assert get_dataset_palette(9999) is None
+
+
+def test_global_land_cover_categories():
+    palette = get_dataset_palette(1)
+    assert palette is not None
+    assert palette["dataset_name"] == "Global land cover"
+    slugs = [c["slug"] for c in palette["categories"]]
+    assert slugs == [
+        "tree_cover",
+        "short_vegetation",
+        "wetland_short_vegetation",
+        "bare_and_sparse_vegetation",
+        "water",
+        "snow_ice",
+        "cropland",
+        "cultivated_grasslands",
+        "built_up",
+    ]
+    assert palette["series_color"] is None
+    assert palette["divergent_colors"] is None
+    assert palette["legend_categories"] is True
+
+
+def test_sbtn_natural_lands_has_21_categories():
+    palette = get_dataset_palette(3)
+    assert palette is not None
+    assert len(palette["categories"]) == 21
+    assert len({c["slug"] for c in palette["categories"]}) == 21
+
+
+def test_sbtn_natural_lands_opts_out_of_legend_categories():
+    """SBTN Natural Lands intentionally curates its map legend down to fewer,
+    collapsed rows — the registry still supplies chart colors for all 21
+    categories, but the frontend must not expand its legend to match."""
+    palette = get_dataset_palette(3)
+    assert palette is not None
+    assert palette["legend_categories"] is False
+
+
+def test_tree_cover_loss_by_driver_has_categories_and_series_color():
+    palette = get_dataset_palette(8)
+    assert palette is not None
+    assert len(palette["categories"]) == 8
+    assert palette["series_color"] == "#DC6C9A"
+
+
+def test_tree_cover_loss_series_color():
+    palette = get_dataset_palette(4)
+    assert palette is not None
+    assert palette["categories"] == []
+    assert palette["series_color"] == "#DC6C9A"
+
+
+def test_forest_ghg_net_flux_divergent_colors():
+    palette = get_dataset_palette(6)
+    assert palette is not None
+    assert palette["divergent_colors"] == {
+        "positive": "#9a65c0",
+        "negative": "#137375",
+    }
+
+
+def test_legend_categories_defaults_true_except_natural_lands():
+    for dataset_id, palette in PALETTES.items():
+        expected = dataset_id != 3
+        assert palette["legend_categories"] is expected, dataset_id
+
+
+def test_all_colors_are_valid_hex():
+    hex_re = re.compile(r"^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+    for palette in PALETTES.values():
+        for category in palette["categories"]:
+            assert hex_re.match(category["color"]), category
+        if palette["series_color"] is not None:
+            assert hex_re.match(palette["series_color"])
+        if palette["divergent_colors"] is not None:
+            assert hex_re.match(palette["divergent_colors"]["positive"])
+            assert hex_re.match(palette["divergent_colors"]["negative"])

--- a/uv.lock
+++ b/uv.lock
@@ -3038,7 +3038,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.22.1"
+version = "2026.7.24"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Chart and map-legend colors (land cover classes, tree-cover-loss drivers,
dataset series colors) currently live only in `project-zeno-next`, keyed by
literal English strings. This breaks once the agent translates category
labels for non-English users, and has already produced at least one drift
bug between the frontend's two color files (a GHG dataset name mismatch).

This PR is **phase 1** of a plan to make the backend the single source of
truth for these colors. Full design and rationale in
[`docs/insight-chart-colors-plan.md`](docs/insight-chart-colors-plan.md).

## Overall plan

- **Phase 1 (this PR)**: canonical color registry lives in the dataset
  catalog YAMLs (`categories`/`series_color`/`divergent_colors`, keyed by a
  stable English slug — verified no dataset's analytics API actually
  returns a numeric class code, only string labels). A new
  `GET /api/datasets/catalog` endpoint exposes it. The companion
  `project-zeno-next` PR wires the map legend to read from this endpoint
  instead of its own hardcoded colors. Ships independently, zero risk to
  chart generation, fixes an existing color-drift bug as a side effect.
- **Phase 2 (not started)**: thread a stable category slug through the
  code-executor LLM prompt and `InsightChart` schema (today the LLM writes
  already-translated category labels straight into `chart_data`, with no
  stable key surviving translation), add a deterministic (non-LLM) color
  resolution step, migrate `InsightChartOrm`, and cut the chart-rendering
  frontend over from its local color file to backend-supplied colors.
- **Phase 3**: delete the now-redundant frontend color files once phase 2
  is verified in production.

## Changes

- 9 catalog YAMLs gain `categories`/`series_color`/`divergent_colors`
  (verbatim ported hex values, no new color design) and, for SBTN Natural
  Lands, a `legend_categories: false` flag — that dataset's map legend
  intentionally collapses non-natural classes into one row, which this flag
  preserves without hardcoding a dataset-id special case anywhere.
- `src/agent/datasets/palette.py`: loader/registry with hex validation.
- `GET /api/datasets/catalog` (`src/api/routers/metadata.py`) + schemas.

## Test plan

- [x] `uv run pytest tests/tools/test_dataset_palette.py tests/api/test_metadata.py tests/unit` — 439 passed
- [x] Verified the 9 YAMLs still parse via `src.agent.datasets.config.DATASETS`
- [x] Confirmed pre-existing live-LLM test flakes in `test_pick_dataset.py` reproduce identically without this change (stash-tested)
- [x] ruff / ruff-format / mypy clean on touched files