### PR TITLE
PZB-1271: Derive the GADM name repairs from GADM's own hierarchy

### DIFF
--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -854,14 +854,6 @@ _GADM_CHILD_NAME_MIN_SHARE = 0.5
 # applying it further down would rename a unit after an unrelated child.
 _GADM_SHIFTED_NAME_SUBTYPE = "district-county"
 
-# The three level-1 rows PZB-1270 patched by hand. Superseded by
-# _derive_gadm_name_repairs in the next commit.
-_GADM_NAME_PATCHES = {
-    "GBR.1_1": "England, United Kingdom",
-    "IRL.4_1": "Cork, Ireland",
-    "NLD.14_1": "Zuid-Holland, Netherlands",
-}
-
 
 async def _table_exists(session: AsyncSession, table: str) -> bool:
     result = await session.execute(
@@ -1043,31 +1035,6 @@ async def _derive_gadm_name_repairs(
     return {row[0]: row[1] for row in result.all()}
 
 
-def _gadm_name_patch_sql(id_col: str) -> tuple[str, dict[str, str]]:
-    """Return the patched ``name`` expression and its bound parameters.
-
-    An identifier cannot be a bound parameter, so the placeholder *names* are
-    generated from ``_GADM_NAME_PATCHES``; every id and name the query compares
-    or returns is bound, so no source value is ever interpolated into SQL.
-    """
-    if not _GADM_NAME_PATCHES:
-        return "name", {}
-
-    params: dict[str, str] = {}
-    whens: list[str] = []
-    for i, (gadm_id, patched) in enumerate(sorted(_GADM_NAME_PATCHES.items())):
-        params[f"patch_id_{i}"] = gadm_id
-        params[f"patch_name_{i}"] = patched
-        whens.append(
-            f"WHEN CAST(:patch_id_{i} AS TEXT) "
-            f"THEN CAST(:patch_name_{i} AS TEXT)"
-        )
-    expr = (
-        f'CASE CAST("{id_col}" AS TEXT) ' + " ".join(whens) + " ELSE name END"
-    )
-    return expr, params
-
-
 async def _build_reference_aois(
     session: AsyncSession, source: str, *, nchunks: int, dry_run: bool
 ) -> int:
@@ -1081,6 +1048,13 @@ async def _build_reference_aois(
     cross-chunk boundary effects. Note chunking does *not* bound the cost of any
     single geometry -- that is the job of the part-wise repair in
     ``multipolygon_sql`` and the ``MATERIALIZED`` CTE (compute each shape once).
+
+    The gadm name repair is derived once, before the loop, and passed in as two
+    bound arrays. It has to be: it reads a row's *children*, which the hash
+    partition scatters across other chunks, so a lookup inside the chunked
+    statement would have to be careful never to be chunk-filtered. Deriving it
+    once also pays for its self-join once (~20s on the full table) instead of
+    once per pass.
     """
     table = SOURCE_STAGING_TABLES[source]
     id_col = AOI_SOURCE_ID_COLUMNS[source]
@@ -1095,9 +1069,10 @@ async def _build_reference_aois(
     )
 
     # Only gadm carries broken source names, so every other source selects
-    # `name` unchanged and binds no patch parameters.
+    # `name` unchanged, joins nothing extra and binds no repair parameters.
     name_expr = "name"
-    patch_params: dict[str, str] = {}
+    repair_join = ""
+    repair_params: dict[str, object] = {}
     if source == "gadm":
         # subtype -> GADM admin level (0..5), in GADM_LEVELS declaration order.
         admin_expr = (
@@ -1110,7 +1085,27 @@ async def _build_reference_aois(
         # Disputed territories (e.g. "Z01") lack a 3-letter ISO prefix; keep
         # the rows but flag them so search can exclude via its partial index.
         disputed_expr = f"NOT (\"{id_col}\" ~ '{GADM_STANDARD_ID_RE}')"
-        name_expr, patch_params = _gadm_name_patch_sql(id_col)
+
+        repairs = await _derive_gadm_name_repairs(session, table, id_col)
+        if repairs:
+            click.echo(
+                f"🔧 {source}: {len(repairs)} name(s) repaired from GADM's "
+                "own hierarchy."
+            )
+            # unnest of two bound arrays: one hash join per pass, and it scales
+            # with however many rows the rules reach. Not chunk-filtered, on
+            # purpose -- see the docstring.
+            repair_join = (
+                " LEFT JOIN unnest("
+                "CAST(:repair_ids AS text[]), CAST(:repair_names AS text[])"
+                ") AS r(repair_id, repair_name)"
+                f' ON r.repair_id = CAST("{id_col}" AS TEXT)'
+            )
+            name_expr = "COALESCE(r.repair_name, name)"
+            repair_params = {
+                "repair_ids": list(repairs),
+                "repair_names": list(repairs.values()),
+            }
     else:
         admin_expr = "NULL::smallint"
         disputed_expr = "false"
@@ -1141,7 +1136,7 @@ async def _build_reference_aois(
                 {iso3_expr} AS iso3,
                 {admin_expr} AS admin_level,
                 {disputed_expr} AS is_disputed
-            FROM {table}
+            FROM {table}{repair_join}
             WHERE name IS NOT NULL AND geometry IS NOT NULL
               AND (abs(hashtext(CAST("{id_col}" AS TEXT))::bigint) % :nchunks)
                   = :chunk
@@ -1182,7 +1177,7 @@ async def _build_reference_aois(
     inserted = 0
     for chunk in range(nchunks):
         result = await session.execute(
-            text(sql), {"nchunks": nchunks, "chunk": chunk, **patch_params}
+            text(sql), {"nchunks": nchunks, "chunk": chunk, **repair_params}
         )
         inserted += result.rowcount
         # One transaction per chunk: bounds the open transaction and makes a

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -22,7 +22,7 @@ import asyncio
 import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import bcrypt
 import click
@@ -881,31 +881,25 @@ async def _resolve_column(
     return None
 
 
-def _gadm_name_column(id_col: str) -> str:
-    """GADM's name column for the level whose id column is *id_col*.
+class _GadmLevel(NamedTuple):
+    """One GADM admin level's subtype and its two columns in staging."""
 
-    Level 0 is the exception: GADM names that column COUNTRY, not NAME_0.
+    subtype: str
+    id_col: str
+    name_col: str
+
+
+def _gadm_repair_levels() -> list[_GadmLevel]:
+    """GADM's admin levels, shallowest first, from ``GADM_LEVELS``.
+
+    One definition of the hierarchy, so the repair rules can pair a level with
+    the one below it (``zip(levels, levels[1:])``). A parent and its children
+    share the parent's ``id_col``, and both carry the parent's name in their own
+    ``name_col``, which is what lets a broken parent look one level down.
     """
-    return "COUNTRY" if id_col == "GID_0" else id_col.replace("GID_", "NAME_")
-
-
-def _gadm_repair_levels() -> list[tuple[str, str, str, str]]:
-    """(parent subtype, child subtype, shared id column, name column) pairs.
-
-    Derived from ``GADM_LEVELS`` so the admin hierarchy has one definition.
-    Each entry lets a broken parent look one level down: parent and child rows
-    share the parent's ``GID_n`` and both carry the parent's name in their own
-    ``NAME_n``.
-    """
-    subtypes = list(GADM_LEVELS)
     return [
-        (
-            subtype,
-            subtypes[level + 1],
-            GADM_LEVELS[subtype]["col_name"],
-            _gadm_name_column(GADM_LEVELS[subtype]["col_name"]),
-        )
-        for level, subtype in enumerate(subtypes[:-1])
+        _GadmLevel(subtype, level["col_name"], level["name_col"])
+        for subtype, level in GADM_LEVELS.items()
     ]
 
 
@@ -925,24 +919,59 @@ async def _derive_gadm_name_repairs(
       England, Cork and Zuid-Holland at level 1, and at level 2 the multi-child
       counties whose name GADM only stored one level down (Warwickshire,
       Derbyshire, Greater London ...).
-    * **B, leaf name from an only child.** A district-county row with exactly
-      one named municipality child adopts the child's name. Repairs Bristol and
-      57 others, where GADM shifted the name down a level rather than omitting
-      it. Rule A wins where both could fire.
+    * **B, leaf name from an only child.** A district-county row holding
+      exactly one municipality child, which must itself be named, adopts that
+      child's name. A district with one named child *and* one ``'NA'`` child is
+      refused: the SQL counts every child, not just the named ones, so the pair
+      has to be unambiguous. Repairs Bristol and 57 others, where GADM shifted
+      the name down a level rather than omitting it. Rule A wins where both
+      could fire.
 
     Only the broken leading segment of the display name is replaced; every
     parent segment is left byte-identical, so no row's name changes except at
     the position GADM left as ``'NA'``. Rows the rules cannot reach (no
     children, a tie, a multi-child parent with no majority, an unnamed only
     child) keep the name they have today.
+
+    Known gap, accepted: only the *leading* segment is repaired, so a Rule B
+    family leaves the child itself reading "Bristol, NA, England, United
+    Kingdom" -- the parent's own name is fixed, the same name sitting in the
+    child's middle segment is not. Recomposing a display name from its repaired
+    ancestors is SPEC-PR8's design and the durable fix; patching middle
+    segments by string surgery here is not.
     """
-    levels = [
-        level
-        for level in _gadm_repair_levels()
-        if await _resolve_column(session, table, [level[2]])
-        and await _resolve_column(session, table, [level[3]])
-    ]
-    if not levels:
+    # One catalogue read for every level: `_resolve_column` costs a round trip
+    # per candidate and returns the real casing, which nothing here needs --
+    # the column names come from GADM_LEVELS and are quoted as declared.
+    result = await session.execute(
+        text(
+            "SELECT lower(column_name) FROM information_schema.columns "
+            "WHERE table_name = :t"
+        ),
+        {"t": table},
+    )
+    present = {row[0] for row in result.all()}
+
+    levels: list[_GadmLevel] = []
+    for level in _gadm_repair_levels():
+        missing = [
+            col
+            for col in (level.id_col, level.name_col)
+            if col.lower() not in present
+        ]
+        if missing:
+            # A level GADM_LEVELS declares but staging does not carry means a
+            # partial ingest: say so rather than quietly repairing less.
+            click.echo(
+                f"⚠️  gadm: level '{level.subtype}' skipped by the name "
+                f"repair ({', '.join(missing)} not in {table})."
+            )
+        else:
+            levels.append(level)
+
+    # Each rule pairs a level with the one directly below it.
+    pairs = list(zip(levels, levels[1:]))
+    if not pairs:
         return {}
 
     params: dict[str, object] = {
@@ -951,81 +980,100 @@ async def _derive_gadm_name_repairs(
         "min_share": _GADM_CHILD_NAME_MIN_SHARE,
     }
     votes: list[str] = []
-    for i, (subtype, child_subtype, level_id, name_col) in enumerate(levels):
-        params[f"parent_{i}"] = subtype
-        params[f"child_{i}"] = child_subtype
+    for i, (parent, child) in enumerate(pairs):
+        params[f"parent_{i}"] = parent.subtype
+        params[f"child_{i}"] = child.subtype
         # Identifiers cannot be bound, and these come from GADM_LEVELS, not
-        # from data. Every value is a bound parameter.
+        # from data. Every value is a bound parameter. A NULL candidate fails
+        # `NOT IN` on its own, so no null test is needed.
         votes.append(
             f"""
             SELECT CAST(p."{id_col}" AS TEXT) AS source_id,
-                   c."{name_col}" AS candidate,
+                   c."{parent.name_col}" AS candidate,
                    count(*) AS votes
             FROM {table} p
             JOIN {table} c
               ON c.subtype = :child_{i}
-             AND c."{level_id}" = p."{level_id}"
+             AND c."{parent.id_col}" = p."{parent.id_col}"
             WHERE p.subtype = :parent_{i}
-              AND p."{name_col}" = :na
-              AND c."{name_col}" IS NOT NULL
-              AND c."{name_col}" NOT IN ('', :na)
+              AND p."{parent.name_col}" = :na
+              AND c."{parent.name_col}" NOT IN ('', :na)
             GROUP BY 1, 2
             """
         )
 
-    # Rule B is level 2 only: the shifted-name pattern is a district-county
-    # holding a single municipality. `min()` is the only child's name, because
-    # HAVING count(*) = 1 has already restricted the group to one row.
-    b_level = next(
-        (lv for lv in levels if lv[0] == _GADM_SHIFTED_NAME_SUBTYPE), None
-    )
-    rule_b = "SELECT NULL::text AS source_id, NULL::text AS leaf WHERE false"
-    if b_level is not None:
-        parent_subtype, child_subtype, level_id, name_col = b_level
-        child_name_col = _gadm_name_column(
-            GADM_LEVELS[child_subtype]["col_name"]
-        )
-        params["b_parent"] = parent_subtype
-        params["b_child"] = child_subtype
-        rule_b = f"""
-            SELECT CAST(p."{id_col}" AS TEXT) AS source_id,
-                   min(c."{child_name_col}") AS leaf
-            FROM {table} p
-            JOIN {table} c
-              ON c.subtype = :b_child AND c."{level_id}" = p."{level_id}"
-            WHERE p.subtype = :b_parent AND p."{name_col}" = :na
-            GROUP BY 1
-            HAVING count(*) = 1
-               AND min(c."{child_name_col}") IS NOT NULL
-               AND min(c."{child_name_col}") NOT IN ('', :na)
-        """
-
-    # substring(name FROM 3) drops the leading 'NA' and keeps the ', parent'
-    # tail. DISTINCT ON collapses the duplicate ids the staging tables carry
-    # (no unique constraint); duplicates of one id share their composed name.
-    sql = f"""
-        WITH votes AS ({" UNION ALL ".join(votes)}),
-        ranked AS (
+    ctes = [
+        f"votes AS ({' UNION ALL '.join(votes)})",
+        """ranked AS (
             SELECT source_id, candidate, votes,
                    sum(votes) OVER (PARTITION BY source_id) AS total
             FROM votes
-        ),
-        rule_a AS (
-            SELECT DISTINCT ON (source_id) source_id, candidate AS leaf
+        )""",
+        """rule_a AS (
+            -- No tie-break, and none possible: a strict majority of the votes
+            -- admits at most one candidate per source_id. Drop :min_share to
+            -- 0.5 or below and this CTE can emit several rows for one id,
+            -- which `repairs` would carry through as duplicate repairs.
+            SELECT source_id, candidate AS leaf
             FROM ranked
             WHERE votes > :min_share * total
-            ORDER BY source_id, votes DESC, candidate
+        )""",
+    ]
+    repair_arms = ["SELECT source_id, leaf FROM rule_a"]
+
+    # Rule B is level 2 only: the shifted-name pattern is a district-county
+    # holding a single municipality. Emitted only when that level survived the
+    # column check, so there is no empty sentinel CTE to reason about.
+    b_pair = next(
+        (
+            (parent, child)
+            for parent, child in pairs
+            if parent.subtype == _GADM_SHIFTED_NAME_SUBTYPE
         ),
-        rule_b AS ({rule_b}),
-        repairs AS (
-            SELECT source_id, leaf FROM rule_a
-            UNION ALL
-            SELECT source_id, leaf FROM rule_b
-            WHERE source_id NOT IN (SELECT source_id FROM rule_a)
+        None,
+    )
+    if b_pair is not None:
+        parent, child = b_pair
+        params["b_parent"] = parent.subtype
+        params["b_child"] = child.subtype
+        # The inner select groups, the outer only filters, so `min()` is
+        # written once. It is the only child's name, because HAVING has already
+        # restricted the group to one row; a NULL leaf fails `NOT IN`.
+        ctes.append(
+            f"""rule_b AS (
+            SELECT source_id, leaf
+            FROM (
+                SELECT CAST(p."{id_col}" AS TEXT) AS source_id,
+                       min(c."{child.name_col}") AS leaf
+                FROM {table} p
+                JOIN {table} c
+                  ON c.subtype = :b_child
+                 AND c."{parent.id_col}" = p."{parent.id_col}"
+                WHERE p.subtype = :b_parent
+                  AND p."{parent.name_col}" = :na
+                GROUP BY 1
+                HAVING count(*) = 1
+            ) only_child
+            WHERE leaf NOT IN ('', :na)
+        )"""
         )
+        # Rule A wins where both fire.
+        repair_arms.append(
+            "SELECT source_id, leaf FROM rule_b"
+            " WHERE source_id NOT IN (SELECT source_id FROM rule_a)"
+        )
+
+    ctes.append(f"repairs AS ({' UNION ALL '.join(repair_arms)})")
+
+    # substring past the marker drops the leading 'NA' and keeps the ', parent'
+    # tail. DISTINCT ON collapses the duplicate ids the staging tables carry
+    # (no unique constraint); duplicates of one id share their composed name.
+    sql = f"""
+        WITH {", ".join(ctes)}
         SELECT DISTINCT ON (r.source_id)
                r.source_id,
-               r.leaf || substring(g.name FROM 3) AS repaired
+               r.leaf || substring(g.name FROM char_length(:na) + 1)
+                 AS repaired
         FROM repairs r
         JOIN {table} g ON CAST(g."{id_col}" AS TEXT) = r.source_id
         WHERE g.name = :na OR g.name LIKE :na_prefix

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -19,6 +19,7 @@ Usage:
 """
 
 import asyncio
+import json
 import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -1097,9 +1098,9 @@ async def _build_reference_aois(
     single geometry -- that is the job of the part-wise repair in
     ``multipolygon_sql`` and the ``MATERIALIZED`` CTE (compute each shape once).
 
-    The gadm name repair is derived once, before the loop, and passed in as two
-    bound arrays. It has to be: it reads a row's *children*, which the hash
-    partition scatters across other chunks, so a lookup inside the chunked
+    The gadm name repair is derived once, before the loop, and passed in as one
+    bound jsonb object. It has to be: it reads a row's *children*, which the
+    hash partition scatters across other chunks, so a lookup inside the chunked
     statement would have to be careful never to be chunk-filtered. Deriving it
     once also pays for its self-join once (~20s on the full table) instead of
     once per pass.
@@ -1140,20 +1141,23 @@ async def _build_reference_aois(
                 f"🔧 {source}: {len(repairs)} name(s) repaired from GADM's "
                 "own hierarchy."
             )
-            # unnest of two bound arrays: one hash join per pass, and it scales
-            # with however many rows the rules reach. Not chunk-filtered, on
-            # purpose -- see the docstring.
+            # One bound jsonb object rather than two arrays that have to stay
+            # index-aligned: one hash join per pass, scaling with however many
+            # rows the rules reach. Not chunk-filtered, on purpose -- see the
+            # docstring.
             repair_join = (
-                " LEFT JOIN unnest("
-                "CAST(:repair_ids AS text[]), CAST(:repair_names AS text[])"
-                ") AS r(repair_id, repair_name)"
+                " LEFT JOIN jsonb_each_text(CAST(:repairs AS jsonb))"
+                " AS r(repair_id, repair_name)"
                 f' ON r.repair_id = CAST("{id_col}" AS TEXT)'
             )
             name_expr = "COALESCE(r.repair_name, name)"
-            repair_params = {
-                "repair_ids": list(repairs),
-                "repair_names": list(repairs.values()),
-            }
+            repair_params = {"repairs": json.dumps(repairs)}
+        else:
+            # Staging always carries GADM's 'NA' rows, so an empty map means
+            # the rules reached nothing: never let that pass unremarked.
+            click.echo(
+                f"⚠️  {source}: no name(s) repaired from GADM's own hierarchy."
+            )
     else:
         admin_expr = "NULL::smallint"
         disputed_expr = "false"

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -833,11 +833,29 @@ _ISO3_SOURCE_COLUMNS = {
     "landmark": ["iso_code"],
 }
 
-# GADM 4.1 ships the literal string "NA" as NAME_1 for a handful of level-1
-# rows, so their composed display names lose the place name entirely (England
-# becomes "NA, United Kingdom" and is unfindable by search). The correct names
-# are taken from the NAME_1 column of their own child rows. MHL.19_1 has no
-# children and stays broken. See SPEC-PR6 / PZB-1270.
+# GADM 4.1 ships the literal string "NA" as its no-data marker, and ingest
+# composes display names from the NAME_* columns without recognising it, so
+# England's row is named "NA, United Kingdom" and is unfindable by search.
+# 2,930 rows are affected globally. See SPEC-PR7 / PZB-1271.
+_GADM_NO_DATA_NAME = "NA"
+
+# Rule A adopts a candidate name only when it holds this share of the parent's
+# *named* immediate children. GADM's own child rows disagree with each other,
+# so unanimity is not available: England's level-2 children include two that
+# say "NA", Cork's include one "Cork City", Zuid-Holland's one "Zuid Hollandse
+# Meren". A strict majority keeps all three, and refuses the all-NA ghost row
+# whose two children split 1-1 between England and Scotland. The one
+# plurality-adjacent case it admits is CHL.15.1_1 -> Tamarugal (5 of 7, GADM's
+# row spanning two Chilean provinces); raise this to 0.8 to exclude it.
+_GADM_CHILD_NAME_MIN_SHARE = 0.5
+
+# Rule B's level. GADM shifted names down a level only for district-counties
+# holding a single municipality (Bristol, Tameside, Trafford, Wiltshire ...);
+# applying it further down would rename a unit after an unrelated child.
+_GADM_SHIFTED_NAME_SUBTYPE = "district-county"
+
+# The three level-1 rows PZB-1270 patched by hand. Superseded by
+# _derive_gadm_name_repairs in the next commit.
 _GADM_NAME_PATCHES = {
     "GBR.1_1": "England, United Kingdom",
     "IRL.4_1": "Cork, Ireland",
@@ -869,6 +887,160 @@ async def _resolve_column(
         if found:
             return found
     return None
+
+
+def _gadm_name_column(id_col: str) -> str:
+    """GADM's name column for the level whose id column is *id_col*.
+
+    Level 0 is the exception: GADM names that column COUNTRY, not NAME_0.
+    """
+    return "COUNTRY" if id_col == "GID_0" else id_col.replace("GID_", "NAME_")
+
+
+def _gadm_repair_levels() -> list[tuple[str, str, str, str]]:
+    """(parent subtype, child subtype, shared id column, name column) pairs.
+
+    Derived from ``GADM_LEVELS`` so the admin hierarchy has one definition.
+    Each entry lets a broken parent look one level down: parent and child rows
+    share the parent's ``GID_n`` and both carry the parent's name in their own
+    ``NAME_n``.
+    """
+    subtypes = list(GADM_LEVELS)
+    return [
+        (
+            subtype,
+            subtypes[level + 1],
+            GADM_LEVELS[subtype]["col_name"],
+            _gadm_name_column(GADM_LEVELS[subtype]["col_name"]),
+        )
+        for level, subtype in enumerate(subtypes[:-1])
+    ]
+
+
+async def _derive_gadm_name_repairs(
+    session: AsyncSession, table: str, id_col: str
+) -> dict[str, str]:
+    """Derive ``{source_id: repaired display name}`` from GADM's hierarchy.
+
+    Read-only: staging is never written, so the map is recomputed identically on
+    every build and re-applies itself after any re-ingest, GADM v5 included.
+
+    Two rules, both taking the name from rows GADM did fill in:
+
+    * **A, parent name from children.** A row whose own ``NAME_n`` is ``'NA'``
+      adopts the name its immediate children carry in *their* ``NAME_n``, when
+      one candidate holds a strict majority of the named children. Repairs
+      England, Cork and Zuid-Holland at level 1, and at level 2 the multi-child
+      counties whose name GADM only stored one level down (Warwickshire,
+      Derbyshire, Greater London ...).
+    * **B, leaf name from an only child.** A district-county row with exactly
+      one named municipality child adopts the child's name. Repairs Bristol and
+      57 others, where GADM shifted the name down a level rather than omitting
+      it. Rule A wins where both could fire.
+
+    Only the broken leading segment of the display name is replaced; every
+    parent segment is left byte-identical, so no row's name changes except at
+    the position GADM left as ``'NA'``. Rows the rules cannot reach (no
+    children, a tie, a multi-child parent with no majority, an unnamed only
+    child) keep the name they have today.
+    """
+    levels = [
+        level
+        for level in _gadm_repair_levels()
+        if await _resolve_column(session, table, [level[2]])
+        and await _resolve_column(session, table, [level[3]])
+    ]
+    if not levels:
+        return {}
+
+    params: dict[str, object] = {
+        "na": _GADM_NO_DATA_NAME,
+        "na_prefix": f"{_GADM_NO_DATA_NAME}, %",
+        "min_share": _GADM_CHILD_NAME_MIN_SHARE,
+    }
+    votes: list[str] = []
+    for i, (subtype, child_subtype, level_id, name_col) in enumerate(levels):
+        params[f"parent_{i}"] = subtype
+        params[f"child_{i}"] = child_subtype
+        # Identifiers cannot be bound, and these come from GADM_LEVELS, not
+        # from data. Every value is a bound parameter.
+        votes.append(
+            f"""
+            SELECT CAST(p."{id_col}" AS TEXT) AS source_id,
+                   c."{name_col}" AS candidate,
+                   count(*) AS votes
+            FROM {table} p
+            JOIN {table} c
+              ON c.subtype = :child_{i}
+             AND c."{level_id}" = p."{level_id}"
+            WHERE p.subtype = :parent_{i}
+              AND p."{name_col}" = :na
+              AND c."{name_col}" IS NOT NULL
+              AND c."{name_col}" NOT IN ('', :na)
+            GROUP BY 1, 2
+            """
+        )
+
+    # Rule B is level 2 only: the shifted-name pattern is a district-county
+    # holding a single municipality. `min()` is the only child's name, because
+    # HAVING count(*) = 1 has already restricted the group to one row.
+    b_level = next(
+        (lv for lv in levels if lv[0] == _GADM_SHIFTED_NAME_SUBTYPE), None
+    )
+    rule_b = "SELECT NULL::text AS source_id, NULL::text AS leaf WHERE false"
+    if b_level is not None:
+        parent_subtype, child_subtype, level_id, name_col = b_level
+        child_name_col = _gadm_name_column(
+            GADM_LEVELS[child_subtype]["col_name"]
+        )
+        params["b_parent"] = parent_subtype
+        params["b_child"] = child_subtype
+        rule_b = f"""
+            SELECT CAST(p."{id_col}" AS TEXT) AS source_id,
+                   min(c."{child_name_col}") AS leaf
+            FROM {table} p
+            JOIN {table} c
+              ON c.subtype = :b_child AND c."{level_id}" = p."{level_id}"
+            WHERE p.subtype = :b_parent AND p."{name_col}" = :na
+            GROUP BY 1
+            HAVING count(*) = 1
+               AND min(c."{child_name_col}") IS NOT NULL
+               AND min(c."{child_name_col}") NOT IN ('', :na)
+        """
+
+    # substring(name FROM 3) drops the leading 'NA' and keeps the ', parent'
+    # tail. DISTINCT ON collapses the duplicate ids the staging tables carry
+    # (no unique constraint); duplicates of one id share their composed name.
+    sql = f"""
+        WITH votes AS ({" UNION ALL ".join(votes)}),
+        ranked AS (
+            SELECT source_id, candidate, votes,
+                   sum(votes) OVER (PARTITION BY source_id) AS total
+            FROM votes
+        ),
+        rule_a AS (
+            SELECT DISTINCT ON (source_id) source_id, candidate AS leaf
+            FROM ranked
+            WHERE votes > :min_share * total
+            ORDER BY source_id, votes DESC, candidate
+        ),
+        rule_b AS ({rule_b}),
+        repairs AS (
+            SELECT source_id, leaf FROM rule_a
+            UNION ALL
+            SELECT source_id, leaf FROM rule_b
+            WHERE source_id NOT IN (SELECT source_id FROM rule_a)
+        )
+        SELECT DISTINCT ON (r.source_id)
+               r.source_id,
+               r.leaf || substring(g.name FROM 3) AS repaired
+        FROM repairs r
+        JOIN {table} g ON CAST(g."{id_col}" AS TEXT) = r.source_id
+        WHERE g.name = :na OR g.name LIKE :na_prefix
+        ORDER BY r.source_id, repaired
+    """
+    result = await session.execute(text(sql), params)
+    return {row[0]: row[1] for row in result.all()}
 
 
 def _gadm_name_patch_sql(id_col: str) -> tuple[str, dict[str, str]]:

--- a/src/shared/geocoding_helpers.py
+++ b/src/shared/geocoding_helpers.py
@@ -58,14 +58,33 @@ SOURCE_STAGING_TABLES = {
 }
 
 
-# GADM LEVELS
+# GADM LEVELS. `col_name` is the level's id column in GADM's own files,
+# `name_col` the column holding that level's name. Level 0 is the exception
+# GADM calls COUNTRY rather than NAME_0, which is why `name_col` is declared
+# per level instead of derived from `col_name` by the callers that need it.
 GADM_LEVELS = {
-    "country": {"col_name": "GID_0", "name": "iso"},
-    "state-province": {"col_name": "GID_1", "name": "adm1"},
-    "district-county": {"col_name": "GID_2", "name": "adm2"},
-    "municipality": {"col_name": "GID_3", "name": "adm3"},
-    "locality": {"col_name": "GID_4", "name": "adm4"},
-    "neighbourhood": {"col_name": "GID_5", "name": "adm5"},
+    "country": {"col_name": "GID_0", "name_col": "COUNTRY", "name": "iso"},
+    "state-province": {
+        "col_name": "GID_1",
+        "name_col": "NAME_1",
+        "name": "adm1",
+    },
+    "district-county": {
+        "col_name": "GID_2",
+        "name_col": "NAME_2",
+        "name": "adm2",
+    },
+    "municipality": {
+        "col_name": "GID_3",
+        "name_col": "NAME_3",
+        "name": "adm3",
+    },
+    "locality": {"col_name": "GID_4", "name_col": "NAME_4", "name": "adm4"},
+    "neighbourhood": {
+        "col_name": "GID_5",
+        "name_col": "NAME_5",
+        "name": "adm5",
+    },
 }
 
 GADM_SUBTYPE_MAP = {val["col_name"]: key for key, val in GADM_LEVELS.items()}

--- a/tests/cli/test_build_aois_cli.py
+++ b/tests/cli/test_build_aois_cli.py
@@ -332,6 +332,39 @@ async def test_rows_the_rules_cannot_reach_are_left_alone(gadm_staging):
 
 
 @pytest.mark.asyncio
+async def test_repair_survives_the_chunked_insert(gadm_staging):
+    """The repair is derived once, so chunk boundaries cannot split a family.
+
+    The INSERT is hash-partitioned by source id, so a parent and its children
+    routinely land in different passes. This test first asserts the seeded ids
+    really do straddle a boundary, then that the repaired names still arrive.
+    """
+    async with async_session_maker() as session:
+        buckets = await session.execute(
+            text(
+                "SELECT gadm_id,"
+                " abs(hashtext(gadm_id)::bigint) % :n AS chunk"
+                " FROM geometries_gadm"
+                " WHERE gadm_id IN ('GBR.1_1', 'GBR.1.1_1', 'GBR.1.2_1',"
+                " 'GBR.1.2.1_1')"
+            ),
+            {"n": _CHUNKS},
+        )
+        chunk = dict(buckets.all())
+
+    assert (
+        chunk["GBR.1_1"] != chunk["GBR.1.1_1"]
+    ), "seed ids stopped straddling"
+    assert chunk["GBR.1.2_1"] != chunk["GBR.1.2.1_1"]
+
+    await _build("gadm")
+
+    names = await _aoi_names("gadm")
+    assert names["GBR.1_1"] == "England, United Kingdom"
+    assert names["GBR.1.2_1"] == "Bristol, England, United Kingdom"
+
+
+@pytest.mark.asyncio
 async def test_gadm_build_writes_the_repaired_names(gadm_staging):
     """The rows GADM ships as "NA" reach ``aois`` under their real names."""
     await _build("gadm")
@@ -339,6 +372,7 @@ async def test_gadm_build_writes_the_repaired_names(gadm_staging):
     names = await _aoi_names("gadm")
     assert names["GBR.1_1"] == "England, United Kingdom"
     assert names["IRL.4_1"] == "Cork, Ireland"
+    assert names["GBR.1.5_1"] == "Warwickshire, England, United Kingdom"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_build_aois_cli.py
+++ b/tests/cli/test_build_aois_cli.py
@@ -233,52 +233,48 @@ def test_prune_rejects_inspect():
     assert "--prune cannot run with --inspect" in result.output
 
 
-@pytest.mark.asyncio
-async def test_rule_a_takes_the_majority_child_name(gadm_staging):
-    """A broken parent adopts the name most of its named children carry.
+# (source id, repaired name or None if the rules must refuse, why).
+_DERIVATION_CASES = [
+    (
+        "GBR.1_1",
+        "England, United Kingdom",
+        "Rule A: England wins 2 of 3 named votes -- the child saying 'NA'"
+        " never votes, and the one saying 'Wales' is outvoted",
+    ),
+    (
+        "IRL.4_1",
+        "Cork, Ireland",
+        "Rule A holds against a near-miss dissenter ('Cork City')",
+    ),
+    (
+        "GBR.1.5_1",
+        "Warwickshire, England, United Kingdom",
+        "Rule A is not level-1 only: GADM shifts county names down too",
+    ),
+    (
+        "GBR.1.2_1",
+        "Bristol, England, United Kingdom",
+        "Rule B: a district holding one named municipality takes that name",
+    ),
+    ("MHL.19_1", None, "refused: no children, so no name to borrow"),
+    ("NA", None, "refused: the ghost row's two children split 1-1"),
+    ("GBR.1.6_1", None, "refused: no child carries the parent's name"),
+    ("GBR.1.7_1", None, "refused: the only child is unnamed too"),
+    ("GBR.2_1", None, "not broken in the first place"),
+]
 
-    England wins 2 of 3 named votes: the child that says "NA" never votes, and
-    the one that says "Wales" is outvoted.
+
+@pytest.mark.asyncio
+async def test_derives_a_name_only_where_gadm_supplies_one(gadm_staging):
+    """Both rules and every refusal, against one seeding of the hierarchy.
+
+    A loop rather than ``parametrize``: the map is identical for every case, so
+    parametrizing at function scope would only re-derive it per assertion.
     """
     repairs = await _repairs()
 
-    assert repairs["GBR.1_1"] == "England, United Kingdom"
-    assert repairs["IRL.4_1"] == "Cork, Ireland"
-
-
-@pytest.mark.asyncio
-async def test_rule_a_repairs_a_county_named_only_in_its_children(
-    gadm_staging,
-):
-    """Rule A is not level-1 only: GADM shifts county names down too."""
-    repairs = await _repairs()
-
-    assert repairs["GBR.1.5_1"] == "Warwickshire, England, United Kingdom"
-
-
-@pytest.mark.asyncio
-async def test_rule_b_adopts_an_only_childs_name(gadm_staging):
-    """A district holding one named municipality takes that name."""
-    repairs = await _repairs()
-
-    assert repairs["GBR.1.2_1"] == "Bristol, England, United Kingdom"
-
-
-@pytest.mark.asyncio
-async def test_rows_the_rules_cannot_reach_are_left_alone(gadm_staging):
-    """Four ways a name is genuinely absent from GADM's hierarchy.
-
-    No children, a tie between children, several children that all omit the
-    parent name, and an only child that is itself unnamed. Every one keeps the
-    broken name it has today rather than inventing one.
-    """
-    repairs = await _repairs()
-
-    assert "MHL.19_1" not in repairs  # no children
-    assert "NA" not in repairs  # ghost row: children split 1-1
-    assert "GBR.1.6_1" not in repairs  # no child carries the parent name
-    assert "GBR.1.7_1" not in repairs  # only child is unnamed too
-    assert "GBR.2_1" not in repairs  # not broken in the first place
+    for source_id, expected, why in _DERIVATION_CASES:
+        assert repairs.get(source_id) == expected, why
 
 
 @pytest.mark.asyncio
@@ -313,15 +309,6 @@ async def test_repair_survives_the_chunked_insert(gadm_staging):
     names = await _aoi_names("gadm")
     assert names["GBR.1_1"] == "England, United Kingdom"
     assert names["GBR.1.2_1"] == "Bristol, England, United Kingdom"
-
-
-@pytest.mark.asyncio
-async def test_gadm_build_writes_the_repaired_names(gadm_staging):
-    """The rows GADM ships as "NA" reach ``aois`` under their real names."""
-    await _build("gadm")
-
-    names = await _aoi_names("gadm")
-    assert names["GBR.1_1"] == "England, United Kingdom"
     assert names["IRL.4_1"] == "Cork, Ireland"
     assert names["GBR.1.5_1"] == "Warwickshire, England, United Kingdom"
 
@@ -341,6 +328,25 @@ async def test_gadm_build_leaves_unrepairable_names_alone(gadm_staging):
     assert names["GBR.1.6_1"] == "NA, England, United Kingdom"
     assert names["GBR.1.7_1"] == "NA, England, United Kingdom"
     assert names["GBR.1.8_1"] == "NA, England, United Kingdom"
+
+
+@pytest.mark.asyncio
+async def test_a_repaired_parent_leaves_its_childs_middle_segment_broken(
+    gadm_staging,
+):
+    """Pinned gap, not a bug to fix here.
+
+    The repair replaces one *leading* segment, so Bristol's district row is
+    fixed while the municipality under it still reads its parent as "NA" in
+    the middle of its own name. Recomposing display names from repaired
+    ancestors is SPEC-PR8's design and the durable fix; this asserts today's
+    outcome so that change shows up as a deliberate one.
+    """
+    await _build("gadm")
+
+    names = await _aoi_names("gadm")
+    assert names["GBR.1.2_1"] == "Bristol, England, United Kingdom"
+    assert names["GBR.1.2.1_1"] == "Bristol, NA, England, United Kingdom"
 
 
 @pytest.mark.asyncio

--- a/tests/cli/test_build_aois_cli.py
+++ b/tests/cli/test_build_aois_cli.py
@@ -1,4 +1,4 @@
-"""Tests for ``build-aois``: its argument guards and the gadm name patch.
+"""Tests for ``build-aois``: its argument guards and the gadm name repair.
 
 ``--prune`` deletes rows, so the command rejects a combination that cannot
 prune. Both guards raise before ``asyncio.run``, so those tests need no
@@ -9,6 +9,10 @@ schema does not contain: they are bulk-loaded by GeoPandas, not declared in
 ``Base.metadata``. The fixtures below create a minimal one and drop it again.
 Dropping matters: ``conftest.clear_tables`` only truncates the tables in
 ``Base.metadata``, so a leaked staging table would leak into later tests.
+
+The seeded hierarchy is a miniature of the real GADM dirt, because the repair
+rules turn on exactly that dirt: children that disagree with each other, a
+parent with no children, a tie, and names GADM stored one level down.
 """
 
 import pytest
@@ -16,7 +20,7 @@ import pytest_asyncio
 from click.testing import CliRunner
 from sqlalchemy import text
 
-from src.api.cli import _build_reference_aois, cli
+from src.api.cli import _build_reference_aois, _derive_gadm_name_repairs, cli
 from tests.conftest import async_session_maker
 
 # One valid square for every seeded row: the transform derives geometry, bbox
@@ -25,38 +29,59 @@ _SQUARE = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
 
 # Chunk count for the seeded builds. The real default is 16; a smaller number
 # keeps the tests quick while still running the multi-pass, per-chunk-commit
-# path rather than a single statement.
+# path rather than a single statement. The seeded ids deliberately hash into
+# different chunks from their own children (see the cross-chunk test).
 _CHUNKS = 4
+
+_STAGING_COLUMNS = (
+    "GID_0",
+    "COUNTRY",
+    "GID_1",
+    "NAME_1",
+    "GID_2",
+    "NAME_2",
+    "GID_3",
+    "NAME_3",
+    "gadm_id",
+    "name",
+    "subtype",
+)
+
+
+def _row(gadm_id: str, name: str, subtype: str, **columns) -> dict:
+    """A staging row: ids and names as GADM ships them, others left NULL."""
+    row = {col.lower(): None for col in _STAGING_COLUMNS}
+    row.update(
+        gadm_id=gadm_id, name=name, subtype=subtype, country="United Kingdom"
+    )
+    row.update({key.lower(): value for key, value in columns.items()})
+    return row
 
 
 async def _seed_gadm_staging(rows: list[dict]) -> None:
     """Create ``geometries_gadm`` and insert *rows*.
 
-    Only the columns the gadm transform reads are declared. The real table has
-    ~90 columns from GADM's own schema; the quoted upper-case names mirror the
-    casing GeoPandas preserves, which ``_resolve_column`` depends on.
+    Only the columns the gadm transform and the repair read are declared. The
+    real table has ~90 columns from GADM's own schema; the quoted upper-case
+    names mirror the casing GeoPandas preserves, which ``_resolve_column``
+    depends on.
     """
+    declared = ", ".join(f'"{col}" text' for col in _STAGING_COLUMNS)
+    columns = ", ".join(f'"{col}"' for col in _STAGING_COLUMNS)
+    values = ", ".join(f":{col.lower()}" for col in _STAGING_COLUMNS)
     async with async_session_maker() as session:
         await session.execute(text("DROP TABLE IF EXISTS geometries_gadm"))
         await session.execute(
             text(
-                "CREATE TABLE geometries_gadm ("
-                ' "GID_0" text,'
-                ' "COUNTRY" text,'
-                ' "NAME_1" text,'
-                " gadm_id text,"
-                " name text,"
-                " subtype text,"
+                f"CREATE TABLE geometries_gadm ({declared},"
                 " geometry geometry(MultiPolygon, 4326))"
             )
         )
         for row in rows:
             await session.execute(
                 text(
-                    "INSERT INTO geometries_gadm "
-                    '("GID_0", "COUNTRY", "NAME_1", gadm_id, name, subtype,'
-                    " geometry) VALUES (:iso3, :country, :name_1, :gadm_id,"
-                    " :name, :subtype,"
+                    f"INSERT INTO geometries_gadm ({columns}, geometry)"
+                    f" VALUES ({values},"
                     " ST_Multi(ST_GeomFromText(:geom, 4326)))"
                 ),
                 {"geom": _SQUARE, **row},
@@ -81,37 +106,154 @@ async def _build(source: str) -> int:
         )
 
 
-def _state(gadm_id: str, name: str, name_1: str, iso3: str, country: str):
-    return {
-        "gadm_id": gadm_id,
-        "name": name,
-        "name_1": name_1,
-        "subtype": "state-province",
-        "iso3": iso3,
-        "country": country,
-    }
+async def _repairs() -> dict[str, str]:
+    async with async_session_maker() as session:
+        return await _derive_gadm_name_repairs(
+            session, "geometries_gadm", "gadm_id"
+        )
 
 
-# The three patched rows as GADM actually ships them, plus two controls: a
-# named sibling, and the level-1 row that has no child rows to derive a name
-# from and so must keep its broken name.
+def _district(gadm_id: str, name_2: str, **columns) -> dict:
+    """A GBR district row, with its display name composed as ingest does."""
+    cols = {"GID_0": "GBR", "GID_1": "GBR.1_1", "NAME_1": "England"}
+    cols.update(columns)
+    cols.update({"GID_2": gadm_id, "NAME_2": name_2})
+    name = f"{name_2}, {cols['NAME_1']}, United Kingdom"
+    return _row(gadm_id, name, "district-county", **cols)
+
+
+def _municipality(gadm_id: str, parent: str, name_2: str, name_3: str) -> dict:
+    return _row(
+        gadm_id,
+        f"{name_3}, {name_2}, England, United Kingdom",
+        "municipality",
+        GID_0="GBR",
+        GID_1="GBR.1_1",
+        NAME_1="England",
+        GID_2=parent,
+        NAME_2=name_2,
+        GID_3=gadm_id,
+        NAME_3=name_3,
+    )
+
+
+# A miniature of the real hierarchy. Every group below is one rule or one
+# refusal; the comments name the real row each stands in for.
 _GADM_ROWS = [
-    _state("GBR.1_1", "NA, United Kingdom", "NA", "GBR", "United Kingdom"),
-    _state(
+    # Level 1, Rule A. England's children disagree exactly as GADM's do: most
+    # say England, one says NA (never a vote), one says Wales (a real GADM
+    # error). England takes 2 of the 3 named votes.
+    _row("GBR", "United Kingdom", "country", GID_0="GBR"),
+    _row(
+        "GBR.1_1",
+        "NA, United Kingdom",
+        "state-province",
+        GID_0="GBR",
+        GID_1="GBR.1_1",
+        NAME_1="NA",
+    ),
+    _district("GBR.1.1_1", "Barnsley"),
+    _district("GBR.1.4_1", "Wakefield", NAME_1="Wales"),
+    _district("GBR.1.3_1", "Sheffield", NAME_1="NA"),
+    # Level 1 control: a sibling GADM named correctly.
+    _row(
         "GBR.2_1",
         "Scotland, United Kingdom",
-        "Scotland",
-        "GBR",
-        "United Kingdom",
+        "state-province",
+        GID_0="GBR",
+        GID_1="GBR.2_1",
+        NAME_1="Scotland",
     ),
-    _state("IRL.4_1", "NA, Ireland", "NA", "IRL", "Ireland"),
-    _state(
+    # Level 1 refusal: MHL.19_1 has no children at all, so nothing to borrow.
+    _row(
         "MHL.19_1",
         "NA, Marshall Islands",
-        "NA",
-        "MHL",
-        "Marshall Islands",
+        "state-province",
+        GID_0="MHL",
+        COUNTRY="Marshall Islands",
+        GID_1="MHL.19_1",
+        NAME_1="NA",
     ),
+    # Level 1 refusal: the all-NA ghost row, whose children split 1-1.
+    _row("NA", "NA, NA", "state-province", GID_1="NA", NAME_1="NA"),
+    _row(
+        "NA.1_1",
+        "NA, England, United Kingdom",
+        "district-county",
+        GID_1="NA",
+        NAME_1="England",
+        GID_2="NA.1_1",
+        NAME_2="NA",
+    ),
+    _row(
+        "NA.2_1",
+        "NA, Scotland, United Kingdom",
+        "district-county",
+        GID_1="NA",
+        NAME_1="Scotland",
+        GID_2="NA.2_1",
+        NAME_2="NA",
+    ),
+    # Level 1, Rule A with a near-miss dissenter, as Ireland ships it.
+    _row(
+        "IRL.4_1",
+        "NA, Ireland",
+        "state-province",
+        GID_0="IRL",
+        COUNTRY="Ireland",
+        GID_1="IRL.4_1",
+        NAME_1="NA",
+    ),
+    _row(
+        "IRL.4.1_1",
+        "Cobh, Cork, Ireland",
+        "district-county",
+        GID_0="IRL",
+        COUNTRY="Ireland",
+        GID_1="IRL.4_1",
+        NAME_1="Cork",
+        GID_2="IRL.4.1_1",
+        NAME_2="Cobh",
+    ),
+    _row(
+        "IRL.4.2_1",
+        "Youghal, Cork, Ireland",
+        "district-county",
+        GID_0="IRL",
+        COUNTRY="Ireland",
+        GID_1="IRL.4_1",
+        NAME_1="Cork",
+        GID_2="IRL.4.2_1",
+        NAME_2="Youghal",
+    ),
+    _row(
+        "IRL.4.3_1",
+        "Mahon, Cork City, Ireland",
+        "district-county",
+        GID_0="IRL",
+        COUNTRY="Ireland",
+        GID_1="IRL.4_1",
+        NAME_1="Cork City",
+        GID_2="IRL.4.3_1",
+        NAME_2="Mahon",
+    ),
+    # Level 2, Rule B: GADM stored Bristol's name on its only child.
+    _district("GBR.1.2_1", "NA"),
+    _municipality("GBR.1.2.1_1", "GBR.1.2_1", "NA", "Bristol"),
+    # Level 2, Rule A: Warwickshire, named only in its children's NAME_2.
+    _district("GBR.1.5_1", "NA"),
+    _municipality("GBR.1.5.1_1", "GBR.1.5_1", "Warwickshire", "Nuneaton"),
+    _municipality("GBR.1.5.2_1", "GBR.1.5_1", "Warwickshire", "Rugby"),
+    _municipality("GBR.1.5.3_1", "GBR.1.5_1", "Warwickshire", "Warwick"),
+    # Level 2 refusal: several children, none of which carries the parent name.
+    _district("GBR.1.6_1", "NA"),
+    _municipality("GBR.1.6.1_1", "GBR.1.6_1", "NA", "Chesterfield"),
+    _municipality("GBR.1.6.2_1", "GBR.1.6_1", "NA", "Bolsover"),
+    # Level 2 refusal: an only child that GADM did not name either.
+    _district("GBR.1.7_1", "NA"),
+    _municipality("GBR.1.7.1_1", "GBR.1.7_1", "NA", "NA"),
+    # Level 2 refusal: no children.
+    _district("GBR.1.8_1", "NA"),
 ]
 
 
@@ -142,7 +284,55 @@ def test_prune_rejects_inspect():
 
 
 @pytest.mark.asyncio
-async def test_gadm_build_patches_the_broken_names(gadm_staging):
+async def test_rule_a_takes_the_majority_child_name(gadm_staging):
+    """A broken parent adopts the name most of its named children carry.
+
+    England wins 2 of 3 named votes: the child that says "NA" never votes, and
+    the one that says "Wales" is outvoted.
+    """
+    repairs = await _repairs()
+
+    assert repairs["GBR.1_1"] == "England, United Kingdom"
+    assert repairs["IRL.4_1"] == "Cork, Ireland"
+
+
+@pytest.mark.asyncio
+async def test_rule_a_repairs_a_county_named_only_in_its_children(
+    gadm_staging,
+):
+    """Rule A is not level-1 only: GADM shifts county names down too."""
+    repairs = await _repairs()
+
+    assert repairs["GBR.1.5_1"] == "Warwickshire, England, United Kingdom"
+
+
+@pytest.mark.asyncio
+async def test_rule_b_adopts_an_only_childs_name(gadm_staging):
+    """A district holding one named municipality takes that name."""
+    repairs = await _repairs()
+
+    assert repairs["GBR.1.2_1"] == "Bristol, England, United Kingdom"
+
+
+@pytest.mark.asyncio
+async def test_rows_the_rules_cannot_reach_are_left_alone(gadm_staging):
+    """Four ways a name is genuinely absent from GADM's hierarchy.
+
+    No children, a tie between children, several children that all omit the
+    parent name, and an only child that is itself unnamed. Every one keeps the
+    broken name it has today rather than inventing one.
+    """
+    repairs = await _repairs()
+
+    assert "MHL.19_1" not in repairs  # no children
+    assert "NA" not in repairs  # ghost row: children split 1-1
+    assert "GBR.1.6_1" not in repairs  # no child carries the parent name
+    assert "GBR.1.7_1" not in repairs  # only child is unnamed too
+    assert "GBR.2_1" not in repairs  # not broken in the first place
+
+
+@pytest.mark.asyncio
+async def test_gadm_build_writes_the_repaired_names(gadm_staging):
     """The rows GADM ships as "NA" reach ``aois`` under their real names."""
     await _build("gadm")
 
@@ -152,18 +342,20 @@ async def test_gadm_build_patches_the_broken_names(gadm_staging):
 
 
 @pytest.mark.asyncio
-async def test_gadm_build_leaves_unpatched_names_alone(gadm_staging):
-    """A patch entry is the only thing that changes a name.
+async def test_gadm_build_leaves_unrepairable_names_alone(gadm_staging):
+    """An irreparable name stays broken on purpose.
 
-    ``MHL.19_1`` is the level-1 row whose name GADM's own hierarchy cannot
-    recover, so it stays broken on purpose: unfindable junk today, unfindable
-    junk after, which is the safe state.
+    Unfindable junk today, unfindable junk after: search hygiene for those rows
+    is a separate decision (SPEC-PR7 rule C), not a name to invent here.
     """
     await _build("gadm")
 
     names = await _aoi_names("gadm")
     assert names["GBR.2_1"] == "Scotland, United Kingdom"
     assert names["MHL.19_1"] == "NA, Marshall Islands"
+    assert names["GBR.1.6_1"] == "NA, England, United Kingdom"
+    assert names["GBR.1.7_1"] == "NA, England, United Kingdom"
+    assert names["GBR.1.8_1"] == "NA, England, United Kingdom"
 
 
 @pytest.mark.asyncio
@@ -171,7 +363,8 @@ async def test_gadm_rebuild_is_idempotent(gadm_staging):
     """A second build upserts the same rows to the same names.
 
     This is the ``ON CONFLICT ... DO UPDATE`` path every environment takes,
-    because build-aois is re-run rather than reset.
+    because build-aois is re-run rather than reset. The repair is re-derived
+    from staging on each run, which is what makes a re-ingest self-healing.
     """
     first = await _build("gadm")
     before = await _aoi_names("gadm")
@@ -185,11 +378,11 @@ async def test_gadm_rebuild_is_idempotent(gadm_staging):
 
 
 @pytest.mark.asyncio
-async def test_patch_does_not_touch_other_sources():
-    """The patch is keyed on gadm ids, and applies to the gadm source only.
+async def test_repair_does_not_touch_other_sources():
+    """The repair reads GADM's hierarchy, so it applies to gadm only.
 
-    Seeding a kba row under a patched gadm id is the sharpest form of the
-    question: a source-blind patch would rename it.
+    Seeding a kba row under a gadm id that the rules do repair is the sharpest
+    form of the question: a source-blind repair would rename it.
     """
     async with async_session_maker() as session:
         await session.execute(text("DROP TABLE IF EXISTS geometries_kba"))

--- a/tests/cli/test_build_aois_cli.py
+++ b/tests/cli/test_build_aois_cli.py
@@ -6,7 +6,7 @@ database and no ``DatabaseManager``.
 
 The transform itself reads the ``geometries_*`` staging tables, which the test
 schema does not contain: they are bulk-loaded by GeoPandas, not declared in
-``Base.metadata``. The fixtures below create a minimal one and drop it again.
+``Base.metadata``. ``_staging_table`` creates a minimal one and drops it again.
 Dropping matters: ``conftest.clear_tables`` only truncates the tables in
 ``Base.metadata``, so a leaked staging table would leak into later tests.
 
@@ -15,17 +15,20 @@ rules turn on exactly that dirt: children that disagree with each other, a
 parent with no children, a tie, and names GADM stored one level down.
 """
 
+from contextlib import asynccontextmanager
+
 import pytest
 import pytest_asyncio
 from click.testing import CliRunner
 from sqlalchemy import text
 
 from src.api.cli import _build_reference_aois, _derive_gadm_name_repairs, cli
-from tests.conftest import async_session_maker
-
-# One valid square for every seeded row: the transform derives geometry, bbox
-# and area from it, and none of these tests assert on those.
-_SQUARE = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
+from src.shared.geocoding_helpers import (
+    AOI_SOURCE_ID_COLUMNS,
+    GADM_LEVELS,
+    SOURCE_STAGING_TABLES,
+)
+from tests.conftest import UNIT_SQUARE_WKT, async_session_maker
 
 # Chunk count for the seeded builds. The real default is 16; a smaller number
 # keeps the tests quick while still running the multi-pass, per-chunk-commit
@@ -33,7 +36,9 @@ _SQUARE = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
 # different chunks from their own children (see the cross-chunk test).
 _CHUNKS = 4
 
-_STAGING_COLUMNS = (
+# GADM's own column names, spelled as GADM ships them: pinning that file format
+# is the point of the fixture, so these stay literal.
+_GADM_COLUMNS = (
     "GID_0",
     "COUNTRY",
     "GID_1",
@@ -47,46 +52,131 @@ _STAGING_COLUMNS = (
     "subtype",
 )
 
+_GADM_SUBTYPES = list(GADM_LEVELS)
+_GADM_LEVEL_COLUMNS = list(GADM_LEVELS.values())
 
-def _row(gadm_id: str, name: str, subtype: str, **columns) -> dict:
-    """A staging row: ids and names as GADM ships them, others left NULL."""
-    row = {col.lower(): None for col in _STAGING_COLUMNS}
-    row.update(
-        gadm_id=gadm_id, name=name, subtype=subtype, country="United Kingdom"
-    )
-    row.update({key.lower(): value for key, value in columns.items()})
+
+@asynccontextmanager
+async def _staging_table(source: str, columns: tuple[str, ...], rows: list):
+    """Create ``geometries_<source>``, seed *rows*, and drop it again.
+
+    Only the columns the transform and the repair read are declared, all text.
+    The real tables have ~90 columns from the source file's own schema. The
+    quoted names preserve the casing GeoPandas keeps, which ``_resolve_column``
+    and the repair's column check both depend on. Every row gets the same
+    square: none of these tests assert on geometry, bbox or area.
+    """
+    table = SOURCE_STAGING_TABLES[source]
+    declared = ", ".join(f'"{col}" text' for col in columns)
+    names = ", ".join(f'"{col}"' for col in columns)
+    binds = ", ".join(f":{col}" for col in columns)
+    try:
+        async with async_session_maker() as session:
+            await session.execute(text(f"DROP TABLE IF EXISTS {table}"))
+            await session.execute(
+                text(
+                    f"CREATE TABLE {table} ({declared},"
+                    " geometry geometry(MultiPolygon, 4326))"
+                )
+            )
+            await session.execute(
+                text(
+                    f"INSERT INTO {table} ({names}, geometry)"
+                    f" VALUES ({binds},"
+                    " ST_Multi(ST_GeomFromText(:geom, 4326)))"
+                ),
+                [{"geom": UNIT_SQUARE_WKT, **row} for row in rows],
+            )
+            await session.commit()
+        yield
+    finally:
+        async with async_session_maker() as session:
+            await session.execute(text(f"DROP TABLE IF EXISTS {table}"))
+            await session.commit()
+
+
+def _gadm(gadm_id: str, *path: str, **columns) -> dict:
+    """The staging row GADM ships for the unit at *path*, country first.
+
+    ``_gadm("IRL.4.3_1", "Ireland", "Cork City", "Mahon")`` is Mahon's row.
+    Everything follows from the id and the path, as it does in GADM's own
+    files: the subtype from the path's depth, each ``NAME_n`` from the path,
+    the display name from the path reversed (how ingest composes it), and each
+    ancestor's ``GID_n`` by dropping trailing segments off the id. That last
+    rule is what reproduces GADM's malformed "NA" rows, whose ids are one
+    segment short and so leave ``GID_0`` null.
+
+    *columns* overrides a single column for a row GADM ships inconsistently.
+    """
+    level = len(path) - 1
+    parts = gadm_id.removesuffix("_1").split(".")
+
+    row: dict = {col: None for col in _GADM_COLUMNS}
+    row["gadm_id"] = gadm_id
+    row["name"] = ", ".join(reversed(path))
+    row["subtype"] = _GADM_SUBTYPES[level]
+    for depth, ancestor in enumerate(path):
+        row[_GADM_LEVEL_COLUMNS[depth]["name_col"]] = ancestor
+
+    row[_GADM_LEVEL_COLUMNS[level]["col_name"]] = gadm_id
+    for depth in range(level - 1, -1, -1):
+        head = parts[: len(parts) - (level - depth)]
+        if head:
+            suffix = "_1" if len(head) > 1 else ""
+            row[_GADM_LEVEL_COLUMNS[depth]["col_name"]] = (
+                ".".join(head) + suffix
+            )
+
+    row.update(columns)
     return row
 
 
-async def _seed_gadm_staging(rows: list[dict]) -> None:
-    """Create ``geometries_gadm`` and insert *rows*.
+_UK = "United Kingdom"
 
-    Only the columns the gadm transform and the repair read are declared. The
-    real table has ~90 columns from GADM's own schema; the quoted upper-case
-    names mirror the casing GeoPandas preserves, which ``_resolve_column``
-    depends on.
-    """
-    declared = ", ".join(f'"{col}" text' for col in _STAGING_COLUMNS)
-    columns = ", ".join(f'"{col}"' for col in _STAGING_COLUMNS)
-    values = ", ".join(f":{col.lower()}" for col in _STAGING_COLUMNS)
-    async with async_session_maker() as session:
-        await session.execute(text("DROP TABLE IF EXISTS geometries_gadm"))
-        await session.execute(
-            text(
-                f"CREATE TABLE geometries_gadm ({declared},"
-                " geometry geometry(MultiPolygon, 4326))"
-            )
-        )
-        for row in rows:
-            await session.execute(
-                text(
-                    f"INSERT INTO geometries_gadm ({columns}, geometry)"
-                    f" VALUES ({values},"
-                    " ST_Multi(ST_GeomFromText(:geom, 4326)))"
-                ),
-                {"geom": _SQUARE, **row},
-            )
-        await session.commit()
+# A miniature of the real hierarchy. Every group below is one rule or one
+# refusal; the comments name the real row each stands in for.
+_GADM_ROWS = [
+    # Level 1, Rule A. England's children disagree exactly as GADM's do: most
+    # say England, one says NA (never a vote), one says Wales (a real GADM
+    # error). England takes 2 of the 3 named votes.
+    _gadm("GBR", _UK),
+    _gadm("GBR.1_1", _UK, "NA"),
+    _gadm("GBR.1.1_1", _UK, "England", "Barnsley"),
+    _gadm("GBR.1.4_1", _UK, "Wales", "Wakefield"),
+    _gadm("GBR.1.3_1", _UK, "NA", "Sheffield"),
+    # Level 1 control: a sibling GADM named correctly.
+    _gadm("GBR.2_1", _UK, "Scotland"),
+    # Level 1 refusal: MHL.19_1 has no children at all, so nothing to borrow.
+    _gadm("MHL.19_1", "Marshall Islands", "NA"),
+    # Level 1 refusal: the all-NA ghost row, whose children split 1-1. GADM's
+    # own carries a country name that its display name does not, hence the
+    # override; the null GID_0 falls out of the short id.
+    _gadm("NA", "NA", "NA", COUNTRY=_UK),
+    _gadm("NA.1_1", _UK, "England", "NA"),
+    _gadm("NA.2_1", _UK, "Scotland", "NA"),
+    # Level 1, Rule A with a near-miss dissenter, as Ireland ships it.
+    _gadm("IRL.4_1", "Ireland", "NA"),
+    _gadm("IRL.4.1_1", "Ireland", "Cork", "Cobh"),
+    _gadm("IRL.4.2_1", "Ireland", "Cork", "Youghal"),
+    _gadm("IRL.4.3_1", "Ireland", "Cork City", "Mahon"),
+    # Level 2, Rule B: GADM stored Bristol's name on its only child.
+    _gadm("GBR.1.2_1", _UK, "England", "NA"),
+    _gadm("GBR.1.2.1_1", _UK, "England", "NA", "Bristol"),
+    # Level 2, Rule A: Warwickshire, named only in its children's NAME_2.
+    _gadm("GBR.1.5_1", _UK, "England", "NA"),
+    _gadm("GBR.1.5.1_1", _UK, "England", "Warwickshire", "Nuneaton"),
+    _gadm("GBR.1.5.2_1", _UK, "England", "Warwickshire", "Rugby"),
+    _gadm("GBR.1.5.3_1", _UK, "England", "Warwickshire", "Warwick"),
+    # Level 2 refusal: several children, none of which carries the parent name.
+    _gadm("GBR.1.6_1", _UK, "England", "NA"),
+    _gadm("GBR.1.6.1_1", _UK, "England", "NA", "Chesterfield"),
+    _gadm("GBR.1.6.2_1", _UK, "England", "NA", "Bolsover"),
+    # Level 2 refusal: an only child that GADM did not name either.
+    _gadm("GBR.1.7_1", _UK, "England", "NA"),
+    _gadm("GBR.1.7.1_1", _UK, "England", "NA", "NA"),
+    # Level 2 refusal: no children.
+    _gadm("GBR.1.8_1", _UK, "England", "NA"),
+]
 
 
 async def _aoi_names(source: str) -> dict[str, str]:
@@ -109,162 +199,22 @@ async def _build(source: str) -> int:
 async def _repairs() -> dict[str, str]:
     async with async_session_maker() as session:
         return await _derive_gadm_name_repairs(
-            session, "geometries_gadm", "gadm_id"
+            session,
+            SOURCE_STAGING_TABLES["gadm"],
+            AOI_SOURCE_ID_COLUMNS["gadm"],
         )
 
 
-def _district(gadm_id: str, name_2: str, **columns) -> dict:
-    """A GBR district row, with its display name composed as ingest does."""
-    cols = {"GID_0": "GBR", "GID_1": "GBR.1_1", "NAME_1": "England"}
-    cols.update(columns)
-    cols.update({"GID_2": gadm_id, "NAME_2": name_2})
-    name = f"{name_2}, {cols['NAME_1']}, United Kingdom"
-    return _row(gadm_id, name, "district-county", **cols)
-
-
-def _municipality(gadm_id: str, parent: str, name_2: str, name_3: str) -> dict:
-    return _row(
-        gadm_id,
-        f"{name_3}, {name_2}, England, United Kingdom",
-        "municipality",
-        GID_0="GBR",
-        GID_1="GBR.1_1",
-        NAME_1="England",
-        GID_2=parent,
-        NAME_2=name_2,
-        GID_3=gadm_id,
-        NAME_3=name_3,
-    )
-
-
-# A miniature of the real hierarchy. Every group below is one rule or one
-# refusal; the comments name the real row each stands in for.
-_GADM_ROWS = [
-    # Level 1, Rule A. England's children disagree exactly as GADM's do: most
-    # say England, one says NA (never a vote), one says Wales (a real GADM
-    # error). England takes 2 of the 3 named votes.
-    _row("GBR", "United Kingdom", "country", GID_0="GBR"),
-    _row(
-        "GBR.1_1",
-        "NA, United Kingdom",
-        "state-province",
-        GID_0="GBR",
-        GID_1="GBR.1_1",
-        NAME_1="NA",
-    ),
-    _district("GBR.1.1_1", "Barnsley"),
-    _district("GBR.1.4_1", "Wakefield", NAME_1="Wales"),
-    _district("GBR.1.3_1", "Sheffield", NAME_1="NA"),
-    # Level 1 control: a sibling GADM named correctly.
-    _row(
-        "GBR.2_1",
-        "Scotland, United Kingdom",
-        "state-province",
-        GID_0="GBR",
-        GID_1="GBR.2_1",
-        NAME_1="Scotland",
-    ),
-    # Level 1 refusal: MHL.19_1 has no children at all, so nothing to borrow.
-    _row(
-        "MHL.19_1",
-        "NA, Marshall Islands",
-        "state-province",
-        GID_0="MHL",
-        COUNTRY="Marshall Islands",
-        GID_1="MHL.19_1",
-        NAME_1="NA",
-    ),
-    # Level 1 refusal: the all-NA ghost row, whose children split 1-1.
-    _row("NA", "NA, NA", "state-province", GID_1="NA", NAME_1="NA"),
-    _row(
-        "NA.1_1",
-        "NA, England, United Kingdom",
-        "district-county",
-        GID_1="NA",
-        NAME_1="England",
-        GID_2="NA.1_1",
-        NAME_2="NA",
-    ),
-    _row(
-        "NA.2_1",
-        "NA, Scotland, United Kingdom",
-        "district-county",
-        GID_1="NA",
-        NAME_1="Scotland",
-        GID_2="NA.2_1",
-        NAME_2="NA",
-    ),
-    # Level 1, Rule A with a near-miss dissenter, as Ireland ships it.
-    _row(
-        "IRL.4_1",
-        "NA, Ireland",
-        "state-province",
-        GID_0="IRL",
-        COUNTRY="Ireland",
-        GID_1="IRL.4_1",
-        NAME_1="NA",
-    ),
-    _row(
-        "IRL.4.1_1",
-        "Cobh, Cork, Ireland",
-        "district-county",
-        GID_0="IRL",
-        COUNTRY="Ireland",
-        GID_1="IRL.4_1",
-        NAME_1="Cork",
-        GID_2="IRL.4.1_1",
-        NAME_2="Cobh",
-    ),
-    _row(
-        "IRL.4.2_1",
-        "Youghal, Cork, Ireland",
-        "district-county",
-        GID_0="IRL",
-        COUNTRY="Ireland",
-        GID_1="IRL.4_1",
-        NAME_1="Cork",
-        GID_2="IRL.4.2_1",
-        NAME_2="Youghal",
-    ),
-    _row(
-        "IRL.4.3_1",
-        "Mahon, Cork City, Ireland",
-        "district-county",
-        GID_0="IRL",
-        COUNTRY="Ireland",
-        GID_1="IRL.4_1",
-        NAME_1="Cork City",
-        GID_2="IRL.4.3_1",
-        NAME_2="Mahon",
-    ),
-    # Level 2, Rule B: GADM stored Bristol's name on its only child.
-    _district("GBR.1.2_1", "NA"),
-    _municipality("GBR.1.2.1_1", "GBR.1.2_1", "NA", "Bristol"),
-    # Level 2, Rule A: Warwickshire, named only in its children's NAME_2.
-    _district("GBR.1.5_1", "NA"),
-    _municipality("GBR.1.5.1_1", "GBR.1.5_1", "Warwickshire", "Nuneaton"),
-    _municipality("GBR.1.5.2_1", "GBR.1.5_1", "Warwickshire", "Rugby"),
-    _municipality("GBR.1.5.3_1", "GBR.1.5_1", "Warwickshire", "Warwick"),
-    # Level 2 refusal: several children, none of which carries the parent name.
-    _district("GBR.1.6_1", "NA"),
-    _municipality("GBR.1.6.1_1", "GBR.1.6_1", "NA", "Chesterfield"),
-    _municipality("GBR.1.6.2_1", "GBR.1.6_1", "NA", "Bolsover"),
-    # Level 2 refusal: an only child that GADM did not name either.
-    _district("GBR.1.7_1", "NA"),
-    _municipality("GBR.1.7.1_1", "GBR.1.7_1", "NA", "NA"),
-    # Level 2 refusal: no children.
-    _district("GBR.1.8_1", "NA"),
-]
-
-
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="module")
 async def gadm_staging():
-    """Seed ``geometries_gadm``, and drop it however the test ends."""
-    await _seed_gadm_staging(_GADM_ROWS)
-    yield
-    async with async_session_maker() as session:
-        await session.execute(text("DROP TABLE IF EXISTS geometries_gadm"))
-        await session.commit()
+    """Seed ``geometries_gadm`` once for the module.
+
+    Module-scoped because nothing under test writes to staging: the repair is
+    read-only and ``build-aois`` only writes ``aois``, which the autouse
+    ``clear_tables`` still truncates between tests.
+    """
+    async with _staging_table("gadm", _GADM_COLUMNS, _GADM_ROWS):
+        yield
 
 
 def test_prune_needs_the_custom_source():
@@ -339,13 +289,14 @@ async def test_repair_survives_the_chunked_insert(gadm_staging):
     routinely land in different passes. This test first asserts the seeded ids
     really do straddle a boundary, then that the repaired names still arrive.
     """
+    id_col = AOI_SOURCE_ID_COLUMNS["gadm"]
     async with async_session_maker() as session:
         buckets = await session.execute(
             text(
-                "SELECT gadm_id,"
-                " abs(hashtext(gadm_id)::bigint) % :n AS chunk"
-                " FROM geometries_gadm"
-                " WHERE gadm_id IN ('GBR.1_1', 'GBR.1.1_1', 'GBR.1.2_1',"
+                f"SELECT {id_col},"
+                f" abs(hashtext({id_col})::bigint) % :n AS chunk"
+                f" FROM {SOURCE_STAGING_TABLES['gadm']}"
+                f" WHERE {id_col} IN ('GBR.1_1', 'GBR.1.1_1', 'GBR.1.2_1',"
                 " 'GBR.1.2.1_1')"
             ),
             {"n": _CHUNKS},
@@ -418,30 +369,16 @@ async def test_repair_does_not_touch_other_sources():
     Seeding a kba row under a gadm id that the rules do repair is the sharpest
     form of the question: a source-blind repair would rename it.
     """
-    async with async_session_maker() as session:
-        await session.execute(text("DROP TABLE IF EXISTS geometries_kba"))
-        await session.execute(
-            text(
-                "CREATE TABLE geometries_kba ("
-                ' "ISO3" text, sitrecid text, name text, subtype text,'
-                " geometry geometry(MultiPolygon, 4326))"
-            )
-        )
-        await session.execute(
-            text(
-                "INSERT INTO geometries_kba VALUES ('GBR', 'GBR.1_1',"
-                " 'NA, United Kingdom', 'key-biodiversity-area',"
-                " ST_Multi(ST_GeomFromText(:geom, 4326)))"
-            ),
-            {"geom": _SQUARE},
-        )
-        await session.commit()
+    columns = ("ISO3", AOI_SOURCE_ID_COLUMNS["kba"], "name", "subtype")
+    row = {
+        "ISO3": "GBR",
+        AOI_SOURCE_ID_COLUMNS["kba"]: "GBR.1_1",
+        "name": "NA, United Kingdom",
+        "subtype": "key-biodiversity-area",
+    }
 
-    try:
+    async with _staging_table("kba", columns, [row]):
         await _build("kba")
+
         names = await _aoi_names("kba")
         assert names == {"GBR.1_1": "NA, United Kingdom"}
-    finally:
-        async with async_session_maker() as session:
-            await session.execute(text("DROP TABLE IF EXISTS geometries_kba"))
-            await session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,9 @@ async_session_maker = sessionmaker(
 Base.metadata.bind = engine_test
 
 
-_UNIT_SQUARE_WKT = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
+# One valid square, for any test that needs a geometry but asserts nothing
+# about it (the transform still derives bbox and area from it).
+UNIT_SQUARE_WKT = "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"
 
 
 async def seed_reference_aoi(
@@ -48,7 +50,7 @@ async def seed_reference_aoi(
     name,
     subtype,
     *,
-    geometry_wkt=_UNIT_SQUARE_WKT,
+    geometry_wkt=UNIT_SQUARE_WKT,
     bbox=(0, 0, 1, 1),
     is_disputed=False,
 ):

--- a/tests/evals/datasets/pzb-1271.csv
+++ b/tests/evals/datasets/pzb-1271.csv
@@ -1,0 +1,3 @@
+test_id,test_group,status,query,expected_aoi_ids,expected_aoi_source,expected_dataset_id,expected_dataset_name,expected_context_layer,expected_start_date,expected_end_date,expected_answer,expected_clarification,expected_text,expected_suggested_datasets
+pzb-1271-1,regression,ready,"Tree cover loss in Bristol, England",GBR.1.12_1,gadm,4,Tree cover loss,,,,,,"Must analyse Bristol as a named AOI in England, never an area called NA, and must not analyse a Bristol in the United States.",
+pzb-1271-2,regression,ready,"Tree cover loss in Warwickshire, England",GBR.1.108_1,gadm,4,Tree cover loss,,,,,,"Must analyse Warwickshire as a named AOI in England, never an area called NA.",


### PR DESCRIPTION
## Problem

Stacked on #797. The hardcoded three-row patch fixes England but leaves the wider GADM "NA" name problem (2,930 rows globally; [PZB-1271](https://gfw.atlassian.net/browse/PZB-1271)) and would not survive a GADM v5 re-ingest without maintenance.

## Changes

Replaces `_GADM_NAME_PATCHES` with `_derive_gadm_name_repairs`: a single read-only SQL derivation over the staging hierarchy, computed once per build and applied via a single jsonb-bound join (staging is never written, so the repair recomputes identically on every build and re-applies itself after any re-ingest).

- **Rule A (parent name from children):** a row whose own `NAME_n` is "NA" adopts the modal name among its *named* immediate children, on a strict majority (`_GADM_CHILD_NAME_MIN_SHARE = 0.5`). GADM's child rows are not unanimous (England 115/117, Cork 8/9, Zuid-Holland 52/53). Applied at all admin levels — at level 2 this recovers the multi-child English counties from the grandchildren's `NAME_2`, superseding the HASC-lookup idea (SPEC-PR7 rule D). The all-NA ghost row is refused on its 1-1 child tie.
- **Rule B (leaf name from an only child):** a district-county with exactly one child, which must be named, adopts the child's name — GADM shifted these names down a level (Bristol, Tameside, Trafford, Wiltshire...). Rule A wins where both could fire.
- Only the broken leading "NA" segment is replaced (sliced by `char_length` of the marker, not a hardcoded offset); parent segments stay byte-identical. Column resolution failures and a zero-repair gadm build are echoed loudly.

Plurality-adjacent case, deliberate: `CHL.15.1_1` → Tamarugal (5 of 7 children; GADM's own row spans two Chilean provinces). Raising the threshold to 0.8 excludes it; the constant's comment records the trade-off. Known recorded gap: Rule B families keep "NA" mid-name in their descendant rows (e.g. the municipality under Bristol) — pinned by a test; the durable fix is SPEC-PR8's compose-from-ancestors design.

## Evidence (complete)

- **87 repairs, byte-identical** between the hand-measured derivation, the pre-simplify implementation and the final code, against the real 356k-row staging table; the real dev-DB `build-aois --source gadm` printed `87 name(s) repaired from GADM's own hierarchy` and the rebuilt `aois` holds England, Cork, Zuid-Holland, Bristol, Warwickshire and Tamarugal, with `MHL.19_1` and the ghost row untouched.
- **Eval run, 3 trials: 2/2 passed, mean 1.000** — "Tree cover loss in Bristol, England" resolves `GBR.1.12_1` and "…Warwickshire, England" resolves `GBR.1.108_1`; both rows are findable only because of rules B and A-at-level-2.
- **GOLD regression gate** (gnw-gold-evals, filtered 54-case set: direct/parent-child/comparative/multilingual, 3 trials, matched env/ff/caseset on both sides, dev DB constant): baseline `20260825T155745Z_local` (main) vs `20260825T165921Z_local` (this branch): **15 recoveries, 9 nominal regressions — every regressed check belongs to families the flakiness tool shows flapping within a single run** (`chart_well_formed` flapped on 12 cases; `answered_without_data`/`chart_produced`/`dataset_id_match` over their stability gates), none touch AOI resolution, and two of the regressed check-pairs are the same checks recovering on other cases. Verdict: no real regression; the authoritative full-set gate runs on staging post-deploy per gnw-gold-evals practice.
- Gate: 800 tests passed, 0 failed (known shared-test-DB teardown noise only); pre-commit clean.
- **`/simplify` pass applied** (4-angle review, 19 fixes in 6 commits): single-sourced GADM name columns via `GADM_LEVELS`, one column-existence query, loud failure on unresolvable columns, jsonb-bound repair map, consolidated path-based test fixtures. The 87-repair invariant was re-verified byte-identical after the pass.

## Out of scope

Rule C (search exclusion of residual "NA, " rows) — superseded by the SPEC-PR8 search-architecture work. Residual junk after this PR: `MHL.19_1`, the ghost row, 22 level-2 rows, ~2,815 childless RUS/THA/ARE municipalities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBJ9WNghZmk4GZSsJ5Yybk

[PZB-1271]: https://gfw.atlassian.net/browse/PZB-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