### PR TITLE
chore(profile): update sector option labels

### DIFF
--- a/src/api/user_profile_configs/sectors.py
+++ b/src/api/user_profile_configs/sectors.py
@@ -1,15 +1,15 @@
 """Sector configuration for user profiles."""
 
 SECTORS = {
-    "government": "Government/ Public Sector",
+    "government": "Government/Public Sector",
     "donor": "Philanthropic Organization",
-    "local_ngo": "Local NGO (national or subnational)",
-    "international_ngo": "International NGO",
-    "un_international": "Intergovernmental / Multilateral Organization",
+    "local_ngo": "NGO - National or Local",
+    "international_ngo": "NGO - International",
+    "un_international": "Intergovernmental/Multilateral Organization",
     "academic": "Academic / Research Organization",
     "journalist": "Journalist / Media Organization",
     "indigenous": "Indigenous of Community-Based Organization",
-    "private_sector": "Private Sector / Business",
+    "private_sector": "Business/Private Sector",
     "individual": "Individual / No Affiliation",
     "other": "Other",
 }


### PR DESCRIPTION
Updates the display labels for the Sector dropdown on the onboarding form. These are served to the frontend via `/api/profile/config`, so the copy change lives here rather than in `project-zeno-next`.

Sector **keys** are unchanged — `sector_code` is persisted against user profiles, so renaming keys would orphan existing data. Only the human-readable labels change.

| Key | Was | Now |
|---|---|---|
| `private_sector` | Private Sector / Business | Business/Private Sector |
| `government` | Government/ Public Sector | Government/Public Sector |
| `un_international` | Intergovernmental / Multilateral Organization | Intergovernmental/Multilateral Organization |
| `international_ngo` | International NGO | NGO - International |
| `local_ngo` | Local NGO (national or subnational) | NGO - National or Local |

Note: the requested copy list also included `Donor Institution/Agency` → `Philanthropic Organization`, but `donor` already read "Philanthropic Organization" — that rename landed previously, so no change was needed.

## Test plan

- [ ] `GET /api/profile/config` returns the new `sectors` labels
- [ ] Onboarding form Sector dropdown renders the updated options
- [ ] Selecting a sector still populates the correct role list (keys unchanged, so `SECTOR_ROLES` lookups are unaffected)
- [ ] Existing user profiles with a stored `sector_code` still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7jPxnkuwtuzzWqV2F37dS