### PR TITLE
feat(custom-areas): add CSV and zipped shapefile upload endpoint

### DIFF
--- a/db/alembic/versions/e7c1f4a92b58_add_custom_area_properties_and_upload_batch.py
+++ b/db/alembic/versions/e7c1f4a92b58_add_custom_area_properties_and_upload_batch.py
@@ -1,0 +1,42 @@
+"""add custom_areas properties and upload_batch_id
+
+Revision ID: e7c1f4a92b58
+Revises: d4a1c7b93e02
+Create Date: 2026-08-29 12:00:00.000000
+
+``properties`` carries the non-geometry attributes of an uploaded feature and is
+projected into ``aois.properties`` by the custom-area mirror. ``upload_batch_id``
+groups the rows created by one file upload; a drawn area leaves it null. No
+index on ``upload_batch_id`` yet — nothing queries by it.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+# revision identifiers, used by Alembic.
+revision: str = "e7c1f4a92b58"
+down_revision: Union[str, None] = "d4a1c7b93e02"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "custom_areas",
+        sa.Column("properties", JSONB, nullable=True),
+    )
+    op.add_column(
+        "custom_areas",
+        sa.Column("upload_batch_id", UUID, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("custom_areas", "upload_batch_id")
+    op.drop_column("custom_areas", "properties")

--- a/db/alembic/versions/e7c1f4a92b58_add_custom_area_properties_and_upload_batch.py
+++ b/db/alembic/versions/e7c1f4a92b58_add_custom_area_properties_and_upload_batch.py
@@ -1,7 +1,7 @@
 """add custom_areas properties and upload_batch_id
 
 Revision ID: e7c1f4a92b58
-Revises: d4a1c7b93e02
+Revises: c9f1a2b3d4e5
 Create Date: 2026-08-29 12:00:00.000000
 
 ``properties`` carries the non-geometry attributes of an uploaded feature and is
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 # revision identifiers, used by Alembic.
 revision: str = "e7c1f4a92b58"
-down_revision: Union[str, None] = "d4a1c7b93e02"
+down_revision: Union[str, None] = "c9f1a2b3d4e5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/docs/area-uploads.md
+++ b/docs/area-uploads.md
@@ -1,0 +1,170 @@
+# Area uploads: CSV & zipped shapefile
+
+`POST /api/custom_areas/upload` creates custom areas from an uploaded CSV or
+zipped shapefile, one area per feature. Uploaded areas are ordinary
+`custom_areas` rows (`source='custom'`): they are owner-scoped in search,
+work with the existing rename/delete endpoints, and are mirrored into `aois`
+like drawn areas. Rows from one upload share a generated `upload_batch_id`
+(null on drawn areas).
+
+## Design
+
+The AOI architecture plan originally sketched uploads as a new `upload`
+source written directly into `aois`. Uploads were implemented as custom areas
+instead:
+
+- The existing custom-area CRUD endpoints and frontend list apply unchanged.
+- Owner scoping in `search_aois` tests the literal `'custom'` in four places
+  (`src/shared/geocoding_helpers.py`); a second user-owned source would have
+  to update all four or leak uploaded areas across users.
+- The agent, analytics, thumbnail and mosaic paths already handle
+  `custom`/`custom-area` and need no new branches.
+
+Costs: two nullable columns on `custom_areas` (migration `e7c1f4a92b58`:
+`properties jsonb`, `upload_batch_id uuid`), and geometry stored twice
+(GeoJSON in `custom_areas.geometries`, normalized MultiPolygon in the `aois`
+mirror), as for drawn areas.
+
+The write is a single transaction: parse and validate the file, insert n
+`custom_areas` rows, mirror all n into `aois` with owner links in one
+statement (`upsert_custom_aoi(session, area_ids=...)`), commit. The mirror
+projects `custom_areas.properties` into `aois.properties`.
+
+## Endpoint
+
+Multipart form, single field `file`, authentication required. The filename
+extension selects the parser: `.csv` or `.zip`; anything else returns 415.
+
+```sh
+curl -X POST https://…/api/custom_areas/upload \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@my_areas.csv"     # or my_areas.zip
+```
+
+Response — no geometries; refetch the paginated list for full rows:
+
+```json
+{
+  "upload_batch_id": "0d9c1f4e-…",
+  "areas": [
+    {"id": "7be2c1aa-…", "name": "Upland North"},
+    {"id": "91d40f2b-…", "name": "Upland South"}
+  ]
+}
+```
+
+## File contracts
+
+**CSV** — UTF-8 with a header row. Required columns, matched
+case-insensitively:
+
+- `name` — non-empty after trimming.
+- `geom` — WKT `POLYGON` or `MULTIPOLYGON` in WGS84 lon/lat degrees.
+  Coordinates outside ±180/±90 are rejected (catches projected coordinates).
+
+All other columns are stored per row in `properties`, as strings.
+
+```csv
+name,geom,region
+Upland North,"POLYGON ((30 10, 30 11, 31 11, 31 10, 30 10))",Kivu
+```
+
+**Zipped shapefile** — one zip containing the sidecar set (`.shp`, `.shx`,
+`.dbf`, `.prj`). The `.prj` is required; without it the upload is rejected.
+Any declared CRS is accepted and reprojected to WGS84 with a real coordinate
+transform (not a SRID relabel). A `name` attribute is required, matched
+case-insensitively (`NAME` works). Geometries must be `Polygon` or
+`MultiPolygon`. All other attributes are stored in `properties`, coerced to
+JSON: `NaN`/`NaT`/null → `null`, dates and timestamps → ISO-8601 strings,
+numbers → numbers, everything else → its string form.
+
+## Limits and errors
+
+Constants in `src/api/services/area_upload.py`:
+
+| Condition | Status | Body |
+| --- | --- | --- |
+| File over 10 MB (`MAX_UPLOAD_BYTES`) | 413 | `{"detail": "file too large; the limit is 10 MB"}` |
+| Over 500 features (`MAX_FEATURES`) | 422 | `{"detail": {"errors": ["too many rows; the limit is 500"]}}` |
+| Invalid content | 422 | `{"detail": {"errors": ["row 3: geom is empty", …]}}` |
+| Extension not `.csv`/`.zip` | 415 | `{"detail": "unsupported file type; …"}` |
+| Missing/invalid bearer token | 401 | standard auth error |
+
+Validation is all-or-nothing: every problem in the file is collected and
+returned as row-indexed errors (`row N` for CSV data rows, `feature N` for
+shapefile features, counting from 1) and nothing is created.
+
+## Frontend integration
+
+Upload with a progress bar. Upload progress is reported by the browser
+against the plain multipart POST; no chunked-upload protocol is involved.
+Use axios or XHR — `fetch` cannot report upload progress. Do not set
+`Content-Type`; the browser adds the multipart boundary.
+
+```js
+const fd = new FormData();
+fd.append("file", fileInput.files[0]); // keep the .csv/.zip filename
+
+await axios.post("/api/custom_areas/upload", fd, {
+  headers: { Authorization: `Bearer ${token}` },
+  onUploadProgress: (e) => setProgress(Math.round((100 * e.loaded) / e.total)),
+});
+```
+
+Handle the outcomes. On 422, show every entry of `detail.errors` — the file
+failed as a whole and nothing was created.
+
+```js
+try {
+  const { data } = await upload(file);
+  // refetch the list; select/zoom via data.areas ids
+} catch (err) {
+  const res = err.response;
+  if (res?.status === 422) showErrors(res.data.detail.errors);
+  else if (res?.status === 413 || res?.status === 415) showError(res.data.detail);
+  else showError("Upload failed");
+}
+```
+
+List with pagination. `GET /api/custom_areas` takes `limit` (1–100, default
+50) and `offset`, ordered newest first. When another page exists, the
+`X-Next-Offset` response header holds the next offset; it is exposed through
+CORS. An unparameterized call returns only the first 50 rows — code that
+assumed the list returns everything must follow the header.
+
+```js
+async function fetchAllAreas() {
+  const areas = [];
+  let offset = 0;
+  while (offset != null) {
+    const res = await axios.get("/api/custom_areas", {
+      params: { limit: 100, offset },
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    areas.push(...res.data);
+    const next = res.headers["x-next-offset"]; // absent on the last page
+    offset = next != null ? Number(next) : null;
+  }
+  return areas;
+}
+```
+
+Distinguish uploaded from drawn areas by `upload_batch_id`; `properties`
+holds the file's extra columns/attributes.
+
+```js
+const uploaded = areas.filter((a) => a.upload_batch_id != null);
+const byBatch = Map.groupBy(uploaded, (a) => a.upload_batch_id);
+```
+
+## Out of scope
+
+- **Delete a whole upload** — straightforward now that the batch id exists;
+  add an index on `upload_batch_id` in the same change.
+- **GeoJSON / KML** — one more parser in `area_upload.py` returning the same
+  `ParsedFeature` list; the write path is format-agnostic.
+- **Larger files** — past these caps, switch to presigned-URL upload to
+  S3/minio with an async processing job and a status endpoint, rather than
+  raising the constants.
+- **Owner-scoping registry refactor** — not needed for this design; required
+  before any future non-`custom` user-owned source.

--- a/docs/area-uploads.md
+++ b/docs/area-uploads.md
@@ -61,6 +61,8 @@ case-insensitively:
 - `name` — non-empty after trimming.
 - `geom` — WKT `POLYGON` or `MULTIPOLYGON` in WGS84 lon/lat degrees.
   Coordinates outside ±180/±90 are rejected (catches projected coordinates).
+  A single WKT value is bounded only by the file size cap, so a dense boundary
+  of many thousands of vertices is fine.
 
 All other columns are stored per row in `properties`, as strings.
 
@@ -72,7 +74,11 @@ Upland North,"POLYGON ((30 10, 30 11, 31 11, 31 10, 30 10))",Kivu
 **Zipped shapefile** — one zip containing the sidecar set (`.shp`, `.shx`,
 `.dbf`, `.prj`). The `.prj` is required; without it the upload is rejected.
 Any declared CRS is accepted and reprojected to WGS84 with a real coordinate
-transform (not a SRID relabel). A `name` attribute is required, matched
+transform (not a SRID relabel). A CRS with no path to WGS84 — an engineering or
+local CRS, or one needing a PROJ grid that is not installed — is rejected with a
+422 rather than a 500. Reprojected coordinates are allowed 1e-6 degrees of slack
+past ±180/±90, which covers the transform's own float drift; the CSV path takes
+the user's numbers as given and gets none. A `name` attribute is required, matched
 case-insensitively (`NAME` works). Geometries must be `Polygon` or
 `MultiPolygon`. All other attributes are stored in `properties`, coerced to
 JSON: `NaN`/`NaT`/null → `null`, dates and timestamps → ISO-8601 strings,
@@ -86,13 +92,16 @@ Constants in `src/api/services/area_upload.py`:
 | --- | --- | --- |
 | File over 10 MB (`MAX_UPLOAD_BYTES`) | 413 | `{"detail": "file too large; the limit is 10 MB"}` |
 | Over 500 features (`MAX_FEATURES`) | 422 | `{"detail": {"errors": ["too many rows; the limit is 500"]}}` |
+| Zip expanding past 200 MB (`MAX_UNCOMPRESSED_BYTES`) | 422 | `{"detail": {"errors": ["zip contents expand to 240 MB; the limit is 200 MB"]}}` |
+| Unreadable zip, or a CRS with no path to WGS84 | 422 | `{"detail": {"errors": ["could not reproject the shapefile to WGS84: …"]}}` |
 | Invalid content | 422 | `{"detail": {"errors": ["row 3: geom is empty", …]}}` |
 | Extension not `.csv`/`.zip` | 415 | `{"detail": "unsupported file type; …"}` |
 | Missing/invalid bearer token | 401 | standard auth error |
 
 Validation is all-or-nothing: every problem in the file is collected and
