### PR TITLE
Promote dashboard and explore skills to the default profile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.8.12"
+version = "2026.8.13"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -124,7 +124,6 @@ EXPERIMENTAL_SKILLS = ()
 EXPERIMENTAL_TOOLS = (
     inspect_view_context_spec,
     update_insight_display_spec,
-    search_insights_spec,
 )
 
 

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -6,8 +6,8 @@ Profiles form a chain, each one a small delta on its parent:
                    generate_insights), no skills. Ships on its own so raw
                    tool-calling can be evaluated without recipe guidance.
     default      — base + the core skills (analyze, pull-data, capabilities,
-                   wri-insights).
-    experimental — default + opt-in skills and standalone tools.
+                   show-imagery, wri-insights, dashboard, explore).
+    experimental — default + standalone tools not yet owned by any skill.
 
 An ``AgentConfig`` declares three things:
 
@@ -109,19 +109,22 @@ DEFAULT_SKILLS = (
     "capabilities",
     "show-imagery",
     "wri-insights",
+    "dashboard",
+    "explore",
 )
 # Datasets hidden from normal traffic; revealed by opting into a flag whose
 # profile omits them (see EXPERIMENTAL_PROFILE below).
 DEFAULT_EXCLUDED_DATASETS = frozenset({"Land GHG Monitoring System (LGMS)"})
 
-# Experimental, opt-in additions over the default profile.
+# Experimental additions over the default profile: standalone tools not yet
+# owned by any skill's workflow. No opt-in skills remain here — the last two
+# (dashboard, explore) graduated to DEFAULT_SKILLS above.
 EXPERIMENTAL_PROFILE = "experimental"
-EXPERIMENTAL_SKILLS = ("dashboard", "explore")
+EXPERIMENTAL_SKILLS = ()
 EXPERIMENTAL_TOOLS = (
     inspect_view_context_spec,
     update_insight_display_spec,
     search_insights_spec,
-    send_nudge_spec,
 )
 
 

--- a/src/agent/docs/feature-flags.md
+++ b/src/agent/docs/feature-flags.md
@@ -11,7 +11,7 @@ base         core toolbox (pick_aoi, pick_dataset, pull_data, generate_insights)
   └─ default       base + core skills (analyze, pull-data, capabilities, show-imagery,
                     wri-insights, dashboard, explore)
        └─ experimental  default + standalone tools not yet owned by any skill
-                        (inspect_view_context, update_insight_display, search_insights)
+                        (inspect_view_context, update_insight_display)
 ```
 
 `base` ships as its own flag so raw tool-calling can be evaluated without recipe guidance. `default` is what unknown or absent `ff` values fall back to. Each production profile's full derived surface (skills, subagents, tools) is snapshot-tested in `tests/unit/agent/test_profile_manifest.py` — run `config.describe()` to see it, and update the snapshot when you change a profile on purpose.

--- a/src/agent/docs/feature-flags.md
+++ b/src/agent/docs/feature-flags.md
@@ -8,9 +8,10 @@ Profiles form a chain, each one a small delta on its parent:
 
 ```
 base         core toolbox (pick_aoi, pick_dataset, pull_data, generate_insights), no skills
