### PR TITLE
Bump version to 2026.7.24.2 and sync uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.24.1"
+version = "2026.7.24.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/uv.lock
+++ b/uv.lock
@@ -3038,7 +3038,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.24"
+version = "2026.7.24.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Version-only fix, split out of #773 so it can land independently.

`pyproject.toml` was bumped to `2026.7.24.1` by the `bump-calver` pre-commit hook when #771 merged, but `uv.lock`'s `project-zeno` entry was never regenerated to match — it was still pinned at `2026.7.24`. That drift makes the `bump-calver` hook fail in CI on any branch forked from main at that state (e.g. #773's Lint check), since the hook sees `pyproject.toml` already equal to main's version and tries to bump further, and `uv lock` then reports the file as out of sync.

This bumps to `2026.7.24.2` and regenerates `uv.lock` so both are consistent again.

## Test plan

- [x] `pre-commit run --all-files` — clean
- [x] `uv lock` — resolves without changes after commit