### PR TITLE
Move show-imagery skill from experimental to default profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.27.1"
+version = "2026.7.27.2"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -101,11 +101,17 @@ CORE_TOOLS = (
 
 # The core skills layered on the base toolbox.
 DEFAULT_PROFILE = "default"
-DEFAULT_SKILLS = ("analyze", "pull-data", "capabilities", "wri-insights")
+DEFAULT_SKILLS = (
+    "analyze",
+    "pull-data",
+    "capabilities",
+    "show-imagery",
+    "wri-insights",
+)
 
 # Experimental, opt-in additions over the default profile.
 EXPERIMENTAL_PROFILE = "experimental"
-EXPERIMENTAL_SKILLS = ("dashboard", "show-imagery", "explore")
+EXPERIMENTAL_SKILLS = ("dashboard", "explore")
 EXPERIMENTAL_TOOLS = (
     inspect_view_context_spec,
     update_insight_display_spec,

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -252,6 +252,7 @@ def test_default_profile_derives_exactly_the_core_tools():
             "generate_insights",
             "read_skill",
             "search_blogs",
+            "show_imagery",
         }
     )
 
@@ -302,18 +303,18 @@ async def test_fetch_zeno_binds_the_resolved_configs_availability():
 
 
 def test_experimental_config_adds_experimental_tools_and_skills():
-    """The experimental profile layers show_imagery (and its skill, plus
-    explore) on top of the default set; the default profile exposes
-    neither."""
+    """The experimental profile layers dashboard and explore on top of the
+    default set (which already has show-imagery)."""
     default = default_registry.resolve(DEFAULT_PROFILE)
     experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
 
     default_tools = {t.name for t in default.bound_tools()}
     experimental_tools = {t.name for t in experimental.bound_tools()}
-    assert "show_imagery" not in default_tools
+    assert "show_imagery" in default_tools
     assert {"show_imagery", "search_blogs"} <= experimental_tools
 
     default_skills = {s.name for s in default.skill_metas()}
     experimental_skills = {s.name for s in experimental.skill_metas()}
-    assert {"show-imagery", "explore"} & default_skills == set()
+    assert "show-imagery" in default_skills
+    assert {"show-imagery", "explore", "wri-insights"} <= experimental_skills
     assert {"show-imagery", "explore", "wri-insights"} <= experimental_skills

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -36,6 +36,7 @@ skills:
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
   - pull-data (requires: pick_aoi, pick_dataset, pull_data)
+  - show-imagery (requires: pick_aoi, show_imagery)
   - wri-insights (requires: search_blogs)
 subagents:
   - pick_aoi
@@ -44,7 +45,8 @@ subagents:
   - search_blogs
 tools:
   - pull_data
-  - read_skill"""
+  - read_skill
+  - show_imagery"""
 
 EXPERIMENTAL_MANIFEST = """\
 profile: experimental

--- a/uv.lock
+++ b/uv.lock
@@ -3038,7 +3038,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.27.1"
+version = "2026.7.27.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Move the `show-imagery` skill from the `experimental` profile to the `default` profile so satellite imagery is available alongside the core skills (analyze, pull-data, etc.).

**Changes:**
- `src/agent/agent_config.py`: moved `"show-imagery"` from `EXPERIMENTAL_SKILLS` to `DEFAULT_SKILLS`
- `tests/unit/agent/test_profile_manifest.py`: updated default manifest snapshot
- `tests/unit/agent/test_feature_flag.py`: updated feature flag assertions

The experimental profile still inherits show-imagery via the extends chain.