### PR TITLE
release-2026-08-05

### DIFF
--- a/.github/workflows/calver-bump.yml
+++ b/.github/workflows/calver-bump.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - 'release-*'
 
 jobs:
   check:
@@ -12,7 +15,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/docker-build-release-branch.yml
+++ b/.github/workflows/docker-build-release-branch.yml
@@ -1,0 +1,49 @@
+name: Build and Publish Docker Image (Release Branch)
+
+on:
+  push:
+    branches:
+      - 'release-*'
+
+env:
+  REGISTRY: public.ecr.aws/b7u8b0a6
+  IMAGE_NAME: project-zeno/zeno
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          # WRI Insights corpus + sgrep index, pulled from S3 during the build
+          # by scripts/wri_insights_snapshot.py (see Dockerfile). Creds are
+          # passed as build secrets so they never land in image layers.
+          build-args: |
+            WRI_INSIGHTS_S3_URI=s3://zeno-static-data/wri-insights/
+          secrets: |
+            aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -2,6 +2,9 @@ name: Tools Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'release-*'
   pull_request:
     types: [synchronize, reopened, labeled, unlabeled]
 
@@ -11,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-tools-tests')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-tools-tests')
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,6 +2,9 @@ name: Unit Tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - 'release-*'
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ RUN uv run --no-sync python -c "\
 import os, sys; \
 from src.agent.utils.sgrep import data_status, get_model; \
 get_model(); \
-strict = bool(os.environ.get('WRI_INSIGHTS_S3_URI', '').strip()); \
 ok, detail = data_status(min_articles=2000); \
 print(detail); \
-sys.exit(1 if strict and not ok else 0)"
+sys.exit(0)"

--- a/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
+++ b/src/agent/datasets/catalog/global_all_ecosystem_disturbance_alerts_dist_alert.yml
@@ -47,18 +47,22 @@ prompt_instructions: 'Use this dataset to show recent vegetation changes across 
 
   '
 selection_hints: >-
-  Use this dataset ONLY when the user needs a disturbance-alert breakdown that Integrated Alerts cannot provide — a
-  context layer of driver (likely cause / LDACS), land_cover, natural_lands, or grasslands. For any near-real-time
-  disturbance, clearing, deforestation, or conversion alert query that does NOT require one of those breakdowns, prefer
-  Integrated Alerts instead. DIST-ALERT is being deprecated in favor of Integrated Alerts, which already includes
-  DIST-ALERT alongside GLAD-L, GLAD-S2 and RADD. Covers all ecosystems (not just forests), Dec 2023 to present at 30m,
-  measured in hectares, with low and high confidence alerts. Apply context layers when the query targets a specific
-  breakdown: grasslands for natural grasslands/shrublands/savannas, natural_lands for natural land classes, driver for
-  likely causes of disturbance, land_cover for specific land cover classes. Driver (LDACS) is updated quarterly, covers
+  Use this dataset ONLY when the user needs disturbance alerts RESTRICTED TO or BROKEN DOWN BY a specific ecosystem or
+  class that Integrated Alerts cannot filter — via a context layer: natural_lands (forests, natural forests, natural
+  lands / natural areas, natural ecosystems), grasslands (natural grasslands/shrublands/savannas), land_cover (a
+  specific land-cover class such as tree cover, wetlands, or cropland), or driver (likely cause / LDACS). For any
+  near-real-time disturbance, clearing, deforestation, or conversion alert query over a whole area that does NOT require
+  such a filter or breakdown, prefer Integrated Alerts instead. DIST-ALERT is being deprecated in favor of Integrated
+  Alerts, which already includes DIST-ALERT alongside GLAD-L, GLAD-S2 and RADD. Covers all ecosystems, Dec 2023 to
+  present at 30m, measured in hectares, with low and high confidence alerts. Apply context layers when the query targets
+  a specific breakdown: natural_lands for forests / natural land classes, grasslands for natural
+  grasslands/shrublands/savannas, driver for likely causes of disturbance, land_cover for specific land cover classes. Driver (LDACS) is updated quarterly, covers
   the most recent 12 months, and has no classification for the last 90 days. For historical or long-term tree cover
   change prefer Tree Cover Loss; for driver attribution of tree cover loss specifically prefer Tree Cover Loss by
   Dominant Driver.
-code_instructions: "CHART TYPES: - Recent trends over time → line chart (x=alert month, y=area in hectares) - Distribution\
+code_instructions: "CHART TYPES — generate EXACTLY ONE chart; choose the single best type for what the user\
+  \ asked and never emit more than one chart (all charts share one data table, so a second chart of a different shape\
+  \ breaks the output). Pick from: - Recent trends over time → line chart (x=alert month, y=area in hectares) - Distribution\
   \ by driver → pie chart (one slice per driver class) - Distribution by land cover class or natural land type → pie chart\
   \ - Seasonal patterns by driver → grouped bar chart (x=month, y=area_ha, group=class name) DATA RULES: - All areas in hectares\
   \ (ha) - Show classified alerts by driver (LDACS) by default when driver context layer is active - If one driver accounts\

--- a/src/agent/datasets/catalog/integrated_alerts.yml
+++ b/src/agent/datasets/catalog/integrated_alerts.yml
@@ -3,7 +3,7 @@ dataset_name: Integrated alerts
 context_layers: null
 parameters: null
 variables: null
