### PR TITLE
Type the known view_context keys, drop dead 'report' naming, render dashboard text widgets

### DIFF
--- a/docs/view-context-pages.md
+++ b/docs/view-context-pages.md
@@ -51,8 +51,7 @@ loads and formats dashboards and insights from the DB on demand.
 `view_context` remains frontend-owned and free-form. The parts the backend
 assigns meaning to:
 
-- `page`: `"map"` | `"dashboard"` (`"report"` is sent today but has no
-  registered semantics yet). Unknown values degrade gracefully — generic
+- `page`: `"map"` | `"dashboard"`. Unknown values degrade gracefully — generic
   breadcrumb, no prompt section.
 - On the dashboard page: `dashboard_id` (used by `add_to_dashboard` as the
   default target and by `inspect_view_context` to load the dashboard) and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.28.1"
+version = "2026.7.29"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -9,7 +9,7 @@ a query that refers to what the user is looking at.
 
 Insights are the exception to "just echo what the frontend sent": they carry a
 lot of content that lives in the database, not the snapshot. When the frontend
-reports visible insight ids (typically on the report page), the tool loads each
+reports visible insight ids (on the map or dashboard page), the tool loads each
 insight and prints its most important content — summary, chart titles and the
 variables behind each chart — so the agent can reason about what's on screen
 even when that detail isn't already in the conversation history.
@@ -61,6 +61,10 @@ DATA_SKIP_COLUMNS = {"aoi_id", "aoi_type"}
 # Secondary cap on full-table output; if the formatted table exceeds this,
 # fall back to stats even if row count is below the threshold.
 DATA_TABLE_CHAR_LIMIT = 4000
+# Cap on a text widget's markdown body; the agent composes these itself
+# (add_text_widget) so they're normally short, but this guards against a
+# pathological note dominating the dashboard rendering.
+TEXT_WIDGET_CHAR_LIMIT = 2000
 
 
 def _label(item: object, *keys: str) -> str:
@@ -360,13 +364,28 @@ def _format_map_widget(config: dict) -> Optional[str]:
     return None
 
 
+def _format_text_widget(config: dict) -> str:
+    """A text widget's markdown body, capped to guard against a runaway note.
+
+    The body is agent-composed (add_text_widget) so it's normally short;
+    this is a defensive cap, not a routine truncation.
+    """
+    text = str(config.get("text") or "").strip()
+    if not text:
+        return "(empty)"
+    if len(text) > TEXT_WIDGET_CHAR_LIMIT:
+        return text[:TEXT_WIDGET_CHAR_LIMIT] + "… (truncated)"
+    return text
+
+
 async def format_dashboard(dashboard: DashboardOrm) -> str:
     """Render the dashboard being viewed: name, area(s) and its widgets.
 
     Insight widgets are expanded with the shared `format_insights` rendering
     (visibility-filtered), so the agent can reason about what each widget
     shows; map widgets are summarized by dataset name/dates or imagery
-    date/areas; anything else is listed by type and config.
+    date/areas; text widgets show their markdown body; anything else is
+    listed by type and config.
     """
     lines = [f"Dashboard being viewed: '{dashboard.name}' ({dashboard.id})"]
     if dashboard.description:
@@ -383,9 +402,14 @@ async def format_dashboard(dashboard: DashboardOrm) -> str:
     for widget in widgets:
         if widget.widget_type == "insight":
             continue  # detail comes from the insight rendering below
-        summary = _format_map_widget(widget.config or {})
-        if summary is None:
-            summary = json.dumps(widget.config or {}, default=str)
+        config = widget.config or {}
+        summary: str
+        if widget.widget_type == "text":
+            summary = _format_text_widget(config)
+        else:
+            summary = _format_map_widget(config) or json.dumps(
+                config, default=str
+            )
         lines.append(
             f"  Widget {widget.position} ({widget.widget_type}): {summary}"
         )
