### PR TITLE
Expose full model name in /api/metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.28.1"
+version = "2026.7.29"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/routers/metadata.py
+++ b/src/api/routers/metadata.py
@@ -39,8 +39,10 @@ async def api_metadata() -> dict:
         "model": {
             "current": current_model_name,
             "model_class": current_model.__class__.__name__,
+            "model_name": current_model.model,
             "small": small_model_name,
             "small_model_class": small_model.__class__.__name__,
+            "small_model_name": small_model.model,
         },
     }
 

--- a/tests/api/test_metadata.py
+++ b/tests/api/test_metadata.py
@@ -30,8 +30,10 @@ async def test_metadata_model_info(client):
 
     assert "current" in model_info
     assert "model_class" in model_info
+    assert "model_name" in model_info
     assert "small" in model_info
     assert "small_model_class" in model_info
+    assert "small_model_name" in model_info
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `/api/metadata` only returned our internal registry keys (e.g. `"gemini"`, `"gemini-flash"`), not the actual provider model id in use.
- Add `model_name`/`small_model_name` fields with the full underlying model string (e.g. `"gemini-3.1-pro-preview"`, `"gemini-3-flash-preview"`), read off `.model` on the langchain chat model instances.
- Existing `current`/`small`/`model_class`/`small_model_class` fields are unchanged for backwards compatibility.

## Test plan
- [x] `uv run pytest tests/api/test_metadata.py -q` — 10 passed