### PR TITLE
Add phase 2 of the insight chart color registry (slug threading + resolver)

### DIFF
--- a/db/alembic/versions/d4f7b1e9a3c2_add_chart_color_registry_fields.py
+++ b/db/alembic/versions/d4f7b1e9a3c2_add_chart_color_registry_fields.py
@@ -1,0 +1,53 @@
+"""add chart color registry fields to insight_charts
+
+Revision ID: d4f7b1e9a3c2
+Revises: ceea2a027738
+Create Date: 2026-07-24 00:00:00.000000
+
+Phase 2 of the insight chart color registry (see
+docs/insight-chart-colors-plan.md): persists the dataset_id colors were
+resolved against plus the resolved color_map/series_color/divergent_colors
+onto each chart, so a later display revision can re-resolve colors without
+re-running the code executor.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "d4f7b1e9a3c2"
+down_revision: Union[str, None] = "ceea2a027738"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "insight_charts", sa.Column("dataset_id", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "insight_charts",
+        sa.Column(
+            "color_map",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+    op.add_column(
+        "insight_charts", sa.Column("series_color", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "insight_charts",
+        sa.Column("divergent_colors", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("insight_charts", "divergent_colors")
+    op.drop_column("insight_charts", "series_color")
+    op.drop_column("insight_charts", "color_map")
+    op.drop_column("insight_charts", "dataset_id")

--- a/docs/insight-chart-colors-plan.md
+++ b/docs/insight-chart-colors-plan.md
@@ -1,8 +1,10 @@
 # Insight chart colors — implementation plan
 
-*Status: agreed design, phase 1 in progress. Written 2026-07-24. This document
-is self-contained: a fresh session can pick up any phase from here without
-prior conversation context.*
+*Status: agreed design. Written 2026-07-24. Phase 1 and phase 2 are both
+implemented (same day) on top of each other in the existing phase-1
+branches/PRs (backend PR #771, frontend PR #615) — phase 3 cleanup is not yet
+started. This document is self-contained: a fresh session can pick up any
+phase from here without prior conversation context.*
 
 ## Problem
 
@@ -242,13 +244,37 @@ this same registry.
 
 ## Build order
 
-1. **Phase 1 (this pass)**: registry data (A) + loader + new endpoint (B) +
+1. **Phase 1 (done)**: registry data (A) + loader + new endpoint (B) +
    frontend legend fetch (part of F). Ships independently, fixes the GHG
    drift bug, zero risk to the agent/LLM pipeline.
-2. **Phase 2**: slug threading (C) + resolver (D) + schema/DB (E) + chart-side
-   frontend cutover (rest of F) — the harder LLM-prompt/schema work.
-3. **Phase 3 (cleanup)**: delete dead frontend color code once phase 2 is
-   verified in production for a while.
+2. **Phase 2 (done)**: slug threading (C) + resolver (D) + schema/DB (E) +
+   chart-side frontend cutover (rest of F).
+   - C/D: `EXECUTOR_WORKFLOW` (`src/agent/subagents/analyst/prompts.py`) now
+     instructs the code executor to emit a `{column}__slug` sibling column
+     next to any categorical color column, using canonical slugs passed in
+     via a new `category_slug_hints` section of the analysis prompt
+     (`Analyst._resolve_charts` in `tool.py`, built from
+     `get_dataset_palette(dataset_id)`). A new deterministic resolver,
+     `resolve_chart_colors()` in
+     `src/agent/subagents/analyst/charts/color_resolver.py`, attaches
+     `color_map` (slug -> hex, with a hashed fallback for unrecognized
+     slugs), `series_color` and `divergent_colors` onto each `InsightChart`
+     after the executor runs. `update_insight_display` re-runs this resolver
+     when a revision changes which column drives color, using the
+     `dataset_id` persisted on the original chart.
+   - E: `InsightChart` (model + ORM + `InsightChartResponse`) gained
+     `dataset_id`, `color_map`, `series_color`, `divergent_colors` — see
+     migration `d4f7b1e9a3c2_add_chart_color_registry_fields`.
+   - F (chart side): `formatChartData` (project-zeno-next
+     `app/utils/formatCharts.tsx`) now takes an optional `colorOverrides`
+     param (`colorMap`/`seriesColor`/`divergentColors`) read off each
+     `InsightWidget`/`ChartDTO`, preferred over the local
+     `chartColorMappings.ts` config. Pie-chart row coloring resolves via the
+     row's `{field}__slug` value when present, falling back to the raw field
+     value for chart data with no slug column (e.g. pre-migration insights).
+3. **Phase 3 (cleanup, not started)**: delete dead frontend color code
+   (`chartColorMappings.ts`) once phase 2 is verified in production for a
+   while.
 
 ## Out of scope (deliberately)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.30"
+version = "2026.7.31"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/subagents/analyst/charts/__init__.py
+++ b/src/agent/subagents/analyst/charts/__init__.py
@@ -1,6 +1,9 @@
 """Chart layer for the analyst: the canonical `InsightChart`/`Insight`
 seam model shared by both insight paths."""
 
+from src.agent.subagents.analyst.charts.color_resolver import (
+    resolve_chart_colors,
+)
 from src.agent.subagents.analyst.charts.model import (
     Insight,
     InsightChart,
@@ -9,4 +12,5 @@ from src.agent.subagents.analyst.charts.model import (
 __all__ = [
     "Insight",
     "InsightChart",
+    "resolve_chart_colors",
 ]

--- a/src/agent/subagents/analyst/charts/color_resolver.py
+++ b/src/agent/subagents/analyst/charts/color_resolver.py
@@ -1,0 +1,100 @@
+"""Deterministic color resolution for `InsightChart` (phase 2).
+
+Attaches `color_map` / `series_color` / `divergent_colors` onto a chart from
+the backend color registry (`src/agent/datasets/palette.py`), keyed by
+`dataset_id` plus the stable English slug the code-executor emits alongside a
+chart's categorical grouping column — see docs/insight-chart-colors-plan.md,
+decisions 2 and 5.
+
+This is a plain, deterministic post-processing step: it never asks an LLM to
+invent colors. A category slug with no registry entry (e.g. an LLM-invented
+grouped bucket like "Agriculture") gets a deterministic fallback color, hashed
+from the slug so the same slug always gets the same color across
+regenerations of the same insight.
+"""
+
+import hashlib
+from typing import Optional
+
+from src.agent.datasets.palette import get_dataset_palette
+
+# The code-executor emits this sibling column next to any categorical column
+# used for chart coloring, e.g. "driver__slug" next to "driver".
+SLUG_COLUMN_SUFFIX = "__slug"
+
+# Fallback palette for slugs with no registry entry. Order is irrelevant — the
+# pick is a hash of the slug, not a position.
+_FALLBACK_PALETTE = [
+    "#4C78A8",
+    "#F58518",
+    "#54A24B",
+    "#B279A2",
+    "#E45756",
+    "#72B7B2",
+    "#EECA3B",
+    "#FF9DA6",
+    "#9D755D",
+    "#BAB0AC",
+]
+
+
+def _fallback_color(slug: str) -> str:
+    digest = hashlib.sha256(slug.encode("utf-8")).digest()
+    return _FALLBACK_PALETTE[digest[0] % len(_FALLBACK_PALETTE)]
+
+
+def _categorical_column(chart) -> str:
+    """The chart_data column whose values drive per-category coloring, if any.
+
+    Bar/line/area/scatter/grouped-bar/stacked-bar use `color_field` when set.
+    Pie charts group by their category column, which the code executor always
+    puts in `x_axis` (pie has no `color_field`).
+    """
+    if chart.color_field:
+        return chart.color_field
+    if chart.chart_type == "pie":
+        return chart.x_axis
+    return ""
+
+
+def resolve_chart_colors(chart, dataset_id: Optional[int]):
+    """Return `chart` with `dataset_id`/`color_map`/`series_color`/
+    `divergent_colors` attached from the registry. Mutates and returns
+    `chart` in place; `chart_data` and field mappings are untouched.
+    """
+    chart.dataset_id = dataset_id
+    palette = (
+        get_dataset_palette(dataset_id) if dataset_id is not None else None
+    )
+    if palette is None:
+        chart.color_map = {}
+        chart.series_color = None
+        chart.divergent_colors = None
+        return chart
+
+    column = _categorical_column(chart)
+    if column:
+        slug_column = f"{column}{SLUG_COLUMN_SUFFIX}"
+        registry_colors = {
+            category["slug"]: category["color"]
+            for category in palette["categories"]
+        }
+        slugs: set[str] = set()
+        for row in chart.chart_data:
+            value = row.get(slug_column, row.get(column))
+            if value is not None:
+                slugs.add(str(value))
+        chart.color_map = {
+            slug: registry_colors.get(slug) or _fallback_color(slug)
+            for slug in slugs
+        }
+    else:
+        chart.color_map = {}
+
+    chart.series_color = palette["series_color"]
+    chart.divergent_colors = (
+        dict(palette["divergent_colors"])
+        if palette["divergent_colors"] is not None
+        else None
+    )
+    return chart

--- a/src/agent/subagents/analyst/charts/model.py
+++ b/src/agent/subagents/analyst/charts/model.py
@@ -13,7 +13,7 @@ text stage.
 """
 
 import math