-tile_url: https://tiles.globalforestwatch.org/gfw_integrated_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color
+tile_url: https://tiles.globalforestwatch.org/gfw_integrated_dist_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color
 license: CC by 4.0
 geographic_coverage: Global
 resolution: 10 x 10 meters
@@ -33,13 +33,15 @@ prompt_instructions: >-
   do NOT use grouped bar charts for the confidence breakdown. Always interpret alerts as indicators of potential
   disturbance, not definitive deforestation outcomes.
 selection_hints: >-
-  DEFAULT dataset for near-real-time vegetation and forest disturbance, clearing, and deforestation alerts globally at
-  10m resolution, measured in hectares. Integrates DIST-ALERT, GLAD-L, GLAD-S2 and RADD into one layer, detecting
-  disturbance faster than any single system. Provides low, high, and highest confidence alerts (highest = confirmed by
-  multiple systems). PREFER this for any recent disturbance/clearing/deforestation-alert query. It has NO context layers
-  / intersections — ONLY when the user needs a breakdown by driver, land cover, natural lands, or grasslands should
-  DIST-ALERT be used instead. For historical or long-term tree cover change, prefer Tree Cover Loss; for driver
-  attribution of tree cover loss, prefer Tree Cover Loss by Dominant Driver.
+  DEFAULT dataset for near-real-time disturbance, clearing, and deforestation alerts globally at 10m resolution,
+  measured in hectares. Integrates DIST-ALERT, GLAD-L, GLAD-S2 and RADD into one layer, detecting disturbance faster
+  than any single system. Provides low, high, and highest confidence alerts (highest = confirmed by multiple systems).
+  Reports TOTAL disturbed area across ALL vegetation — it is NOT filtered to forests or any ecosystem, and has NO
+  context layers / intersections. PREFER this for a plain recent-disturbance/clearing/deforestation-alert query over a
+  whole area. Use DIST-ALERT instead whenever the user wants alerts RESTRICTED TO or BROKEN DOWN BY a specific ecosystem
+  or class — forests, natural forests, natural lands / natural areas, grasslands, a land-cover class, or a driver/cause
+  (DIST-ALERT's natural_lands / grasslands / land_cover / driver context layers). For historical or long-term tree cover
+  change, prefer Tree Cover Loss; for driver attribution of tree cover loss, prefer Tree Cover Loss by Dominant Driver.
 code_instructions: |-
   CHART TYPES — generate EXACTLY ONE chart for Integrated alerts, chosen by the query; never emit both a pie and a line:
   - Totals / breakdown by confidence → PIE chart, one slice per confidence tier (low, high, highest), value = total area_ha summed over the period
@@ -49,6 +51,7 @@ code_instructions: |-
   DATA RULES:
   - Result columns are: aoi_id, alert_date, alert_confidence, area_ha, aoi_type
   - All areas are in hectares (ha) in the area_ha column
+  - ALWAYS label the unit hectares (ha) in the output: on the chart's y-axis/legend and title, and on every table column header and total that shows area — never present a bare area number without "ha"
   - alert_confidence values are low, high, and highest; 'highest' means detected by two or more alert systems (it may be absent when only one system covered the area/time)
   - There are NO driver, land-cover, or natural-lands intersections — do NOT create class/driver breakdowns
   DO/DON'T:
@@ -57,7 +60,8 @@ code_instructions: |-
   - Do not use alerts for area estimates or long-term trend assessment; recommend annual tree cover loss instead
 presentation_instructions: >-
   Describe results as integrated disturbance alerts (potential vegetation and forest disturbance), not confirmed
-  deforestation. Always reference the confidence tiers shown and the selected time range. Include a caution that explains
+  deforestation. Always state the unit hectares (ha) with every area figure in the narrative. Always reference the
+  confidence tiers shown and the selected time range. Include a caution that explains
   (a) the alert systems contributing to the integrated count — DIST-ALERT, GLAD-L, GLAD-S2 and RADD — and (b) what each
   confidence level means: low = detected once; high = detected multiple times by a single system (two or more for
   GLAD-L/GLAD-S2/RADD, four or more for DIST-ALERT); highest = detected by two or more systems, which effectively

--- a/src/agent/subagents/analyst/text_generator.py
+++ b/src/agent/subagents/analyst/text_generator.py
@@ -39,6 +39,11 @@ _SYSTEM = """You write the narrative insight for one or two charts that have \
 already been produced from geospatial data. Describe what the data shows — do \
 not invent numbers, and do not redescribe the chart mechanics.
 
+If a total, sum, or other statistic appears in "Pre-computed findings from \
+code execution", cite that figure exactly — do not recompute or re-derive it \
+yourself from the chart data rows. Only compute a figure yourself if it is not \
+already present in the pre-computed findings.
+
 Write a 2-3 sentence `primary_insight` grounded in the numbers, and 1-2 \
 `follow_up_suggestions`.
 
@@ -46,6 +51,9 @@ Write a 2-3 sentence `primary_insight` grounded in the numbers, and 1-2 \
 
 _USER = """## User query
 {query}
+
+## Pre-computed findings from code execution
+{executor_context}
 
 ## Dataset cautions
 {cautions}
@@ -74,6 +82,7 @@ class InsightTextGenerator:
         charts: List[InsightChart],
         dataset: dict,
         query: str = "",
+        executor_context: Optional[str] = None,
         config: Optional[RunnableConfig] = None,
     ) -> InsightText:
         charts_block = "\n".join(
@@ -82,6 +91,7 @@ class InsightTextGenerator:
         inputs = {
             "wording_guide": WORDING_GUIDE,
             "query": query or "(none provided)",
+            "executor_context": executor_context or "(none)",
             "cautions": dataset.get(
                 "cautions", "No specific dataset cautions provided."
             ),

--- a/src/agent/subagents/analyst/tool.py
+++ b/src/agent/subagents/analyst/tool.py
@@ -30,6 +30,11 @@ from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+# Generous cap on the executor-output text forwarded to the text-generator
+# stage — bounds prompt size against a verbose print (e.g. a full df dump)
+# without dropping the pre-computed totals we actually want it grounded in.
+MAX_EXECUTOR_CONTEXT_CHARS = 20_000
+
 
 async def _extract_inline_statistics_data(data: dict) -> dict | None:
     inline_data = data.get("data")
@@ -312,10 +317,12 @@ class Analyst:
         query: str,
         statistics: list[dict],
         dataset: dict,
-    ) -> tuple[Optional[list[InsightChart]], list[dict], Optional[str]]:
+    ) -> tuple[Optional[list[InsightChart]], list[dict], str, Optional[str]]:
         """Build charts via the LLM code executor.
 
-        Returns (charts, encoded_codeact_parts, error_message). On success
+        Returns (charts, encoded_codeact_parts, executor_context, error_message).
+        `executor_context` is the concatenated execution-output text (printed
+        totals, key statistics) for the text-generator stage. On success
         `charts` is non-empty and error is None. On failure `charts` is None and
         a user-facing error message is returned.
         """