-returned as row-indexed errors (`row N` for CSV data rows, `feature N` for
-shapefile features, counting from 1) and nothing is created.
+returned together, and nothing is created. Problems belonging to one row are
+indexed (`row N` for CSV data rows, `feature N` for shapefile features, counting
+from 1); file-level problems, such as the row cap, carry no index.
 
 ## Frontend integration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.8"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -87,7 +87,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
-    expose_headers=["Content-Disposition", "X-Next-Cursor"],
+    expose_headers=["Content-Disposition", "X-Next-Cursor", "X-Next-Offset"],
 )
 
 

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -158,6 +158,8 @@ class CustomAreaOrm(Base):
     user_id = Column(String, ForeignKey("users.id"), nullable=False)
     name = Column(String, nullable=False)
     geometries = Column(JSONB, nullable=False)
+    properties = Column(JSONB, nullable=True)
+    upload_batch_id = Column(PostgresUUID, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(
         DateTime,

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -14,6 +14,7 @@ from fastapi import (
     Depends,
     HTTPException,
     Query,
+    Request,
     Response,
     UploadFile,
 )
@@ -38,6 +39,7 @@ from src.api.services.area_upload import (
     MAX_UPLOAD_BYTES,
     UploadValidationError,
     parse_csv,
+    parse_shapefile_zip,
 )
 from src.shared.database import get_session_from_pool_dependency
 from src.shared.logging_config import get_logger
@@ -119,47 +121,67 @@ async def create_custom_area(
     "/api/custom_areas/upload", response_model=CustomAreaUploadResponse
 )
 async def upload_custom_areas(
+    request: Request,
     file: UploadFile,
     user: UserModel = Depends(require_auth),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ):
     """Create custom areas from an uploaded file, one per feature.
 
-    Accepts a ``.csv`` file as the multipart field ``file``:
+    Accepts, as the multipart field ``file``:
 
-    - Required columns (case-insensitive): ``name``, and ``geom`` holding WKT
-      ``POLYGON`` or ``MULTIPOLYGON`` in WGS84 lon/lat degrees.
-    - Every other column is stored in the area's ``properties``.
-    - Limits: 10 MB (413) and 500 features (422).
-    - All-or-nothing: any invalid row fails the whole upload with a 422 whose
-      ``detail.errors`` lists each problem by data-row number.
+    - A ``.csv`` file with required columns (case-insensitive) ``name`` and
+      ``geom`` holding WKT ``POLYGON`` or ``MULTIPOLYGON`` in WGS84 lon/lat
+      degrees.
+    - A zipped shapefile (``.zip``) with a required ``name`` attribute
+      (case-insensitive). The ``.prj`` must be included; geometries are
+      reprojected to WGS84 and must be ``Polygon`` or ``MultiPolygon``.
+
+    Every other column or attribute is stored in the area's ``properties``.
+    Limits: 10 MB (413) and 500 features (422). All-or-nothing: any invalid
+    row fails the whole upload with a 422 whose ``detail.errors`` lists each
+    problem by row number.
 
     The created areas share one ``upload_batch_id``. Each is a regular custom
     area: it appears in ``GET /api/custom_areas``, is mirrored into ``aois``,
     and is searchable by its owner through ``GET /api/aois``. The response is
     deliberately light; refetch the paginated list for the full rows.
     """
-    filename = file.filename or ""
-    if not filename.lower().endswith(".csv"):
+    filename = (file.filename or "").lower()
+    if filename.endswith(".csv"):
+        parser = parse_csv
+    elif filename.endswith(".zip"):
+        parser = parse_shapefile_zip
+    else:
         raise HTTPException(
             status_code=415,
-            detail="unsupported file type; upload a .csv file",
+            detail=(
+                "unsupported file type; upload a .csv file or a zipped "
+                "shapefile (.zip)"
+            ),
         )
+
+    too_large = HTTPException(
+        status_code=413,
+        detail=(
+            "file too large; the limit is "
+            f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB"
+        ),
+    )
+    # Fail fast on the declared size. The header counts multipart overhead,
+    # so allow slack; the chunked read below is the precise cap.
+    declared = request.headers.get("content-length", "")
+    if declared.isdigit() and int(declared) > MAX_UPLOAD_BYTES + 4096:
+        raise too_large
 
     data = bytearray()
     while chunk := await file.read(1024 * 1024):
         data.extend(chunk)
         if len(data) > MAX_UPLOAD_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail=(
-                    "file too large; the limit is "
-                    f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB"
-                ),
-            )
+            raise too_large
 
     try:
-        features = await run_in_threadpool(parse_csv, bytes(data))
+        features = await run_in_threadpool(parser, bytes(data))
     except UploadValidationError as exc:
         raise HTTPException(status_code=422, detail={"errors": exc.errors})
 

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -9,7 +9,7 @@ the CRUD. ``src/api/services/aoi_sync.py`` holds that mirror.
 import json
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -102,17 +102,33 @@ async def create_custom_area(
 
 @router.get("/api/custom_areas", response_model=list[CustomAreaModel])
 async def list_custom_areas(
+    response: Response,
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
     user: UserModel = Depends(require_auth),
     session: AsyncSession = Depends(get_session_from_pool_dependency),
 ):
-    """List all custom areas belonging to the authenticated user.
+    """List the custom areas belonging to the authenticated user, newest first.
+
+    When more results are available, the next page offset is returned in the
+    ``X-Next-Offset`` response header.
 
     This reads ``custom_areas`` and returns the drawn parts unchanged. It is
     not the search surface; use ``GET /api/aois?source=custom`` for that.
     """
-    stmt = select(CustomAreaOrm).filter_by(user_id=user.id)
+    stmt = (
+        select(CustomAreaOrm)
+        .filter_by(user_id=user.id)
+        .order_by(CustomAreaOrm.created_at.desc(), CustomAreaOrm.id)
+        # Fetch one extra row to determine whether more pages exist.
+        .limit(limit + 1)
+        .offset(offset)
+    )
     result = await session.execute(stmt)
-    areas = result.scalars().all()
+    areas = list(result.scalars().all())
+    if len(areas) > limit:
+        areas = areas[:limit]
+        response.headers["X-Next-Offset"] = str(offset + limit)
     results = []
     for area in areas:
         area.geometries = [json.loads(i) for i in area.geometries]

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -128,24 +128,29 @@ async def upload_custom_areas(
 ):
     """Create custom areas from an uploaded file, one per feature.
 
-    Accepts, as the multipart field ``file``:
+    Accepts, as the multipart field ``file``, one of (any other extension
+    is a 415):
 
-    - A ``.csv`` file with required columns (case-insensitive) ``name`` and
-      ``geom`` holding WKT ``POLYGON`` or ``MULTIPOLYGON`` in WGS84 lon/lat
-      degrees.
+    - A ``.csv`` file (UTF-8) with required columns (case-insensitive)
+      ``name`` and ``geom`` holding WKT ``POLYGON`` or ``MULTIPOLYGON`` in
+      WGS84 lon/lat degrees.
     - A zipped shapefile (``.zip``) with a required ``name`` attribute
       (case-insensitive). The ``.prj`` must be included; geometries are
       reprojected to WGS84 and must be ``Polygon`` or ``MultiPolygon``.
 
     Every other column or attribute is stored in the area's ``properties``.
-    Limits: 10 MB (413) and 500 features (422). All-or-nothing: any invalid
-    row fails the whole upload with a 422 whose ``detail.errors`` lists each
-    problem by row number.
+    Limits: 10 MB (413) and 500 features (422). Validation is all-or-nothing:
+    any invalid row fails the whole upload with a 422 whose ``detail.errors``
+    lists every problem by row number (``"row 3: geom is empty"``), and
+    nothing is created.
 
-    The created areas share one ``upload_batch_id``. Each is a regular custom
-    area: it appears in ``GET /api/custom_areas``, is mirrored into ``aois``,
-    and is searchable by its owner through ``GET /api/aois``. The response is
-    deliberately light; refetch the paginated list for the full rows.
+    The created areas share one ``upload_batch_id`` (null on drawn areas).
+    Each is a regular custom area: it appears in ``GET /api/custom_areas``,
+    is mirrored into ``aois``, and is searchable by its owner through
+    ``GET /api/aois``; rename and delete use the standard custom-area
+    endpoints. The response is deliberately light; refetch the paginated
+    list for the full rows. The full guide, including frontend integration,
+    is ``docs/area-uploads/``.
     """
     filename = (file.filename or "").lower()
     if filename.endswith(".csv"):

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -7,9 +7,17 @@ the CRUD. ``src/api/services/aoi_sync.py`` holds that mirror.
 """
 
 import json
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Query,
+    Response,
+    UploadFile,
+)
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,9 +29,16 @@ from src.api.schemas import (
     CustomAreaModel,
     CustomAreaNameRequest,
     CustomAreaNameResponse,
+    CustomAreaUploadResponse,
+    UploadedAreaSummary,
     UserModel,
 )
 from src.api.services.aoi_sync import delete_custom_aoi, upsert_custom_aoi
+from src.api.services.area_upload import (
+    MAX_UPLOAD_BYTES,
+    UploadValidationError,
+    parse_csv,
+)
 from src.shared.database import get_session_from_pool_dependency
 from src.shared.logging_config import get_logger
 
@@ -97,6 +112,81 @@ async def create_custom_area(
         created_at=custom_area.created_at,
         updated_at=custom_area.updated_at,
         geometries=[json.loads(i) for i in custom_area.geometries],
+    )
+
+
+@router.post(
+    "/api/custom_areas/upload", response_model=CustomAreaUploadResponse
+)
+async def upload_custom_areas(
+    file: UploadFile,
+    user: UserModel = Depends(require_auth),
+    session: AsyncSession = Depends(get_session_from_pool_dependency),
+):
+    """Create custom areas from an uploaded file, one per feature.
+
+    Accepts a ``.csv`` file as the multipart field ``file``:
+
+    - Required columns (case-insensitive): ``name``, and ``geom`` holding WKT
+      ``POLYGON`` or ``MULTIPOLYGON`` in WGS84 lon/lat degrees.
+    - Every other column is stored in the area's ``properties``.
+    - Limits: 10 MB (413) and 500 features (422).
+    - All-or-nothing: any invalid row fails the whole upload with a 422 whose
+      ``detail.errors`` lists each problem by data-row number.
+
+    The created areas share one ``upload_batch_id``. Each is a regular custom
+    area: it appears in ``GET /api/custom_areas``, is mirrored into ``aois``,
+    and is searchable by its owner through ``GET /api/aois``. The response is
+    deliberately light; refetch the paginated list for the full rows.
+    """
+    filename = file.filename or ""
+    if not filename.lower().endswith(".csv"):
+        raise HTTPException(
+            status_code=415,
+            detail="unsupported file type; upload a .csv file",
+        )
+
+    data = bytearray()
+    while chunk := await file.read(1024 * 1024):
+        data.extend(chunk)
+        if len(data) > MAX_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    "file too large; the limit is "
+                    f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB"
+                ),
+            )
+
+    try:
+        features = await run_in_threadpool(parse_csv, bytes(data))
+    except UploadValidationError as exc:
+        raise HTTPException(status_code=422, detail={"errors": exc.errors})
+
+    batch_id = uuid4()
+    areas = [
+        CustomAreaOrm(
+            user_id=user.id,
+            name=feature.name,
+            geometries=[feature.geometry],
+            properties=feature.properties,
+            upload_batch_id=batch_id,
+        )
+        for feature in features
+    ]
+    session.add_all(areas)
+    # Flush so that the mirror can read the rows, and their generated ids, in
+    # this same transaction. The rows and their aois projection then commit
+    # together.
+    await session.flush()
+    await upsert_custom_aoi(session, area_ids=[area.id for area in areas])
+    await session.commit()
+
+    return CustomAreaUploadResponse(
+        upload_batch_id=batch_id,
+        areas=[
+            UploadedAreaSummary(id=area.id, name=area.name) for area in areas
+        ],
     )
 
 

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -277,6 +277,8 @@ async def get_custom_area(
         created_at=custom_area.created_at,
         updated_at=custom_area.updated_at,
         geometries=[json.loads(i) for i in custom_area.geometries],
+        properties=custom_area.properties,
+        upload_batch_id=custom_area.upload_batch_id,
     )
 
 