@@ -405,14 +429,14 @@ async def inspect_view_context(
 ) -> Command:
     """Return what the user is currently looking at in the app.
 
-    Reports the current page (map vs report vs dashboard), the map viewport,
-    the layers and AOIs visible on screen, and — when the frontend reports
-    visible insights (e.g. on the report page) — the key content of each
+    Reports the current page (map vs dashboard), the map viewport, the layers
+    and AOIs visible on screen, and — when the frontend reports visible
+    insights (on the map or dashboard page) — the key content of each
     insight: its summary, chart titles and the variables behind each chart.
     When the user is viewing a dashboard, reports its name, area(s) and
     widgets, with insight widgets expanded the same way. Call this when the
-    user refers to "this", "here", the current view, the report, the
-    dashboard, or an insight on screen, and you need those details to answer.
+    user refers to "this", "here", the current view, the dashboard, or an
+    insight on screen, and you need those details to answer.
     """
     view = (state or {}).get("view_context") or {}
     logger.info(

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -109,7 +109,11 @@ async def chat(
                     user_persona=chat_request.user_persona,
                     thread_id=thread_id,
                     ui_context=chat_request.ui_context,
-                    view_context=chat_request.view_context,
+                    view_context=(
+                        chat_request.view_context.model_dump(exclude_none=True)
+                        if chat_request.view_context
+                        else None
+                    ),
                     ui_action_only=chat_request.ui_action_only,
                     langfuse_metadata=langfuse_metadata,
                     user=user_dict,

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 from uuid import UUID
 
 from geojson_pydantic import Polygon
@@ -342,6 +342,56 @@ class CustomAreaCreate(BaseModel):
     geometries: List[Polygon]
 
 
+class ViewportContext(BaseModel):
+    """The map's current extent, as reported by the frontend."""
+
+    model_config = ConfigDict(extra="allow")
+    bbox: Optional[List[float]] = None  # [minx, miny, maxx, maxy]
+    zoom: Optional[float] = None
+
+
+class VisibleLayerContext(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    id: Optional[str] = None
+    name: Optional[str] = None
+
+
+class VisibleAoiContext(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    source: Optional[str] = None
+    src_id: Optional[str] = None
+    name: Optional[str] = None
+
+
+class ViewContext(BaseModel):
+    """Ambient frontend view state — what the user is currently looking at.
+
+    Unlike ui_context (deliberate actions), this is reference material the
+    agent consults on demand via the inspect_view_context tool; it is NOT
+    turned into a message or eagerly merged into the agent's selections.
+
+    Typed for the keys `inspect_view_context` understands (see its
+    `_KNOWN_KEYS`), but every field is optional and `extra="allow"` lets
+    unrecognized keys — a new field the frontend has started sending ahead
+    of backend support, or one this model hasn't caught up with yet — pass
+    through untouched rather than fail validation. `inspect_view_context`
+    dumps anything it doesn't recognize verbatim under "Other", so nothing
+    is lost either way. See docs/view-context-pages.md.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    page: Optional[str] = None  # known values: "map" | "dashboard"
+    viewport: Optional[ViewportContext] = None
+    visible_layers: Optional[List[VisibleLayerContext]] = None
+    visible_aois: Optional[List[VisibleAoiContext]] = None
+    # Entries may be bare insight ids or {"id": ...} dicts.
+    visible_insights: Optional[List[Union[str, dict]]] = None
+    # Set on the dashboard page, alongside dashboard_name.
+    dashboard_id: Optional[str] = None
+    dashboard_name: Optional[str] = None
+
+
 class ChatRequest(BaseModel):
     query: str = Field(..., description="The query")
     user_persona: Optional[str] = Field(None, description="The user persona")
@@ -351,22 +401,7 @@ class ChatRequest(BaseModel):
         None  # {"aoi_selected": {...}, "dataset_selected": {...}, "daterange_selected": {...}}
     )
 
-    # Ambient frontend view state — what the user is currently looking at.
-    # Unlike ui_context (deliberate actions), this is reference material the
-    # agent consults on demand via the inspect_view_context tool; it is NOT
-    # turned into a message or eagerly merged into the agent's selections.
-    # Free-form (the frontend owns the shape), e.g.:
-    #   {"page": "map" | "report",
-    #    "viewport": {"bbox": [minx, miny, maxx, maxy], "zoom": 5},
-    #    "visible_layers": [{"id": "...", "name": "..."}],
-    #    "visible_aois": [{"source": "...", "src_id": "...", "name": "..."}],
-    #    "visible_insights": ["<uuid>", "<uuid>"]}
-    # On the dashboard page the snapshot carries the dashboard being viewed:
-    #   {"page": "dashboard", "dashboard_id": "<uuid>", "dashboard_name": "…"}
-    # Known "page" values get scope semantics on the backend (session-block
-    # line + system-prompt section) via src/agent/view_pages.py; see
-    # docs/view-context-pages.md. Unknown pages degrade gracefully.
-    view_context: Optional[dict] = Field(
+    view_context: Optional[ViewContext] = Field(
         None,
         description="Ambient frontend view state (page, viewport, visible layers/AOIs)",
     )

--- a/tests/agent/test_inspect_view_context.py
+++ b/tests/agent/test_inspect_view_context.py
@@ -9,9 +9,11 @@ import pytest
 
 from src.agent.middleware import format_session_block
 from src.agent.tools.inspect_view_context import (
+    TEXT_WIDGET_CHAR_LIMIT,
     _chart_variables,
     _extract_insight_ids,
     _format_map_widget,
+    _format_text_widget,
     format_chart_data,
     format_dashboard,
     format_insights,
@@ -22,7 +24,7 @@ from src.agent.tools.inspect_view_context import (
 
 VIEW_STATE = {
     "view_context": {
-        "page": "report",
+        "page": "sandbox",
         "viewport": {"bbox": [-74, -34, -34, 5], "zoom": 5},
         "visible_layers": [
             {"id": "tree-cover", "name": "Tree cover"},
@@ -73,7 +75,7 @@ async def test_inspect_view_context_returns_snapshot():
         state=VIEW_STATE, tool_call_id="t1"
     )
     content = _content(command)
-    assert "Page: report" in content
+    assert "Page: sandbox" in content
     assert "Tree cover" in content
     assert "Fire alerts" in content
     assert "São Paulo" in content
@@ -93,7 +95,7 @@ def test_format_view_context_empty():
 
 def test_breadcrumb_present_with_view_context():
     block = format_session_block(VIEW_STATE)
-    assert "View: report page · 2 layer(s) · 1 AOI(s) visible" in block
+    assert "View: sandbox page · 2 layer(s) · 1 AOI(s) visible" in block
     assert "call inspect_view_context for details" in block
     # The bulky detail (exact viewport, layer ids) stays out of the prompt.
     assert "BRA.24_1" not in block
@@ -104,7 +106,7 @@ def test_breadcrumb_none_without_view_context():
 
 
 def test_breadcrumb_includes_insight_count():
-    state = {"view_context": {"page": "report", "visible_insights": [{}, {}]}}
+    state = {"view_context": {"page": "sandbox", "visible_insights": [{}, {}]}}
     assert "2 insight(s) on screen" in format_session_block(state)
 
 
@@ -185,6 +187,24 @@ def test_format_map_widget_unknown_config():
     assert _format_map_widget({"default_view": "map"}) is None
 
 
+def test_format_text_widget_renders_the_markdown_body():
+    assert _format_text_widget(
+        {"text": "  ## Findings\n\nDeforestation up.  "}
+    ) == ("## Findings\n\nDeforestation up.")
+
+
+def test_format_text_widget_empty():
+    assert _format_text_widget({}) == "(empty)"
+    assert _format_text_widget({"text": "   "}) == "(empty)"
+
+
+def test_format_text_widget_truncates_a_runaway_note():
+    body = "x" * (TEXT_WIDGET_CHAR_LIMIT + 500)
+    out = _format_text_widget({"text": body})
+    assert out.endswith("… (truncated)")
+    assert len(out) == TEXT_WIDGET_CHAR_LIMIT + len("… (truncated)")
+
+
 @pytest.mark.asyncio
 async def test_format_dashboard_summarizes_map_widgets():
     dashboard = SimpleNamespace(
@@ -222,12 +242,20 @@ async def test_format_dashboard_summarizes_map_widgets():
                     }
                 },
             ),
+            SimpleNamespace(
+                widget_type="text",
+                position=2,
+                insight_id=None,
+                config={"text": "## Summary\n\nLoss accelerated in 2024."},
+            ),
         ],
     )
     out = await format_dashboard(dashboard)
     assert "map: dataset 'Tree cover loss' (2024-01-01–2024-12-31)" in out
     assert "map: Sentinel-2 imagery around 2024-06-01 (Paraná)" in out
     assert "https://t/{z}" not in out
+    assert "## Summary\n\nLoss accelerated in 2024." in out
+    assert '{"text"' not in out
 
 
 @pytest.mark.asyncio
@@ -235,7 +263,7 @@ async def test_inspect_view_context_loads_insights():
     insight = _fake_insight()
     view = {
         "view_context": {
-            "page": "report",
+            "page": "map",
             "visible_insights": [{"id": str(insight.id)}],
         }
     }

--- a/tests/unit/agent/test_view_pages.py
+++ b/tests/unit/agent/test_view_pages.py
@@ -40,7 +40,7 @@ def test_get_page_resolves_registered_pages():
 def test_get_page_unknown_or_malformed():
     assert get_page(None) is None
     assert get_page({}) is None
-    assert get_page({"page": "report"}) is None  # unregistered page
+    assert get_page({"page": "sandbox"}) is None  # unregistered page
     assert get_page({"page": {"nested": "junk"}}) is None  # not a string
 
 
@@ -77,12 +77,12 @@ def test_dashboard_session_line_without_name_or_id():
 def test_unregistered_page_falls_back_to_generic_breadcrumb():
     state = {
         "view_context": {
-            "page": "report",
+            "page": "sandbox",
             "visible_insights": [{}, {}],
         }
     }
     block = format_session_block(state)
-    assert "View: report page · 2 insight(s) on screen" in block
+    assert "View: sandbox page · 2 insight(s) on screen" in block
     assert "call inspect_view_context for details" in block
 
 
@@ -105,7 +105,7 @@ def test_prompt_section_for_registered_pages():
 
 def test_prompt_section_unknown_is_none():
     assert prompt_section(None, NOTHING_AVAILABLE) is None
-    assert prompt_section("report", NOTHING_AVAILABLE) is None
+    assert prompt_section("sandbox", NOTHING_AVAILABLE) is None
     assert prompt_section("", NOTHING_AVAILABLE) is None
 
 
@@ -144,7 +144,7 @@ def test_get_prompt_includes_surface_section_only_for_known_pages():
     # is unavailable — the surface section must not point at it.
     assert "skill `dashboard`" not in dashboard
 
-    assert "# Current surface" not in get_prompt(page="report")
+    assert "# Current surface" not in get_prompt(page="sandbox")
 
 
 def test_get_prompt_dashboard_surface_names_the_skill_when_available():

--- a/uv.lock
+++ b/uv.lock
@@ -3038,7 +3038,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.28"
+version = "2026.7.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
Follow-up to #778/#780's chart-data inspection work, prompted by a review of `inspect_view_context` against the frontend's actual (and planned) `view_context` payload:

- **Typed `ViewContext` schema** for the keys the tool already understands (`page`, `viewport`, `visible_layers`, `visible_aois`, `visible_insights`, `dashboard_id`, `dashboard_name`). Every field stays optional and `extra="allow"` applies at every level, so a typo'd/malformed known field is now caught by validation instead of silently landing in the "Other" catch-all, while genuinely new fields the frontend hasn't been backed yet still pass through untouched.
- **Dropped `"report"` as a page value** — it was never actually sent by the frontend (only `"map"`/`"dashboard"` are real surfaces) but lingered in the schema comment, tool docstrings, and `docs/view-context-pages.md`. Test fixtures that used `"report"` purely as a stand-in for "some unregistered page" were renamed to `"sandbox"` so they stop implying it's a real (or once-real) page.
- **Dashboard text widgets now render their markdown body** in `inspect_view_context` instead of falling through to a raw `{"text": "..."}` JSON dump — every other widget type already got a readable summary; this was the one gap. Capped defensively at 2000 chars, matching the existing chart-table cap pattern.

## Test plan
- [x] `uv run pytest tests/agent/test_inspect_view_context.py tests/unit -q` — 428 passed
- [x] `ruff` / `ruff-format` / `mypy` pre-commit hooks pass

Frontend counterpart (sends `viewport` + `visible_insights` on the map page): wri/project-zeno-next#621