-  └─ default       base + core skills (analyze, pull-data, capabilities)
-       └─ experimental  default + opt-in skills (dashboard, show-imagery, wri-insights, explore)
-                        + standalone tools (inspect_view_context, update_insight_display, search_insights)
+  └─ default       base + core skills (analyze, pull-data, capabilities, show-imagery,
+                    wri-insights, dashboard, explore)
+       └─ experimental  default + standalone tools not yet owned by any skill
+                        (inspect_view_context, update_insight_display, search_insights)
 ```
 
 `base` ships as its own flag so raw tool-calling can be evaluated without recipe guidance. `default` is what unknown or absent `ff` values fall back to. Each production profile's full derived surface (skills, subagents, tools) is snapshot-tested in `tests/unit/agent/test_profile_manifest.py` — run `config.describe()` to see it, and update the snapshot when you change a profile on purpose.

--- a/src/agent/skills/skills_md/dashboard.md
+++ b/src/agent/skills/skills_md/dashboard.md
@@ -2,7 +2,7 @@
 name: dashboard
 description: Create a dashboard for an area and fill it with insights (new or recalled), map widgets, and text notes.
 when_to_use: User asks to build/create a dashboard for a place, to add an insight/analysis to a dashboard, or to add a map layer / satellite imagery to a dashboard. Not for one-off analysis without a dashboard — use `analyze`.
-requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, send_nudge
+requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, send_nudge, search_insights
 ---
 
 # Dashboards

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -310,6 +310,7 @@ def test_default_profile_derives_exactly_the_core_tools():
             "read_skill",
             "search_blogs",
             "show_imagery",
+            "search_insights",
             "create_dashboard",
             "add_to_dashboard",
             "add_map_widget",

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -310,6 +310,12 @@ def test_default_profile_derives_exactly_the_core_tools():
             "read_skill",
             "search_blogs",
             "show_imagery",
+            "create_dashboard",
+            "add_to_dashboard",
+            "add_map_widget",
+            "add_text_widget",
+            "edit_text_widget",
+            "send_nudge",
         }
     )
 
@@ -360,22 +366,29 @@ async def test_fetch_zeno_binds_the_resolved_configs_availability():
     assert available.tools == frozenset({"_fake_tool", "read_skill"})
 
 
-def test_experimental_config_adds_experimental_tools_and_skills():
-    """The experimental profile layers dashboard and explore on top of the
-    default set (which already has show-imagery)."""
+def test_experimental_config_adds_only_standalone_tools():
+    """dashboard and explore graduated into the default set; experimental now
+    layers only standalone tools not yet owned by any skill."""
     default = default_registry.resolve(DEFAULT_PROFILE)
     experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
 
     default_tools = {t.name for t in default.bound_tools()}
     experimental_tools = {t.name for t in experimental.bound_tools()}
-    assert "show_imagery" in default_tools
-    assert {"show_imagery", "search_blogs"} <= experimental_tools
+    assert {
+        "show_imagery",
+        "search_blogs",
+        "add_to_dashboard",
+    } <= default_tools
+    assert {"inspect_view_context", "update_insight_display"} <= (
+        experimental_tools - default_tools
+    )
 
     default_skills = {s.name for s in default.skill_metas()}
     experimental_skills = {s.name for s in experimental.skill_metas()}
-    assert "show-imagery" in default_skills
-    assert {"show-imagery", "explore", "wri-insights"} <= experimental_skills
-    assert {"show-imagery", "explore", "wri-insights"} <= experimental_skills
+    assert {"show-imagery", "explore", "wri-insights", "dashboard"} <= (
+        default_skills
+    )
+    assert experimental_skills == default_skills
 
 
 # --- excluded_datasets enforcement in pick_dataset ---------------------------

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -35,6 +35,8 @@ extends: base
 skills:
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
+  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, send_nudge)
+  - explore (requires: search_blogs)
   - pull-data (requires: pick_aoi, pick_dataset, pull_data)
   - show-imagery (requires: pick_aoi, show_imagery)
   - wri-insights (requires: search_blogs)
@@ -46,7 +48,13 @@ subagents:
 tools:
   - pull_data
   - read_skill
-  - show_imagery"""
+  - show_imagery
+  - create_dashboard
+  - add_to_dashboard
+  - add_map_widget
+  - add_text_widget
+  - edit_text_widget
+  - send_nudge"""
 
 EXPERIMENTAL_MANIFEST = """\
 profile: experimental

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -35,7 +35,7 @@ extends: base
 skills:
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
-  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, send_nudge)
+  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, send_nudge, search_insights)
   - explore (requires: search_blogs)
   - pull-data (requires: pick_aoi, pick_dataset, pull_data)
   - show-imagery (requires: pick_aoi, show_imagery)
@@ -49,6 +49,7 @@ tools:
   - pull_data
   - read_skill
   - show_imagery
+  - search_insights
   - create_dashboard
   - add_to_dashboard
   - add_map_widget
@@ -62,7 +63,7 @@ extends: default
 skills:
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
-  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, send_nudge)
+  - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, send_nudge, search_insights)
   - explore (requires: search_blogs)
   - pull-data (requires: pick_aoi, pick_dataset, pull_data)
   - show-imagery (requires: pick_aoi, show_imagery)

--- a/tests/unit/agent/test_view_pages.py
+++ b/tests/unit/agent/test_view_pages.py
@@ -140,9 +140,9 @@ def test_get_prompt_includes_surface_section_only_for_known_pages():
     assert "add_to_dashboard, which defaults to the dashboard" in dashboard
     # The rest of the prompt is unchanged.
     assert "# Routing" in dashboard
-    # The default profile has no dashboard tools, so the dashboard skill
-    # is unavailable — the surface section must not point at it.
-    assert "skill `dashboard`" not in dashboard
+    # The default profile carries the dashboard skill, so the surface
+    # section points at it.
+    assert "skill `dashboard`" in dashboard
 
     assert "# Current surface" not in get_prompt(page="sandbox")
 
@@ -154,3 +154,14 @@ def test_get_prompt_dashboard_surface_names_the_skill_when_available():
     config = default_registry.resolve(EXPERIMENTAL_PROFILE)
     dashboard = get_prompt(config=config, page="dashboard")
     assert "skill `dashboard`" in dashboard
+
+
+def test_get_prompt_dashboard_surface_omits_skill_when_unavailable():
+    """A leaner profile without the dashboard skill's tools bound must not be
+    told to read it — read_skill would just refuse."""
+    from src.agent.agent_config import BASE_PROFILE, default_registry
+    from src.agent.graph import get_prompt
+
+    config = default_registry.resolve(BASE_PROFILE)
+    dashboard = get_prompt(config=config, page="dashboard")
+    assert "skill `dashboard`" not in dashboard

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -277,12 +277,12 @@ def test_get_prompt_has_no_per_skill_routing_rows():
 def test_get_prompt_routing_gates_recall_row_on_search_insights():
     """The recall row routes to the search_insights tool; a profile that
     doesn't bind it must not see the row."""
-    from src.agent.agent_config import EXPERIMENTAL_PROFILE, default_registry
+    from src.agent.agent_config import BASE_PROFILE, default_registry
     from src.agent.graph import get_prompt
 
-    default_prompt = get_prompt()
-    assert "Recall a past insight" not in default_prompt
-    assert "search_insights" not in default_prompt
+    base_prompt = get_prompt(config=default_registry.resolve(BASE_PROFILE))
+    assert "Recall a past insight" not in base_prompt
+    assert "search_insights" not in base_prompt
 
-    experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
-    assert "Recall a past insight" in get_prompt(config=experimental)
+    default_prompt = get_prompt()
+    assert "Recall a past insight" in default_prompt

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.8.12"
+version = "2026.8.13"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Moves the last two experimental-only skills, `dashboard` and `explore`, into `DEFAULT_SKILLS` — they now ship in every default agent instead of requiring `ff=experimental`.
- `EXPERIMENTAL_SKILLS` is now empty; the experimental profile is now just the default plus two standalone tools not yet owned by any skill (`inspect_view_context`, `update_insight_display`).
- **Fix:** `dashboard.md`'s body already instructed the agent to call `search_insights` to recall a past finding, but that tool wasn't in the skill's `requires:` — it only rode along because it happened to be bundled separately in `EXPERIMENTAL_TOOLS` alongside `dashboard`. That coincidence broke once `dashboard` graduated to `default` without `search_insights` following it, so `search_insights` is now added to `dashboard`'s `requires:` (structurally tying it to wherever the skill is declared) and dropped from `EXPERIMENTAL_TOOLS`.
- Updates the profile manifest snapshot tests and feature-flag/view-page/routing tests that hardcoded the old split.
- Fixes the `src/agent/docs/feature-flags.md` profile-chain diagram, which was already stale (missing `show-imagery` from `default`) even before this change.

## Test plan
- [x] `tests/unit/agent` (229 tests) passes, including updated `test_profile_manifest.py`, `test_feature_flag.py`, `test_view_pages.py`, `test_skills.py`
