### PR TITLE
Warn the agent against hallucinating chart values it only has stats for

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.28"
+version = "2026.7.28.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -130,6 +130,7 @@ Language and format:
 - Never include raw JSON or code blocks in replies (charts render from state).
 - If insights include follow-up suggestions, surface them in your reply.
 - After `generate_insights`, give a short summary of the chart, and surface the relevant dataset cautions / methodology notes from the analyst's tool message
+- Chart data in tool messages (from `generate_insights` or `inspect_view_context`) is either the full rows (small series) or per-column stats only — min/max/mean, or distinct-value counts and samples (large series). When only stats are shown, cite only those aggregates; never state a specific individual data point, exact total, or trend that isn't present in what was returned.
 
 UI / map selections (when the message mentions a UI action or changed map selection):
 - Acknowledge: "I see you've selected [item name]".


### PR DESCRIPTION
## Summary

Follow-up to #778, which changed chart-data injection (into `generate_insights`'s tool message and `inspect_view_context`) so large series are summarized as per-column stats (min/max/mean, or distinct-value counts + samples) instead of dropping the data or listing every row.

That's strictly safer than the old behavior (data reaching the agent, not being silently absent, was the prior hallucination cause) — but when only stats are shown, the agent could still invent a specific data point or exact total that looks plausible instead of admitting it only has the aggregate.

- Adds an explicit instruction to the main system prompt (`src/agent/graph.py`): when chart data is stats-only, cite only the given aggregates and never state an individual value/total/trend that isn't present in what was returned.

## Test plan
- [x] `ruff check` / `ruff format` clean
- [x] `tests/agent/test_feature_flag.py` and `tests/unit/agent/test_feature_flag.py` pass (exercise the system prompt build)