### PR TITLE
docs: add PR title convention for squash-merge commit history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Working in this repository
+
+## PR titles and commit history
+
+`main` is protected by a squash-only ruleset with required linear history: every PR collapses into a single commit on merge, and that commit's message is the PR title. Write PR titles accordingly.
+
+- Use Conventional Commits format: `type(scope): summary`
+- Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`
+- Summary is imperative, lowercase after the colon, no trailing period
+- Put ticket references (e.g. `PZB-1234`) in the PR description, not the title
+
+Examples:
+- `fix(geocoder): handle empty AOI results`
+- `feat(dashboards): add section grouping for widgets`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.8.28"
+version = "2026.9.1"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"


### PR DESCRIPTION
## Summary
- PZB-1309: `main`'s ruleset was just switched to squash-only merges with required linear history, so the PR title is now the permanent commit message
- Adds a CLAUDE.md convention: PR titles should follow Conventional Commits (`type(scope): summary`), with ticket refs in the description instead of the title

## Test plan
- [x] N/A (docs only)

https://claude.ai/code/session_014pKxYi66ym7wDn6y2NCYAV
