### PR TITLE
fix: sort TCL chart rows by year

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.8.7"
+version = "2026.8.7.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/services/charts.py
+++ b/src/api/services/charts.py
@@ -42,7 +42,12 @@ class TCLChartGenerator(ChartGenerator):
         return dataset_id == self.dataset_id
 
     def generate(self, rows: List[dict]) -> List[InsightChart]:
-        rows = [r for r in rows if r.get("area_ha") != 0]
+        # The analytics API returns rows in arbitrary order; sort by year so
+        # the chart's category x-axis reads 2001 → 2025 rather than a shuffle.
+        rows = sorted(
+            (r for r in rows if r.get("area_ha") != 0),
+            key=lambda r: r.get("tree_cover_loss_year") or 0,
+        )
         return [
             InsightChart(
                 position=0,

--- a/tests/unit/api/services/test_chart_generators.py
+++ b/tests/unit/api/services/test_chart_generators.py
@@ -64,6 +64,25 @@ def test_drops_rows_where_area_ha_is_zero():
             assert row["area_ha"] != 0
 
 
+def test_sorts_rows_by_year():
+    # The analytics API returns rows in arbitrary order (e.g. 2004 first,
+    # 2023 last); the chart must come out year-ascending or the frontend's
+    # category x-axis renders the years shuffled.
+    scrambled = column_to_rows(
+        {
+            "tree_cover_loss_year": [2004, 2021, 2001, 2023, 2010],
+            "area_ha": [100.0, 200.0, 300.0, 400.0, 500.0],
+            "carbon_emissions_MgCO2e": [50.0, 100.0, 150.0, 200.0, 250.0],
+            "aoi_id": ["BRA"] * 5,
+            "aoi_type": ["admin"] * 5,
+        }
+    )
+    charts = TCLChartGenerator(TREE_COVER_LOSS_ID).generate(scrambled)
+    for chart in charts:
+        years = [row["tree_cover_loss_year"] for row in chart.chart_data]
+        assert years == [2001, 2004, 2010, 2021, 2023]
+
+
 # --- Integrated Alerts -------------------------------------------------------
 IA_DATA = {
     "alert_date": ["2024-03-01", "2024-03-20", "2024-04-05", "2024-04-18"],


### PR DESCRIPTION
## Summary

The GFW analytics API returns result rows in arbitrary order. `TCLChartGenerator` passed that order straight into the loss and emissions charts' `chart_data`, and the frontend renders bar charts on a category x-axis in row order — so the year axis came out shuffled (e.g. reading 2004 first and 2023 last despite the data covering all of 2001–2025). Reported via the dashboard curated-analysis work in project-zeno-next, but it affects every consumer of `/api/analyze` TCL insights (map direct analysis, dashboards, thread replay).

Sort rows by `tree_cover_loss_year` after the existing zero-loss filter, matching the ordering `IntegratedAlertsChartGenerator` already applies via `sorted(totals.items())`.

Note: already-persisted insights keep their stored (scrambled) `chart_data`; a complementary defensive sort on numeric x-axes is going into the frontend to cover those.

## Test plan
- [x] New unit test `test_sorts_rows_by_year` — scrambled input rows come out year-ascending in both charts (red before the fix, green after)
- [x] `uv run pytest tests/unit/api/services/test_chart_generators.py` — 12 passed
- [x] `ruff check` / `ruff format --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHyeX4A8pTMmE5zfx1cRrS