-from typing import List
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -58,6 +58,15 @@ class InsightChart(BaseModel):
     series_fields: List[str] = Field(default_factory=list)
     chart_data: List[dict] = Field(default_factory=list)
     insight: str = ""
+
+    # Color registry resolution (phase 2, see docs/insight-chart-colors-plan.md).
+    # `dataset_id` identifies which catalog entry the colors were resolved
+    # from; it is not itself sent to the frontend, only persisted so a later
+    # display revision can re-resolve colors against the same dataset.
+    dataset_id: Optional[int] = None
+    color_map: Dict[str, str] = Field(default_factory=dict)
+    series_color: Optional[str] = None
+    divergent_colors: Optional[Dict[str, str]] = None
 
     @field_validator("chart_data")
     @classmethod
@@ -111,6 +120,9 @@ class InsightChart(BaseModel):
             "stackField": self.stack_field,
             "groupField": self.group_field,
             "seriesFields": self.series_fields,
+            "colorMap": self.color_map,
+            "seriesColor": self.series_color,
+            "divergentColors": self.divergent_colors,
         }
 
     @classmethod
@@ -152,6 +164,10 @@ class InsightChart(BaseModel):
             group_field=row.group_field,
             series_fields=row.series_fields or [],
             chart_data=row.chart_data or [],
+            dataset_id=row.dataset_id,
+            color_map=row.color_map or {},
+            series_color=row.series_color,
+            divergent_colors=row.divergent_colors,
         )
 
 