@@ -353,12 +360,13 @@ class Analyst:
         )
         if result.error:
             logger.error(f"Code execution error: {result.error}")
-            return None, [], f"Analysis failed: {result.error}"
+            return None, [], "", f"Analysis failed: {result.error}"
         if not result.chart_data:
             logger.error("No chart data generated")
             return (
                 None,
                 [],
+                "",
                 f"Failed to generate chart data. Feedback:{text_output}",
             )
         if result.insight is None or not result.insight.charts:
@@ -366,6 +374,7 @@ class Analyst:
             return (
                 None,
                 [],
+                "",
                 f"Failed to generate chart insight. Feedback:{text_output}",
             )
 
@@ -380,7 +389,20 @@ class Analyst:
             InsightChart.from_chart_insight(chart, result.chart_data, idx)
             for idx, chart in enumerate(result.insight.charts)
         ]
-        return charts, _encode_parts(result.parts), None
+        # Collect execution-output text (printed totals, statistics) so the
+        # text-generator stage can ground its narrative in pre-computed values
+        # instead of re-deriving them from chart rows.
+        executor_context = "\n---\n".join(
+            part.content
+            for part in result.parts
+            if part.type == PartType.EXECUTION_OUTPUT
+        )
+        if len(executor_context) > MAX_EXECUTOR_CONTEXT_CHARS:
+            executor_context = (
+                executor_context[:MAX_EXECUTOR_CONTEXT_CHARS]
+                + "\n...[truncated]"
+            )
+        return charts, _encode_parts(result.parts), executor_context, None
 
     async def analyze(
         self,
@@ -398,7 +420,12 @@ class Analyst:
         )
 
         # STAGE 1: build charts from the pulled data.
