### PR TITLE
Remove custom temperature overrides for Gemini thinking models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.7.29"
+version = "2026.7.29.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/llms.py
+++ b/src/agent/llms.py
@@ -21,7 +21,6 @@ HAIKU = ChatAnthropic(
 # Google
 GEMINI = ChatGoogleGenerativeAI(
     model="gemini-3.1-pro-preview",
-    temperature=1.0,
     max_tokens=None,  # max_tokens=None means no limit
     include_thoughts=False,
     thinking_level="low",
@@ -30,7 +29,6 @@ GEMINI = ChatGoogleGenerativeAI(
 )
 GEMINI_FLASH = ChatGoogleGenerativeAI(
     model="gemini-3-flash-preview",
-    temperature=0.3,
     max_tokens=None,  # max_tokens=None means no limit
     include_thoughts=False,
     max_retries=AgentSettings.llm_max_retries,
@@ -39,7 +37,6 @@ GEMINI_FLASH = ChatGoogleGenerativeAI(
 )
 GEMINI_FLASH_LITE = ChatGoogleGenerativeAI(
     model="gemini-3.1-flash-lite-preview",
-    temperature=0.3,
     max_tokens=None,  # max_tokens=None means no limit
     include_thoughts=False,
     max_retries=AgentSettings.llm_max_retries,
@@ -51,7 +48,6 @@ GEMINI_FLASH_LITE = ChatGoogleGenerativeAI(
 # for tasks that need no reasoning at all, just a short constrained answer.
 GEMINI_FLASH_LITE_MINIMAL = ChatGoogleGenerativeAI(
     model="gemini-3.1-flash-lite-preview",
-    temperature=0,
     max_tokens=20,
     include_thoughts=False,
     max_retries=AgentSettings.llm_max_retries,

--- a/uv.lock
+++ b/uv.lock
@@ -3038,7 +3038,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.7.28"
+version = "2026.7.29"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Drop the hardcoded `temperature` values on `GEMINI`, `GEMINI_FLASH`, `GEMINI_FLASH_LITE`, and `GEMINI_FLASH_LITE_MINIMAL` in `src/agent/llms.py`, letting each fall back to the model's default.

## Why
For thinking-enabled Gemini models, Google recommends leaving `temperature` at its default rather than overriding it. A custom (especially low) temperature constrains the sampling diversity the model uses during its internal reasoning steps, which can shallow out the thinking process and degrade output quality. `thinking_level` (already set on all four models) is the intended lever for controlling reasoning depth/latency, making the temperature overrides redundant and counterproductive.

## Test plan
- [x] Sanity check agent responses on a couple of representative queries with the default temperature to confirm no regression in answer quality.