@@ -310,6 +312,8 @@ async def update_custom_area_name(
         created_at=area.created_at,
         updated_at=area.updated_at,
         geometries=[json.loads(i) for i in area.geometries],
+        properties=area.properties,
+        upload_batch_id=area.upload_batch_id,
     )
 
 

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -150,7 +150,7 @@ async def upload_custom_areas(
     ``GET /api/aois``; rename and delete use the standard custom-area
     endpoints. The response is deliberately light; refetch the paginated
     list for the full rows. The full guide, including frontend integration,
-    is ``docs/area-uploads/``.
+    is ``docs/area-uploads.md``.
     """
     filename = (file.filename or "").lower()
     if filename.endswith(".csv"):
@@ -173,8 +173,10 @@ async def upload_custom_areas(
             f"{MAX_UPLOAD_BYTES // (1024 * 1024)} MB"
         ),
     )
-    # Fail fast on the declared size. The header counts multipart overhead,
-    # so allow slack; the chunked read below is the precise cap.
+    # FastAPI spools the whole body to a temp file before this runs, so neither
+    # check bounds the work; they only turn an oversize upload into a clean 413.
+    # The real ingress cap belongs in the reverse proxy. The header counts
+    # multipart overhead, so allow slack; the chunked read below is the exact cap.
     declared = request.headers.get("content-length", "")
     if declared.isdigit() and int(declared) > MAX_UPLOAD_BYTES + 4096:
         raise too_large

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -141,8 +141,8 @@ async def upload_custom_areas(
     Every other column or attribute is stored in the area's ``properties``.
     Limits: 10 MB (413) and 500 features (422). Validation is all-or-nothing:
     any invalid row fails the whole upload with a 422 whose ``detail.errors``
-    lists every problem by row number (``"row 3: geom is empty"``), and
-    nothing is created.
+    lists every problem, indexed by row where the problem belongs to one
+    (``"row 3: geom is empty"``), and nothing is created.
 
     The created areas share one ``upload_batch_id`` (null on drawn areas).
     Each is a regular custom area: it appears in ``GET /api/custom_areas``,

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -363,6 +363,18 @@ class CustomAreaCreate(BaseModel):
     geometries: List[Polygon]
 
 
+class UploadedAreaSummary(BaseModel):
+    id: UUID
+    name: str
+
+
+class CustomAreaUploadResponse(BaseModel):
+    """The result of a file upload. Refetch the list endpoint for full rows."""
+
+    upload_batch_id: UUID
+    areas: List[UploadedAreaSummary]
+
+
 class ViewportContext(BaseModel):
     """The map's current extent, as reported by the frontend."""
 

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -352,6 +352,8 @@ class CustomAreaModel(BaseModel):
     user_id: str
     name: str
     geometries: List
+    properties: Optional[dict] = None
+    upload_batch_id: Optional[UUID] = None
     created_at: datetime
     updated_at: datetime
 

--- a/src/api/services/aoi_sync.py
+++ b/src/api/services/aoi_sync.py
@@ -14,7 +14,7 @@ The first such gap is every delete that happened before the write-through
 existed. A direct database delete, or a failed deploy, opens the same gap.
 """
 
-from typing import Optional
+from typing import Optional, Sequence
 from uuid import UUID
 
 import click
@@ -31,8 +31,8 @@ logger = get_logger(__name__)
 
 
 def _upsert_sql(scoped: bool) -> str:
-    """Build the custom-area upsert. *scoped* limits it to one ``ca.id``."""
-    where_area = "WHERE ca.id = :area_id" if scoped else ""
+    """Build the custom-area upsert. *scoped* limits it to given ``ca.id``s."""
+    where_area = "WHERE ca.id = ANY(:area_ids)" if scoped else ""
     return f"""
         WITH collected AS (
             SELECT
@@ -92,15 +92,14 @@ _SKIPPED_SQL = f"""
            OR ST_IsEmpty({CUSTOM_AREA_GEOM_SQL}))
 """
 
-# Check if the upsert wrote a row for this area. A `rowcount` of 0 does not show
-# that the area was skipped, because the owner link uses ON CONFLICT DO NOTHING
+# Count how many of the areas the upsert wrote. A `rowcount` does not show
+# which areas were skipped, because the owner link uses ON CONFLICT DO NOTHING
 # and a repeated patch correctly inserts no link. This query reads the unique
 # index instead.
 _MIRRORED_SQL = """
-    SELECT EXISTS (
-        SELECT 1 FROM aois
-        WHERE source = 'custom' AND source_id = :src_id AND NOT is_deprecated
-    )
+    SELECT count(*) FROM aois
+    WHERE source = 'custom' AND source_id = ANY(:src_ids)
+      AND NOT is_deprecated
 """
 
 
@@ -108,32 +107,45 @@ async def upsert_custom_aoi(
     session: AsyncSession,
     *,
     area_id: Optional[UUID] = None,
+    area_ids: Optional[Sequence[UUID]] = None,
 ) -> int:
     """Project ``custom_areas`` into ``aois``, with one ``owner`` link for each.
 
-    This function is idempotent. With *area_id* it projects only that area, which
-    is the CRUD write-through. Without *area_id* it projects every custom area,
-    which is the backfill. It returns the number of owner links upserted.
+    This function is idempotent. With *area_id* it projects only that area,
+    which is the CRUD write-through. *area_ids* projects a set of areas in one
+    statement, which is the file upload. Without either it projects every
+    custom area, which is the backfill. It returns the number of owner links
+    upserted.
 
     A geometry with no areal component is skipped, and not stored empty. The
     ``custom_areas`` row still exists and the CRUD call still succeeds, but the
     area is not searchable. The scoped path logs a warning. The backfill prints a
     count to the CLI.
     """
-    scoped = area_id is not None
-    params = {"area_id": area_id} if scoped else {}
+    if area_id is not None and area_ids is not None:
+        raise ValueError("pass area_id or area_ids, not both")
+    ids = (
+        [area_id]
+        if area_id is not None
+        else (list(area_ids) if area_ids is not None else None)
+    )
+    if ids is not None and not ids:
+        raise ValueError("area_ids must not be empty")
+    scoped = ids is not None
+    params = {"area_ids": ids} if scoped else {}
 
     result = await session.execute(text(_upsert_sql(scoped)), params)
 
-    if scoped:
+    if ids is not None:
         mirrored = await session.scalar(
-            text(_MIRRORED_SQL), {"src_id": str(area_id)}
+            text(_MIRRORED_SQL), {"src_ids": [str(i) for i in ids]}
         )
-        if not mirrored:
+        if mirrored < len(ids):
             logger.warning(
-                "Custom area not mirrored into aois: geometries not "
+                "Custom area(s) not mirrored into aois: geometries not "
                 "coercible to a non-empty MultiPolygon.",
-                custom_area_id=str(area_id),
+                skipped=len(ids) - mirrored,
+                custom_area_ids=[str(i) for i in ids],
             )
     else:
         skipped = await session.scalar(text(_SKIPPED_SQL))

--- a/src/api/services/aoi_sync.py
+++ b/src/api/services/aoi_sync.py
@@ -39,6 +39,7 @@ def _upsert_sql(scoped: bool) -> str:
                 ca.id,
                 ca.user_id,
                 ca.name,
+                ca.properties,
                 ca.created_at,
                 ca.updated_at,
                 {CUSTOM_AREA_GEOM_SQL} AS geom
@@ -48,7 +49,7 @@ def _upsert_sql(scoped: bool) -> str:
         ins AS (
             INSERT INTO aois (
                 source, source_id, name, subtype, geometry,
-                bbox, area_km2, created_by, created_at, updated_at
+                bbox, area_km2, properties, created_by, created_at, updated_at
             )
             SELECT
                 'custom',
@@ -58,6 +59,7 @@ def _upsert_sql(scoped: bool) -> str:
                 geom,
                 {bbox_float_array_sql("geom")},
                 ST_Area(geom::geography) / 1e6,
+                properties,
                 user_id,
                 created_at,
                 updated_at
@@ -69,6 +71,7 @@ def _upsert_sql(scoped: bool) -> str:
                 geometry = EXCLUDED.geometry,
                 bbox = EXCLUDED.bbox,
                 area_km2 = EXCLUDED.area_km2,
+                properties = EXCLUDED.properties,
                 updated_at = now()
             RETURNING id AS aoi_id, created_by AS user_id
         )

--- a/src/api/services/aoi_sync.py
+++ b/src/api/services/aoi_sync.py
@@ -92,12 +92,12 @@ _SKIPPED_SQL = f"""
            OR ST_IsEmpty({CUSTOM_AREA_GEOM_SQL}))
 """
 
-# Count how many of the areas the upsert wrote. A `rowcount` does not show
-# which areas were skipped, because the owner link uses ON CONFLICT DO NOTHING
-# and a repeated patch correctly inserts no link. This query reads the unique
-# index instead.
-_MIRRORED_SQL = """
-    SELECT count(*) FROM aois
+# Which of the areas the upsert wrote. A `rowcount` does not show what was
+# skipped, because the owner link uses ON CONFLICT DO NOTHING and a repeated
+# patch correctly inserts no link. This query reads the unique index instead,
+# and returns ids rather than a count so the warning can name the ones it lost.
+_MIRRORED_IDS_SQL = """
+    SELECT source_id FROM aois
     WHERE source = 'custom' AND source_id = ANY(:src_ids)
       AND NOT is_deprecated
 """
@@ -119,8 +119,9 @@ async def upsert_custom_aoi(
 
     A geometry with no areal component is skipped, and not stored empty. The
     ``custom_areas`` row still exists and the CRUD call still succeeds, but the
-    area is not searchable. The scoped path logs a warning. The backfill prints a
-    count to the CLI.
+    area is not searchable; the upload endpoint returns 200 and lists such an
+    area in its response like any other. The scoped path logs a warning naming
+    the skipped ids. The backfill prints a count to the CLI.
     """
     if area_id is not None and area_ids is not None:
         raise ValueError("pass area_id or area_ids, not both")
@@ -137,15 +138,17 @@ async def upsert_custom_aoi(
     result = await session.execute(text(_upsert_sql(scoped)), params)
 
     if ids is not None:
-        mirrored = await session.scalar(
-            text(_MIRRORED_SQL), {"src_ids": [str(i) for i in ids]}
+        rows = await session.execute(
+            text(_MIRRORED_IDS_SQL), {"src_ids": [str(i) for i in ids]}
         )
-        if mirrored < len(ids):
+        mirrored = {str(row[0]) for row in rows}
+        skipped = [str(i) for i in ids if str(i) not in mirrored]
+        if skipped:
             logger.warning(
                 "Custom area(s) not mirrored into aois: geometries not "
                 "coercible to a non-empty MultiPolygon.",
-                skipped=len(ids) - mirrored,
-                custom_area_ids=[str(i) for i in ids],
+                skipped=len(skipped),
+                skipped_area_ids=skipped,
             )
     else:
         skipped = await session.scalar(text(_SKIPPED_SQL))

--- a/src/api/services/area_upload.py
+++ b/src/api/services/area_upload.py
@@ -24,6 +24,10 @@ from shapely.geometry import mapping
 MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 MAX_FEATURES = 500
 
+# csv defaults to a 131072-char field, which one WKT polygon of a few thousand
+# vertices exceeds. Raise it to the upload cap, so file size is the only limit.
+csv.field_size_limit(MAX_UPLOAD_BYTES)
+
 _AREAL_TYPES = ("Polygon", "MultiPolygon")
 
 
@@ -100,37 +104,42 @@ def parse_csv(data: bytes) -> list[ParsedFeature]:
 
     features: list[ParsedFeature] = []
     errors: list[str] = []
-    for index, row in enumerate(reader, start=1):
-        if index > MAX_FEATURES:
-            raise UploadValidationError(
-                [f"too many rows; the limit is {MAX_FEATURES}"]
+    index = 0
+    try:
+        for index, row in enumerate(reader, start=1):
+            if index > MAX_FEATURES:
+                errors.append(f"too many rows; the limit is {MAX_FEATURES}")
+                break
+            name = (row.get(name_col) or "").strip()
+            if not name:
+                errors.append(f"row {index}: name is empty")
+            geom = None
+            wkt_value = (row.get(geom_col) or "").strip()
+            if not wkt_value:
+                errors.append(f"row {index}: geom is empty")
+            else:
+                try:
+                    geom = _validate_geometry(wkt_value)
+                except ValueError as exc:
+                    errors.append(f"row {index}: {exc}")
+            if errors or geom is None:
+                continue
+            properties = {
+                k: v
+                for k, v in row.items()
+                if k is not None and k not in (name_col, geom_col)
+            }
+            features.append(
+                ParsedFeature(
+                    name=name,
+                    geometry=json.dumps(mapping(geom)),
+                    properties=properties or None,
+                )
             )
-        name = (row.get(name_col) or "").strip()
-        if not name:
-            errors.append(f"row {index}: name is empty")
-        geom = None
-        wkt_value = (row.get(geom_col) or "").strip()
-        if not wkt_value:
-            errors.append(f"row {index}: geom is empty")
-        else:
-            try:
-                geom = _validate_geometry(wkt_value)
-            except ValueError as exc:
-                errors.append(f"row {index}: {exc}")
-        if errors or geom is None:
-            continue
-        properties = {
-            k: v
-            for k, v in row.items()
-            if k is not None and k not in (name_col, geom_col)
-        }
-        features.append(
-            ParsedFeature(
-                name=name,
-                geometry=json.dumps(mapping(geom)),
-                properties=properties or None,
-            )
-        )
+    except csv.Error as exc:
+        # csv.Error is not a ValueError, so an unhandled one would escape the
+        # router's UploadValidationError handler as a 500.
+        errors.append(f"row {index + 1}: could not read the row ({exc})")
 
     if errors:
         raise UploadValidationError(errors)

--- a/src/api/services/area_upload.py
+++ b/src/api/services/area_upload.py
@@ -1,0 +1,228 @@
+"""Parse uploaded area files into features for ``custom_areas`` rows.
+
+An upload creates one custom area per feature, so this module's output is a
+list of ``ParsedFeature``: a name, one GeoJSON geometry string ready for the
+``custom_areas.geometries`` list, and the remaining attributes as properties.
+
+Validation is all-or-nothing. Every invalid row is collected into one
+``UploadValidationError``, indexed by data-row number, and nothing is created.
+"""
+
+import csv
+import datetime
+import io
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import shapely.wkt
+from shapely.errors import ShapelyError
+from shapely.geometry import mapping
+
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+MAX_FEATURES = 500
+
+_AREAL_TYPES = ("Polygon", "MultiPolygon")
+
+
+@dataclass(frozen=True)
+class ParsedFeature:
+    name: str
+    geometry: str  # GeoJSON string of one Polygon or MultiPolygon.
+    properties: Optional[dict]
+
+
+class UploadValidationError(ValueError):
+    """Invalid upload content. ``errors`` holds row-indexed messages."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def _require_column(fieldnames: Sequence[str], wanted: str) -> str:
+    """Return the one header matching *wanted* case-insensitively."""
+    matches = [
+        f for f in fieldnames if f is not None and f.strip().lower() == wanted
+    ]
+    if not matches:
+        raise UploadValidationError([f"missing required column: {wanted}"])
+    if len(matches) > 1:
+        raise UploadValidationError([f"duplicate column: {wanted}"])
+    return matches[0]
+
+
+def _validate_geometry(wkt_value: str):
+    """Parse WKT into a non-empty areal WGS84 geometry, or raise ValueError."""
+    try:
+        geom = shapely.wkt.loads(wkt_value)
+    except (ShapelyError, ValueError, TypeError) as exc:
+        raise ValueError(f"invalid WKT ({exc})")
+    _check_geometry(geom)
+    return geom
+
+
+def _check_geometry(geom) -> None:
+    """Require a non-empty areal WGS84 geometry, or raise ValueError."""
+    if geom.geom_type not in _AREAL_TYPES:
+        raise ValueError(
+            f"geometry must be a Polygon or MultiPolygon, got {geom.geom_type}"
+        )
+    if geom.is_empty:
+        raise ValueError("geometry is empty")
+    minx, miny, maxx, maxy = geom.bounds
+    if minx < -180 or maxx > 180 or miny < -90 or maxy > 90:
+        raise ValueError(
+            "coordinates out of range; geom must be WGS84 lon/lat degrees"
+        )
+
+
+def parse_csv(data: bytes) -> list[ParsedFeature]:
+    """Parse a CSV upload.
+
+    Required columns (case-insensitive): ``name``, and ``geom`` holding WKT
+    ``POLYGON``/``MULTIPOLYGON`` in WGS84 lon/lat. Every other column goes into
+    the feature's properties as a string. Row numbers in errors count data rows
+    from 1, excluding the header.
+    """
+    try:
+        text = data.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise UploadValidationError(["file is not valid UTF-8"])
+
+    reader = csv.DictReader(io.StringIO(text))
+    if not reader.fieldnames:
+        raise UploadValidationError(["file is empty"])
+    name_col = _require_column(reader.fieldnames, "name")
+    geom_col = _require_column(reader.fieldnames, "geom")
+
+    features: list[ParsedFeature] = []
+    errors: list[str] = []
+    for index, row in enumerate(reader, start=1):
+        if index > MAX_FEATURES:
+            raise UploadValidationError(
+                [f"too many rows; the limit is {MAX_FEATURES}"]
+            )
+        name = (row.get(name_col) or "").strip()
+        if not name:
+            errors.append(f"row {index}: name is empty")
+        geom = None
+        wkt_value = (row.get(geom_col) or "").strip()
+        if not wkt_value:
+            errors.append(f"row {index}: geom is empty")
+        else:
+            try:
+                geom = _validate_geometry(wkt_value)
+            except ValueError as exc:
+                errors.append(f"row {index}: {exc}")
+        if errors or geom is None:
+            continue
+        properties = {
+            k: v
+            for k, v in row.items()
+            if k is not None and k not in (name_col, geom_col)
+        }
+        features.append(
+            ParsedFeature(
+                name=name,
+                geometry=json.dumps(mapping(geom)),
+                properties=properties or None,
+            )
+        )
+
+    if errors:
+        raise UploadValidationError(errors)
+    if not features:
+        raise UploadValidationError(["file has no data rows"])
+    return features
+
+
+def _to_jsonable(value):
+    """Coerce a shapefile attribute value to a JSON-storable value."""
+    import numpy
+    import pandas
+
+    if value is None or pandas.isna(value):
+        return None
+    if isinstance(value, numpy.generic):
+        value = value.item()
+    if isinstance(value, (pandas.Timestamp, datetime.date)):
+        return value.isoformat()
+    if isinstance(value, (str, bool, int, float)):
+        return value
+    return str(value)
+
+
+def parse_shapefile_zip(data: bytes) -> list[ParsedFeature]:
+    """Parse a zipped-shapefile upload.
+
+    Required attribute (case-insensitive): ``name``. The zip must include the
+    ``.prj``; geometries are reprojected to WGS84 and must be ``Polygon`` or
+    ``MultiPolygon``. Every other attribute goes into the feature's
+    properties, coerced to JSON. Row numbers in errors count features from 1.
+    """
+    import geopandas  # Deferred: keeps the API import path light.
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "upload.zip")
+        with open(path, "wb") as handle:
+            handle.write(data)
+        try:
+            gdf = geopandas.read_file(path)
+        except Exception as exc:
+            raise UploadValidationError(
+                [f"could not read the shapefile: {exc}"]
+            )
+
+    if "geometry" not in gdf.columns:
+        raise UploadValidationError(["shapefile has no geometry"])
+    if gdf.crs is None:
+        raise UploadValidationError(
+            ["shapefile has no .prj, so the CRS is unknown; include the .prj"]
+        )
+    if len(gdf) == 0:
+        raise UploadValidationError(["shapefile has no features"])
+    if len(gdf) > MAX_FEATURES:
+        raise UploadValidationError(
+            [f"too many features; the limit is {MAX_FEATURES}"]
+        )
+    gdf = gdf.to_crs(4326)
+    name_col = _require_column(
+        [c for c in gdf.columns if c != "geometry"], "name"
+    )
+
+    features: list[ParsedFeature] = []
+    errors: list[str] = []
+    for index, (_, row) in enumerate(gdf.iterrows(), start=1):
+        name_value = _to_jsonable(row[name_col])
+        name = str(name_value).strip() if name_value is not None else ""
+        if not name:
+            errors.append(f"feature {index}: name is empty")
+        geom = row.geometry
+        try:
+            if geom is None:
+                raise ValueError("geometry is missing")
+            _check_geometry(geom)
+        except ValueError as exc:
+            errors.append(f"feature {index}: {exc}")
+            continue
+        if errors:
+            continue
+        properties = {
+            col: _to_jsonable(row[col])
+            for col in gdf.columns
+            if col not in (name_col, "geometry")
+        }
+        features.append(
+            ParsedFeature(
+                name=name,
+                geometry=json.dumps(mapping(geom)),
+                properties=properties or None,
+            )
+        )
+
+    if errors:
+        raise UploadValidationError(errors)
+    return features

--- a/src/api/services/area_upload.py
+++ b/src/api/services/area_upload.py
@@ -14,6 +14,7 @@ import io
 import json
 import os
 import tempfile
+import zipfile
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
@@ -23,6 +24,10 @@ from shapely.geometry import mapping
 
 MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 MAX_FEATURES = 500
+# A zip is read in full before the feature cap applies, so the compressed size
+# alone does not bound the work. 20x the upload cap leaves room for the sidecar
+# files, which compress well, without admitting a gigabyte expansion.
+MAX_UNCOMPRESSED_BYTES = 20 * MAX_UPLOAD_BYTES
 
 # csv defaults to a 131072-char field, which one WKT polygon of a few thousand
 # vertices exceeds. Raise it to the upload cap, so file size is the only limit.
@@ -164,6 +169,27 @@ def _to_jsonable(value):
     return str(value)
 
 
+def _check_uncompressed_size(data: bytes) -> None:
+    """Reject a zip whose members expand past ``MAX_UNCOMPRESSED_BYTES``.
+
+    This trusts the sizes in the zip's own headers, which a crafted archive can
+    understate. GDAL does the real decompression, so bounding it exactly would
+    mean decompressing twice; the header check stops an honest oversized file.
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            total = sum(info.file_size for info in archive.infolist())
+    except zipfile.BadZipFile as exc:
+        raise UploadValidationError([f"could not read the zip file: {exc}"])
+    if total > MAX_UNCOMPRESSED_BYTES:
+        raise UploadValidationError(
+            [
+                f"zip contents expand to {total // (1024 * 1024)} MB; "
+                f"the limit is {MAX_UNCOMPRESSED_BYTES // (1024 * 1024)} MB"
+            ]
+        )
+
+
 def parse_shapefile_zip(data: bytes) -> list[ParsedFeature]:
     """Parse a zipped-shapefile upload.
 
@@ -173,6 +199,8 @@ def parse_shapefile_zip(data: bytes) -> list[ParsedFeature]:
     properties, coerced to JSON. Row numbers in errors count features from 1.
     """
     import geopandas  # Deferred: keeps the API import path light.
+
+    _check_uncompressed_size(data)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         path = os.path.join(tmpdir, "upload.zip")
@@ -197,7 +225,14 @@ def parse_shapefile_zip(data: bytes) -> list[ParsedFeature]:
         raise UploadValidationError(
             [f"too many features; the limit is {MAX_FEATURES}"]
         )
-    gdf = gdf.to_crs(4326)
+    try:
+        gdf = gdf.to_crs(4326)
+    except Exception as exc:
+        # A local or engineering CRS, or a transform needing a PROJ grid that
+        # is not installed, raises out of pyproj rather than as a ValueError.
+        raise UploadValidationError(
+            [f"could not reproject the shapefile to WGS84: {exc}"]
+        )
     name_col = _require_column(
         [c for c in gdf.columns if c != "geometry"], "name"
     )

--- a/src/api/services/area_upload.py
+++ b/src/api/services/area_upload.py
@@ -35,6 +35,12 @@ csv.field_size_limit(MAX_UPLOAD_BYTES)
 
 _AREAL_TYPES = ("Polygon", "MultiPolygon")
 
+# Reprojecting to WGS84 can land a coordinate a hair outside the valid range —
+# 180.0000001 for a file that was correct. This slack covers our own float drift
+# and stays far below the thousands a genuinely projected coordinate is off by.
+# The CSV path takes the user's numbers as given and gets no slack.
+_REPROJECTION_TOLERANCE = 1e-6
+
 
 @dataclass(frozen=True)
 class ParsedFeature:
@@ -73,8 +79,12 @@ def _validate_geometry(wkt_value: str):
     return geom
 
 
-def _check_geometry(geom) -> None:
-    """Require a non-empty areal WGS84 geometry, or raise ValueError."""
+def _check_geometry(geom, tolerance: float = 0.0) -> None:
+    """Require a non-empty areal WGS84 geometry, or raise ValueError.
+
+    *tolerance* widens the coordinate bounds, for geometries this module
+    reprojected itself.
+    """
     if geom.geom_type not in _AREAL_TYPES:
         raise ValueError(
             f"geometry must be a Polygon or MultiPolygon, got {geom.geom_type}"
@@ -82,7 +92,12 @@ def _check_geometry(geom) -> None:
     if geom.is_empty:
         raise ValueError("geometry is empty")
     minx, miny, maxx, maxy = geom.bounds
-    if minx < -180 or maxx > 180 or miny < -90 or maxy > 90:
+    if (
+        minx < -180 - tolerance
+        or maxx > 180 + tolerance
+        or miny < -90 - tolerance
+        or maxy > 90 + tolerance
+    ):
         raise ValueError(
             "coordinates out of range; geom must be WGS84 lon/lat degrees"
         )
@@ -179,7 +194,9 @@ def _check_uncompressed_size(data: bytes) -> None:
     try:
         with zipfile.ZipFile(io.BytesIO(data)) as archive:
             total = sum(info.file_size for info in archive.infolist())
-    except zipfile.BadZipFile as exc:
+    except Exception as exc:
+        # A truncated or crafted archive raises OSError/ValueError as readily as
+        # BadZipFile, and any of them would escape the router's handler as a 500.
         raise UploadValidationError([f"could not read the zip file: {exc}"])
     if total > MAX_UNCOMPRESSED_BYTES:
         raise UploadValidationError(
@@ -248,7 +265,7 @@ def parse_shapefile_zip(data: bytes) -> list[ParsedFeature]:
         try:
             if geom is None:
                 raise ValueError("geometry is missing")
-            _check_geometry(geom)
+            _check_geometry(geom, tolerance=_REPROJECTION_TOLERANCE)
         except ValueError as exc:
             errors.append(f"feature {index}: {exc}")
             continue

--- a/tests/api/test_aoi_sync.py
+++ b/tests/api/test_aoi_sync.py
@@ -10,7 +10,10 @@ must not change.
 import pytest
 from sqlalchemy import text
 
-from src.api.services.aoi_sync import prune_orphan_custom_aois
+from src.api.services.aoi_sync import (
+    prune_orphan_custom_aois,
+    upsert_custom_aoi,
+)
 from tests.conftest import async_session_maker, seed_reference_aoi
 
 AUTH = {"Authorization": "Bearer abc123"}
@@ -245,6 +248,68 @@ async def test_mirror_is_scoped_to_the_created_area(
     assert second_links[0]["user_id"] == "test-user-ds"
     assert first_aoi["created_by"] == "test-user-wri"
     assert second_aoi["created_by"] == "test-user-ds"
+
+
+# ---------------------------------------------------------------------------
+# properties: projected into aois.properties
+# ---------------------------------------------------------------------------
+
+
+async def _set_properties(area_id, properties):
+    """Set ``custom_areas.properties`` directly and re-run the mirror.
+
+    The create API does not accept properties; the upload endpoint sets them.
+    This drives the same upsert SQL that endpoint runs.
+    """
+    async with async_session_maker() as session:
+        await session.execute(
+            text(
+                "UPDATE custom_areas SET properties = CAST(:props AS jsonb) "
+                "WHERE id::text = :id"
+            ),
+            {"props": properties, "id": area_id},
+        )
+        await upsert_custom_aoi(session, area_id=area_id)
+        await session.commit()
+
+
+async def _fetch_properties(area_id):
+    async with async_session_maker() as session:
+        return await session.scalar(
+            text(
+                "SELECT properties FROM aois "
+                "WHERE source = 'custom' AND source_id = :src_id"
+            ),
+            {"src_id": area_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_properties_mirrored_on_update(auth_override, client):
+    """The DO UPDATE branch projects properties over the existing row."""
+    auth_override("test-user-wri")
+    area_id = await _create_area(client, "With Properties")
+    assert await _fetch_properties(area_id) is None
+
+    await _set_properties(area_id, '{"region": "Kivu", "code": 7}')
+
+    assert await _fetch_properties(area_id) == {"region": "Kivu", "code": 7}
+
+
+@pytest.mark.asyncio
+async def test_null_properties_stays_null(auth_override, client):
+    """A drawn area has no properties, and the mirror must keep the null."""
+    auth_override("test-user-wri")
+    area_id = await _create_area(client, "Drawn")
+
+    res = await client.patch(
+        f"/api/custom_areas/{area_id}",
+        json={"name": "Still Drawn"},
+        headers=AUTH,
+    )
+    assert res.status_code == 200, res.text
+
+    assert await _fetch_properties(area_id) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_aoi_sync.py
+++ b/tests/api/test_aoi_sync.py
@@ -7,9 +7,12 @@ not assert the CRUD response bodies, which ``test_custom_area.py`` covers and wh
 must not change.
 """
 
+from uuid import UUID
+
 import pytest
 from sqlalchemy import text
 
+from src.api.services import aoi_sync
 from src.api.services.aoi_sync import (
     prune_orphan_custom_aois,
     upsert_custom_aoi,
@@ -200,6 +203,33 @@ async def test_degenerate_geometry_skipped_but_crud_succeeds(
     aoi, links = await _fetch_aoi(area_id)
     assert aoi is None
     assert links == []
+
+
+@pytest.mark.asyncio
+async def test_batch_warning_names_only_the_skipped_areas(
+    auth_override, client, monkeypatch
+):
+    """A batch of 500 must not log 500 ids to report the one it dropped."""
+    auth_override("test-user-wri")
+    good_id = await _create_area(client, "Good")
+    bad_id = await _create_area(client, "Degenerate", [_DEGENERATE])
+
+    warnings = []
+    monkeypatch.setattr(
+        aoi_sync.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(kwargs),
+    )
+
+    async with async_session_maker() as session:
+        await upsert_custom_aoi(
+            session, area_ids=[UUID(good_id), UUID(bad_id)]
+        )
+        await session.commit()
+
+    assert len(warnings) == 1
+    assert warnings[0]["skipped"] == 1
+    assert warnings[0]["skipped_area_ids"] == [bad_id]
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_area_upload.py
+++ b/tests/api/test_area_upload.py
@@ -301,8 +301,12 @@ async def test_upload_rejects_oversize_file(auth_override, client):
 # ---------------------------------------------------------------------------
 
 
-def _shapefile_zip(gdf, drop_prj=False):
-    """Write *gdf* to a shapefile in a temp dir and zip every sidecar file."""
+def _shapefile_zip(gdf, drop_prj=False, prj_text=None):
+    """Write *gdf* to a shapefile in a temp dir and zip every sidecar file.
+
+    *prj_text* replaces the generated ``.prj``, which is how a file with a CRS
+    that cannot be reprojected is built.
+    """
     import os
     import tempfile
     import zipfile
@@ -312,10 +316,20 @@ def _shapefile_zip(gdf, drop_prj=False):
         gdf.to_file(os.path.join(tmpdir, "areas.shp"))
         if drop_prj:
             os.remove(os.path.join(tmpdir, "areas.prj"))
+        elif prj_text is not None:
+            with open(os.path.join(tmpdir, "areas.prj"), "w") as handle:
+                handle.write(prj_text)
         with zipfile.ZipFile(buf, "w") as archive:
             for entry in sorted(os.listdir(tmpdir)):
                 archive.write(os.path.join(tmpdir, entry), entry)
     return buf.getvalue()
+
+
+# An engineering CRS: pyproj reads it, but it has no path to WGS84.
+_LOCAL_CRS_PRJ = (
+    'LOCAL_CS["Engineering CRS",LOCAL_DATUM["Local Datum",0],'
+    'UNIT["metre",1.0],AXIS["X",EAST],AXIS["Y",NORTH]]'
+)
 
 
 def _square(minx, miny):
@@ -425,6 +439,55 @@ async def test_shapefile_projected_crs_is_reprojected(auth_override, client):
         )
     assert bbox[0] == pytest.approx(30, abs=1e-6)
     assert bbox[1] == pytest.approx(10, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_shapefile_unprojectable_crs_is_a_422(auth_override, client):
+    """A CRS with no path to WGS84 is reported, not raised as a 500."""
+    import geopandas as gpd
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {"name": ["Local"], "geometry": [_square(30, 10)]},
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(
+        client, _shapefile_zip(gdf, prj_text=_LOCAL_CRS_PRJ)
+    )
+    assert res.status_code == 422
+    assert "could not reproject" in res.json()["detail"]["errors"][0]
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_shapefile_zip_expansion_capped(
+    auth_override, client, monkeypatch
+):
+    """A zip is rejected on its uncompressed size, before GDAL reads it."""
+    import geopandas as gpd
+
+    from src.api.services import area_upload
+
+    auth_override("test-user-wri")
+    monkeypatch.setattr(area_upload, "MAX_UNCOMPRESSED_BYTES", 64)
+    gdf = gpd.GeoDataFrame(
+        {"name": ["Shape"], "geometry": [_square(30, 10)]},
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(client, _shapefile_zip(gdf))
+    assert res.status_code == 422
+    assert "expand to" in res.json()["detail"]["errors"][0]
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_upload_zip_that_is_not_a_zip(auth_override, client):
+    auth_override("test-user-wri")
+    res = await _upload_zip(client, b"not a zip file at all")
+    assert res.status_code == 422
+    assert "could not read the zip file" in res.json()["detail"]["errors"][0]
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_area_upload.py
+++ b/tests/api/test_area_upload.py
@@ -1,0 +1,464 @@
+"""Tests for ``POST /api/custom_areas/upload`` with a CSV file.
+
+Each uploaded feature becomes a regular custom area, so these tests assert the
+whole chain: the ``custom_areas`` rows, the shared ``upload_batch_id``, the
+mirror into ``aois``, search through ``GET /api/aois``, and owner scoping.
+"""
+
+import csv
+import io
+
+import pytest
+from sqlalchemy import text
+
+from src.api.services.area_upload import MAX_FEATURES, MAX_UPLOAD_BYTES
+from tests.conftest import async_session_maker
+
+AUTH = {"Authorization": "Bearer abc123"}
+
+_SQUARE = "POLYGON ((30 10, 30 11, 31 11, 31 10, 30 10))"
+_MULTI = "MULTIPOLYGON (((5 5, 5 6, 6 6, 6 5, 5 5)))"
+
+
+def _csv(rows, header=("name", "geom")):
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(header)
+    writer.writerows(rows)
+    return buf.getvalue().encode()
+
+
+async def _upload(client, content, filename="areas.csv"):
+    return await client.post(
+        "/api/custom_areas/upload",
+        files={"file": (filename, content, "text/csv")},
+        headers=AUTH,
+    )
+
+
+async def _counts():
+    async with async_session_maker() as session:
+        areas = await session.scalar(text("SELECT count(*) FROM custom_areas"))
+        aois = await session.scalar(
+            text("SELECT count(*) FROM aois WHERE source = 'custom'")
+        )
+    return areas, aois
+
+
+@pytest.mark.asyncio
+async def test_upload_creates_areas_and_mirrors(
+    auth_override, client, user_ds
+):
+    auth_override("test-user-wri")
+    content = _csv(
+        [
+            ("Upland North", _SQUARE, "Kivu", "7"),
+            ("Upland South", _MULTI, "Ituri", ""),
+        ],
+        header=("name", "geom", "region", "code"),
+    )
+
+    res = await _upload(client, content)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["upload_batch_id"]
+    assert [a["name"] for a in body["areas"]] == [
+        "Upland North",
+        "Upland South",
+    ]
+
+    # The rows are regular custom areas, newest first in the list.
+    res = await client.get("/api/custom_areas", headers=AUTH)
+    listed = res.json()
+    assert len(listed) == 2
+    by_name = {a["name"]: a for a in listed}
+    assert (
+        by_name["Upland North"]["upload_batch_id"] == (body["upload_batch_id"])
+    )
+    assert (
+        by_name["Upland South"]["upload_batch_id"] == (body["upload_batch_id"])
+    )
+    assert by_name["Upland North"]["properties"] == {
+        "region": "Kivu",
+        "code": "7",
+    }
+    assert by_name["Upland North"]["geometries"][0]["type"] == "Polygon"
+    assert by_name["Upland South"]["geometries"][0]["type"] == "MultiPolygon"
+
+    # The mirror projects each row, with its properties.
+    async with async_session_maker() as session:
+        rows = (
+            (
+                await session.execute(
+                    text(
+                        "SELECT name, properties, "
+                        "ST_GeometryType(geometry) AS gtype "
+                        "FROM aois WHERE source = 'custom' ORDER BY name"
+                    )
+                )
+            )
+            .mappings()
+            .all()
+        )
+    assert [r["name"] for r in rows] == ["Upland North", "Upland South"]
+    assert rows[0]["properties"] == {"region": "Kivu", "code": "7"}
+    assert all(r["gtype"] == "ST_MultiPolygon" for r in rows)
+
+    # The owner finds the areas through search; another user does not.
+    res = await client.get("/api/aois?name=Upland&source=custom", headers=AUTH)
+    assert {r["name"] for r in res.json()} == {
+        "Upland North",
+        "Upland South",
+    }
+
+    auth_override("test-user-ds")
+    res = await client.get("/api/aois?name=Upland&source=custom", headers=AUTH)
+    assert res.json() == []
+    res = await client.get("/api/custom_areas", headers=AUTH)
+    assert res.json() == []
+
+
+@pytest.mark.asyncio
+async def test_drawn_area_has_no_batch_id(auth_override, client):
+    auth_override("test-user-wri")
+    res = await client.post(
+        "/api/custom_areas",
+        json={
+            "name": "Drawn",
+            "geometries": [
+                {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                }
+            ],
+        },
+        headers=AUTH,
+    )
+    assert res.status_code == 200, res.text
+
+    res = await client.get("/api/custom_areas", headers=AUTH)
+    assert res.json()[0]["upload_batch_id"] is None
+    assert res.json()[0]["properties"] is None
+
+
+@pytest.mark.asyncio
+async def test_upload_missing_geom_column(auth_override, client):
+    auth_override("test-user-wri")
+    res = await _upload(client, _csv([("Area", "x")], header=("name", "wkt")))
+    assert res.status_code == 422
+    assert res.json()["detail"]["errors"] == ["missing required column: geom"]
+
+
+@pytest.mark.asyncio
+async def test_upload_uppercase_headers_accepted(auth_override, client):
+    auth_override("test-user-wri")
+    res = await _upload(
+        client, _csv([("Area", _SQUARE)], header=("NAME", "GEOM"))
+    )
+    assert res.status_code == 200, res.text
+
+
+@pytest.mark.asyncio
+async def test_upload_bad_rows_report_each_and_create_nothing(
+    auth_override, client
+):
+    auth_override("test-user-wri")
+    content = _csv(
+        [
+            ("Bad WKT", "POLYGON((oops"),
+            ("A Point", "POINT (30 10)"),
+            ("", _SQUARE),
+            ("Good", _SQUARE),
+        ]
+    )
+
+    res = await _upload(client, content)
+    assert res.status_code == 422
+    errors = res.json()["detail"]["errors"]
+    assert len(errors) == 3
+    assert errors[0].startswith("row 1: invalid WKT")
+    assert errors[1] == (
+        "row 2: geometry must be a Polygon or MultiPolygon, got Point"
+    )
+    assert errors[2] == "row 3: name is empty"
+
+    # All-or-nothing: the good row must not survive the bad ones.
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_upload_projected_coordinates_rejected(auth_override, client):
+    auth_override("test-user-wri")
+    projected = (
+        "POLYGON ((500000 4649776, 500000 4650776, "
+        "501000 4650776, 500000 4649776))"
+    )
+    res = await _upload(client, _csv([("Projected", projected)]))
+    assert res.status_code == 422
+    assert "WGS84" in res.json()["detail"]["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_upload_empty_and_header_only_files(auth_override, client):
+    auth_override("test-user-wri")
+    res = await _upload(client, b"")
+    assert res.status_code == 422
+    assert res.json()["detail"]["errors"] == ["file is empty"]
+
+    res = await _upload(client, _csv([]))
+    assert res.status_code == 422
+    assert res.json()["detail"]["errors"] == ["file has no data rows"]
+
+
+@pytest.mark.asyncio
+async def test_upload_too_many_rows(auth_override, client):
+    auth_override("test-user-wri")
+    rows = [(f"Area {i}", _SQUARE) for i in range(MAX_FEATURES + 1)]
+    res = await _upload(client, _csv(rows))
+    assert res.status_code == 422
+    assert "limit is" in res.json()["detail"]["errors"][0]
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_unsupported_extension(auth_override, client):
+    auth_override("test-user-wri")
+    res = await _upload(client, _csv([("Area", _SQUARE)]), "areas.txt")
+    assert res.status_code == 415
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_oversize_file(auth_override, client):
+    auth_override("test-user-wri")
+    res = await _upload(client, b"a" * (MAX_UPLOAD_BYTES + 1))
+    assert res.status_code == 413
+    assert await _counts() == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Zipped shapefile uploads
+# ---------------------------------------------------------------------------
+
+
+def _shapefile_zip(gdf, drop_prj=False):
+    """Write *gdf* to a shapefile in a temp dir and zip every sidecar file."""
+    import os
+    import tempfile
+    import zipfile
+
+    buf = io.BytesIO()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gdf.to_file(os.path.join(tmpdir, "areas.shp"))
+        if drop_prj:
+            os.remove(os.path.join(tmpdir, "areas.prj"))
+        with zipfile.ZipFile(buf, "w") as archive:
+            for entry in sorted(os.listdir(tmpdir)):
+                archive.write(os.path.join(tmpdir, entry), entry)
+    return buf.getvalue()
+
+
+def _square(minx, miny):
+    from shapely.geometry import Polygon
+
+    return Polygon(
+        [
+            (minx, miny),
+            (minx, miny + 1),
+            (minx + 1, miny + 1),
+            (minx + 1, miny),
+        ]
+    )
+
+
+async def _upload_zip(client, content, filename="areas.zip"):
+    return await client.post(
+        "/api/custom_areas/upload",
+        files={"file": (filename, content, "application/zip")},
+        headers=AUTH,
+    )
+
+
+@pytest.mark.asyncio
+async def test_shapefile_upload_creates_areas_and_mirrors(
+    auth_override, client
+):
+    import geopandas as gpd
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["Shape North", "Shape South"],
+            "region": ["Kivu", "Ituri"],
+            "geometry": [_square(30, 10), _square(5, 5)],
+        },
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(client, _shapefile_zip(gdf))
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert [a["name"] for a in body["areas"]] == [
+        "Shape North",
+        "Shape South",
+    ]
+
+    res = await client.get("/api/custom_areas", headers=AUTH)
+    by_name = {a["name"]: a for a in res.json()}
+    assert len(by_name) == 2
+    assert by_name["Shape North"]["properties"] == {"region": "Kivu"}
+    assert (
+        by_name["Shape North"]["upload_batch_id"] == (body["upload_batch_id"])
+    )
+
+    assert await _counts() == (2, 2)
+
+
+@pytest.mark.asyncio
+async def test_shapefile_uppercase_name_field(auth_override, client):
+    import geopandas as gpd
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {"NAME": ["Upper"], "geometry": [_square(30, 10)]},
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(client, _shapefile_zip(gdf))
+    assert res.status_code == 200, res.text
+    assert res.json()["areas"][0]["name"] == "Upper"
+
+
+@pytest.mark.asyncio
+async def test_shapefile_missing_prj(auth_override, client):
+    import geopandas as gpd
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {"name": ["No CRS"], "geometry": [_square(30, 10)]},
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(client, _shapefile_zip(gdf, drop_prj=True))
+    assert res.status_code == 422
+    assert ".prj" in res.json()["detail"]["errors"][0]
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_shapefile_projected_crs_is_reprojected(auth_override, client):
+    import geopandas as gpd
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {"name": ["Projected"], "geometry": [_square(30, 10)]},
+        crs="EPSG:4326",
+    ).to_crs("EPSG:3857")
+
+    res = await _upload_zip(client, _shapefile_zip(gdf))
+    assert res.status_code == 200, res.text
+
+    # The mirror must hold lon/lat again, not Web Mercator meters.
+    async with async_session_maker() as session:
+        bbox = await session.scalar(
+            text("SELECT bbox FROM aois WHERE source = 'custom'")
+        )
+    assert bbox[0] == pytest.approx(30, abs=1e-6)
+    assert bbox[1] == pytest.approx(10, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_shapefile_point_geometry_rejected(auth_override, client):
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {"name": ["A Point"], "geometry": [Point(30, 10)]},
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(client, _shapefile_zip(gdf))
+    assert res.status_code == 422
+    errors = res.json()["detail"]["errors"]
+    assert errors[0] == (
+        "feature 1: geometry must be a Polygon or MultiPolygon, got Point"
+    )
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_shapefile_attributes_sanitized_to_json(auth_override, client):
+    import datetime
+
+    import geopandas as gpd
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": ["First", "Second"],
+            "code": [7.0, None],
+            "when": [datetime.date(2026, 1, 15), datetime.date(2026, 2, 2)],
+            "geometry": [_square(30, 10), _square(5, 5)],
+        },
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(client, _shapefile_zip(gdf))
+    assert res.status_code == 200, res.text
+
+    res = await client.get("/api/custom_areas", headers=AUTH)
+    by_name = {a["name"]: a for a in res.json()}
+    assert by_name["First"]["properties"]["code"] == 7.0
+    assert by_name["Second"]["properties"]["code"] is None
+    assert by_name["First"]["properties"]["when"].startswith("2026-01-15")
+
+
+@pytest.mark.asyncio
+async def test_shapefile_empty_name_rejected(auth_override, client):
+    import geopandas as gpd
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {"name": [None], "geometry": [_square(30, 10)]},
+        crs="EPSG:4326",
+    )
+
+    res = await _upload_zip(client, _shapefile_zip(gdf))
+    assert res.status_code == 422
+    assert res.json()["detail"]["errors"] == ["feature 1: name is empty"]
+
+
+@pytest.mark.asyncio
+async def test_zip_without_a_shapefile(auth_override, client):
+    import zipfile
+
+    auth_override("test-user-wri")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("readme.txt", "not a shapefile")
+
+    res = await _upload_zip(client, buf.getvalue())
+    assert res.status_code == 422
+    assert "could not read" in res.json()["detail"]["errors"][0]
+
+
+def test_shapefile_feature_cap():
+    import geopandas as gpd
+
+    from src.api.services.area_upload import (
+        UploadValidationError,
+        parse_shapefile_zip,
+    )
+
+    count = MAX_FEATURES + 1
+    gdf = gpd.GeoDataFrame(
+        {
+            "name": [f"Area {i}" for i in range(count)],
+            "geometry": [_square(i % 100, i % 50) for i in range(count)],
+        },
+        crs="EPSG:4326",
+    )
+
+    with pytest.raises(UploadValidationError) as excinfo:
+        parse_shapefile_zip(_shapefile_zip(gdf))
+    assert "limit is" in excinfo.value.errors[0]

--- a/tests/api/test_area_upload.py
+++ b/tests/api/test_area_upload.py
@@ -7,6 +7,7 @@ mirror into ``aois``, search through ``GET /api/aois``, and owner scoping.
 
 import csv
 import io
+import math
 
 import pytest
 from sqlalchemy import text
@@ -18,6 +19,22 @@ AUTH = {"Authorization": "Bearer abc123"}
 
 _SQUARE = "POLYGON ((30 10, 30 11, 31 11, 31 10, 30 10))"
 _MULTI = "MULTIPOLYGON (((5 5, 5 6, 6 6, 6 5, 5 5)))"
+
+
+def _dense_ring_wkt(vertices=8000):
+    """A circle whose WKT is longer than csv's default field limit.
+
+    An administrative boundary of a few thousand vertices is ordinary, and its
+    WKT runs past the 131072-char default that ``parse_csv`` has to raise.
+    """
+    step = 2 * math.pi / vertices
+    points = [
+        f"{30 + 0.5 * math.cos(i * step):.10f} "
+        f"{10 + 0.5 * math.sin(i * step):.10f}"
+        for i in range(vertices)
+    ]
+    points.append(points[0])
+    return f"POLYGON (({', '.join(points)}))"
 
 
 def _csv(rows, header=("name", "geom")):
@@ -217,6 +234,50 @@ async def test_upload_too_many_rows(auth_override, client):
     res = await _upload(client, _csv(rows))
     assert res.status_code == 422
     assert "limit is" in res.json()["detail"]["errors"][0]
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_upload_too_many_rows_keeps_the_row_errors(
+    auth_override, client
+):
+    """The row cap does not swallow the errors already collected."""
+    auth_override("test-user-wri")
+    rows = [("Bad WKT", "POLYGON((oops")] + [
+        (f"Area {i}", _SQUARE) for i in range(MAX_FEATURES)
+    ]
+    res = await _upload(client, _csv(rows))
+    assert res.status_code == 422
+    errors = res.json()["detail"]["errors"]
+    assert errors[0].startswith("row 1: invalid WKT")
+    assert errors[-1] == f"too many rows; the limit is {MAX_FEATURES}"
+    assert await _counts() == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_upload_accepts_wkt_past_the_csv_field_default(
+    auth_override, client
+):
+    """A dense boundary is accepted; only the file size caps a field."""
+    auth_override("test-user-wri")
+    wkt = _dense_ring_wkt()
+    assert len(wkt) > 131072
+    res = await _upload(client, _csv([("Dense Ring", wkt)]))
+    assert res.status_code == 200, res.text
+    assert await _counts() == (1, 1)
+
+
+@pytest.mark.asyncio
+async def test_upload_csv_read_failure_is_a_422(auth_override, client):
+    """A csv-level read failure is reported, not raised as a 500."""
+    auth_override("test-user-wri")
+    previous = csv.field_size_limit(10)
+    try:
+        res = await _upload(client, _csv([("Area", _SQUARE)]))
+    finally:
+        csv.field_size_limit(previous)
+    assert res.status_code == 422
+    assert "could not read the row" in res.json()["detail"]["errors"][0]
     assert await _counts() == (0, 0)
 
 

--- a/tests/api/test_area_upload.py
+++ b/tests/api/test_area_upload.py
@@ -561,6 +561,81 @@ async def test_upload_zip_that_is_not_a_zip(auth_override, client):
 
 
 @pytest.mark.asyncio
+async def test_shapefile_zip_open_failure_is_a_422(
+    auth_override, client, monkeypatch
+):
+    """A zip that fails to open for any reason is a 422, not a 500.
+
+    ``zipfile`` raises OSError or ValueError on some malformed archives, not
+    only BadZipFile, and the router only converts UploadValidationError.
+    """
+    import geopandas as gpd
+
+    from src.api.services import area_upload
+
+    auth_override("test-user-wri")
+    gdf = gpd.GeoDataFrame(
+        {"name": ["Shape"], "geometry": [_square(30, 10)]},
+        crs="EPSG:4326",
+    )
+    content = _shapefile_zip(gdf)
+
+    def boom(*args, **kwargs):
+        raise OSError("Bad magic number for central directory")
+
+    monkeypatch.setattr(area_upload.zipfile, "ZipFile", boom)
+    res = await _upload_zip(client, content)
+    assert res.status_code == 422, res.text
+    assert "could not read the zip file" in res.json()["detail"]["errors"][0]
+    assert await _counts() == (0, 0)
+
+
+def test_reprojection_drift_past_the_antimeridian_is_accepted():
+    """Our own float drift must not read as a projected coordinate.
+
+    A polygon touching 180 can reproject to 180.0000001, which the bounds
+    check would otherwise reject with "geom must be WGS84 lon/lat degrees".
+    """
+    from shapely.geometry import Polygon
+
+    from src.api.services.area_upload import (
+        _REPROJECTION_TOLERANCE,
+        _check_geometry,
+    )
+
+    drift = _REPROJECTION_TOLERANCE / 2
+    nudged = Polygon(
+        [
+            (179.9, 10.0),
+            (179.9, 11.0),
+            (180.0 + drift, 11.0),
+            (180.0 + drift, 10.0),
+        ]
+    )
+    # Tolerated for a geometry we reprojected...
+    _check_geometry(nudged, tolerance=_REPROJECTION_TOLERANCE)
+    # ...but the CSV path, which takes the user's own numbers, still rejects it.
+    with pytest.raises(ValueError, match="coordinates out of range"):
+        _check_geometry(nudged)
+
+
+def test_projected_shapefile_coordinates_still_rejected():
+    """The tolerance must not admit genuinely projected coordinates."""
+    from shapely.geometry import Polygon
+
+    from src.api.services.area_upload import (
+        _REPROJECTION_TOLERANCE,
+        _check_geometry,
+    )
+
+    utm_like = Polygon(
+        [(500000, 4649776), (500000, 4649777), (500001, 4649777)]
+    )
+    with pytest.raises(ValueError, match="coordinates out of range"):
+        _check_geometry(utm_like, tolerance=_REPROJECTION_TOLERANCE)
+
+
+@pytest.mark.asyncio
 async def test_shapefile_point_geometry_rejected(auth_override, client):
     import geopandas as gpd
     from shapely.geometry import Point

--- a/tests/api/test_area_upload.py
+++ b/tests/api/test_area_upload.py
@@ -159,6 +159,76 @@ async def test_drawn_area_has_no_batch_id(auth_override, client):
 
 
 @pytest.mark.asyncio
+async def test_item_endpoints_return_properties_and_batch_id(
+    auth_override, client
+):
+    """GET-by-id and PATCH must carry the upload fields, as the list does.
+
+    Both build their response by hand rather than serializing the row, so they
+    are the two places a new column silently reads back as null. A client that
+    stores the PATCH response would otherwise lose both fields on a rename.
+    """
+    auth_override("test-user-wri")
+    content = _csv(
+        [("Upland North", _SQUARE, "Kivu")],
+        header=("name", "geom", "region"),
+    )
+    res = await _upload(client, content)
+    assert res.status_code == 200, res.text
+    batch_id = res.json()["upload_batch_id"]
+    area_id = res.json()["areas"][0]["id"]
+
+    res = await client.get(f"/api/custom_areas/{area_id}", headers=AUTH)
+    assert res.status_code == 200, res.text
+    assert res.json()["upload_batch_id"] == batch_id
+    assert res.json()["properties"] == {"region": "Kivu"}
+
+    res = await client.patch(
+        f"/api/custom_areas/{area_id}",
+        json={"name": "Renamed"},
+        headers=AUTH,
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["name"] == "Renamed"
+    assert res.json()["upload_batch_id"] == batch_id
+    assert res.json()["properties"] == {"region": "Kivu"}
+
+
+@pytest.mark.asyncio
+async def test_item_endpoints_null_upload_fields_for_drawn_areas(
+    auth_override, client
+):
+    """The same two endpoints report a drawn area's fields as null, not absent."""
+    auth_override("test-user-wri")
+    res = await client.post(
+        "/api/custom_areas",
+        json={
+            "name": "Drawn",
+            "geometries": [
+                {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                }
+            ],
+        },
+        headers=AUTH,
+    )
+    area_id = res.json()["id"]
+
+    res = await client.get(f"/api/custom_areas/{area_id}", headers=AUTH)
+    assert res.json()["upload_batch_id"] is None
+    assert res.json()["properties"] is None
+
+    res = await client.patch(
+        f"/api/custom_areas/{area_id}",
+        json={"name": "Renamed"},
+        headers=AUTH,
+    )
+    assert res.json()["upload_batch_id"] is None
+    assert res.json()["properties"] is None
+
+
+@pytest.mark.asyncio
 async def test_upload_missing_geom_column(auth_override, client):
     auth_override("test-user-wri")
     res = await _upload(client, _csv([("Area", "x")], header=("name", "wkt")))

--- a/tests/api/test_custom_area.py
+++ b/tests/api/test_custom_area.py
@@ -107,3 +107,77 @@ async def test_custom_area_endpoints(auth_override, client):
 
     assert res.status_code == 200
     assert res.json() == []
+
+
+_SQUARE = {
+    "type": "Polygon",
+    "coordinates": [
+        [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]]
+    ],
+}
+
+AUTH = {"Authorization": "Bearer abc123"}
+
+
+async def _create(client, name):
+    res = await client.post(
+        "/api/custom_areas",
+        json={"name": name, "geometries": [_SQUARE]},
+        headers=AUTH,
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_list_paginates_newest_first(auth_override, client):
+    auth_override("test-user-wri")
+    for name in ("First", "Second", "Third", "Fourth", "Fifth"):
+        await _create(client, name)
+
+    res = await client.get("/api/custom_areas?limit=2", headers=AUTH)
+    assert res.status_code == 200, res.text
+    assert [a["name"] for a in res.json()] == ["Fifth", "Fourth"]
+    assert res.headers["X-Next-Offset"] == "2"
+
+    res = await client.get("/api/custom_areas?limit=2&offset=2", headers=AUTH)
+    assert [a["name"] for a in res.json()] == ["Third", "Second"]
+    assert res.headers["X-Next-Offset"] == "4"
+
+    # The last page is short, and it carries no next-offset header.
+    res = await client.get("/api/custom_areas?limit=2&offset=4", headers=AUTH)
+    assert [a["name"] for a in res.json()] == ["First"]
+    assert "X-Next-Offset" not in res.headers
+
+
+@pytest.mark.asyncio
+async def test_list_full_page_without_more_has_no_header(
+    auth_override, client
+):
+    """A page that is exactly full must not promise a next page."""
+    auth_override("test-user-wri")
+    await _create(client, "One")
+    await _create(client, "Two")
+
+    res = await client.get("/api/custom_areas?limit=2", headers=AUTH)
+    assert len(res.json()) == 2
+    assert "X-Next-Offset" not in res.headers
+
+
+@pytest.mark.asyncio
+async def test_list_offset_past_the_end_is_empty(auth_override, client):
+    auth_override("test-user-wri")
+    await _create(client, "Only")
+
+    res = await client.get("/api/custom_areas?offset=5", headers=AUTH)
+    assert res.status_code == 200
+    assert res.json() == []
+    assert "X-Next-Offset" not in res.headers
+
+
+@pytest.mark.asyncio
+async def test_list_rejects_out_of_range_paging(auth_override, client):
+    auth_override("test-user-wri")
+    for query in ("limit=0", "limit=101", "offset=-1"):
+        res = await client.get(f"/api/custom_areas?{query}", headers=AUTH)
+        assert res.status_code == 422, query

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Adds an API endpoint for users to upload CSVs or shapefiles with custom areas. Docs have been added to docs/area-uploads.md, pasting that below - I _think_ the only breaking change to flag is that the Custom Areas endpoint will now be paginated (usage below) -- with users being able to batch upload custom areas, we should not return an unbounded list for custom areas.

This is **not** designed to handle very large uploads - we can tweak the limits a bit but if we do want to support large file uploads, we would need to reconsider the design a bit - likely something like:

  - Use S3 Presigned URLs to upload directly to s3
  - Trigger a background job with the s3 path to handle processing and ingestion
  - Have a way for frontend to poll for progress and report status to the user

I think I'd recommend going ahead with the current design and enforce lower limits (we can tweak what's below a bit if we need) - and if we really do need to support large uploads, handle that as a follow-up.

cc @yellowcap @01painadam 

# Area uploads: CSV & zipped shapefile

`POST /api/custom_areas/upload` creates custom areas from an uploaded CSV or
zipped shapefile, one area per feature. Uploaded areas are ordinary
`custom_areas` rows (`source='custom'`): they are owner-scoped in search,
work with the existing rename/delete endpoints, and are mirrored into `aois`
like drawn areas. Rows from one upload share a generated `upload_batch_id`
(null on drawn areas).

## Design

The AOI architecture plan originally sketched uploads as a new `upload`
source written directly into `aois`. Uploads were implemented as custom areas
instead:

- The existing custom-area CRUD endpoints and frontend list apply unchanged.
- Owner scoping in `search_aois` tests the literal `'custom'` in four places
  (`src/shared/geocoding_helpers.py`); a second user-owned source would have
  to update all four or leak uploaded areas across users.
- The agent, analytics, thumbnail and mosaic paths already handle
  `custom`/`custom-area` and need no new branches.

Costs: two nullable columns on `custom_areas` (migration `e7c1f4a92b58`:
`properties jsonb`, `upload_batch_id uuid`), and geometry stored twice
(GeoJSON in `custom_areas.geometries`, normalized MultiPolygon in the `aois`
mirror), as for drawn areas.

The write is a single transaction: parse and validate the file, insert n
`custom_areas` rows, mirror all n into `aois` with owner links in one
statement (`upsert_custom_aoi(session, area_ids=...)`), commit. The mirror
projects `custom_areas.properties` into `aois.properties`.

## Endpoint

Multipart form, single field `file`, authentication required. The filename
extension selects the parser: `.csv` or `.zip`; anything else returns 415.

```sh
curl -X POST https://…/api/custom_areas/upload \
  -H "Authorization: Bearer $TOKEN" \
  -F "file=@my_areas.csv"     # or my_areas.zip
```

Response — no geometries; refetch the paginated list for full rows:

```json
{
  "upload_batch_id": "0d9c1f4e-…",
  "areas": [
    {"id": "7be2c1aa-…", "name": "Upland North"},
    {"id": "91d40f2b-…", "name": "Upland South"}
  ]
}
```

## File contracts

**CSV** — UTF-8 with a header row. Required columns, matched
case-insensitively:

- `name` — non-empty after trimming.
- `geom` — WKT `POLYGON` or `MULTIPOLYGON` in WGS84 lon/lat degrees.
  Coordinates outside ±180/±90 are rejected (catches projected coordinates).
  A single WKT value is bounded only by the file size cap, so a dense boundary
  of many thousands of vertices is fine.

All other columns are stored per row in `properties`, as strings.

```csv
name,geom,region
Upland North,"POLYGON ((30 10, 30 11, 31 11, 31 10, 30 10))",Kivu
```

**Zipped shapefile** — one zip containing the sidecar set (`.shp`, `.shx`,
`.dbf`, `.prj`). The `.prj` is required; without it the upload is rejected.
Any declared CRS is accepted and reprojected to WGS84 with a real coordinate
transform (not a SRID relabel). A CRS with no path to WGS84 — an engineering or
local CRS, or one needing a PROJ grid that is not installed — is rejected with a
422 rather than a 500. Reprojected coordinates are allowed 1e-6 degrees of slack
past ±180/±90, which covers the transform's own float drift; the CSV path takes
the user's numbers as given and gets none. A `name` attribute is required, matched
case-insensitively (`NAME` works). Geometries must be `Polygon` or
`MultiPolygon`. All other attributes are stored in `properties`, coerced to
JSON: `NaN`/`NaT`/null → `null`, dates and timestamps → ISO-8601 strings,
numbers → numbers, everything else → its string form.

## Limits and errors

Constants in `src/api/services/area_upload.py`:

| Condition | Status | Body |
| --- | --- | --- |
| File over 10 MB (`MAX_UPLOAD_BYTES`) | 413 | `{"detail": "file too large; the limit is 10 MB"}` |
| Over 500 features (`MAX_FEATURES`) | 422 | `{"detail": {"errors": ["too many rows; the limit is 500"]}}` |
| Zip expanding past 200 MB (`MAX_UNCOMPRESSED_BYTES`) | 422 | `{"detail": {"errors": ["zip contents expand to 240 MB; the limit is 200 MB"]}}` |
| Unreadable zip, or a CRS with no path to WGS84 | 422 | `{"detail": {"errors": ["could not reproject the shapefile to WGS84: …"]}}` |
| Invalid content | 422 | `{"detail": {"errors": ["row 3: geom is empty", …]}}` |
| Extension not `.csv`/`.zip` | 415 | `{"detail": "unsupported file type; …"}` |
| Missing/invalid bearer token | 401 | standard auth error |

Validation is all-or-nothing: every problem in the file is collected and
returned together, and nothing is created. Problems belonging to one row are
indexed (`row N` for CSV data rows, `feature N` for shapefile features, counting
from 1); file-level problems, such as the row cap, carry no index.

## Frontend integration

Upload with a progress bar. Upload progress is reported by the browser
against the plain multipart POST; no chunked-upload protocol is involved.
Use axios or XHR — `fetch` cannot report upload progress. Do not set
`Content-Type`; the browser adds the multipart boundary.

```js
const fd = new FormData();
fd.append("file", fileInput.files[0]); // keep the .csv/.zip filename

await axios.post("/api/custom_areas/upload", fd, {
  headers: { Authorization: `Bearer ${token}` },
  onUploadProgress: (e) => setProgress(Math.round((100 * e.loaded) / e.total)),
});
```

Handle the outcomes. On 422, show every entry of `detail.errors` — the file
failed as a whole and nothing was created.

```js
try {
  const { data } = await upload(file);
  // refetch the list; select/zoom via data.areas ids
} catch (err) {
  const res = err.response;
  if (res?.status === 422) showErrors(res.data.detail.errors);
  else if (res?.status === 413 || res?.status === 415) showError(res.data.detail);
  else showError("Upload failed");
}
```

List with pagination. `GET /api/custom_areas` takes `limit` (1–100, default
50) and `offset`, ordered newest first. When another page exists, the
`X-Next-Offset` response header holds the next offset; it is exposed through
CORS. An unparameterized call returns only the first 50 rows — code that
assumed the list returns everything must follow the header.

```js
async function fetchAllAreas() {
  const areas = [];
  let offset = 0;
  while (offset != null) {
    const res = await axios.get("/api/custom_areas", {
      params: { limit: 100, offset },
      headers: { Authorization: `Bearer ${token}` },
    });
    areas.push(...res.data);
    const next = res.headers["x-next-offset"]; // absent on the last page
    offset = next != null ? Number(next) : null;
  }
  return areas;
}
```

Distinguish uploaded from drawn areas by `upload_batch_id`; `properties`
holds the file's extra columns/attributes.

```js
const uploaded = areas.filter((a) => a.upload_batch_id != null);
const byBatch = Map.groupBy(uploaded, (a) => a.upload_batch_id);
```

## Out of scope

- **Delete a whole upload** — straightforward now that the batch id exists;
  add an index on `upload_batch_id` in the same change.
- **GeoJSON / KML** — one more parser in `area_upload.py` returning the same
  `ParsedFeature` list; the write path is format-agnostic.
- **Larger files** — past these caps, switch to presigned-URL upload to
  S3/minio with an async processing job and a status endpoint, rather than
  raising the constants.
- **Owner-scoping registry refactor** — not needed for this design; required
  before any future non-`custom` user-owned source.

--- end Docs paste ---