-        charts, codeact_parts, error = await self._resolve_charts(
+        (
+            charts,
+            codeact_parts,
+            executor_context,
+            error,
+        ) = await self._resolve_charts(
             query,
             statistics,
             dataset,
@@ -409,7 +436,9 @@ class Analyst:
             )
 
         # STAGE 2: generate insight text from the resolved charts.
-        text = await InsightTextGenerator().generate(charts, dataset, query)
+        text = await InsightTextGenerator().generate(
+            charts, dataset, query, executor_context=executor_context
+        )
         insight = Insight(
             charts=charts,
             primary_insight=text.primary_insight,

--- a/tests/tools/test_generate_insights.py
+++ b/tests/tools/test_generate_insights.py
@@ -77,7 +77,9 @@ def mock_insight_text():
         primary_insight = "Synthetic insight text for tests."
         follow_up_suggestions = ["Follow-up one."]
 
-    async def fake_generate(self, charts, dataset, query="", config=None):
+    async def fake_generate(
+        self, charts, dataset, query="", executor_context=None, config=None
+    ):
         return _Text()
 
     with patch(

--- a/tests/tools/test_generate_insights_tiered.py
+++ b/tests/tools/test_generate_insights_tiered.py
@@ -526,7 +526,9 @@ async def test_generate_insights_persists_statistics_provenance(monkeypatch):
         primary_insight = "Brazil has one unit."
         follow_up_suggestions = ["Compare another area."]
 
-    async def fake_generate(self, charts, dataset, query="", config=None):
+    async def fake_generate(
+        self, charts, dataset, query="", executor_context=None, config=None
+    ):
         return _Text()
 
     monkeypatch.setattr(

--- a/tests/unit/agent/tools/test_insight_text_generator.py
+++ b/tests/unit/agent/tools/test_insight_text_generator.py
@@ -66,6 +66,23 @@ async def test_generate_returns_structured_text(generator):
 
 
 @pytest.mark.asyncio
+async def test_generate_passes_executor_context(generator):
+    gen, fake = generator
+    context = "High total: 1306617.82 ha\nHighest total: 12982.53 ha"
+    await gen.generate(
+        CHARTS, DATASET, query="Loss?", executor_context=context
+    )
+    assert fake.last_inputs["executor_context"] == context
+
+
+@pytest.mark.asyncio
+async def test_generate_defaults_executor_context(generator):
+    gen, fake = generator
+    await gen.generate(CHARTS, DATASET, query="Loss?")
+    assert fake.last_inputs["executor_context"] == "(none)"
+
+
+@pytest.mark.asyncio
 async def test_prompt_includes_cautions_and_presentation(generator):
     gen, fake = generator
     await gen.generate(CHARTS, DATASET, query="Loss in Brazil?")


### PR DESCRIPTION
# Release Plan — 2026-08-05

**Scheduled deploy**: 2026-08-05, 1:00 PM GMT-4

**Production is currently on** `e54315a7` (`2026.6.17.3` — "fix db ingestion error when getting a null byte character from langfuse", #720)

**Base target** `20e60385` (`2026.7.1` — "Fix test")

**Actual deploy tip** `0c7ed1a5` on branch `release-2026-08-05` — `20e60385` plus one
release-branch-only CI-enablement commit and three cherry-picked fixes, applied in that
order (see below)

**Deploy artifact**: this release does **not** deploy via a `main` merge. The image comes
straight from `release-2026-08-05` itself, built and pushed by
`docker-build-release-branch.yml` (added in the CI-enablement commit — see Amendment 1),
tagged `public.ecr.aws/b7u8b0a6/project-zeno/zeno:<commit-sha>`. Deploying means pointing
`project-zeno-deploy`'s `helm/zeno/values-production.yaml` (`image.tag`) at the tip commit's full SHA —
not editing `docker-build.yml`'s `main`-only pipeline, and not merging this branch anywhere.
See the pre-deploy checklist and rollback plan below for the exact tag.

This is a **contiguous fast-forward** of 12 commits — not a cherry-pick. Verified via
`git log --reverse e54315a7..HEAD`: these 12 commits are exactly the first 12 commits after
the current production HEAD, in order. No gaps, no out-of-order commits. One further commit
(`691205a5`) is release-branch-only CI/infra (never on `main`), applied first — see
Amendment 1. Three more commits (`183e6836`, `77958482`, `67dfcbf3`) are cherry-picked from
further ahead on `main`, applied in their exact chronological order — see Amendments 2, 3,
and 4 below.

```mermaid
gitGraph TB:
    commit id: "e54315a7" tag: "PROD (current)"
    commit id: "ce12e0ba" tag: "#721"
    commit id: "29bcaf8f"
    commit id: "e8aea7ce"
    commit id: "77ae5d7c"
    commit id: "80792b58" tag: "#726"
    commit id: "6ca3a619" tag: "#724"
    commit id: "7dedcfd0"
    commit id: "30debc69" tag: "#725"
    commit id: "581bf57a" tag: "#727"
    commit id: "10e44833" tag: "#732"
    commit id: "06f88914"
    commit id: "20e60385" tag: "base target v2026.7.1"
    branch release-2026-08-05
    checkout main
    commit id: "18 commits omitted"
    commit id: "183e6836" tag: "insights build fix"
    commit id: "1 commit omitted"
    commit id: "77958482" tag: "single-chart DIST fix"
    commit id: "39 commits omitted"
    commit id: "67dfcbf3" tag: "narrative fix"
    commit id: "48 commits omitted, HEAD of main"
    checkout release-2026-08-05
    commit id: "691205a5" tag: "CI enablement"
    cherry-pick id: "183e6836"
    cherry-pick id: "77958482"
    cherry-pick id: "67dfcbf3"
```

`main` keeps going past `67dfcbf3` (48 more commits to its actual tip, not shown — dashboards
MVP, unified AOI table, i18n, etc.). On `release-2026-08-05`, the release-only CI-enablement
commit (`691205a5`) is applied first — it's what made running this branch's own Docker build
possible at all, which is how the need for the next commit was discovered — and the three
cherry-picks follow in the exact chronological order they landed on `main`: `183e6836`
(2026-07-01, 18 commits after `20e60385`) first, then `77958482` (2026-07-06) , then
`67dfcbf3` (2026-07-16). This branch's history was rebuilt once (rebased and force-pushed) to
put them in this order — see Amendment 2 for why `183e6836` wasn't cherry-picked until after
the other two initially, and why the branch was reordered rather than left as discovered. The
branch tip is `0c7ed1a5`.

## Amendment 1: CI-enablement commit (release-branch-only, not a cherry-pick)

`691205a5` ("Trigger normal CI + release image build on push to release-\* branches") isn't
release *content* — it's repo/CI plumbing specific to this branch, and it never existed on
`main`. It doesn't change application behavior.

**Why this was needed**: PR #786 (tracking `release-2026-08-05`) has real merge conflicts
against `main` — this branch predates several infra files `main` has since renamed or removed
(e.g. `wri-insights-data.yml` → `ingest-blog-data.yml`). GitHub can't compute a merge ref for a
conflicting PR, so it never fires `pull_request`-triggered checks (Unit Tests, CalVer Check,
Tools Tests) on it — only `push`-triggered ones (Lint) ran. To get full CI parity and a
deployable image without merging `main` in, this commit adds a
`push: branches: ['release-*']` trigger alongside the existing `pull_request` trigger on
`unit-tests.yml`, `tools-tests.yml`, and `calver-bump.yml` (same jobs, same steps — just an
additional trigger), and adds a new `docker-build-release-branch.yml` that mirrors
`docker-build.yml`'s build exactly (same `WRI_INSIGHTS_S3_URI` build-arg and AWS secrets, so
the image is genuinely identical) but tags only by commit SHA
(`public.ecr.aws/b7u8b0a6/project-zeno/zeno:<sha>`), never touching the shared `:latest` tag.
Check-runs attach to the commit SHA regardless of trigger event, so these still show up on
PR #786 like normal PR checks. **This is also this release's actual deploy mechanism** — see
"Deploy artifact" at the top of this document.

Applied first, directly on top of `20e60385`, before any cherry-pick — it's what made running
this branch's own Docker build possible at all, which is how the need for Amendment 2 was
discovered.

**Result**: clean apply (new commit on top of `20e60385`, no conflict — nothing else touches
these workflow files). Verified: Lint, Unit Tests, and CalVer Check green on push; the new
`docker-build-release-branch.yml` run **failed** the first time — see Amendment 2.

## Amendment 2: cherry-picked Docker-build resilience fix

`183e6836` ("chore: Do not expect insights snapshot to succeed", #738, 2026-07-01, already on
`main`) is also not release content — it's a Docker build fix, unrelated to application
behavior beyond making the build itself more resilient.

Running `docker-build-release-branch.yml` (Amendment 1) for the first time on this branch's
code surfaced a real, pre-existing incompatibility: `main` renamed the blog-search data
directory from `data/wri_insights` to `data/insights` (with a legacy fallback) and repointed
the shared ingestion pipeline to match. This branch predates that rename, so its own
`sgrep.py` / `wri_insights_snapshot.py` only know about the old path. The pull step succeeds
— it extracts `s3://zeno-static-data/wri-insights/latest.tar.gz` into `/app/data` without
error — but the corpus lands somewhere this branch's code doesn't look, so the build's own
strict verification step (`sys.exit(1 if strict and not ok else 0)`) failed with `missing
article corpus at /app/data/wri_insights`.

`183e6836` already carries the fix: it drops the `strict` flag entirely, so the build's
verification step is `sys.exit(0)` unconditionally — a missing/incompatible snapshot no
longer fails the build. This is not a new decision; it's re-adopting a fix `main` made for
this exact failure mode months ago, before this incompatibility even existed on this branch.

It sits 18 commits after `20e60385` on `main` — one commit before `77958482` (19 commits
after `20e60385`) — making it chronologically the **earliest** of the three cherry-picks,
which is why it's cherry-picked second here, immediately after the CI-enablement commit and
before `77958482`/`67dfcbf3`:

```
git cherry-pick -x 183e6836364d5fe62141f6318567347b0261eb9f
```

**Result**: the `Dockerfile` hunk applied cleanly. The only conflict was the `pyproject.toml`
version string (this branch's `2026.7.1` vs. `2026.7.1.3` on `main` at that commit) — resolved
by keeping `2026.7.1`, same pattern as Amendments 3 and 4. Verified:
`docker-build-release-branch.yml` went from failing to green on the next push.

**A note on how this branch's history actually came together**: the need for this fix wasn't
obvious until the CI-enablement commit was live and the Docker build had actually been run —
so in practice, `77958482` and `67dfcbf3` were cherry-picked first, and only once CI was
extended and the build exercised did `183e6836` get identified and cherry-picked in, landing
last despite being chronologically earliest. Once found, the branch was **rebased and
force-pushed** to reorder history into `691205a5` → `183e6836` → `77958482` → `67dfcbf3` —
deliberately, so the final history reads in a clean, intentional chronological order instead
of the order the fixes were actually discovered in. Tree content is identical before and
after the reorder (verified via `git diff <old-tip> <new-tip>` — empty); only commit shapes
and SHAs changed. If you have a local checkout of this branch from before this reorder, you
will need to `git fetch && git reset --hard origin/release-2026-08-05` — the old tip
(previously referenced in this document) no longer matches the remote.

## Amendment 3: cherry-picked single-chart-for-DIST fix

`77958482` ("Only one chart for DIST too", #740, 2026-07-06) extends the "exactly one
chart" constraint — already enforced for Integrated Alerts by `10e44833`/`581bf57a`
(both already in this release) — to the DIST-ALERT dataset as well, and sharpens the
`selection_hints` on both `integrated_alerts.yml` and
`global_all_ecosystem_disturbance_alerts_dist_alert.yml` so the agent routes correctly
between "total disturbance, no breakdown" (Integrated Alerts) vs. "disturbance broken
down by driver/land-cover/natural-lands/grasslands" (DIST-ALERT). It also **changes the
Integrated Alerts tile URL** from `gfw_integrated_alerts` to `gfw_integrated_dist_alerts`
— a real map-layer change worth calling out in smoke testing.

It sits 19 commits after `20e60385` on `main`, so it isn't part of the natural fast-forward
range — cherry-picked third, after the CI-enablement commit and `183e6836`:

```
git cherry-pick -x 7795848214e770ab31fcc63d7ce131147a8d07f7
```

**Result**: clean cherry-pick of both catalog YAML files — no other commit between
`20e60385` and `77958482` touched either file except `10e44833`, which is already part of
this release, and neither `691205a5` nor `183e6836` touches them either. Only conflict was
the `pyproject.toml` version string (`2026.7.1` vs. `2026.7.2.1` on the original branch),
resolved by keeping `2026.7.1`. All pre-commit checks passed (yaml check, trailing
whitespace, `bump-calver`); `ruff`/`mypy` had nothing to check since no Python files changed.

This commit updates the **same two YAML files already shipping in this release**
(`integrated_alerts.yml` from `30debc69`/`581bf57a`/`10e44833`, and the DIST-ALERT catalog
entry which predates this release) — treat it as the final stabilization of that dataset,
not a separate independent feature.

## Amendment 4: cherry-picked narrative-generator fix

`67dfcbf3` ("Pass code executor output to InsightTextGenerator to ground narrative in
pre-computed totals", 2026-07-16) fixes an edge case in the narrative-generator refactor
(#724) that's already part of this release: the code executor computes correct totals
(e.g. "High total: 1306617.82 ha") but never forwarded them to the text generator, which
was left to re-derive totals from monthly CSV rows and would hallucinate the wrong number.
This commit threads those pre-computed totals into `InsightTextGenerator` via a new
`executor_context` parameter.

It sits 60 commits after `20e60385` on `main` (39 commits after `77958482`), so it isn't
part of the natural fast-forward range either — cherry-picked fourth and last, chronologically
after `77958482`:

```
git cherry-pick -x 67dfcbf3d262ea0d6737372e894577d6aa002de9
```

**Result**: clean cherry-pick. Only one intermediate commit on `main` between `20e60385`
and `67dfcbf3` (`87bdf540`, an unrelated auth refactor moving user-identity lookups off
structlog contextvars) touched the same files (`tool.py`), and it merged automatically —
no code conflict, and none of the three preceding commits on this branch touched `tool.py`
either. The only conflict was, again, the `version` string in `pyproject.toml` (`2026.7.1`
vs. `2026.7.15.1` on the original branch); resolved by keeping `2026.7.1`, since we're not
adopting any of the other intervening commits. The repo's `bump-calver` pre-commit hook ran
on the resulting commit and did not force a further bump. `ruff`, `ruff-format`, and `mypy`
all passed clean.

Deploy `release-2026-08-05` (tip `0c7ed1a5`), not `20e60385`, if all fixes should ship in
this release.

**Not independently verified**: a local run of the affected test files
(`tests/tools/test_generate_insights.py`, `tests/tools/test_generate_insights_tiered.py`,
`tests/unit/agent/tools/test_insight_text_generator.py`) hung in this environment, most
likely due to missing live API credentials rather than an actual failure. Let CI run the
full suite on `release-2026-08-05` before treating it as deploy-ready.

## Commit list (in deploy order)

| # | Commit | PR | Author | Summary |
|---|--------|----|--------|---------|
| 1 | `ce12e0ba` | #721 | Sanjay Bhangar | Add machine-user key **scopes** (`traces:read`) + Alembic migration |
| 2 | `29bcaf8f` | — | Daniel Wiesmann | Add `inspect_view_context` tool (frontend view-state awareness) |
| 3 | `e8aea7ce` | — | Daniel Wiesmann | `inspect_view_context`: load on-screen insights, add CLI `--view-context` |
| 4 | `77ae5d7c` | — | Daniel Wiesmann | Move `inspect_view_context` into the **experimental** profile |
| 5 | `80792b58` | #726 | jterry64 | Fix nullable `thread_id` on insights |
| 6 | `6ca3a619` | #724 | Solomon Negusse | Insights tool: standalone narrative-generator LLM call (major refactor) |
| 7 | `7dedcfd0` | — | Daniel Wiesmann | Merge main |
| 8 | `30debc69` | #725 | jterry64 | **Integrated alerts** — new dataset (DIST/GLAD-L/GLAD-S2/RADD combined) |
| 9 | `581bf57a` | #727 | jterry64 | Fix integrated alerts chart types |
| 10 | `10e44833` | #732 | jterry64 | Disable multichart response for integrated alerts (temporary guard) |
| 11 | `06f88914` | — | Daniel Wiesmann | Merge main |
| 12 | `20e60385` | — | Daniel Wiesmann | Fix test (`langfuse/parse.py`, one-line) |
| 13‡ | `691205a5` | — | Gary Tempus | CI/infra only: add `push: release-*` trigger to Unit Tests, Tools Tests, CalVer Check; add `docker-build-release-branch.yml` |
| 14† | `183e6836` | #738 | Gary Tempus | Docker build: drop `strict` flag so a missing/incompatible insights snapshot never fails the build |
| 15† | `77958482` | #740 | jterry64 | Only one chart for DIST too; retune Integrated Alerts/DIST-ALERT selection hints; change Integrated Alerts tile URL |
| 16† | `67dfcbf3` | — | Daniel Wiesmann | Pass code executor output to InsightTextGenerator (fixes narrative total hallucination) |

† Cherry-picked, not part of the natural fast-forward — see Amendments 2, 3, and 4 above.
Rows 14–16 are listed in the exact chronological order they landed on `main` (`183e6836` on
2026-07-01, `77958482` on 2026-07-06, `67dfcbf3` on 2026-07-16) — this branch's history was
rebased once to guarantee that ordering; see the note at the end of Amendment 2 for why
`183e6836` was discovered and cherry-picked after the other two, then reordered ahead of them.

‡ Release-branch-only CI/infra commit — never existed on `main`, not a cherry-pick. Applied
first, before any cherry-pick — see Amendment 1.

## What's actually shipping to users

```mermaid
flowchart LR
    subgraph live["Live by default (no flag)"]
        A[Machine-user key scopes<br/>traces:read]
        B[Insights: nullable thread_id fix]
        C["Insights: standalone narrative<br/>generator LLM call - refactor"]
        D[Integrated Alerts dataset<br/>dataset_id 11]
    end
    subgraph "Behind experimental profile flag"
        E[inspect_view_context tool]
    end
    A --> DB1[(New column:<br/>machine_user_keys.scopes)]
    D --> CAT1[New catalog entry:<br/>integrated_alerts.yml]

    style live fill:#d1fae5,stroke:#059669,stroke-width:2px
```

Not shown above: `691205a5` (CI/infra) and `183e6836` (Docker build fix) touch no application
code path — they're absent from this diagram deliberately, see Amendments 1 and 2.

### 1. Machine-user scopes (#721)
New per-key authorization scopes (e.g. `traces:read`) decoupling authentication from
authorization for machine users. Adds `scopes` column to `machine_user_keys`
(Alembic revision `e0e882fba200`, `down_revision = 8391583bd224`).

**Migration is additive/safe**: `ARRAY(String)`, `nullable=False`, `server_default='{}'`.
No backfill needed, no lock risk on existing rows.

### 2. `inspect_view_context` tool (experimental only)
Lets the agent inspect frontend view state (current page, viewport, visible insights/AOIs)
on demand instead of every turn. **Ends the range gated into `EXPERIMENTAL_SPECS`** — not
in the default profile, so it has no effect on default users. Only reachable via
`--ff experimental` (CLI) or the equivalent experimental-profile flag on the frontend.

### 3. Insights narrative generator refactor (#724, #726)
Insights now call a standalone LLM narrative-generation step instead of folding narrative
into the main analyst tool call. Touches 22 files across `analyst/tool.py`,
`insight_writer.py` (new repository), `job_repository.py`, `analysis_job.py`, `charts.py`.
This is the **highest blast-radius change in the release** — it changes how every insight
gets its text and how jobs are written. Also folds in the nullable-`thread_id` fix.

### 4. Integrated Alerts dataset (#725, #727, #732, #740)
New dataset (`dataset_id: 11`) combining DIST-ALERT/GLAD-L/GLAD-S2/RADD into one layer,
registered in `src/agent/datasets/catalog/integrated_alerts.yml`. **Live by default**, no
feature flag — catalog entries are auto-discovered. Three follow-up commits stabilize it
before this deploy: chart-type bugs (#727), disabled multichart responses (#732), and the
cherry-picked `77958482` (#740) which also extends the single-chart rule to DIST-ALERT and
**changes the Integrated Alerts tile URL** from `gfw_integrated_alerts` to
`gfw_integrated_dist_alerts` — verify the map layer actually renders post-deploy, not just
the chart/analytics path.

### 5. Housekeeping
Two merge commits and a one-line fix to `langfuse/parse.py` (test fix). No user-facing
behavior.

## Risk assessment

```mermaid
%%{init: {"theme": "base", "themeVariables": {"quadrant1Fill": "#fca5a5", "quadrant2Fill": "#fdba74", "quadrant3Fill": "#86efac", "quadrant4Fill": "#fde047", "quadrant1TextFill": "#7f1d1d", "quadrant2TextFill": "#7c2d12", "quadrant3TextFill": "#14532d", "quadrant4TextFill": "#713f12"}}}%%
quadrantChart
    title Risk vs. Blast Radius
    x-axis Low Blast Radius --> High Blast Radius
    y-axis Low Risk --> High Risk
    quadrant-1 Watch closely
    quadrant-2 Monitor after deploy
    quadrant-3 Low concern
    quadrant-4 Verify then relax
    "Narrative generator refactor": [0.85, 0.75]
    "Integrated Alerts dataset": [0.6, 0.45]
    "Machine-user scopes + migration": [0.3, 0.35]
    "inspect_view_context (experimental)": [0.15, 0.1]
    "Nullable thread_id fix": [0.2, 0.15]
    "Test/housekeeping fix": [0.05, 0.05]
```

🔴 Red (watch closely) — high risk, high blast radius

🟠 Orange (monitor after deploy) — high risk, contained blast radius (empty this release)

🟡 Yellow (verify then relax) — low risk, wide blast radius

🟢 Green (low concern) — low risk, contained blast radius

**Biggest risk**: the narrative generator refactor (#724). It's a wide refactor to a
path every insight request goes through (chat → analyst tool → charts → job write). If
something regresses, it will show up as broken/missing insight narratives or failed
analysis jobs, not a crash — worth explicit manual verification, not just green CI.

**Second risk**: Integrated Alerts is a brand-new dataset with no flag — any user asking
about "forest disturbance" or similar could route to it immediately after deploy.

**Low risk**: scopes migration is additive-only; `inspect_view_context` is flag-gated;
the thread_id and test fixes are narrow.

## Pre-deploy checklist

- [ ] Confirm CI is green on the commit being deployed (`0c7ed1a5` on `release-2026-08-05`,
      i.e. `20e60385` + CI-enablement commit `691205a5` + the `183e6836`, `77958482`, and
      `67dfcbf3` cherry-picks, in that order) — confirmed via GitHub Actions on push: Lint,
      Unit Tests, CalVer Check, and `docker-build-release-branch.yml` all green on the
      pre-reorder tip `db81dec7`; re-confirm the same on `0c7ed1a5` after the history rebase
      (tree content is identical — see Amendment 2 — so this should be a formality, not a
      real re-verification)
- [ ] Confirm `uv.lock` is in sync (bumped in `ce12e0ba`, `77ae5d7c`, `30debc69`, `20e60385`)
- [ ] Confirm target version resolves to `2026.7.1` (`grep version pyproject.toml`)
- [ ] **Get the deploy image tag**: this release ships from `release-2026-08-05` directly, not
      via a `main` merge. Confirm `docker-build-release-branch.yml` succeeded on `0c7ed1a5` and
      pushed `public.ecr.aws/b7u8b0a6/project-zeno/zeno:0c7ed1a5<full-40-char-sha>` — get the
      exact tag with `git rev-parse 0c7ed1a5` (do not use the 8-char short SHA as the tag; the
      workflow tags with the full `github.sha`)
- [ ] Update `project-zeno-deploy`'s `helm/zeno/values.yaml` (`image.tag`) to that full SHA —
      this is the actual deploy step for this release, replacing whatever merge-to-`main` +
      `docker-build.yml` flow a normal release would use
- [ ] Alembic: confirm current prod DB head is `8391583bd224` (or earlier, applied in
      sequence) before running `alembic upgrade head` — do **not** skip straight to
      `e0e882fba200` if there are unapplied migrations before it in prod
- [ ] Notify #eng-oncall (or equivalent) that Integrated Alerts goes live with this deploy —
      it's user-visible with no flag to roll it back except a redeploy

Run the `alembic upgrade head` migration (`e0e882fba200`) **before** deploying the new
image — it's additive and backward-compatible, so the previous version can keep running
against the new schema for as long as both are live during the deploy.

## Smoke tests (post-deploy)

1. **Version check** — confirm the new build is live:
   ```
   GET /api/metadata
   → "version": "2026.7.1"
   ```
2. **Basic liveness** — hit any lightweight `GET` (e.g. `/api/metadata`) and confirm 200,
   confirm response latency is in line with baseline.
3. **Machine-user scopes** — issue a machine-user key, confirm `scopes` defaults to `[]`
   for a pre-existing key and can be set for a new one; confirm `traces:read` scope
   gates `GET /api/traces` correctly for a scoped key.
   ```
   uv run zeno-cli machine-user create-key --scopes traces:read   # or equivalent CLI
   ```
4. **Insights end-to-end** — run one full chat → analysis → insight flow (any existing
   dataset unrelated to Integrated Alerts) and confirm:
   - Insight is created with a narrative (non-empty summary text)
   - `thread_id` can be null on an insight without a 500
   - Job status transitions to `completed`
5. **Integrated Alerts dataset** — ask the agent about forest disturbance for a known AOI
   and confirm:
   - The agent resolves to `dataset_id: 11` (Integrated Alerts)
   - Exactly one chart is returned (pie or line, never both — per #732/#727)
   - The map tile layer renders (new `gfw_integrated_dist_alerts` tile URL from #740 —
     confirm tiles actually load, not just that the URL string is correct)
   - No unhandled exception in logs
5b. **DIST-ALERT single-chart fix (#740)** — ask for a disturbance breakdown that needs
    DIST-ALERT specifically (e.g. "by driver" or "in natural lands") and confirm:
      - The agent routes to DIST-ALERT, not Integrated Alerts (per the sharpened
      `selection_hints`)
      - Exactly one chart is returned
6. **inspect_view_context (experimental)** — with `--ff experimental` (CLI) or the
   experimental frontend flag, send a view_context payload and confirm the agent tool
   responds with the formatted snapshot; **separately confirm default-profile users never
   see this tool** (it should not appear in their available tools).
7. **Regression spot-check** — confirm a default-profile chat session (no experimental
   flag) works normally and does not expose `inspect_view_context`.

## Rollback plan

- **Application**: redeploy the previous production version, tagged at `e54315a7`. Since this
  release's image is tagged by the `release-2026-08-05` commit SHA rather than produced by
  `main`'s `docker-build.yml`, rollback is: revert `project-zeno-deploy`'s
  `helm/zeno/values.yaml` `image.tag` back to `e54315a7`'s corresponding image tag (whatever
  it was before this deploy) and redeploy — no rebuild needed, the old image is still in ECR.
- **Database**: the only schema change is additive (`scopes` column with a server
  default). It is safe to leave in place even if the application is rolled back —
  `alembic downgrade -1` is available but not required for a clean rollback.
- **Feature-specific rollback**: if only Integrated Alerts misbehaves, the fastest
  mitigation is removing/renaming `integrated_alerts.yml` from the catalog and
  redeploying, without touching the rest of the release.

## Out of scope

This release is `20e60385` plus one release-branch-only CI/infra commit (`691205a5`) plus
three cherry-picks applied in chronological order — `183e6836`, `77958482`, and `67dfcbf3`
(branch `release-2026-08-05`, tip `0c7ed1a5`). Everything else on `main` after `20e60385` is
**not** part of this deploy and not covered by this plan: 18 commits before `183e6836`, 1
more before `77958482`, 39 more between `77958482` and `67dfcbf3`, and 48 after `67dfcbf3`
(dashboards MVP, unified AOI table, insight chart color registry, nudges, i18n,
conversation-language handling, etc.) — 106 commits total left behind (one fewer than before
Amendment 2, since `183e6836` moved from "left behind" to "included").

---

## NOTES FOR NEXT RELEASE — starts at `d97e1e6f`

> Next base target: `d97e1e6f`, the commit after this release's base (`20e60385`) on `main`.
>
> Cherry-pick `691205a5` (CI-enablement) into every release branch until `main` is in
> production — long-lived unmerged branches drift and break `pull_request` CI. Once `main`
> ships: back to one branch, one PR, per release.