--- a/src/agent/subagents/analyst/prompts.py
+++ b/src/agent/subagents/analyst/prompts.py
@@ -57,13 +57,28 @@ Now prepare the data for visualization in Recharts.js:
          - **Pie**: [{"name": "Category A", "value": 100}], max 6–8 slices
          - **IMPORTANT**: For every non-pie/non-table chart, either y_axis OR series_fields MUST be set. Never leave both empty.
 
-   c) **SAVE THE DATA**: Save as `chart_data.csv` — pipeline only reads this file. Final step must call `to_csv('chart_data.csv', index=False)`.
+   c) **STABLE CATEGORY SLUG COLUMN** (for consistent coloring across languages):
+      - For the categorical column that drives chart coloring — `color_field`
+        for bar/line/area/scatter, or the category/name column for pie charts —
+        add a sibling column named "{column}__slug" with a stable, ENGLISH,
+        snake_case identifier per row. Never put translated text or invented
+        hex colors in this column.
+      - If canonical slugs for this dataset are listed above (under STABLE
+        CATEGORY SLUGS), use them verbatim for any row whose category matches
+        one unchanged.
+      - If you group or rename raw categories (per the dataset-specific rules
+        above), invent a new snake_case slug for each new bucket instead — keep
+        it stable if the same bucket recurs elsewhere in the output.
+      - Skip this column entirely for charts with no categorical color column
+        (e.g. a simple time series with a single numeric y_axis).
 
-   d) **SAVE THE CHART SPEC**: Save the chart spec(s) as `insight.json` — the
+   d) **SAVE THE DATA**: Save as `chart_data.csv` — pipeline only reads this file. Final step must call `to_csv('chart_data.csv', index=False)`.
+
+   e) **SAVE THE CHART SPEC**: Save the chart spec(s) as `insight.json` — the
       pipeline only reads this file. A separate stage generates the narrative,
       so do not write any insight text here.
 
-   e) **PRINT CHART TYPE**: State the recommended chart type in the output
+   f) **PRINT CHART TYPE**: State the recommended chart type in the output
 """
 
 WORDING_GUIDE = """# Wording

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -11,11 +11,13 @@ from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
 
+from src.agent.datasets.palette import get_dataset_palette
 from src.agent.i18n import t
 from src.agent.language import DEFAULT_LANGUAGE, language_name
 from src.agent.subagents.analyst.charts import (
     Insight,
     InsightChart,
+    resolve_chart_colors,
 )
 from src.agent.subagents.analyst.code_executors import GeminiCodeExecutor
 from src.agent.subagents.analyst.code_executors.base import (
@@ -187,6 +189,7 @@ def build_analysis_prompt(
     code_instructions: Optional[str] = None,
     context_layer: Optional[str] = None,
     language: str = DEFAULT_LANGUAGE,
+    category_slug_hints: Optional[str] = None,
 ) -> str:
     """
     Build the analysis prompt for the code executor.
@@ -200,6 +203,9 @@ def build_analysis_prompt(
         context_layer: Active context layer name, if any (e.g. "driver")
         language: Conversation language for human-readable chart text (titles,
             axis/series labels) — column/field names stay English identifiers
+        category_slug_hints: "label_en -> slug" lines from the dataset's color
+            registry entry, if it has one — see EXECUTOR_WORKFLOW's stable
+            category slug column instructions.
 
     Returns:
         Formatted prompt string
@@ -232,6 +238,14 @@ def build_analysis_prompt(
 ---
 """
 
+    slug_hints_section = ""
+    if category_slug_hints:
+        slug_hints_section = f"""
+### STABLE CATEGORY SLUGS (for the `__slug` sibling column — see workflow step 3c):
+{category_slug_hints}
+---
+"""
+
     return f"""### User Query:
 {query}
 
@@ -250,6 +264,7 @@ regardless of language.
 ---
 {guidelines_section}
 {dataset_rules_section}
+{slug_hints_section}
 {cautions_section}
 
 {EXECUTOR_WORKFLOW}
@@ -360,6 +375,19 @@ class Analyst:
             "cautions", "No specific dataset cautions provided."
         )
 
+        dataset_id = dataset.get("dataset_id")
+        palette = (
+            get_dataset_palette(dataset_id) if dataset_id is not None else None
+        )
+        category_slug_hints = (
+            "\n".join(
+                f'- "{category["label_en"]}" -> {category["slug"]}'
+                for category in palette["categories"]
+            )
+            if palette and palette["categories"]
+            else None
+        )
+
         executor = GeminiCodeExecutor()
         analysis_prompt = build_analysis_prompt(
             query,
@@ -369,6 +397,7 @@ class Analyst:
             code_instructions=code_instructions,
             context_layer=dataset.get("context_layer"),
             language=language,
+            category_slug_hints=category_slug_hints,
         )
         logger.debug(f"Analysis prompt:\n{analysis_prompt}")
 
@@ -408,7 +437,10 @@ class Analyst:
                 )
 
         charts = [
-            InsightChart.from_chart_insight(chart, result.chart_data, idx)
+            resolve_chart_colors(
+                InsightChart.from_chart_insight(chart, result.chart_data, idx),
+                dataset_id,
+            )
             for idx, chart in enumerate(result.insight.charts)
         ]
         # Collect execution-output text (printed totals, statistics) so the

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -21,6 +21,9 @@ from langgraph.types import Command
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from src.agent.subagents.analyst.charts.color_resolver import (
+    resolve_chart_colors,
+)
 from src.agent.subagents.analyst.charts.model import Insight, InsightChart
 from src.agent.subagents.analyst.display_reviser import (
     InsightDisplayReviser,
@@ -105,17 +108,20 @@ def _apply_revision(
             new_charts.append(original)
             continue
         new_charts.append(
-            InsightChart(
-                position=original.position,
-                title=rc.title,
-                chart_type=rc.chart_type,
-                x_axis=rc.x_axis,
-                y_axis=rc.y_axis,
-                color_field=rc.color_field,
-                stack_field=rc.stack_field,
-                group_field=rc.group_field,
-                series_fields=rc.series_fields,
-                chart_data=original.chart_data,
+            resolve_chart_colors(
+                InsightChart(
+                    position=original.position,
+                    title=rc.title,
+                    chart_type=rc.chart_type,
+                    x_axis=rc.x_axis,
+                    y_axis=rc.y_axis,
+                    color_field=rc.color_field,
+                    stack_field=rc.stack_field,
+                    group_field=rc.group_field,
+                    series_fields=rc.series_fields,
+                    chart_data=original.chart_data,
+                ),
+                original.dataset_id,
             )
         )
 

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -400,6 +400,12 @@ class InsightChartOrm(Base):
     series_fields = Column(JSONB, nullable=False, server_default="[]")
     chart_data = Column(JSONB, nullable=False)
 
+    # Color registry resolution (phase 2, see docs/insight-chart-colors-plan.md).
+    dataset_id = Column(Integer, nullable=True)
+    color_map = Column(JSONB, nullable=False, server_default="{}")
+    series_color = Column(String, nullable=True)
+    divergent_colors = Column(JSONB, nullable=True)
+
     insight = relationship("InsightOrm", back_populates="charts")
 
 

--- a/src/api/routers/insights.py
+++ b/src/api/routers/insights.py
@@ -45,6 +45,10 @@ def _row_to_response(row: InsightOrm) -> InsightResponse:
                 group_field=chart.group_field,
                 series_fields=chart.series_fields or [],
                 chart_data=chart.chart_data or [],
+                dataset_id=chart.dataset_id,
+                color_map=chart.color_map or {},
+                series_color=chart.series_color,
+                divergent_colors=chart.divergent_colors,
             )
             for chart in (row.charts or [])
         ],

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from geojson_pydantic import Polygon
@@ -452,6 +452,10 @@ class InsightChartResponse(BaseModel):
     group_field: str
     series_fields: List[str]
     chart_data: List[dict]
+    dataset_id: Optional[int] = None
+    color_map: Dict[str, str] = {}
+    series_color: Optional[str] = None
+    divergent_colors: Optional[Dict[str, str]] = None
 
 
 class InsightResponse(BaseModel):

--- a/tests/agent/test_update_insight_display.py
+++ b/tests/agent/test_update_insight_display.py
@@ -52,6 +52,10 @@ def _fake_orm_row(**kwargs):
                 group_field="",
                 series_fields=[],
                 chart_data=[{"year": 2020, "loss": 5, "gain": 2}],
+                dataset_id=4,
+                color_map={},
+                series_color="#DC6C9A",
+                divergent_colors=None,
             )
         ],
     )
@@ -84,6 +88,47 @@ def test_apply_revision_restyles_and_keeps_data():
     assert chart.chart_data == [{"year": 2020, "loss": 5, "gain": 2}]
     # stamp_insight copies the primary onto each chart.
     assert chart.insight == "New summary"
+
+
+def test_apply_revision_preserves_dataset_id_and_recolors():
+    original = InsightChart(
+        position=0,
+        title="Old title",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="loss",
+        color_field="",
+        dataset_id=8,
+        chart_data=[
+            {
+                "year": 2020,
+                "loss": 5,
+                "driver": "Logging",
+                "driver__slug": "logging",
+            }
+        ],
+    )
+    revised = RevisedInsight(
+        primary_insight="x",
+        follow_up_suggestions=["f"],
+        charts=[
+            RevisedChart(
+                position=0,
+                title="By driver",
+                chart_type="bar",
+                x_axis="year",
+                y_axis="loss",
+                color_field="driver",
+            )
+        ],
+    )
+    out = _apply_revision([original], revised)
+    chart = out.charts[0]
+    # dataset_id carried over from the original chart (not part of RevisedChart).
+    assert chart.dataset_id == 8
+    # color_field changed to a categorical column -> colors re-resolved against it.
+    assert chart.color_map == {"logging": "#52A44E"}
+    assert chart.series_color == "#DC6C9A"
 
 
 def test_apply_revision_drops_unknown_columns():

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -696,4 +696,8 @@ async def test_insight_response_shape(client, auth_override):
         "group_field",
         "series_fields",
         "chart_data",
+        "dataset_id",
+        "color_map",
+        "series_color",
+        "divergent_colors",
     }

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -560,6 +560,102 @@ async def test_generate_insights_persists_statistics_provenance(monkeypatch):
     assert _last_insight_row.statistics_ids == []
 
 
+async def test_generate_insights_threads_dataset_id_and_resolves_colors(
+    monkeypatch,
+):
+    """Phase 2: dataset_id flows into the analysis prompt (as category slug
+    hints) and into the resulting chart's colorMap, resolved from the
+    registry — see docs/insight-chart-colors-plan.md."""
+    captured_prompt: dict[str, str] = {}
+
+    _insight = MultiChartInsight(
+        charts=[
+            ChartInsight(
+                title="Land cover breakdown",
+                chart_type="pie",
+                x_axis="land_cover_type",
+            )
+        ],
+    )
+
+    class FakeExecutionResult:
+        error = None
+        chart_data = [
+            {
+                "land_cover_type": "Tree cover",
+                "land_cover_type__slug": "tree_cover",
+                "value": 10,
+            },
+            {
+                "land_cover_type": "Cropland",
+                "land_cover_type__slug": "cropland",
+                "value": 5,
+            },
+        ]
+        insight = _insight
+        parts = [
+            SimpleNamespace(
+                type=generate_insights_module.PartType.TEXT_OUTPUT,
+                content="Composition summarized.",
+            )
+        ]
+
+        def get_encoded_parts(self):
+            return [
+                {"type": "text_output", "content": "Composition summarized."}
+            ]
+
+    class FakeExecutor:
+        def build_file_references(self, dataframes):
+            return "input_file_0.csv"
+
+        async def prepare_dataframes(self, dataframes):
+            return []
+
+        async def execute(self, analysis_prompt, file_refs):
+            captured_prompt["value"] = analysis_prompt
+            return FakeExecutionResult()
+
+    monkeypatch.setattr(
+        generate_insights_module, "GeminiCodeExecutor", FakeExecutor
+    )
+
+    class _Text:
+        primary_insight = "Tree cover and cropland make up most of the area."
+        follow_up_suggestions = ["Compare by year."]
+
+    async def fake_generate(
+        self,
+        charts,
+        dataset,
+        query="",
+        executor_context=None,
+        language="en",
+        config=None,
+    ):
+        return _Text()
+
+    monkeypatch.setattr(
+        generate_insights_module.InsightTextGenerator,
+        "generate",
+        fake_generate,
+    )
+
+    update = await invoke_generate_insights(
+        "Pie chart of land cover in Brazil",
+        LAND_COVER_DATASET,
+        LAND_COVER_COMPOSITION_STATS,
+    )
+    chart = chart_from(update)
+    assert chart is not None
+    assert chart["colorMap"] == {
+        "tree_cover": "#246E24",
+        "cropland": "#fff183",
+    }
+    assert "STABLE CATEGORY SLUGS" in captured_prompt["value"]
+    assert '"Tree cover" -> tree_cover' in captured_prompt["value"]
+
+
 # ---------------------------------------------------------------------------
 # Dataset fixtures — loaded directly from the YAML catalog so they stay in sync
 # ---------------------------------------------------------------------------

--- a/tests/unit/agent/tools/test_color_resolver.py
+++ b/tests/unit/agent/tools/test_color_resolver.py
@@ -1,0 +1,125 @@
+"""Unit tests for the phase 2 deterministic chart color resolver."""
+
+from src.agent.subagents.analyst.charts.color_resolver import (
+    resolve_chart_colors,
+)
+from src.agent.subagents.analyst.charts.model import InsightChart
+
+# Global land cover (dataset_id=1): categories only, no series/divergent color.
+LAND_COVER_ID = 1
+# Tree cover loss by dominant driver: categories AND a series_color.
+DRIVER_ID = 8
+# Tree cover loss: series_color only, no categories.
+TREE_COVER_LOSS_ID = 4
+# Forest GHG net flux: divergent_colors only, no categories.
+GHG_ID = 6
+
+
+def _pie_chart(rows) -> InsightChart:
+    return InsightChart(
+        title="Land cover",
+        chart_type="pie",
+        x_axis="land_cover_type",
+        chart_data=rows,
+    )
+
+
+def test_no_dataset_id_yields_no_colors():
+    chart = InsightChart(
+        title="Loss", chart_type="bar", x_axis="year", y_axis="loss"
+    )
+    resolved = resolve_chart_colors(chart, None)
+    assert resolved.dataset_id is None
+    assert resolved.color_map == {}
+    assert resolved.series_color is None
+    assert resolved.divergent_colors is None
+
+
+def test_non_categorical_chart_gets_no_color_map_but_keeps_dataset_id():
+    chart = InsightChart(
+        title="Loss", chart_type="bar", x_axis="year", y_axis="loss"
+    )
+    resolved = resolve_chart_colors(chart, TREE_COVER_LOSS_ID)
+    assert resolved.dataset_id == TREE_COVER_LOSS_ID
+    assert resolved.color_map == {}
+    assert resolved.series_color == "#DC6C9A"
+    assert resolved.divergent_colors is None
+
+
+def test_pie_chart_resolves_color_map_from_slug_column():
+    rows = [
+        {
+            "land_cover_type": "Bosque",
+            "land_cover_type__slug": "tree_cover",
+            "value": 10,
+        },
+        {
+            "land_cover_type": "Cultivo",
+            "land_cover_type__slug": "cropland",
+            "value": 5,
+        },
+    ]
+    resolved = resolve_chart_colors(_pie_chart(rows), LAND_COVER_ID)
+    assert resolved.color_map == {
+        "tree_cover": "#246E24",
+        "cropland": "#fff183",
+    }
+
+
+def test_pie_chart_falls_back_to_raw_column_without_slug_column():
+    rows = [{"land_cover_type": "tree_cover", "value": 10}]
+    resolved = resolve_chart_colors(_pie_chart(rows), LAND_COVER_ID)
+    assert resolved.color_map == {"tree_cover": "#246E24"}
+
+
+def test_unrecognized_slug_gets_deterministic_fallback_color():
+    rows = [
+        {
+            "land_cover_type": "Agriculture (grouped)",
+            "land_cover_type__slug": "agriculture",
+            "value": 10,
+        }
+    ]
+    first = resolve_chart_colors(_pie_chart(rows), LAND_COVER_ID)
+    second = resolve_chart_colors(_pie_chart(rows), LAND_COVER_ID)
+    assert first.color_map["agriculture"] not in {
+        None,
+        "",
+    }
+    assert first.color_map["agriculture"].startswith("#")
+    # Same slug -> same fallback color across regenerations.
+    assert first.color_map["agriculture"] == second.color_map["agriculture"]
+
+
+def test_color_field_drives_color_map_for_non_pie_charts():
+    rows = [
+        {"year": 2020, "driver": "Logging", "driver__slug": "logging"},
+        {"year": 2021, "driver": "Wildfire", "driver__slug": "wildfire"},
+    ]
+    chart = InsightChart(
+        title="Loss by driver",
+        chart_type="bar",
+        x_axis="year",
+        y_axis="area_ha",
+        color_field="driver",
+        chart_data=[{**r, "area_ha": 1} for r in rows],
+    )
+    resolved = resolve_chart_colors(chart, DRIVER_ID)
+    assert resolved.color_map == {
+        "logging": "#52A44E",
+        "wildfire": "#885128",
+    }
+    # Dataset-level series_color still passes through alongside category colors.
+    assert resolved.series_color == "#DC6C9A"
+
+
+def test_divergent_colors_pass_through():
+    chart = InsightChart(
+        title="Net flux", chart_type="bar", x_axis="country", y_axis="net_flux"
+    )
+    resolved = resolve_chart_colors(chart, GHG_ID)
+    assert resolved.divergent_colors == {
+        "positive": "#9a65c0",
+        "negative": "#137375",
+    }
+    assert resolved.color_map == {}

--- a/tests/unit/agent/tools/test_insight_chart_model.py
+++ b/tests/unit/agent/tools/test_insight_chart_model.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+from types import SimpleNamespace
 
 import pytest
 
@@ -24,6 +25,9 @@ FRONTEND_KEYS = {
     "stackField",
     "groupField",
     "seriesFields",
+    "colorMap",
+    "seriesColor",
+    "divergentColors",
 }
 
 
@@ -60,6 +64,10 @@ def test_to_orm_kwargs_is_snake_case_and_complete():
         "group_field",
         "series_fields",
         "chart_data",
+        "dataset_id",
+        "color_map",
+        "series_color",
+        "divergent_colors",
     }
     assert kwargs["chart_type"] == "bar"
     assert kwargs["y_axis"] == "area_ha"
@@ -117,6 +125,30 @@ def test_axis_validator_rejects_missing_axis():
 def test_axis_validator_allows_pie_without_axis():
     chart = InsightChart(title="ok", chart_type="pie", x_axis="name")
     assert chart.chart_type == "pie"
+
+
+def test_from_orm_row_restores_color_fields():
+    row = SimpleNamespace(
+        position=0,
+        title="Drivers",
+        chart_type="pie",
+        x_axis="driver",
+        y_axis="",
+        color_field="",
+        stack_field="",
+        group_field="",
+        series_fields=[],
+        chart_data=[{"driver": "Logging", "value": 5}],
+        dataset_id=8,
+        color_map={"logging": "#52A44E"},
+        series_color="#DC6C9A",
+        divergent_colors=None,
+    )
+    chart = InsightChart.from_orm_row(row)
+    assert chart.dataset_id == 8
+    assert chart.color_map == {"logging": "#52A44E"}
+    assert chart.series_color == "#DC6C9A"
+    assert chart.divergent_colors is None
 
 
 def test_stamp_insight_copies_text_to_each_chart():

--- a/uv.lock
+++ b/uv.lock
@@ -112,11 +112,11 @@ wheels = [
 
 [[package]]
 name = "annotated-doc"
-version = "0.0.4"
+version = "0.0.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.120.0"
+version = "0.120.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -142,9 +142,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/5c/3331da4fc009d448008a50c78d86cc929e8c937cd1442245ce3f80561c4e/anthropic-0.120.0.tar.gz", hash = "sha256:6ba6007dc9b00365b20f6101a6618f5196ac1ceef81512e4b5cc0e7436d4975d", size = 1008042, upload-time = "2026-07-24T16:32:52.384Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/8a/8522bdf809e1f95f0d9c936540987a3f6afba01d2921a2bf488dedf836a8/anthropic-0.120.0-py3-none-any.whl", hash = "sha256:591bd531563ec7b63a1e138f5c11f14cb94edda99623b349c2ce2ece8e08b8a5", size = 1022602, upload-time = "2026-07-24T16:32:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
 ]
 
 [[package]]
@@ -795,15 +795,6 @@ wheels = [
 ]
 
 [[package]]
-name = "decorator"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
-]
-
-[[package]]
 name = "deepagents"
 version = "0.4.12"
 source = { registry = "https://pypi.org/simple" }
@@ -967,7 +958,7 @@ standard = [
 
 [[package]]
 name = "fastapi-cloud-cli"
-version = "0.22.2"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "detect-installer" },
@@ -980,9 +971,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/f2/36bfe990baa656de89a2b98a77a15dcd018474f7245c8e4a10cada0553c5/fastapi_cloud_cli-0.22.2.tar.gz", hash = "sha256:7ec78c1fed58f578af5eb1fb54ec4b456eba4dc1eaca1c3a93cf499a7cbc7ab3", size = 94480, upload-time = "2026-07-14T09:27:01.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/dc/63aaf9913f455e39a7027c27140edd887a87d47d65ac43532d77a51718e5/fastapi_cloud_cli-0.23.0.tar.gz", hash = "sha256:840895bb8d14309aeffc905e0dcd1334d18c6f5da54b735413a8f1cb385e581e", size = 95295, upload-time = "2026-07-28T14:03:33.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/25/e01631a63a5213fc783e5b84e8a27eca800f21549aa414644a0a29181045/fastapi_cloud_cli-0.22.2-py3-none-any.whl", hash = "sha256:37c6b05adb94a4c9f59916a559d041c565db36b5f3dddeed420bf0a51182c363", size = 77744, upload-time = "2026-07-14T09:27:02.571Z" },
+    { url = "https://files.pythonhosted.org/packages/86/96/7e9aba6fabce3cb05f320abeef5b81efd5134823ae85d1a517872cb83cbc/fastapi_cloud_cli-0.23.0-py3-none-any.whl", hash = "sha256:1cd2ffa56e92e92c1fc63acc426c214dd928cbeed2a4c7c6a9a5fc85ea73de16", size = 78058, upload-time = "2026-07-28T14:03:34.386Z" },
 ]
 
 [[package]]
@@ -1011,20 +1002,20 @@ wheels = [
 
 [[package]]
 name = "fastjsonschema"
-version = "2.22.0"
+version = "2.22.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/11/c802f752919c1fd83d44b3b955c6e7120c79f355d4a448c358198a11178c/fastjsonschema-2.22.0.tar.gz", hash = "sha256:6eb12e8f9900db6166c3d396d178ebdf6a4215fe22a06e19792edd612a20035a", size = 382291, upload-time = "2026-07-25T20:32:35.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/98/474719c58eddaf77fa443b063693e76d49db32bbe851bcbaf58d2700119f/fastjsonschema-2.22.1.tar.gz", hash = "sha256:0b83d1ce8d7845b959dcb20e1a5c3c8883b6541d9c52ab02cce5166b75ec805f", size = 382291, upload-time = "2026-07-27T13:31:08.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/9d/4a0f9355ca3e540b2d22d5f269212e2f227b8f277835b02d8908355245d1/fastjsonschema-2.22.0-py3-none-any.whl", hash = "sha256:60f4c92fda6f93efe3b3261638836478e1e11abc01c647e36e478199f7a86a37", size = 26248, upload-time = "2026-07-25T20:32:33.616Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/62cc96341f01bdff2ba967441939178fcd1900d11ce7e6554d9954a5d7ec/fastjsonschema-2.22.1-py3-none-any.whl", hash = "sha256:cf377ff5c9a6f4f3125fb35f75a2c5767bd824ffbcf62c209a93cd48d1453999", size = 26239, upload-time = "2026-07-27T13:31:03.251Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.32.0"
+version = "3.32.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
 ]
 
 [[package]]
@@ -1553,11 +1544,10 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.15.0"
+version = "9.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
     { name = "ipython-pygments-lexers" },
     { name = "jedi" },
     { name = "matplotlib-inline" },
@@ -1568,9 +1558,9 @@ dependencies = [
     { name = "stack-data" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/49/04360f83b4d110195751b4171b75dc1cd7b97ba122b18da34b5828172d59/ipython-9.16.0.tar.gz", hash = "sha256:d2f92587b1ef51d84f934dffe05fabb9255f0038ed0a21426f2ea761e39ad09a", size = 4515375, upload-time = "2026-07-31T08:02:51.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/3a/948263ca3b9d65bb2b1b0c521b3a49fad5d59ada58724bd87d2bd5ff3f36/ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e", size = 630895, upload-time = "2026-06-26T11:03:33.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/82/d30656b9eb33b8ed4e421ca55c13c7fff412086f0405bbe53c39a7ee4a3b/ipython-9.16.0-py3-none-any.whl", hash = "sha256:3d02b96de2a59074d153b1ac1c3865de738df114e430e879e6e5ef100a4d470c", size = 625973, upload-time = "2026-07-31T08:02:50.114Z" },
 ]
 
 [[package]]
@@ -2227,7 +2217,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/ea/4c/0fb7d900d3b0b9c87
 
 [[package]]
 name = "langsmith"
-version = "0.10.10"
+version = "0.10.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2245,9 +2235,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/38/c709ff119172e490a8e8bccd10deeda8da239f15f11521009a58c7b904ac/langsmith-0.10.10.tar.gz", hash = "sha256:e0e175e9dd8de6d96dbb55244482e20590a2691ec7c5e087afc1f302e33d98fe", size = 4739726, upload-time = "2026-07-23T04:18:56.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/c2/804558586a5363af85fc5b03ea327d0ba5d4d83da4c7d53fbed2413ef681/langsmith-0.10.14.tar.gz", hash = "sha256:edd3711ed1a334e5fb87b15eb0777b5abe5ad931dc13bfb79b93fffcbd2c2b4c", size = 4782076, upload-time = "2026-07-30T23:27:22.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/ec/0b2348bea502e07cb3c2a6e5109423debd82aef9fcef6f807c159ceb5297/langsmith-0.10.10-py3-none-any.whl", hash = "sha256:eb5e9da635f5853fc657cddd1c27f40a8e8b2f00c38051555d608c8e57eb605d", size = 675232, upload-time = "2026-07-23T04:18:54.399Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/178c8c5bb50efd3e88986212993349aa027ff90364ccd4db4e3c596aede6/langsmith-0.10.14-py3-none-any.whl", hash = "sha256:185432f170c1639e9be14aad4116ba59079753a5762c7e1a26c11cf9988f8288", size = 726292, upload-time = "2026-07-30T23:27:20.333Z" },
 ]
 
 [[package]]
@@ -2742,7 +2732,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.48.0"
+version = "2.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2754,9 +2744,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/d4d1835488c0350424009dac5095b9a3e173bee12fd2e421ee27e2142c42/openai-2.48.0.tar.gz", hash = "sha256:231b1e7661dda14574986c2f71451e9d584b7fe69e0ee6480e12ed090b48fc16", size = 1093427, upload-time = "2026-07-23T20:15:50.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/d8/06fda9685e47d9a8fc177ef57f8af75207938fad49a45ce23bfa7b6a2a5c/openai-2.51.0.tar.gz", hash = "sha256:4d61287c42eba54086d09346e709cbf7f8cec51822efce9cc399450b9385fba5", size = 1083410, upload-time = "2026-07-30T17:43:26.507Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/2a/dcb891114e303c4379d4a498f10222e33eee540bcef4e1e493bd0af2b242/openai-2.48.0-py3-none-any.whl", hash = "sha256:c98df30aaaf93c51979f64d3e7c5b76464f8be0173368266229eb8fe6bd30f2c", size = 1648520, upload-time = "2026-07-23T20:15:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6f/c49e21245ad4865e886f6885e95e998bc024335b392c202bd571639e9d50/openai-2.51.0-py3-none-any.whl", hash = "sha256:91db13ce59a670fddc820a6983989650095e43e3acac09288bceb69356a8904e", size = 1652344, upload-time = "2026-07-30T17:43:24.225Z" },
 ]
 
 [[package]]
@@ -3038,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.29"
+version = "2026.7.31"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -4613,7 +4603,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/b9/18/61a661be6225176a0
 
 [[package]]
 name = "virtualenv"
-version = "21.7.0"
+version = "21.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -4621,9 +4611,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/fa/18004e5cb15541ad2a68ff219c755233b012b12d4ec8663d06a258082bec/virtualenv-21.7.1.tar.gz", hash = "sha256:d0dbfaa5483487baea28d7210ef8d24c9d1bd0f10f449eeb215568825a9b334e", size = 5525237, upload-time = "2026-07-30T15:40:36.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl", hash = "sha256:6394973f990536e34c05157179146c020284c42fe01da1dfeb0ba16c345280d9", size = 5504576, upload-time = "2026-07-30T15:40:34.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 2 of the insight chart color plan (see `docs/insight-chart-colors-plan.md`, follows phase 1 in #771). Today the code-executor LLM writes already-translated category labels straight into `chart_data`, with no stable key surviving translation. This threads a stable category slug through the pipeline and resolves colors deterministically (never LLM-generated) against the phase-1 registry, so chart colors stay consistent across languages and match the map legend.

## Changes

- `EXECUTOR_WORKFLOW` (`src/agent/subagents/analyst/prompts.py`): instructs the code executor to emit a `{column}__slug` sibling column next to any categorical color column, using canonical slugs from the dataset's registry when available.
- `Analyst._resolve_charts` / `build_analysis_prompt` (`src/agent/subagents/analyst/tool.py`): passes `category_slug_hints` (from `get_dataset_palette(dataset_id)`) into the prompt and threads `dataset_id` through.
- New `resolve_chart_colors()` (`src/agent/subagents/analyst/charts/color_resolver.py`): deterministic, hash-based fallback color for slugs with no registry entry; attaches `color_map`/`series_color`/`divergent_colors` onto `InsightChart`.
- `update_insight_display` (`src/agent/tools/update_insight_display.py`): re-runs the resolver on revision, using the `dataset_id` persisted on the original chart (revisions can re-map `color_field` to a different column).
- New DB columns on `insight_charts` via migration `d4f7b1e9a3c2_add_chart_color_registry_fields`: `dataset_id`, `color_map`, `series_color`, `divergent_colors`.
- `InsightChart` model/schema/API surface carries the new fields through both acquisition paths (chat stream + analysis LRO).

## Compatibility

Additive: new nullable/defaulted DB columns, new optional model fields, new prompt section. Existing charts without a `dataset_id` resolve to empty/`None` colors (falls back to current frontend behavior) until the companion `project-zeno-next` PR consumes `colorMap`/`seriesColor`/`divergentColors`.

## Test plan

- [x] `uv run pytest tests/agent/test_update_insight_display.py tests/tools/test_generate_insights_tiered.py tests/unit/agent/tools/test_color_resolver.py tests/unit/agent/tools/test_insight_chart_model.py tests/api/test_insights.py`
- [x] ruff / ruff-format / mypy clean on touched files