### PR TITLE
fix(traces): account for llm usage outside the agent loop

### DIFF
--- a/db/alembic/versions/f3a8c1d5b204_add_llm_usage_split_to_langfuse_traces.py
+++ b/db/alembic/versions/f3a8c1d5b204_add_llm_usage_split_to_langfuse_traces.py
@@ -1,0 +1,136 @@
+"""add agent/tool llm usage split to langfuse_traces
+
+Revision ID: f3a8c1d5b204
+Revises: c9f1a2b3d4e5
+Create Date: 2026-09-03 11:20:00.000000
+
+Token columns used to be derived from the AIMessage stream, which only carries
+the calls the agent made itself — an LLM call inside a tool returns a
+ToolMessage and so was counted nowhere. Parser v3 sources them from the trace's
+generation observations instead and records the split:
+
+* ``agent_tokens`` / ``agent_cost`` — what the agent spent itself (this is what
+  ``turn_tokens`` used to hold).
+* ``tool_tokens`` / ``tool_cost`` — the remainder, spent by LLM calls inside
+  tools. Roughly a third of cost on the measured production trace.
+* ``generation_count`` — how many LLM calls the turn made in total.
+
+``turn_tokens`` steps up for any turn whose tools call an LLM, so re-run
+ingestion over the window you care about (``ingest-langfuse-traces --backfill
+--since``) to put existing rows on the new basis. The analytics view is
+recreated to expose the new columns.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3a8c1d5b204"
+down_revision: Union[str, None] = "c9f1a2b3d4e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "langfuse_traces"
+_VIEW = "langfuse_traces_analytics"
+
+_NEW_COLUMNS = (
+    ("agent_tokens", sa.Integer()),
+    ("tool_tokens", sa.Integer()),
+    ("agent_cost", sa.Float()),
+    ("tool_cost", sa.Float()),
+    ("generation_count", sa.Integer()),
+)
+
+# Recreated (not CREATE OR REPLACE'd) because adding columns to a view's select
+# list changes its shape, which REPLACE rejects.
+_CREATE_VIEW = f"""
+CREATE VIEW {_VIEW} AS
+SELECT
+    id,
+    session_id,
+    user_id,
+    environment,
+    trace_timestamp,
+    outcome,
+    has_answer,
+    answer_is_refusal,
+    had_tool_call,
+    tool_error_count,
+    aoi_name,
+    aoi_type,
+    primary_dataset_name,
+    has_insight,
+    is_global,
+    insight_id,
+    turn_input_tokens,
+    turn_output_tokens,
+    turn_tokens,
+    turn_tool_calls,
+    agent_tokens,
+    tool_tokens,
+    agent_cost,
+    tool_cost,
+    generation_count,
+    latency_seconds,
+    total_cost,
+    prompt,
+    (
+        row_number() OVER (
+            PARTITION BY COALESCE(session_id, id)
+            ORDER BY trace_timestamp DESC NULLS LAST, id DESC
+        ) = 1
+    ) AS is_final_turn_in_thread
+FROM langfuse_traces;
+"""
+
+_PRIOR_VIEW = f"""
+CREATE VIEW {_VIEW} AS
+SELECT
+    id,
+    session_id,
+    user_id,
+    environment,
+    trace_timestamp,
+    outcome,
+    has_answer,
+    answer_is_refusal,
+    had_tool_call,
+    tool_error_count,
+    aoi_name,
+    aoi_type,
+    primary_dataset_name,
+    has_insight,
+    is_global,
+    insight_id,
+    turn_input_tokens,
+    turn_output_tokens,
+    turn_tokens,
+    turn_tool_calls,
+    latency_seconds,
+    total_cost,
+    prompt,
+    (
+        row_number() OVER (
+            PARTITION BY COALESCE(session_id, id)
+            ORDER BY trace_timestamp DESC NULLS LAST, id DESC
+        ) = 1
+    ) AS is_final_turn_in_thread
+FROM langfuse_traces;
+"""
+
+
+def upgrade() -> None:
+    for name, type_ in _NEW_COLUMNS:
+        op.add_column(_TABLE, sa.Column(name, type_, nullable=True))
+    op.execute(f"DROP VIEW IF EXISTS {_VIEW};")
+    op.execute(_CREATE_VIEW)
+
+
+def downgrade() -> None:
+    op.execute(f"DROP VIEW IF EXISTS {_VIEW};")
+    op.execute(_PRIOR_VIEW)
+    for name, _ in reversed(_NEW_COLUMNS):
+        op.drop_column(_TABLE, name)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,6 +109,19 @@ kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' 
 - Requires `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `DATABASE_URL` in the pod environment.
 - Each run prints a summary line: `fetched=… upserted=… chunks=… failed=… status=… watermark=…`.
 - The watermark only advances on fully-completed chunks, so an interrupted run is safe to re-run.
+- Token counts come from each trace's generation observations, fetched once per window
+  alongside the traces. That is what makes `turn_tokens` cover the LLM calls made inside
+  tools, and it is what splits spend into `agent_*` and `tool_*`. If that fetch fails the
+  window still ingests, on agent-level usage only — watch the `agent_tokens` fill rate in
+  `langfuse_ingestion_runs` for that.
+- Traces tagged `auxiliary` are skipped. Those are single LLM calls made outside a turn
+  (thread naming, area naming, language detection); they carry no `AgentState`, so
+  ingesting them would add zero-token `EMPTY` rows and drag every per-turn average down.
+  Their cost stays visible in Langfuse under the thread's session id.
+- **Parser v3 changed what `turn_tokens` means**: it now covers every LLM call in the
+  turn, not just the agent's own. Re-run with `--backfill --since` over the window you
+  analyse to put existing rows on the new basis, or the series has a step in it where
+  the parser version changes.
 
 ### backfill-turn-fields
 
@@ -139,6 +152,40 @@ kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' 
 - Requires `DATABASE_URL` in the pod environment.
 - Until it runs, pre-existing rows report NULL turn fields — the API tolerates this
   (analytics is just incomplete for those rows), so there's no rush within a deploy.
+
+### langfuse-model-prices
+
+Reports which models Langfuse fails to price. Langfuse works out cost by matching an
+observation's model name against its model-definition table. A model it does not
+recognise — a preview name, or one newly configured in `MODEL` / `SMALL_MODEL` /
+`CODING_MODEL` — is stored with usage but **zero cost**, so cost-per-query understates
+by that model's entire share with nothing in the data to show it. Run this after any
+model change.
+
+**Usage:**
+```bash
+# Which models did the last 24h use, and are they all priced?
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py langfuse-model-prices
+
+# One environment, longer look-back
+kubectl exec $(kubectl get pods --no-headers | grep zeno-api | awk '{print $1}' | head -1) -- \
+  uv run python src/api/cli.py langfuse-model-prices --hours 168 --environment production
+```
+
+**Parameters:**
+- `--hours` (default 24): look-back window.
+- `--environment`: filter to one environment. Default: all.
+
+**Notes:**
+- Requires `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`. It reads
+  Langfuse only — no database, no writes.
+- `UNPRICED` means the model produced tokens and no cost. `PARTIAL` means only some
+  calls were priced, which usually means the definition was added part-way through the
+  window.
+- To fix an `UNPRICED` model: add a model definition with its prices in Langfuse
+  (Settings → Models), then re-run `ingest-langfuse-traces --backfill --since` over the
+  affected window so the stored costs are recomputed.
 
 ### build-aois
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.3"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/i18n.py
+++ b/src/agent/i18n.py
@@ -1065,7 +1065,9 @@ async def _translate_template(key: str, english: str, language: str) -> str:
         f"Template:\n{english}"
     )
     try:
-        response = await SMALL_MODEL.ainvoke(prompt)
+        response = await SMALL_MODEL.ainvoke(
+            prompt, config={"run_name": "translate_template"}
+        )
         translated = _extract_text(response.content).strip() or english
     except Exception:
         logger.exception("i18n_translation_failed", key=key, language=language)

--- a/src/agent/language.py
+++ b/src/agent/language.py
@@ -20,7 +20,7 @@ call is slower (~0.5s with a minimal-thinking Gemini Flash-Lite call) but
 actually understands the sentence instead of scoring character frequencies.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from src.agent.llms import GEMINI_FLASH_LITE_MINIMAL
 from src.api.user_profile_configs.languages import LANGUAGES
@@ -70,14 +70,23 @@ def _extract_text(content) -> str:
     return "".join(parts)
 
 
-async def detect_language(text: Optional[str]) -> Optional[str]:
-    """Best-effort ISO 639-1 code for `text`, or None if undetectable."""
+async def detect_language(
+    text: Optional[str], config: Optional[dict[str, Any]] = None
+) -> Optional[str]:
+    """Best-effort ISO 639-1 code for `text`, or None if undetectable.
+
+    `config` is a LangChain RunnableConfig. Callers running outside a traced
+    graph invocation should pass one carrying the Langfuse callback handler,
+    otherwise this call is billed but never appears in any trace.
+    """
     if not text or len(text.strip()) < _MIN_DETECTION_CHARS:
         return None
 
     prompt = _DETECTION_PROMPT.format(text=text.strip())
     try:
-        response = await GEMINI_FLASH_LITE_MINIMAL.ainvoke(prompt)
+        response = await GEMINI_FLASH_LITE_MINIMAL.ainvoke(
+            prompt, config={"run_name": "detect_language", **(config or {})}
+        )
     except Exception:
         logger.exception("language_detection_failed")
         return None
@@ -91,6 +100,7 @@ async def resolve_language(
     preferred_language_code: Optional[str] = None,
     query: Optional[str] = None,
     already_resolved: bool = False,
+    config: Optional[dict[str, Any]] = None,
 ) -> Optional[str]:
     """Resolve the language to write into AgentState for this turn.
 
@@ -104,7 +114,7 @@ async def resolve_language(
         return preferred_language_code
     if already_resolved:
         return None
-    return await detect_language(query)
+    return await detect_language(query, config=config)
 
 
 def language_name(code: Optional[str]) -> str:

--- a/src/agent/subagents/analyst/code_executors/gemini_executor.py
+++ b/src/agent/subagents/analyst/code_executors/gemini_executor.py
@@ -16,6 +16,7 @@ from src.agent.subagents.analyst.code_executors.base import (
     MultiChartInsight,
     PartType,
 )
+from src.shared.langfuse_tracing import gemini_usage_details, generation_span
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -91,36 +92,55 @@ class GeminiCodeExecutor:
         return inline_data_parts
 
     async def _call_model(self, model: str, content_parts: List[Dict]):
-        """Call a model with retry logic. Returns the raw response."""
+        """Call a model with retry logic. Returns the raw response.
+
+        Wrapped in a Langfuse generation span because this call goes straight to
+        the ``google.genai`` SDK: no LangChain runnable means no callback, so
+        without the span the turn's largest LLM call is absent from the trace in
+        both tokens and cost. The span covers the retry loop, so its latency is
+        the wall-clock time the caller actually waited, and it reports the usage
+        of whichever attempt succeeded.
+        """
         last_error = None
         loop = asyncio.get_running_loop()
-        for attempt in range(self.MAX_RETRIES + 1):
-            try:
-                response = await loop.run_in_executor(
-                    None,
-                    partial(
-                        self.client.models.generate_content,
-                        model=model,
-                        contents=[{"role": "user", "parts": content_parts}],
-                        config=types.GenerateContentConfig(
-                            tools=[
-                                types.Tool(
-                                    code_execution=types.ToolCodeExecution()
-                                )
+        with generation_span(
+            "analyst_code_executor",
+            model=model,
+            metadata={"max_retries": self.MAX_RETRIES},
+        ) as gen:
+            for attempt in range(self.MAX_RETRIES + 1):
+                try:
+                    response = await loop.run_in_executor(
+                        None,
+                        partial(
+                            self.client.models.generate_content,
+                            model=model,
+                            contents=[
+                                {"role": "user", "parts": content_parts}
                             ],
+                            config=types.GenerateContentConfig(
+                                tools=[
+                                    types.Tool(
+                                        code_execution=types.ToolCodeExecution()
+                                    )
+                                ],
+                            ),
                         ),
-                    ),
-                )
-                return response
-            except Exception as e:
-                last_error = e
-                if attempt < self.MAX_RETRIES:
-                    delay = self.INITIAL_DELAY * (self.BACKOFF_FACTOR**attempt)
-                    logger.warning(
-                        f"Model {model} attempt {attempt + 1} failed: {e}, "
-                        f"retrying in {delay:.1f}s"
                     )
-                    await asyncio.sleep(delay)
+                    gen.record(usage=gemini_usage_details(response))
+                    return response
+                except Exception as e:
+                    last_error = e
+                    if attempt < self.MAX_RETRIES:
+                        delay = self.INITIAL_DELAY * (
+                            self.BACKOFF_FACTOR**attempt
+                        )
+                        logger.warning(
+                            f"Model {model} attempt {attempt + 1} failed: {e}, "
+                            f"retrying in {delay:.1f}s"
+                        )
+                        await asyncio.sleep(delay)
+            gen.record(level="ERROR", status_message=str(last_error))
         raise cast(Exception, last_error)
 
     def _log_code_and_outputs(self, parts: List[CodeActPart]) -> None:

--- a/src/agent/subagents/pick_aoi/tool.py
+++ b/src/agent/subagents/pick_aoi/tool.py
@@ -348,10 +348,12 @@ async def select_best_aoi(
         ]
     )
 
-    # Chain for selecting the best location match and returning the src_id
+    # Chain for selecting the best location match and returning the src_id.
+    # run_name is what this call is labelled in Langfuse, and so what
+    # derived.cost_by_component attributes its spend to.
     AOI_SELECTION_CHAIN = (
         AOI_SELECTION_PROMPT | SMALL_MODEL.with_structured_output(AOIId)
-    )
+    ).with_config(run_name="select_aoi")
 
     selected_aoi_index = await AOI_SELECTION_CHAIN.ainvoke(
         {
@@ -747,7 +749,7 @@ class Geocoder:
         chain = (
             GEOCODER_EXTRACTION_PROMPT
             | SMALL_MODEL.with_structured_output(PlaceQuery)
-        )
+        ).with_config(run_name="extract_place_query")
         return await chain.ainvoke({"question": question})
 
     async def lookup(

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -179,7 +179,7 @@ async def select_best_dataset(
     dataset_selection_chain = (
         DATASET_SELECTION_PROMPT
         | SMALL_MODEL.with_structured_output(DatasetSelectionResponse)
-    )
+    ).with_config(run_name="select_dataset")
 
     if aoi_selection is None:
         removed_df = None

--- a/src/agent/subagents/search/blog.py
+++ b/src/agent/subagents/search/blog.py
@@ -514,7 +514,10 @@ async def search_blogs(
     t0 = time.perf_counter()
     try:
         result = await _cached_agent(language=language).ainvoke(
-            {"messages": [{"role": "user", "content": query}]}
+            {"messages": [{"role": "user", "content": query}]},
+            # This is a nested agent loop, so it can be several model calls per
+            # search. run_name labels them all under one component in Langfuse.
+            config={"run_name": "search_blogs_agent"},
         )
     except Exception:
         logger.exception(f"search_blogs failed query={query!r}")

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -173,7 +173,9 @@ async def update_insight_display(
         )
 
     current = Insight.from_orm_row(row)
-    revised = await InsightDisplayReviser().revise(current, instruction)
+    revised = await InsightDisplayReviser().revise(
+        current, instruction, config={"run_name": "revise_insight_display"}
+    )
 
     try:
         updated = _apply_revision(current.charts, revised)

--- a/src/api/cli.py
+++ b/src/api/cli.py
@@ -812,6 +812,85 @@ def backfill_turn_fields_command(batch_size: int, dry_run: bool):
     asyncio.run(_run())
 
 
+@cli.command("langfuse-model-prices")
+@click.option("--hours", type=int, default=24, help="Look-back window.")
+@click.option("--environment", default=None, help="Filter to one environment.")
+def langfuse_model_prices_command(hours: int, environment: Optional[str]):
+    """Report which models Langfuse is failing to price.
+
+    Langfuse computes cost by matching an observation's model name against its
+    model-definition table. A model it does not recognise — a preview name, or a
+    newly configured one — is recorded with usage but **zero cost**, so
+    cost-per-query silently understates by that model's whole share, with
+    nothing in the data to say so.
+
+    For every model flagged UNPRICED here, add a model definition with its
+    prices in Langfuse (Settings → Models), then re-run
+    ``ingest-langfuse-traces --backfill --since`` over the affected window to
+    recompute the stored costs.
+    """
+    from src.api.services.langfuse.fetch import LangfuseClient
+
+    until = datetime.now(timezone.utc)
+    since = until - timedelta(hours=hours)
+    client = LangfuseClient.from_env()
+    # Every type, then filter on "has a model and reported usage": embeddings
+    # are billable too, and an unpriced embedding model is just as invisible as
+    # an unpriced chat one.
+    observations = client.fetch_observations_window(
+        since, until, environment, obs_type=None
+    )
+
+    # model -> [calls, tokens, cost, priced_calls]
+    stats: dict = {}
+    for o in observations:
+        model = o.get("model")
+        usage = o.get("usageDetails") or {}
+        if not model or not usage:
+            continue
+        cost = o.get("totalCost") or 0
+        row = stats.setdefault(model, [0, 0, 0.0, 0])
+        row[0] += 1
+        row[1] += int(usage.get("total") or 0)
+        row[2] += float(cost)
+        if cost:
+            row[3] += 1
+
+    if not stats:
+        click.echo(f"No billable LLM calls in the last {hours}h.")
+        return
+
+    click.echo(
+        f"{'model':38} {'calls':>7} {'tokens':>10} {'cost':>11}  status"
+    )
+    unpriced = []
+    for model, (calls, tokens, cost, priced) in sorted(
+        stats.items(), key=lambda kv: -kv[1][1]
+    ):
+        if priced == 0:
+            status = "UNPRICED"
+            unpriced.append(model)
+        elif priced < calls:
+            status = f"PARTIAL ({priced}/{calls} priced)"
+        else:
+            status = "ok"
+        click.echo(
+            f"{model[:38]:38} {calls:>7} {tokens:>10,} {cost:>11.6f}  {status}"
+        )
+
+    if unpriced:
+        click.echo(
+            "\n⚠️  Unpriced models contribute tokens but no cost: "
+            + ", ".join(unpriced)
+        )
+        click.echo(
+            "   Add a model definition for each in Langfuse, then re-ingest "
+            "the window."
+        )
+    else:
+        click.echo("\n✅ Every model in this window is priced.")
+
+
 # ---------------------------------------------------------------------------
 # build-aois: populate the unified `aois` / `user_aois` tables
 # ---------------------------------------------------------------------------

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -694,15 +694,31 @@ class LangfuseTraceOrm(Base):
     trace_timestamp = Column(DateTime(timezone=True), nullable=True)
     trace_updated_at = Column(DateTime(timezone=True), nullable=True)
 
-    # --- Turn-level metrics (from the active-turn window) ---
+    # --- Turn-level metrics ---
+    # prompt/answer/turn_tool_calls are read from the active-turn window of the
+    # message stream (output.messages is thread-cumulative). Tokens and cost are
+    # not: see the note on the token columns below.
     prompt = Column(String, nullable=True)
     answer = Column(String, nullable=True)
+    # turn_* covers EVERY LLM call in the turn, sourced from the trace's
+    # generation observations (parser v3+). agent_* is the subset the agent made
+    # itself; tool_* is the remainder, i.e. LLM calls made inside tools, which
+    # the AIMessage stream cannot see at all. agent_tokens + tool_tokens ==
+    # turn_tokens by construction. derived.tokens_by_component /
+    # derived.cost_by_component break tool_* down per tool.
     turn_input_tokens = Column(Integer, nullable=True)
     turn_output_tokens = Column(Integer, nullable=True)
     turn_tokens = Column(Integer, nullable=True)
     turn_tool_calls = Column(Integer, nullable=True)
-    # Passthrough per-turn fields from the trace top level.
+    agent_tokens = Column(Integer, nullable=True)
+    tool_tokens = Column(Integer, nullable=True)
+    agent_cost = Column(Float, nullable=True)
+    tool_cost = Column(Float, nullable=True)
+    generation_count = Column(Integer, nullable=True)
+    # Passthrough from the trace top level.
     latency_seconds = Column(Float, nullable=True)
+    # trace.totalCost when Langfuse populates it, else the sum over the trace's
+    # priced observations (it is frequently null even when they are priced).
     total_cost = Column(Float, nullable=True)
 
     # Outcome primitives (durable, auditable signals). ``outcome`` is the label
@@ -740,7 +756,11 @@ class LangfuseTraceOrm(Base):
     # migrations rare. Includes turn_tools_used, turn_datasets, aoi_source,
     # aoi_count, aois, primary_dataset_id, analysis_start/end_date,
     # cache_read_tokens, language(+confidence), datasets_analysed_cumulative,
-    # statistics_ids, state_snapshot, and unknown_output_keys (drift detector).
+    # statistics_ids, state_snapshot, unknown_output_keys (drift detector),
+    # usage_source ("observations" | "messages"), tokens_by_component,
+    # cost_by_component, agent_tokens_from_messages (the independent
+    # message-derived measurement of agent_tokens) and usage_split_agrees
+    # (whether the two agree — False means attribution has drifted).
     derived = Column(JSONB, nullable=True)
 
     # Bookkeeping / drift detection

--- a/src/api/routers/chat.py
+++ b/src/api/routers/chat.py
@@ -62,7 +62,11 @@ async def chat(
     result = await session.execute(stmt)
     thread = result.scalars().first()
     if not thread:
-        thread_name = await generate_thread_name(chat_request.query)
+        thread_name = await generate_thread_name(
+            chat_request.query,
+            thread_id=chat_request.thread_id,
+            user_id=user.id,
+        )
         thread = ThreadOrm(
             id=chat_request.thread_id,
             user_id=user.id,

--- a/src/api/routers/custom_areas.py
+++ b/src/api/routers/custom_areas.py
@@ -25,6 +25,7 @@ from src.api.schemas import (
 )
 from src.api.services.aoi_sync import delete_custom_aoi, upsert_custom_aoi
 from src.shared.database import get_session_from_pool_dependency
+from src.shared.langfuse_tracing import auxiliary_config
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -56,7 +57,12 @@ async def custom_area_name(
         """
         response = await SMALL_MODEL.with_structured_output(
             CustomAreaNameResponse
-        ).ainvoke(prompt.format(features=request.features[0]))
+        ).ainvoke(
+            prompt.format(features=request.features[0]),
+            # Its own endpoint, so no ambient handler: without this config the
+            # call is billed and appears in no trace at all.
+            config=auxiliary_config("name_custom_area", user_id=user.id),
+        )
         return {"name": response.name}
     except Exception as e:
         logger.exception("Error generating area name: %s", e)

--- a/src/api/routers/traces.py
+++ b/src/api/routers/traces.py
@@ -77,11 +77,36 @@ class TraceListItem(BaseModel):
             "previous turn's), vs. datasets_analysed which is thread-cumulative."
         ),
     )
-    turn_tokens: Optional[int] = None
+    turn_tokens: Optional[int] = Field(
+        None,
+        description=(
+            "Every LLM call in the turn, the agent's own and the ones its tools "
+            "made. Equals agent_tokens + tool_tokens."
+        ),
+    )
+    agent_tokens: Optional[int] = Field(
+        None, description="The subset of turn_tokens the agent spent itself."
+    )
+    tool_tokens: Optional[int] = Field(
+        None,
+        description=(
+            "The subset spent by LLM calls inside tools. See "
+            "derived.tokens_by_component for the per-tool breakdown."
+        ),
+    )
     turn_tool_calls: Optional[int] = None
     tool_error_count: Optional[int] = None
+    generation_count: Optional[int] = None
     latency_seconds: Optional[float] = None
     total_cost: Optional[float] = None
+    agent_cost: Optional[float] = None
+    tool_cost: Optional[float] = Field(
+        None,
+        description=(
+            "Cost of the tools' own LLM calls. Runs materially higher than the "
+            "token share suggests: tool prompts get no prompt-cache hits."
+        ),
+    )
     # Sourced from the ``derived`` JSONB (long-tail fields kept out of columns).
     datasets_analysed: Optional[list[str]] = Field(
         None,
@@ -111,6 +136,28 @@ class TraceDetail(TraceListItem):
     insight_id: Optional[str] = None
     turn_input_tokens: Optional[int] = None
     turn_output_tokens: Optional[int] = None
+    usage_source: Optional[str] = Field(
+        None,
+        description=(
+            '"observations" when the token counts came from the trace\'s '
+            'generations (complete), "messages" when the observation fetch '
+            "failed and they cover the agent's own calls only."
+        ),
+    )
+    tokens_by_component: Optional[dict[str, int]] = Field(
+        None, description='Tokens per component: "agent", then each tool name.'
+    )
+    cost_by_component: Optional[dict[str, float]] = Field(
+        None, description="Cost per component, same keys as above."
+    )
+    usage_split_agrees: Optional[bool] = Field(
+        None,
+        description=(
+            "Whether the observation-derived agent_tokens matches the "
+            "independent message-derived figure. False means component "
+            "attribution has drifted and the agent/tool split is unreliable."
+        ),
+    )
     parser_version: Optional[int] = None
     parse_error: Optional[str] = None
     recognized_contract: Optional[bool] = None
@@ -139,10 +186,15 @@ _LIST_COLUMNS = (
     LangfuseTraceOrm.insight_created_this_turn,
     LangfuseTraceOrm.datasets_analysed_this_turn,
     LangfuseTraceOrm.turn_tokens,
+    LangfuseTraceOrm.agent_tokens,
+    LangfuseTraceOrm.tool_tokens,
     LangfuseTraceOrm.turn_tool_calls,
     LangfuseTraceOrm.tool_error_count,
+    LangfuseTraceOrm.generation_count,
     LangfuseTraceOrm.latency_seconds,
     LangfuseTraceOrm.total_cost,
+    LangfuseTraceOrm.agent_cost,
+    LangfuseTraceOrm.tool_cost,
     # Selected so the list response can surface the derived fields below without
     # a per-trace detail fetch (datasets_analysed/language live in JSONB).
     LangfuseTraceOrm.derived,
@@ -293,12 +345,16 @@ class TurnMetrics(BaseModel):
     cost: dict[str, Optional[float]] = Field(
         ...,
         description=(
-            "{avg, p95, total}. The sums (total) are within-bucket totals and are "
-            "NOT comparable across buckets — the terminal bucket aggregates many "
-            "turn positions. Compare averages/percentiles across buckets."
+            "{avg, p95, total, avg_agent, avg_tool, total_agent, total_tool}. "
+            "The *_agent / *_tool pair splits spend between the agent's own LLM "
+            "calls and the ones its tools made. The sums (total*) are "
+            "within-bucket totals and are NOT comparable across buckets — the "
+            "terminal bucket aggregates many turn positions. Compare "
+            "averages/percentiles across buckets."
         ),
     )
-    tokens: dict[str, Optional[float]]  # {avg_turn_tokens, total_turn_tokens}
+    # {avg,total}_turn_tokens plus the same _agent/_tool split as cost.
+    tokens: dict[str, Optional[float]]
     tool_usage: dict[str, Optional[float]]  # {avg_tool_calls, tool_error_rate}
 
 
@@ -427,8 +483,16 @@ _SCALAR_METRICS_SQL = """
   avg(total_cost) AS cost_avg,
   percentile_cont(0.95) WITHIN GROUP (ORDER BY total_cost) AS cost_p95,
   sum(total_cost) AS cost_total,
+  avg(agent_cost) AS cost_agent_avg,
+  avg(tool_cost) AS cost_tool_avg,
+  sum(agent_cost) AS cost_agent_total,
+  sum(tool_cost) AS cost_tool_total,
   avg(turn_tokens) AS tok_avg,
   sum(turn_tokens) AS tok_total,
+  avg(agent_tokens) AS tok_agent_avg,
+  avg(tool_tokens) AS tok_tool_avg,
+  sum(agent_tokens) AS tok_agent_total,
+  sum(tool_tokens) AS tok_tool_total,
   avg(turn_tool_calls) AS tool_avg,
   avg(CASE WHEN tool_error_count > 0 THEN 1.0 ELSE 0.0 END) AS tool_err_rate
 """.strip()
@@ -448,10 +512,18 @@ def _metrics_dict(r: Any) -> dict[str, Any]:
             "avg": _f(r["cost_avg"]),
             "p95": _f(r["cost_p95"]),
             "total": _f(r["cost_total"]),
+            "avg_agent": _f(r["cost_agent_avg"]),
+            "avg_tool": _f(r["cost_tool_avg"]),
+            "total_agent": _f(r["cost_agent_total"]),
+            "total_tool": _f(r["cost_tool_total"]),
         },
         "tokens": {
             "avg_turn_tokens": _f(r["tok_avg"]),
             "total_turn_tokens": _f(r["tok_total"]),
+            "avg_agent_tokens": _f(r["tok_agent_avg"]),
+            "avg_tool_tokens": _f(r["tok_tool_avg"]),
+            "total_agent_tokens": _f(r["tok_agent_total"]),
+            "total_tool_tokens": _f(r["tok_tool_total"]),
         },
         "tool_usage": {
             "avg_tool_calls": _f(r["tool_avg"]),
@@ -735,10 +807,19 @@ async def get_trace(
         turn_tokens=row.turn_tokens,
         turn_input_tokens=row.turn_input_tokens,
         turn_output_tokens=row.turn_output_tokens,
+        agent_tokens=row.agent_tokens,
+        tool_tokens=row.tool_tokens,
         turn_tool_calls=row.turn_tool_calls,
         tool_error_count=row.tool_error_count,
+        generation_count=row.generation_count,
         latency_seconds=row.latency_seconds,
         total_cost=row.total_cost,
+        agent_cost=row.agent_cost,
+        tool_cost=row.tool_cost,
+        usage_source=derived.get("usage_source"),
+        tokens_by_component=derived.get("tokens_by_component"),
+        cost_by_component=derived.get("cost_by_component"),
+        usage_split_agrees=derived.get("usage_split_agrees"),
         datasets_analysed=derived.get("datasets_analysed_cumulative"),
         language=derived.get("language"),
         language_confidence=derived.get("language_confidence"),

--- a/src/api/services/chat.py
+++ b/src/api/services/chat.py
@@ -16,6 +16,7 @@ from src.agent.language import resolve_language
 from src.agent.llms import SMALL_MODEL
 from src.api.schemas import ThreadNameOutput
 from src.shared.geocoding_helpers import fetch_aoi_bbox
+from src.shared.langfuse_tracing import auxiliary_config
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -203,6 +204,16 @@ async def stream_chat(
         preferred_language_code=(user or {}).get("preferred_language_code"),
         query=query,
         already_resolved=bool(existing_state.values.get("language")),
+        # Runs before astream, so there is no ambient handler to inherit and
+        # the call would otherwise be billed untraced. It gets its own
+        # auxiliary trace, joined to this thread by session id.
+        config=auxiliary_config(
+            "detect_language",
+            session_id=thread_id,
+            # The caller's user dict carries profile fields, not the id; the
+            # id is already resolved into langfuse_metadata for the graph.
+            user_id=(langfuse_metadata or {}).get("langfuse_user_id"),
+        ),
     )
     if language:
         state_updates["language"] = language
@@ -284,9 +295,16 @@ async def stream_chat(
         )
 
 
-async def generate_thread_name(query: str) -> str:
+async def generate_thread_name(
+    query: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> str:
     """
     Generate a descriptive name for a chat thread based on the user's query.
+
+    Traced as an auxiliary trace: this runs in the /chat request but outside the
+    graph invocation, so it has no ambient callback handler of its own.
     """
     try:
         prompt = f"""Generate a concise, descriptive title (max 50 chars) for a chat conversation that starts with this query:
@@ -299,7 +317,14 @@ async def generate_thread_name(query: str) -> str:
         """
         response = await SMALL_MODEL.with_structured_output(
             ThreadNameOutput
-        ).ainvoke(prompt)
+        ).ainvoke(
+            prompt,
+            config=auxiliary_config(
+                "generate_thread_name",
+                session_id=thread_id,
+                user_id=user_id,
+            ),
+        )
         name = response.name
         if len(name) > 50:
             return name[:47] + "..."

--- a/src/api/services/langfuse/fetch.py
+++ b/src/api/services/langfuse/fetch.py
@@ -1,4 +1,5 @@
-"""Resilient client for the Langfuse ``/api/public/traces`` list endpoint.
+"""Resilient client for the Langfuse ``traces`` and ``observations`` list
+endpoints.
 
 Design notes (validated against the staging instance, which 500s / hits
 ClickHouse memory limits under load):
@@ -12,6 +13,9 @@ ClickHouse memory limits under load):
   id-dedup makes the refetch safe. If it still fails at size 1, raise loudly
   (``LangfuseFetchError``) so the caller records a failed chunk rather than
   silently dropping data.
+
+Both endpoints share that machinery via ``_fetch_windowed``; they differ only in
+the path and the names of the two timestamp bounds.
 """
 
 from __future__ import annotations
@@ -30,6 +34,7 @@ from src.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 _TRACES_PATH = "/api/public/traces"
+_OBSERVATIONS_PATH = "/api/public/observations"
 
 
 class LangfuseFetchError(RuntimeError):
@@ -79,27 +84,51 @@ class LangfuseClient:
         """Return all traces with ``from_ts <= timestamp < to_ts`` (ascending),
         de-duplicated by id. Raises ``LangfuseFetchError`` on unrecoverable
         failure."""
-        limit = page_size
-        with httpx.Client(timeout=self.timeout) as client:
-            while True:
-                try:
-                    return self._fetch_all_pages(
-                        client, from_ts, to_ts, environment, limit
-                    )
-                except _ServerError as e:
-                    if limit <= 1:
-                        raise LangfuseFetchError(
-                            f"Langfuse 5xx at page size 1 for window "
-                            f"[{_iso(from_ts)}, {_iso(to_ts)}): {e}"
-                        ) from e
-                    new_limit = max(1, limit // 2)
-                    logger.warning(
-                        "langfuse_fetch_halving_page_size",
-                        old_limit=limit,
-                        new_limit=new_limit,
-                        window_start=_iso(from_ts),
-                    )
-                    limit = new_limit
+        return self._fetch_windowed(
+            _TRACES_PATH,
+            "fromTimestamp",
+            "toTimestamp",
+            from_ts,
+            to_ts,
+            environment,
+            page_size,
+            extra={"orderBy": "timestamp.asc"},
+        )
+
+    def fetch_observations_window(
+        self,
+        from_ts: datetime,
+        to_ts: datetime,
+        environment: Optional[str] = None,
+        page_size: int = 50,
+        obs_type: Optional[str] = "GENERATION",
+    ) -> list[dict[str, Any]]:
+        """Return observations whose ``startTime`` is in ``[from_ts, to_ts)``,
+        de-duplicated by id. ``obs_type=None`` fetches every type, which is what
+        the ingest layer needs: a generation's owning component is written on
+        its ancestor spans, not on itself.
+
+        This is the *usage* source: a trace's token counts and cost live on its
+        generation observations, not on the trace itself (``trace.totalCost`` is
+        frequently null). Fetched per window rather than per trace so a window
+        of N traces costs a handful of requests instead of N.
+
+        Callers must group the result by ``traceId`` and keep only the trace ids
+        they actually fetched: a window's observations include children of
+        traces that started in an earlier window. See
+        ``OBSERVATION_WINDOW_PAD`` in the ingest layer for the converse case (a
+        trace near the window's end whose children spill past ``to_ts``).
+        """
+        return self._fetch_windowed(
+            _OBSERVATIONS_PATH,
+            "fromStartTime",
+            "toStartTime",
+            from_ts,
+            to_ts,
+            environment,
+            page_size,
+            extra={"type": obs_type} if obs_type else {},
+        )
 
     def fetch_trace(self, trace_id: str) -> Optional[dict[str, Any]]:
         """Fetch a single trace by id (the cheap/reliable path). Returns the
@@ -138,20 +167,77 @@ class LangfuseClient:
                 return resp.json()
 
     # -- internals --------------------------------------------------------- #
+    def _fetch_windowed(
+        self,
+        path: str,
+        from_param: str,
+        to_param: str,
+        from_ts: datetime,
+        to_ts: datetime,
+        environment: Optional[str],
+        page_size: int,
+        extra: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Page over one closed window, halving the page size on persistent
+        5xx and restarting the window (id-dedup makes the refetch safe)."""
+        limit = page_size
+        with httpx.Client(timeout=self.timeout) as client:
+            while True:
+                try:
+                    return self._fetch_all_pages(
+                        client,
+                        path,
+                        from_param,
+                        to_param,
+                        from_ts,
+                        to_ts,
+                        environment,
+                        limit,
+                        extra,
+                    )
+                except _ServerError as e:
+                    if limit <= 1:
+                        raise LangfuseFetchError(
+                            f"Langfuse 5xx at page size 1 for {path} window "
+                            f"[{_iso(from_ts)}, {_iso(to_ts)}): {e}"
+                        ) from e
+                    new_limit = max(1, limit // 2)
+                    logger.warning(
+                        "langfuse_fetch_halving_page_size",
+                        path=path,
+                        old_limit=limit,
+                        new_limit=new_limit,
+                        window_start=_iso(from_ts),
+                    )
+                    limit = new_limit
+
     def _fetch_all_pages(
         self,
         client: httpx.Client,
+        path: str,
+        from_param: str,
+        to_param: str,
         from_ts: datetime,
         to_ts: datetime,
         environment: Optional[str],
         limit: int,
+        extra: dict[str, Any],
     ) -> list[dict[str, Any]]:
         seen: set[str] = set()
         out: list[dict[str, Any]] = []
         page = 1
         while True:
             data = self._get_page(
-                client, page, limit, from_ts, to_ts, environment
+                client,
+                path,
+                from_param,
+                to_param,
+                page,
+                limit,
+                from_ts,
+                to_ts,
+                environment,
+                extra,
             )
             rows = data.get("data") or []
             for r in rows:
@@ -168,18 +254,22 @@ class LangfuseClient:
     def _get_page(
         self,
         client: httpx.Client,
+        path: str,
+        from_param: str,
+        to_param: str,
         page: int,
         limit: int,
         from_ts: datetime,
         to_ts: datetime,
         environment: Optional[str],
+        extra: dict[str, Any],
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "page": page,
             "limit": limit,
-            "orderBy": "timestamp.asc",
-            "fromTimestamp": _iso(from_ts),
-            "toTimestamp": _iso(to_ts),
+            from_param: _iso(from_ts),
+            to_param: _iso(to_ts),
+            **extra,
         }
         if environment:
             params["environment"] = environment
@@ -189,7 +279,7 @@ class LangfuseClient:
         while True:
             try:
                 resp = client.get(
-                    self.host + _TRACES_PATH,
+                    self.host + path,
                     params=params,
                     auth=(self.public_key, self.secret_key),
                 )

--- a/src/api/services/langfuse/ingest.py
+++ b/src/api/services/langfuse/ingest.py
@@ -5,6 +5,12 @@ contract, idempotently upsert rows, and record a ``langfuse_ingestion_runs`` row
 with watermark + drift-observability metrics (fill rates, soft-FK resolve rates,
 unrecognized-contract rate).
 
+Token counts and cost come from the window's **generation observations**, fetched
+once per window (not once per trace) and grouped by trace id — the message stream
+in ``trace.output`` cannot see LLM calls made inside tools. If that fetch fails
+the window still ingests, on message-derived usage; ``agent_tokens``'s fill rate
+in the run row is the signal that this happened.
+
 Watermark advances only at a fully-completed window/chunk boundary; a chunk that
 fails after retries aborts the run (no silent gaps), leaving the watermark on the
 last contiguous good chunk so the next run resumes there.
@@ -24,12 +30,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.data_models import LangfuseIngestionRunOrm, LangfuseTraceOrm
 from src.api.services.langfuse import parse as P
 from src.api.services.langfuse.fetch import LangfuseClient, LangfuseFetchError
+from src.shared.langfuse_tracing import AUXILIARY_TAG
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 # Langfuse caps list page size (a 300 request 400s); 50 is proven-safe.
 MAX_PAGE_SIZE = 50
+
+# A trace near the end of a window has children that start after the window
+# closes, so the observation fetch reaches past ``to_ts`` by this much. Observed
+# trace latency is tens of seconds; the pad is deliberately far larger, and
+# over-fetching is free because observations for traces outside this window's
+# trace set are discarded.
+OBSERVATION_WINDOW_PAD = timedelta(minutes=30)
 
 # Real columns whose population we monitor for drift (fill-rate per run).
 MONITORED_COLS = (
@@ -42,6 +56,10 @@ MONITORED_COLS = (
     "insight_id",
     "turn_tokens",
     "has_answer",
+    # Null whenever the observation fetch produced nothing, which is how a
+    # regression back to message-only usage shows up in the run row.
+    "agent_tokens",
+    "total_cost",
 )
 
 
@@ -76,10 +94,16 @@ def _strip_nul(value: Any) -> Any:
 # --------------------------------------------------------------------------- #
 # Row building
 # --------------------------------------------------------------------------- #
-def build_row(trace: dict[str, Any]) -> dict[str, Any]:
+def build_row(
+    trace: dict[str, Any],
+    observations: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
     """Map a trace to a langfuse_traces (derived analytics) row dict. Parse
     failures still yield a row (identity + parse_error) so one bad trace never
-    aborts the batch."""
+    aborts the batch.
+
+    ``observations`` is this trace's generation observations, when they could be
+    fetched; see ``parse.parse_trace``."""
     session_id = trace.get("sessionId")
     # Turn position + per-turn diffs are cross-row. Session rows carry None and are
     # filled by the post-upsert recompute; null-session rows are singleton threads
@@ -93,6 +117,8 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         "trace_timestamp": _parse_dt(trace.get("timestamp")),
         "trace_updated_at": _parse_dt(trace.get("updatedAt")),
         "latency_seconds": trace.get("latency"),
+        # Overwritten from COLUMN_KEYS below; kept here so a parse failure
+        # still records whatever cost the trace itself reported.
         "total_cost": trace.get("totalCost"),
         "turn_index": 1 if is_singleton else None,
         "is_final_turn_in_thread": True if is_singleton else None,
@@ -102,7 +128,7 @@ def build_row(trace: dict[str, Any]) -> dict[str, Any]:
         "parse_error": None,
     }
     try:
-        parsed = P.parse_trace(trace)
+        parsed = P.parse_trace(trace, observations)
         for col in P.COLUMN_KEYS:
             row[col] = parsed.get(col)
         row["derived"] = parsed["derived"]
@@ -376,17 +402,33 @@ async def ingest_window(
     batch_size: int = 300,
     dry_run: bool = False,
 ) -> WindowStats:
-    """Fetch one closed window, parse, and upsert (chunked). The sync fetch runs
-    in a thread so it doesn't block the event loop. Fetch page size is clamped to
+    """Fetch one closed window, parse, and upsert (chunked). The sync fetches run
+    in a thread so they don't block the event loop. Fetch page size is clamped to
     the Langfuse list-page max (``MAX_PAGE_SIZE``); the upsert batch is independent."""
     page_size = min(batch_size, MAX_PAGE_SIZE)
     traces = await asyncio.to_thread(
         client.fetch_window, from_ts, to_ts, environment, page_size
     )
+    traces, auxiliary = _split_auxiliary(traces)
+    if auxiliary:
+        logger.info(
+            "langfuse_auxiliary_traces_skipped",
+            window_start=from_ts.isoformat(),
+            skipped=auxiliary,
+        )
+    obs_by_trace = await _fetch_observations(
+        client,
+        from_ts,
+        to_ts,
+        environment,
+        page_size,
+        {tid for t in traces if (tid := t.get("id"))},
+    )
     stats = WindowStats(fetched=len(traces))
     batch: list[dict[str, Any]] = []
     for t in traces:
-        row = build_row(t)
+        trace_id = t.get("id")
+        row = build_row(t, obs_by_trace.get(trace_id) if trace_id else None)
         if row["trace_timestamp"] is not None:
             if stats.max_ts is None or row["trace_timestamp"] > stats.max_ts:
                 stats.max_ts = row["trace_timestamp"]
@@ -397,6 +439,82 @@ async def ingest_window(
     if batch:
         await _flush(session, batch, metrics, stats, dry_run)
     return stats
+
+
+def _split_auxiliary(
+    traces: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int]:
+    """Drop non-turn traces, returning (turns, dropped_count).
+
+    An auxiliary trace is one LLM call made outside an agent turn — thread
+    naming, area naming, language detection (see
+    ``src.shared.langfuse_tracing.AUXILIARY_TAG``). It carries no AgentState, so
+    ingesting it would add a zero-token EMPTY-outcome row and drag down every
+    per-turn average. Its cost stays visible in Langfuse, under the same session
+    id as the thread it belongs to.
+    """
+    turns = [t for t in traces if AUXILIARY_TAG not in (t.get("tags") or [])]
+    return turns, len(traces) - len(turns)
+
+
+async def _fetch_observations(
+    client: LangfuseClient,
+    from_ts: datetime,
+    to_ts: datetime,
+    environment: Optional[str],
+    page_size: int,
+    trace_ids: set[str],
+) -> dict[str, list[dict[str, Any]]]:
+    """This window's observations, grouped by trace id.
+
+    Every observation type is fetched, not only the generations — see the
+    comment on the fetch call. ``parse_observations`` picks the billable ones
+    back out; the rest are the tree it needs to attribute them.
+
+    Degrades rather than fails: on a fetch error the window still ingests, with
+    token counts falling back to the message stream (agent-level only). The
+    ``agent_tokens`` fill rate in the run row is what surfaces that.
+
+    Observations belonging to traces outside ``trace_ids`` are dropped — the
+    padded window necessarily catches children of traces that started earlier.
+    """
+    try:
+        observations = await asyncio.to_thread(
+            client.fetch_observations_window,
+            from_ts,
+            to_ts + OBSERVATION_WINDOW_PAD,
+            environment,
+            page_size,
+            # Every type, not just generations: which component a generation
+            # belongs to is written on its ANCESTORS (the LangGraph ``model``
+            # chain, or the TOOL span above it), never on the generation
+            # itself — both an agent call and a tool's call are named
+            # "ChatGoogleGenerativeAI". Fetch generations alone and the parent
+            # walk finds nothing, so every call lands in ``other`` and the
+            # agent/tool split reads as all-tool.
+            None,
+        )
+    except LangfuseFetchError as e:
+        logger.error(
+            "langfuse_observation_fetch_failed",
+            window_start=from_ts.isoformat(),
+            error=str(e),
+        )
+        return {}
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for o in observations:
+        tid = o.get("traceId")
+        if tid and tid in trace_ids:
+            grouped.setdefault(tid, []).append(o)
+    logger.info(
+        "langfuse_observations_fetched",
+        window_start=from_ts.isoformat(),
+        observations=len(observations),
+        traces_with_usage=len(grouped),
+        traces=len(trace_ids),
+    )
+    return grouped
 
 
 async def _flush(

--- a/src/api/services/langfuse/parse.py
+++ b/src/api/services/langfuse/parse.py
@@ -5,7 +5,7 @@ final ``AgentState`` snapshot (src/agent/state.py) — carrying ``aoi_selection`
 ``dataset``, ``statistics``, ``insight_id`` etc. alongside ``messages`` — so the
 structured domain fields are read directly from that contract (no regex).
 
-Two important correctness points, validated against real staging traces:
+Three important correctness points, validated against real production traces:
 
 * ``output`` (and ``output.messages``) is **thread-cumulative** (state uses
   ``operator.add``). So per-turn metrics (tokens, tool calls) are computed over
@@ -15,6 +15,15 @@ Two important correctness points, validated against real staging traces:
   agent usually recovers, so it must NOT by itself mark the turn a failure. We
   record ``tool_error_count`` as a separate signal and classify the outcome from
   the final active-turn AI message.
+* The message stream only carries the usage of the calls the **agent itself**
+  made: a tool that calls an LLM of its own returns a ToolMessage, never an
+  AIMessage, so its tokens are absent from ``output.messages`` entirely. Token
+  columns therefore come from the trace's **generation observations** when they
+  are supplied, and fall back to the message stream when they are not
+  (``derived.usage_source`` records which). On one measured production trace the
+  message stream accounted for 35,466 of 44,491 tokens and 67% of the cost —
+  the missing third was ``pick_aoi``, ``pick_dataset`` and the insight
+  text generator, which Langfuse had traced correctly all along.
 
 These functions are pure (no IO). ``parse_trace`` returns derived column values
 plus a ``derived`` JSONB bundle; ``ingest`` adds identity/raw fields.
@@ -22,11 +31,17 @@ plus a ``derived`` JSONB bundle; ``ingest`` adds identity/raw fields.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Optional
 
 # Bump on any change to derivation logic; to apply it to existing rows, re-run
 # ingestion for the affected window (`ingest-langfuse-traces --backfill --since`).
-PARSER_VERSION = 2
+# v3: token columns are sourced from generation observations (all LLM calls in
+# the turn) instead of the AIMessage stream (the agent's own calls only), and
+# ``total_cost`` falls back to the observation sum when ``trace.totalCost`` is
+# null. ``turn_tokens`` steps UP for any turn whose tools call an LLM; the
+# agent-only figure it used to hold is kept as ``agent_tokens``.
+PARSER_VERSION = 3
 
 # Top-level keys we expect on ``trace.output`` (the AgentState snapshot).
 # Used for drift detection: unknown keys => additive drift (benign, logged);
@@ -436,6 +451,187 @@ def _detect_language(
         return None, None
 
 
+# The number of JSON-decode passes ``_as_state_dict`` will try. The LangChain
+# callback serialises the graph output to a JSON string before handing it to
+# Langfuse, and an export of the same trace can add a second layer, so two is
+# the observed maximum; the cap just stops a pathological value from looping.
+_MAX_JSON_DECODE_PASSES = 4
+
+
+def _as_state_dict(output: Any) -> Any:
+    """Return ``trace.output`` as a dict when it is one, decoding JSON strings.
+
+    A trace whose ``output`` arrives as a JSON *string* rather than an object
+    used to zero every metric on the row, silently: the message walk needs a
+    dict, and ``parse_state`` classifies a non-dict output as "not applicable"
+    rather than as a contract violation, so the drift monitor stayed quiet too.
+    Decoding here means the shape of the transport cannot cost us the data.
+
+    Anything that does not decode to a dict is returned unchanged, so the
+    existing "output absent" handling still applies.
+    """
+    value = output
+    for _ in range(_MAX_JSON_DECODE_PASSES):
+        if isinstance(value, dict):
+            return value
+        if not isinstance(value, str):
+            return output
+        try:
+            value = json.loads(value)
+        except (ValueError, TypeError):
+            return output
+    return value if isinstance(value, dict) else output
+
+
+# --------------------------------------------------------------------------- #
+# Observations (the usage source)
+# --------------------------------------------------------------------------- #
+# The LangGraph model node. A generation whose nearest named ancestor is this
+# chain is a call the agent made itself; anything under a TOOL observation was
+# made by that tool.
+_AGENT_NODE_NAME = "model"
+AGENT_COMPONENT = "agent"
+OTHER_COMPONENT = "other"
+
+
+def _obs_usage(obs: dict[str, Any]) -> tuple[int, int, int, int]:
+    """Return (input, output, total, cache_read) tokens for one observation.
+
+    Langfuse splits cached prompt tokens out of ``input`` and reports them as
+    ``input_cache_read``, whereas LangChain's ``usage_metadata.input_tokens``
+    includes them. We add them back so the token columns keep the same meaning
+    they had when they were derived from the message stream — otherwise the
+    series silently drops by the cache-hit rate (~45% on measured traces).
+    """
+    u = obs.get("usageDetails") or {}
+    cache = _int(u.get("input_cache_read"))
+    inp = _int(u.get("input")) + cache
+    out = _int(u.get("output"))
+    total = _int(u.get("total")) or (inp + out)
+    return inp, out, total, cache
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _obs_cost(obs: dict[str, Any]) -> float:
+    """Cost of one observation, preferring Langfuse's own total."""
+    total = obs.get("totalCost")
+    if total is not None:
+        try:
+            return float(total)
+        except (TypeError, ValueError):
+            return 0.0
+    try:
+        return float(obs.get("inputCost") or 0) + float(
+            obs.get("outputCost") or 0
+        )
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _component(obs: dict[str, Any], by_id: dict[str, dict[str, Any]]) -> str:
+    """Who made this call: ``agent``, the owning tool's name, or ``other``.
+
+    Walks up ``parentObservationId`` to the nearest TOOL observation (the tool
+    that owns the call) or to the LangGraph ``model`` node (the agent's own
+    call). Anything else — a generation outside both, e.g. one emitted by a
+    manually instrumented span — lands in ``other`` rather than inflating the
+    agent's share.
+    """
+    seen: set[str] = set()
+    cur = by_id.get(obs.get("parentObservationId") or "")
+    while cur is not None:
+        cid = cur.get("id") or ""
+        if cid in seen:  # defensive: a cycle would otherwise hang ingestion
+            break
+        seen.add(cid)
+        if str(cur.get("type") or "").upper() == "TOOL":
+            return cur.get("name") or "unknown_tool"
+        if cur.get("name") == _AGENT_NODE_NAME:
+            return AGENT_COMPONENT
+        cur = by_id.get(cur.get("parentObservationId") or "")
+    return OTHER_COMPONENT
+
+
+def parse_observations(
+    observations: Optional[list[dict[str, Any]]],
+) -> Optional[dict[str, Any]]:
+    """Aggregate a trace's generation observations into usage + cost.
+
+    Returns None when there is nothing to aggregate, which tells ``parse_trace``
+    to fall back to the message stream. ``tool_*`` is defined as "everything the
+    agent did not spend itself" (total minus agent), so the two always add up to
+    the total no matter how the components are labelled.
+    """
+    if not observations:
+        return None
+    by_id = {o.get("id") or "": o for o in observations if isinstance(o, dict)}
+    gens = [
+        o
+        for o in observations
+        if isinstance(o, dict)
+        and str(o.get("type") or "").upper() in ("GENERATION", "EMBEDDING")
+    ]
+    if not gens:
+        return None
+
+    t_in = t_out = t_total = t_cache = 0
+    a_in = a_out = a_total = a_cache = 0
+    cost = a_cost = 0.0
+    tokens_by_component: dict[str, int] = {}
+    cost_by_component: dict[str, float] = {}
+
+    for o in gens:
+        i, out, total, cache = _obs_usage(o)
+        c = _obs_cost(o)
+        t_in += i
+        t_out += out
+        t_total += total
+        t_cache += cache
+        cost += c
+
+        component = _component(o, by_id)
+        tokens_by_component[component] = (
+            tokens_by_component.get(component, 0) + total
+        )
+        cost_by_component[component] = (
+            cost_by_component.get(component, 0.0) + c
+        )
+        if component == AGENT_COMPONENT:
+            a_in += i
+            a_out += out
+            a_total += total
+            a_cache += cache
+            a_cost += c
+
+    return {
+        # columns
+        "turn_input_tokens": t_in,
+        "turn_output_tokens": t_out,
+        "turn_tokens": t_total,
+        "agent_tokens": a_total,
+        "tool_tokens": t_total - a_total,
+        "agent_cost": round(a_cost, 10),
+        "tool_cost": round(cost - a_cost, 10),
+        "generation_count": len(gens),
+        # derived
+        "cache_read_tokens": t_cache,
+        "agent_input_tokens": a_in,
+        "agent_output_tokens": a_out,
+        "agent_cache_read_tokens": a_cache,
+        "tokens_by_component": tokens_by_component,
+        "cost_by_component": {
+            k: round(v, 10) for k, v in cost_by_component.items()
+        },
+        "observation_cost": round(cost, 10),
+    }
+
+
 # --------------------------------------------------------------------------- #
 # Top-level
 # --------------------------------------------------------------------------- #
@@ -460,24 +656,68 @@ COLUMN_KEYS = frozenset(
         "has_insight",
         "is_global",
         "insight_id",
+        "total_cost",
+        "agent_tokens",
+        "tool_tokens",
+        "agent_cost",
+        "tool_cost",
+        "generation_count",
     }
 )
 
 
-def parse_trace(trace: dict[str, Any]) -> dict[str, Any]:
+def parse_trace(
+    trace: dict[str, Any],
+    observations: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
     """Parse one trace into ``{<column>: value, ..., "derived": {...},
     "recognized_contract": bool, "parser_version": int}``.
 
+    ``observations`` is the trace's observation list (see
+    ``LangfuseClient.fetch_observations_window``). When supplied, its
+    generations are the source of the token columns and of the agent/tool
+    split; when omitted, the token columns fall back to the message stream and
+    the split is left null. ``derived.usage_source`` records which happened.
+
     Identity/raw/timestamp fields are added by the ingest layer, not here.
     """
-    output = trace.get("output")
+    output = _as_state_dict(trace.get("output"))
     state = parse_state(output)
     msgs = output.get("messages") if isinstance(output, dict) else None
-    inp = trace.get("input") or {}
+    inp = _as_state_dict(trace.get("input")) or {}
     in_msgs = inp.get("messages") if isinstance(inp, dict) else None
     msg = parse_messages(msgs or [], in_msgs or [])
 
     combined = {**state, **msg}
+
+    usage = parse_observations(observations)
+    if usage is None:
+        combined["usage_source"] = "messages"
+        # No observations: the message-derived counts stand, but they only
+        # cover the agent's own calls, so the split would be a lie.
+        combined["total_cost"] = trace.get("totalCost")
+    else:
+        # The message-derived agent figure is kept alongside: the two are
+        # independent measurements of the same calls, so a divergence is a
+        # drift signal (they matched to the token on the validation trace).
+        from_messages = combined.get("turn_tokens")
+        combined["agent_tokens_from_messages"] = from_messages
+        combined["usage_source"] = "observations"
+        combined.update(usage)
+        # The agent/tool split hinges on the LangGraph model node still being
+        # named ``model`` (see _component). Rename it upstream and every call
+        # silently becomes "other" — which a fill-rate check cannot catch,
+        # because zero is not null. This flag can: it goes False.
+        combined["usage_split_agrees"] = (
+            usage["agent_tokens"] == from_messages if from_messages else None
+        )
+        # ``trace.totalCost`` is frequently null even when the observations
+        # underneath it are priced, so the observation sum is the fallback.
+        trace_cost = trace.get("totalCost")
+        combined["total_cost"] = (
+            trace_cost if trace_cost is not None else usage["observation_cost"]
+        )
+
     row = {k: combined[k] for k in COLUMN_KEYS if k in combined}
     derived = {k: v for k, v in combined.items() if k not in COLUMN_KEYS}
     derived.pop("recognized_contract", None)

--- a/src/shared/langfuse_tracing.py
+++ b/src/shared/langfuse_tracing.py
@@ -1,0 +1,214 @@
+"""Emit Langfuse generation spans for LLM calls LangChain does not make.
+
+The Langfuse LangChain callback traces every call that goes through a LangChain
+runnable, and it propagates into tools on its own (async config propagation), so
+tool-internal chains need nothing from this module. What it cannot see is a call
+made with a provider SDK directly — currently the Gemini code executor in
+``src.agent.subagents.analyst.code_executors``, which drives native code
+execution that LangChain does not model.
+
+Such a call is invisible in both tokens and cost, so a turn that runs it reads
+cheaper than it was. ``generation_span`` puts it back on the trace. The v3
+Langfuse SDK is OpenTelemetry-backed and so is the LangChain callback handler,
+which is why a span opened here nests under the live trace without being handed
+a parent: both read the same ambient OTEL context.
+
+Everything here degrades to a no-op. Langfuse is unconfigured in CLI runs, tests
+and local development, and telemetry must never be the reason an analysis fails.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional, Protocol
+
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Marks a trace that is NOT an agent turn: a one-off LLM call made by its own
+# HTTP request (thread naming, area naming) or before the graph is invoked
+# (language detection). Such a call creates its own root trace, because a
+# LangChain callback handler opens a trace per root invocation and there is no
+# turn to nest it under.
+#
+# The ingest layer drops these from ``langfuse_traces`` — that table is
+# turn-level, and a tiny auxiliary trace carries no AgentState, so it would land
+# as a zero-token EMPTY-outcome row and dilute every per-turn average. Their
+# cost stays visible in Langfuse itself, and they share the thread's session id,
+# so session-level cost remains complete. See
+# ``src.api.services.langfuse.ingest.ingest_window``.
+AUXILIARY_TAG = "auxiliary"
+
+
+class UsageRecorder(Protocol):
+    """What a caller may report once its LLM call returns."""
+
+    def record(
+        self,
+        *,
+        usage: Optional[Dict[str, int]] = None,
+        model: Optional[str] = None,
+        output: Optional[Any] = None,
+        level: Optional[str] = None,
+        status_message: Optional[str] = None,
+    ) -> None: ...
+
+
+class _NullRecorder:
+    """Used when Langfuse is unconfigured or the span could not be opened."""
+
+    def record(
+        self,
+        *,
+        usage: Optional[Dict[str, int]] = None,
+        model: Optional[str] = None,
+        output: Optional[Any] = None,
+        level: Optional[str] = None,
+        status_message: Optional[str] = None,
+    ) -> None:
+        return None
+
+
+class _SpanRecorder:
+    def __init__(self, span: Any) -> None:
+        self._span = span
+
+    def record(
+        self,
+        *,
+        usage: Optional[Dict[str, int]] = None,
+        model: Optional[str] = None,
+        output: Optional[Any] = None,
+        level: Optional[str] = None,
+        status_message: Optional[str] = None,
+    ) -> None:
+        try:
+            fields: Dict[str, Any] = {}
+            if usage:
+                fields["usage_details"] = usage
+            if model:
+                fields["model"] = model
+            if output is not None:
+                fields["output"] = output
+            if level:
+                fields["level"] = level
+            if status_message:
+                fields["status_message"] = status_message
+            if fields:
+                self._span.update(**fields)
+        except Exception:  # pragma: no cover - telemetry must not raise
+            logger.debug("langfuse_generation_update_failed", exc_info=True)
+
+
+@contextmanager
+def generation_span(
+    name: str,
+    *,
+    model: Optional[str] = None,
+    input: Optional[Any] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Iterator[UsageRecorder]:
+    """Open a Langfuse generation span, yielding something to report usage to.
+
+    Nests under whatever trace is currently active, so a call made inside an
+    agent tool lands under that tool. Yields a no-op recorder when Langfuse is
+    unavailable, so callers need no conditional of their own::
+
+        with generation_span("analyst_code_executor", model=model) as gen:
+            response = await call_the_sdk()
+            gen.record(usage=usage_from(response))
+    """
+    try:
+        from langfuse import get_client
+
+        client = get_client()
+    except Exception:
+        logger.debug("langfuse_client_unavailable", exc_info=True)
+        yield _NullRecorder()
+        return
+
+    try:
+        cm = client.start_as_current_observation(
+            as_type="generation",
+            name=name,
+            model=model,
+            input=input,
+            metadata=metadata,
+        )
+    except Exception:  # pragma: no cover - telemetry must not raise
+        logger.debug("langfuse_generation_start_failed", exc_info=True)
+        yield _NullRecorder()
+        return
+
+    with cm as span:
+        yield _SpanRecorder(span)
+
+
+def gemini_usage_details(response: Any) -> Optional[Dict[str, int]]:
+    """Map a ``google.genai`` response's usage onto Langfuse's usage keys.
+
+    Langfuse keys prompt tokens as ``input`` *excluding* the cached ones, which
+    it wants separately as ``input_cache_read`` — the same split the parser
+    relies on (see ``src.api.services.langfuse.parse._obs_usage``). Gemini's
+    ``prompt_token_count`` includes the cached ones, so they are subtracted out
+    here. Thinking tokens are billed as output, so they are folded into it.
+    """
+    usage = getattr(response, "usage_metadata", None)
+    if usage is None:
+        return None
+
+    def _int(value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    cached = _int(getattr(usage, "cached_content_token_count", None))
+    prompt = _int(getattr(usage, "prompt_token_count", None))
+    output = _int(getattr(usage, "candidates_token_count", None)) + _int(
+        getattr(usage, "thoughts_token_count", None)
+    )
+    total = _int(getattr(usage, "total_token_count", None))
+
+    details = {
+        "input": max(prompt - cached, 0),
+        "output": output,
+        "total": total or prompt + output,
+    }
+    if cached:
+        details["input_cache_read"] = cached
+    return details
+
+
+def auxiliary_config(
+    run_name: str,
+    *,
+    session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """A RunnableConfig that traces an LLM call made outside an agent turn.
+
+    Without one of these, a call like thread naming or custom-area naming is
+    billed and never appears anywhere: it runs in its own request, so there is
+    no ambient handler for LangChain's config propagation to find.
+
+    Passing ``session_id`` (the thread id) is what lets the resulting trace be
+    joined back to the conversation it belongs to. Returns a config with no
+    callbacks if Langfuse is unconfigured, so callers need no conditional.
+    """
+    config: Dict[str, Any] = {"run_name": run_name}
+    metadata: Dict[str, Any] = {"langfuse_tags": [AUXILIARY_TAG]}
+    if session_id:
+        metadata["langfuse_session_id"] = session_id
+    if user_id:
+        metadata["langfuse_user_id"] = user_id
+    config["metadata"] = metadata
+
+    try:
+        from langfuse.langchain import CallbackHandler
+
+        config["callbacks"] = [CallbackHandler()]
+    except Exception:
+        logger.debug("langfuse_callback_unavailable", exc_info=True)
+    return config

--- a/tests/unit/agent/test_gemini_executor_tracing.py
+++ b/tests/unit/agent/test_gemini_executor_tracing.py
@@ -1,0 +1,155 @@
+"""The Gemini code executor must report its usage to Langfuse.
+
+This call goes straight to the ``google.genai`` SDK, so no LangChain callback
+sees it. Before it was instrumented it was the single largest LLM call in an
+insight turn and appeared in no trace at all — neither tokens nor cost — which
+made every insight look cheaper than it was. These tests pin the reporting, and
+pin that a telemetry failure can never break an analysis.
+"""
+
+import asyncio
+
+import pytest
+
+from src.agent.subagents.analyst.code_executors import gemini_executor as GE
+
+
+class _Usage:
+    prompt_token_count = 9_000
+    candidates_token_count = 300
+    thoughts_token_count = 0
+    total_token_count = 9_300
+    cached_content_token_count = 0
+
+
+class _Response:
+    usage_metadata = _Usage()
+
+
+class _Recorder:
+    """Captures what the executor reports, standing in for a Langfuse span."""
+
+    def __init__(self):
+        self.calls = []
+
+    def record(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+@pytest.fixture
+def spans(monkeypatch):
+    """Replace generation_span with a recorder, and return the opened spans."""
+    opened = []
+
+    class _Span:
+        def __init__(self, name, kwargs):
+            self.name = name
+            self.kwargs = kwargs
+            self.recorder = _Recorder()
+
+    def fake_span(name, **kwargs):
+        span = _Span(name, kwargs)
+        opened.append(span)
+
+        class _CM:
+            def __enter__(self_inner):
+                return span.recorder
+
+            def __exit__(self_inner, *exc):
+                return False
+
+        return _CM()
+
+    monkeypatch.setattr(GE, "generation_span", fake_span)
+    return opened
+
+
+@pytest.fixture
+def executor(monkeypatch):
+    """A GeminiCodeExecutor with no real client and no real sleeps."""
+    monkeypatch.setattr(GE.genai, "Client", lambda *a, **kw: object())
+    monkeypatch.setattr(GE.asyncio, "sleep", _noop_sleep)
+    ex = GE.GeminiCodeExecutor()
+    ex.INITIAL_DELAY = 0
+    return ex
+
+
+async def _noop_sleep(*_args, **_kwargs):
+    return None
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_successful_call_reports_usage_on_the_span(executor, spans):
+    class _Models:
+        def generate_content(self, **kwargs):
+            return _Response()
+
+    executor.client = type("C", (), {"models": _Models()})()
+
+    result = _run(
+        executor._call_model("gemini-3-flash-preview", [{"text": "x"}])
+    )
+    assert isinstance(result, _Response)
+
+    assert len(spans) == 1
+    assert spans[0].name == "analyst_code_executor"
+    assert spans[0].kwargs["model"] == "gemini-3-flash-preview"
+    # The usage the trace was missing entirely before instrumentation.
+    assert spans[0].recorder.calls == [
+        {"usage": {"input": 9_000, "output": 300, "total": 9_300}}
+    ]
+
+
+def test_exhausted_retries_mark_the_span_as_an_error(executor, spans):
+    class _Models:
+        def generate_content(self, **kwargs):
+            raise RuntimeError("upstream 503")
+
+    executor.client = type("C", (), {"models": _Models()})()
+
+    with pytest.raises(RuntimeError, match="upstream 503"):
+        _run(executor._call_model("gemini-3-flash-preview", [{"text": "x"}]))
+
+    assert len(spans) == 1
+    recorded = spans[0].recorder.calls
+    assert recorded == [{"level": "ERROR", "status_message": "upstream 503"}]
+
+
+def test_one_span_covers_the_whole_retry_loop(executor, spans):
+    """Retries are transient failures of one logical call, so they belong in one
+    span whose latency is the wall-clock time the caller actually waited."""
+    attempts = {"n": 0}
+
+    class _Models:
+        def generate_content(self, **kwargs):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise RuntimeError("flaky")
+            return _Response()
+
+    executor.client = type("C", (), {"models": _Models()})()
+
+    _run(executor._call_model("gemini-3-flash-preview", [{"text": "x"}]))
+    assert attempts["n"] == 3
+    assert len(spans) == 1
+    assert spans[0].recorder.calls == [
+        {"usage": {"input": 9_000, "output": 300, "total": 9_300}}
+    ]
+
+
+def test_call_succeeds_with_langfuse_unconfigured(executor):
+    """Uses the real generation_span, which is what production falls back to
+    whenever Langfuse is unreachable or unconfigured (as it is here)."""
+
+    class _Models:
+        def generate_content(self, **kwargs):
+            return _Response()
+
+    executor.client = type("C", (), {"models": _Models()})()
+
+    assert isinstance(
+        _run(executor._call_model("m", [{"text": "x"}])), _Response
+    )

--- a/tests/unit/shared/test_langfuse_tracing.py
+++ b/tests/unit/shared/test_langfuse_tracing.py
@@ -1,0 +1,133 @@
+"""Unit tests for src/shared/langfuse_tracing.py.
+
+The point of this module is that telemetry never breaks an analysis, so most of
+these assert the no-op paths hold when Langfuse is unconfigured (as it is in
+tests) and that the Gemini usage mapping matches the keys the parser reads back
+out of Langfuse.
+"""
+
+from src.shared.langfuse_tracing import (
+    AUXILIARY_TAG,
+    auxiliary_config,
+    gemini_usage_details,
+    generation_span,
+)
+
+
+class _Usage:
+    prompt_token_count = 12_000
+    candidates_token_count = 400
+    thoughts_token_count = 150
+    total_token_count = 12_550
+    cached_content_token_count = 8_000
+
+
+class _Response:
+    usage_metadata = _Usage()
+
+
+# --------------------------------------------------------------------------- #
+# usage mapping
+# --------------------------------------------------------------------------- #
+def test_cached_tokens_are_reported_separately_from_input():
+    """Langfuse wants `input` net of cache and `input_cache_read` beside it —
+    the same split src/api/services/langfuse/parse.py reads back."""
+    details = gemini_usage_details(_Response())
+    assert details["input"] == 4_000  # 12_000 prompt - 8_000 cached
+    assert details["input_cache_read"] == 8_000
+    # The two must reconstruct Gemini's own prompt count, or the parser's
+    # input + input_cache_read sum is wrong.
+    assert details["input"] + details["input_cache_read"] == 12_000
+
+
+def test_thinking_tokens_are_billed_as_output():
+    assert gemini_usage_details(_Response())["output"] == 550
+
+
+def test_total_is_taken_from_the_response():
+    assert gemini_usage_details(_Response())["total"] == 12_550
+
+
+def test_missing_cache_key_is_omitted_rather_than_zero():
+    class U:
+        prompt_token_count = 10
+        candidates_token_count = 2
+        total_token_count = 12
+
+    class R:
+        usage_metadata = U()
+
+    details = gemini_usage_details(R())
+    assert "input_cache_read" not in details
+    assert details == {"input": 10, "output": 2, "total": 12}
+
+
+def test_response_without_usage_yields_none():
+    assert gemini_usage_details(object()) is None
+
+
+def test_garbage_usage_values_do_not_raise():
+    class U:
+        prompt_token_count = "not a number"
+        candidates_token_count = None
+        total_token_count = None
+
+    class R:
+        usage_metadata = U()
+
+    assert gemini_usage_details(R()) == {"input": 0, "output": 0, "total": 0}
+
+
+# --------------------------------------------------------------------------- #
+# no-op behaviour (Langfuse unconfigured, as in tests and CLI runs)
+# --------------------------------------------------------------------------- #
+def test_generation_span_is_usable_without_langfuse():
+    with generation_span("probe", model="m") as gen:
+        gen.record(usage={"input": 1, "output": 2, "total": 3})
+        gen.record(level="ERROR", status_message="boom")
+
+
+def test_generation_span_yields_a_recorder_even_on_failure():
+    """A caller must never have to guard the record() call."""
+    with generation_span("probe") as gen:
+        assert hasattr(gen, "record")
+
+
+def test_auxiliary_config_tags_and_names_the_call():
+    config = auxiliary_config("generate_thread_name", session_id="t1")
+    assert config["run_name"] == "generate_thread_name"
+    assert config["metadata"]["langfuse_tags"] == [AUXILIARY_TAG]
+    # The session id is what joins the auxiliary trace back to its thread.
+    assert config["metadata"]["langfuse_session_id"] == "t1"
+
+
+def test_auxiliary_config_omits_ids_it_was_not_given():
+    metadata = auxiliary_config("name_custom_area")["metadata"]
+    assert "langfuse_session_id" not in metadata
+    assert "langfuse_user_id" not in metadata
+
+
+def test_a_client_that_raises_still_yields_a_working_recorder(monkeypatch):
+    """The failure the module's try/except exists to absorb: Langfuse present
+    but broken. Callers must still be able to open a span and report to it."""
+    import sys
+
+    class _Exploding:
+        def start_as_current_observation(self, **kwargs):
+            raise RuntimeError("langfuse is down")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "langfuse",
+        type("M", (), {"get_client": staticmethod(lambda: _Exploding())}),
+    )
+    with generation_span("probe", model="m") as gen:
+        gen.record(usage={"input": 1, "output": 1, "total": 2})
+
+
+def test_an_unimportable_client_still_yields_a_recorder(monkeypatch):
+    import sys
+
+    monkeypatch.setitem(sys.modules, "langfuse", None)
+    with generation_span("probe") as gen:
+        gen.record(usage={"input": 1, "output": 1, "total": 2})

--- a/tests/unit/test_langfuse_fetch.py
+++ b/tests/unit/test_langfuse_fetch.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Langfuse fetch client (src/api/services/langfuse/fetch.py).
+
+The traces and observations endpoints share one paging/retry implementation, so
+these pin the per-endpoint parameter names (a silent rename would fetch an empty
+window and zero every token column) and the paging behaviour the module docstring
+promises: closed ascending windows, id-dedup, page-halving on persistent 5xx.
+"""
+
+import httpx
+import pytest
+
+from src.api.services.langfuse import fetch as F
+
+FROM = F.datetime(2026, 9, 1, tzinfo=F.timezone.utc)
+TO = F.datetime(2026, 9, 2, tzinfo=F.timezone.utc)
+
+
+class _Resp:
+    def __init__(self, payload=None, status_code=200):
+        self._payload = payload if payload is not None else {"data": []}
+        self.status_code = status_code
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("boom", request=None, response=None)
+
+
+class _FakeClient:
+    """Stands in for httpx.Client, recording every request it is given."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get(self, url, params=None, auth=None):
+        self.calls.append((url, dict(params or {})))
+        if self._responses:
+            return self._responses.pop(0)
+        return _Resp()
+
+
+@pytest.fixture
+def client():
+    return F.LangfuseClient(host="http://lf", public_key="pk", secret_key="sk")
+
+
+def _install(monkeypatch, responses):
+    fake = _FakeClient(responses)
+    monkeypatch.setattr(F.httpx, "Client", lambda **kw: fake)
+    monkeypatch.setattr(F.time, "sleep", lambda *_: None)
+    return fake
+
+
+# --------------------------------------------------------------------------- #
+# per-endpoint request shape
+# --------------------------------------------------------------------------- #
+def test_traces_window_uses_timestamp_bounds_ascending(monkeypatch, client):
+    fake = _install(monkeypatch, [_Resp({"data": [{"id": "t1"}]})])
+    assert client.fetch_window(FROM, TO) == [{"id": "t1"}]
+
+    url, params = fake.calls[0]
+    assert url == "http://lf/api/public/traces"
+    assert params["fromTimestamp"].startswith("2026-09-01")
+    assert params["toTimestamp"].startswith("2026-09-02")
+    assert params["orderBy"] == "timestamp.asc"
+
+
+def test_observations_window_uses_start_time_bounds_and_filters_generations(
+    monkeypatch, client
+):
+    """These parameter names are load-bearing: get them wrong and the window
+    comes back empty, which silently zeroes every token column."""
+    fake = _install(monkeypatch, [_Resp({"data": [{"id": "o1"}]})])
+    assert client.fetch_observations_window(FROM, TO) == [{"id": "o1"}]
+
+    url, params = fake.calls[0]
+    assert url == "http://lf/api/public/observations"
+    assert params["fromStartTime"].startswith("2026-09-01")
+    assert params["toStartTime"].startswith("2026-09-02")
+    assert params["type"] == "GENERATION"
+
+
+def test_observations_can_fetch_every_type(monkeypatch, client):
+    fake = _install(monkeypatch, [_Resp({"data": []})])
+    client.fetch_observations_window(FROM, TO, obs_type=None)
+    assert "type" not in fake.calls[0][1]
+
+
+def test_environment_is_forwarded_when_given(monkeypatch, client):
+    fake = _install(monkeypatch, [_Resp({"data": []})])
+    client.fetch_window(FROM, TO, environment="production")
+    assert fake.calls[0][1]["environment"] == "production"
+
+
+# --------------------------------------------------------------------------- #
+# paging
+# --------------------------------------------------------------------------- #
+def test_pages_until_total_pages_and_dedupes_by_id(monkeypatch, client):
+    fake = _install(
+        monkeypatch,
+        [
+            _Resp(
+                {"data": [{"id": "a"}, {"id": "b"}], "meta": {"totalPages": 2}}
+            ),
+            # "b" repeats across the page boundary; it must not be counted twice.
+            _Resp(
+                {"data": [{"id": "b"}, {"id": "c"}], "meta": {"totalPages": 2}}
+            ),
+        ],
+    )
+    rows = client.fetch_window(FROM, TO)
+    assert [r["id"] for r in rows] == ["a", "b", "c"]
+    assert [c[1]["page"] for c in fake.calls] == [1, 2]
+
+
+def test_stops_on_an_empty_page(monkeypatch, client):
+    _install(monkeypatch, [_Resp({"data": []})])
+    assert client.fetch_observations_window(FROM, TO) == []
+
+
+# --------------------------------------------------------------------------- #
+# resilience
+# --------------------------------------------------------------------------- #
+def test_persistent_5xx_halves_the_page_size(monkeypatch, client):
+    fake = _install(
+        monkeypatch,
+        [
+            _Resp(status_code=500),
+            _Resp(status_code=500),
+            _Resp(status_code=500),
+        ]
+        + [_Resp({"data": [{"id": "a"}]})],
+    )
+    assert client.fetch_observations_window(FROM, TO, page_size=50) == [
+        {"id": "a"}
+    ]
+    limits = [c[1]["limit"] for c in fake.calls]
+    assert limits[0] == 50
+    assert limits[-1] == 25  # window restarted at half the page size
+
+
+def test_5xx_at_page_size_one_raises_rather_than_dropping_data(
+    monkeypatch, client
+):
+    _install(monkeypatch, [_Resp(status_code=503) for _ in range(30)])
+    with pytest.raises(F.LangfuseFetchError):
+        client.fetch_observations_window(FROM, TO, page_size=1)

--- a/tests/unit/test_langfuse_ingest.py
+++ b/tests/unit/test_langfuse_ingest.py
@@ -5,7 +5,12 @@ Synthetic fixtures only (no real user text). Focus: NUL-byte sanitization, since
 Postgres text/jsonb reject 0x00 and an unsanitized trace once aborted a batch.
 """
 
-from src.api.services.langfuse.ingest import _strip_nul, build_row
+from src.api.services.langfuse.ingest import (
+    _split_auxiliary,
+    _strip_nul,
+    build_row,
+)
+from src.shared.langfuse_tracing import AUXILIARY_TAG
 
 
 def test_strip_nul_scrubs_nested_strings():
@@ -86,3 +91,123 @@ def test_build_row_singleton_without_insight_has_empty_diffs():
     row = build_row({"id": "t1", "environment": "production"})
     assert row["insight_created_this_turn"] is False
     assert row["datasets_analysed_this_turn"] == []
+
+
+# --------------------------------------------------------------------------- #
+# auxiliary traces (LLM calls that are not agent turns)
+# --------------------------------------------------------------------------- #
+def test_auxiliary_traces_are_dropped_from_the_turn_table():
+    """Thread naming and the like carry no AgentState, so ingesting them would
+    add zero-token EMPTY rows and drag every per-turn average down."""
+    turns, dropped = _split_auxiliary(
+        [
+            {"id": "turn", "tags": []},
+            {"id": "naming", "tags": [AUXILIARY_TAG]},
+            {"id": "no_tags_field"},
+        ]
+    )
+    assert [t["id"] for t in turns] == ["turn", "no_tags_field"]
+    assert dropped == 1
+
+
+def test_build_row_records_usage_from_observations():
+    """The row's token columns come from the observations when they are given."""
+    trace = {
+        "id": "t1",
+        "sessionId": None,
+        "output": {"messages": []},
+        "totalCost": None,
+    }
+    observations = [
+        {"id": "root", "type": "CHAIN", "name": "LangGraph"},
+        {
+            "id": "m",
+            "type": "CHAIN",
+            "name": "model",
+            "parentObservationId": "root",
+        },
+        {
+            "id": "g",
+            "type": "GENERATION",
+            "parentObservationId": "m",
+            "usageDetails": {"input": 100, "output": 10, "total": 110},
+            "totalCost": 0.002,
+        },
+    ]
+    row = build_row(trace, observations)
+    assert row["turn_tokens"] == 110
+    assert row["agent_tokens"] == 110
+    assert row["tool_tokens"] == 0
+    # trace.totalCost was null; the observation sum stands in for it.
+    assert row["total_cost"] == 0.002
+
+
+def test_build_row_without_observations_keeps_message_usage():
+    trace = {"id": "t1", "sessionId": None, "output": {"messages": []}}
+    row = build_row(trace)
+    assert row["derived"]["usage_source"] == "messages"
+
+
+def test_observation_fetch_asks_for_every_type_and_pads_the_window():
+    """Two things this must not regress: `obs_type=None` (attribution needs the
+    ancestor spans) and the upper pad (a trace at the window's edge has children
+    that start after it closes)."""
+    import asyncio
+    from datetime import datetime, timezone
+
+    from src.api.services.langfuse.ingest import (
+        OBSERVATION_WINDOW_PAD,
+        _fetch_observations,
+    )
+
+    recorded = {}
+
+    class _Client:
+        def fetch_observations_window(
+            self, from_ts, to_ts, environment, page_size, obs_type
+        ):
+            recorded.update(
+                from_ts=from_ts,
+                to_ts=to_ts,
+                obs_type=obs_type,
+            )
+            return [
+                {"id": "a", "traceId": "keep"},
+                {"id": "b", "traceId": "from_an_earlier_window"},
+            ]
+
+    from_ts = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    to_ts = datetime(2026, 9, 2, tzinfo=timezone.utc)
+    grouped = asyncio.run(
+        _fetch_observations(_Client(), from_ts, to_ts, None, 50, {"keep"})
+    )
+
+    assert recorded["obs_type"] is None
+    assert recorded["to_ts"] == to_ts + OBSERVATION_WINDOW_PAD
+    # Observations of traces this window did not fetch are discarded.
+    assert set(grouped) == {"keep"}
+
+
+def test_observation_fetch_failure_degrades_instead_of_raising():
+    import asyncio
+    from datetime import datetime, timezone
+
+    from src.api.services.langfuse.fetch import LangfuseFetchError
+    from src.api.services.langfuse.ingest import _fetch_observations
+
+    class _Client:
+        def fetch_observations_window(self, *a, **kw):
+            raise LangfuseFetchError("langfuse 500")
+
+    grouped = asyncio.run(
+        _fetch_observations(
+            _Client(),
+            datetime(2026, 9, 1, tzinfo=timezone.utc),
+            datetime(2026, 9, 2, tzinfo=timezone.utc),
+            None,
+            50,
+            {"t"},
+        )
+    )
+    # Empty, not an exception: the window still ingests on message-derived usage.
+    assert grouped == {}

--- a/tests/unit/test_langfuse_parse.py
+++ b/tests/unit/test_langfuse_parse.py
@@ -271,6 +271,248 @@ def test_does_not_crash_on_garbage():
 
 
 # --------------------------------------------------------------------------- #
+# output transport shape
+# --------------------------------------------------------------------------- #
+def test_json_string_output_is_decoded_not_silently_zeroed():
+    """A trace whose output arrives as a JSON string must still parse. It used
+    to zero every metric AND report the contract as N/A rather than violated,
+    so nothing flagged it."""
+    import json as _json
+
+    out = {
+        "messages": [
+            human("Q"),
+            ai("A", finish="end_turn", usage=usage(30, 5)),
+        ]
+    }
+    r = P.parse_trace(trace(_json.dumps(out)))
+    assert r["turn_tokens"] == 35
+    assert r["answer"] == "A"
+    assert r["recognized_contract"] is True
+
+
+def test_double_encoded_output_is_decoded():
+    """The shape a Langfuse UI export actually produces."""
+    import json as _json
+
+    out = {"messages": [human("Q"), ai("A", finish="end_turn")]}
+    r = P.parse_trace(trace(_json.dumps(_json.dumps(out))))
+    assert r["answer"] == "A"
+    assert r["recognized_contract"] is True
+
+
+def test_json_string_input_is_decoded_for_the_prompt():
+    import json as _json
+
+    inp = _json.dumps({"messages": [human("How much forest was lost?")]})
+    r = P.parse_trace(trace(None, inp=inp))
+    assert r["prompt"] == "How much forest was lost?"
+
+
+def test_undecodable_output_still_reports_not_applicable():
+    for bad in ["not json at all", '"a bare string"', "[]", "42"]:
+        r = P.parse_trace(trace(bad))
+        assert r["recognized_contract"] is None
+        assert r["outcome"] == "EMPTY"
+
+
+# --------------------------------------------------------------------------- #
+# usage from observations (the agent/tool split)
+# --------------------------------------------------------------------------- #
+def gen(oid, parent=None, inp=0, out=0, cache=0, cost=0.0, name="ChatModel"):
+    """A GENERATION observation, shaped like the Langfuse observations API."""
+    total = inp + out + cache
+    return {
+        "id": oid,
+        "parentObservationId": parent,
+        "type": "GENERATION",
+        "name": name,
+        "usageDetails": {
+            "input": inp,
+            "output": out,
+            "total": total,
+            "input_cache_read": cache,
+        },
+        "totalCost": cost,
+    }
+
+
+def span(oid, name, otype="CHAIN", parent=None):
+    return {
+        "id": oid,
+        "parentObservationId": parent,
+        "type": otype,
+        "name": name,
+    }
+
+
+def agent_turn_observations():
+    """The real shape: LangGraph > model > generation for the agent's own call,
+    LangGraph > tools > TOOL > RunnableSequence > generation for a tool's."""
+    return [
+        span("root", "LangGraph"),
+        span("m1", "model", parent="root"),
+        gen("g1", parent="m1", inp=2000, out=50, cache=4000, cost=0.001),
+        span("t1", "tools", parent="root"),
+        span("tool1", "pick_aoi", otype="TOOL", parent="t1"),
+        span("seq1", "RunnableSequence", parent="tool1"),
+        gen("g2", parent="seq1", inp=1400, out=40, cost=0.0008),
+    ]
+
+
+def test_observations_split_agent_from_tool_spend():
+    u = P.parse_observations(agent_turn_observations())
+    assert u["agent_tokens"] == 6050  # 2000 + 50 + 4000 cached
+    assert u["tool_tokens"] == 1440
+    assert u["turn_tokens"] == 7490
+    assert u["agent_cost"] == 0.001
+    assert u["tool_cost"] == 0.0008
+    assert u["generation_count"] == 2
+    assert u["tokens_by_component"] == {"agent": 6050, "pick_aoi": 1440}
+    assert u["cost_by_component"] == {"agent": 0.001, "pick_aoi": 0.0008}
+
+
+def test_agent_plus_tool_always_equals_turn():
+    """The invariant the columns are documented on: whatever the component
+    labels turn out to be, the two halves must reconstruct the total."""
+    u = P.parse_observations(agent_turn_observations())
+    assert u["agent_tokens"] + u["tool_tokens"] == u["turn_tokens"]
+
+
+def test_cached_input_tokens_are_added_back_into_input():
+    """Langfuse excludes cached tokens from `input`; LangChain's usage_metadata
+    includes them. The columns keep LangChain's meaning, or the series would
+    silently drop by the cache-hit rate."""
+    u = P.parse_observations(
+        [
+            span("root", "LangGraph"),
+            gen("g", parent="root", inp=100, out=10, cache=900),
+        ]
+    )
+    assert u["turn_input_tokens"] == 1000
+    assert u["cache_read_tokens"] == 900
+
+
+def test_generation_outside_agent_and_tools_is_other_not_agent():
+    """A manually instrumented span must not be silently credited to the agent."""
+    obs = [span("root", "LangGraph"), gen("g", parent="root", inp=10, out=1)]
+    u = P.parse_observations(obs)
+    assert u["tokens_by_component"] == {P.OTHER_COMPONENT: 11}
+    assert u["agent_tokens"] == 0
+    assert u["tool_tokens"] == 11
+
+
+def test_component_walk_survives_a_parent_cycle():
+    """Defensive: a cycle in parentObservationId must not hang ingestion."""
+    a = {"id": "a", "parentObservationId": "b", "type": "CHAIN", "name": "a"}
+    b = {"id": "b", "parentObservationId": "a", "type": "CHAIN", "name": "b"}
+    g = gen("g", parent="a", inp=5, out=1)
+    u = P.parse_observations([a, b, g])
+    assert u["turn_tokens"] == 6
+
+
+def test_component_attribution_needs_the_ancestor_spans():
+    """Why the ingest layer fetches every observation type, not just
+    generations: the agent/tool label lives on a generation's ANCESTORS. Both
+    an agent call and a tool's call are named "ChatGoogleGenerativeAI", so with
+    the parents missing the whole turn reads as non-agent spend."""
+    gens_only = [
+        o for o in agent_turn_observations() if o["type"] == "GENERATION"
+    ]
+    u = P.parse_observations(gens_only)
+    assert u["turn_tokens"] == 7490  # the totals still come out right
+    assert u["tokens_by_component"] == {P.OTHER_COMPONENT: 7490}
+    assert u["agent_tokens"] == 0
+
+
+def test_no_observations_falls_back_to_message_usage():
+    out = {
+        "messages": [
+            human("Q"),
+            ai("A", finish="end_turn", usage=usage(30, 5)),
+        ]
+    }
+    r = P.parse_trace(trace(out))
+    assert r["derived"]["usage_source"] == "messages"
+    assert r["turn_tokens"] == 35
+    # The split would be a lie without observations, so it is left unset.
+    assert "agent_tokens" not in r
+
+
+def test_observations_take_over_the_token_columns():
+    out = {
+        "messages": [
+            human("Q"),
+            ai("A", finish="end_turn", usage=usage(6000, 50)),
+        ]
+    }
+    r = P.parse_trace(trace(out), agent_turn_observations())
+    assert r["derived"]["usage_source"] == "observations"
+    assert r["turn_tokens"] == 7490  # includes the tool's 1440
+    # The message stream is kept as an independent measurement of the same
+    # agent-level calls, so a divergence between the two is a drift signal.
+    assert r["derived"]["agent_tokens_from_messages"] == 6050
+
+
+def test_split_drift_flag_is_true_when_both_measurements_agree():
+    out = {
+        "messages": [
+            human("Q"),
+            ai("A", finish="end_turn", usage=usage(6000, 50)),
+        ]
+    }
+    r = P.parse_trace(trace(out), agent_turn_observations())
+    assert r["derived"]["usage_split_agrees"] is True
+
+
+def test_split_drift_flag_goes_false_if_the_agent_node_is_renamed():
+    """The failure a fill-rate check cannot see: attribution breaks, every call
+    lands in `other`, and agent_tokens is 0 rather than null."""
+    observations = [
+        # LangGraph renamed its model node; the parent walk no longer matches.
+        o if o.get("name") != "model" else {**o, "name": "call_model"}
+        for o in agent_turn_observations()
+    ]
+    out = {
+        "messages": [
+            human("Q"),
+            ai("A", finish="end_turn", usage=usage(6000, 50)),
+        ]
+    }
+    r = P.parse_trace(trace(out), observations)
+    assert r["agent_tokens"] == 0
+    assert r["derived"]["usage_split_agrees"] is False
+
+
+def test_total_cost_falls_back_to_the_observation_sum():
+    """trace.totalCost is frequently null even when the observations under it
+    are priced -- that is why cost-per-query read as empty."""
+    t = trace({"messages": []})
+    t["totalCost"] = None
+    r = P.parse_trace(t, agent_turn_observations())
+    assert r["total_cost"] == 0.0018
+
+
+def test_trace_total_cost_wins_when_langfuse_provides_it():
+    t = trace({"messages": []})
+    t["totalCost"] = 0.5
+    r = P.parse_trace(t, agent_turn_observations())
+    assert r["total_cost"] == 0.5
+
+
+def test_observation_parsing_tolerates_junk():
+    for bad in [
+        None,
+        [],
+        [{}],
+        [None],
+        [{"type": "SPAN"}],
+        [{"type": "GENERATION"}],
+    ]:
+        P.parse_observations(bad)  # must not raise
+
+
+# --------------------------------------------------------------------------- #
 # contract tests: bind to the live agent contract so drift fails CI
 # --------------------------------------------------------------------------- #
 def test_expected_state_keys_match_agent_state():


### PR DESCRIPTION
## Why

We use Langfuse to measure cost per query, and the number was wrong in two independent ways.

`langfuse_traces.turn_tokens` was never a Langfuse figure. `parse_trace` summed `usage_metadata` off the AIMessages in `trace.output`, and only the agent's own model calls put an AIMessage into `AgentState` — a tool that calls an LLM returns a ToolMessage. So every tool-internal LLM call was counted nowhere, **even the ones Langfuse had traced correctly all along**. Meanwhile `total_cost` was `trace.totalCost`, which aggregates all observations. The two columns measured different scopes, and `trace.totalCost` turns out to be null on real traces anyway — so cost per query was not merely understated, it was absent.

Measured on one production trace (`62168a8a1b9269b9d95fdadcbd8dccc4`):

| owner | tokens | cached | cost |
|---|---|---|---|
| agent (5 calls) | 35,466 | 16,092 | $0.011132 |
| `pick_aoi` | 1,479 | 0 | $0.000842 |
| `pick_dataset` | 5,718 | 0 | $0.003327 |
| `generate_insights` → text generator | 1,828 | 0 | $0.001304 |
| **trace total** | **44,491** | 16,092 | **$0.016604** |

The parser recorded 35,466 — identical to the agent-only sum, to the token. It dropped 20% of tokens and **33% of cost**.

Cost share exceeds token share because of caching: agent calls are ~45% prompt-cache reads, every tool call is `input_cache_read: 0`. Tool calls are disproportionately expensive per token, so dropping them skews cost harder than tokens.

Separately, `generate_insights` showed only its stage-2 text call. Stage 1 — `GeminiCodeExecutor`, which calls `google.genai` directly through `run_in_executor` — produced **no observation at all**, despite `codeact_parts` proving it ran two model turns. No LangChain runnable means no callback.

### How much the new instrumentation adds

Unknown, and unknowable until it ships — that is the nature of the gap. The 20%/33% above is what the *parser* was dropping from observations Langfuse already had; the code executor emitted nothing to measure.

A **floor** can be reconstructed from the repo plus this trace, though. Rebuilding the executor's own prompt via `build_analysis_prompt` and counting the code and execution output it echoed back:

| | tokens (~) |
|---|---|
| prompt skeleton, dataset guidance stripped | 2,359 |
| code + execution output echoed back | 920 |
| model turns in the code-exec loop | 2 |
| **floor, prompt resent per turn** | **~5,600** |

That is **~13% on top of the 44,491 this PR now counts**, and it is a floor in three ways: the skeleton excludes the dataset's guidelines, cautions and code instructions; it excludes the inlined CSV (this trace's `statistics.data` was empty, loaded from the DB by id, so its real size is not recoverable); and this was the simplest possible query — one dataset, one year, one AOI.

It also understates cost more than tokens, because the executor runs on `CODING_MODEL`, whose default is `gemini-3.1-pro-preview` — materially pricier per token than the `gemini-3-flash-preview` everything else in this trace used. Worth confirming which model production actually has configured.

Treat ~13% as the lower bound on insight turns and expect the real figure to be higher. `derived.cost_by_component` will report it exactly once this is deployed.

## What changed

**Token columns read Langfuse usage.** `parse_observations` aggregates the trace's generations. `turn_*` now covers every LLM call in the turn; new columns carry the split (`agent_tokens`, `tool_tokens`, `agent_cost`, `tool_cost`, `generation_count`), and `derived.tokens_by_component` / `cost_by_component` break the tool half down per tool. `agent_tokens + tool_tokens == turn_tokens` by construction. `total_cost` falls back to the observation sum when `trace.totalCost` is null.

Langfuse reports `input` net of cached tokens; LangChain's `input_tokens` includes them. The parser adds them back, or the series would silently drop by the cache-hit rate.

**Observations are fetched per window, not per trace** — a handful of requests instead of N — reusing the existing retry/page-halving machinery, with a 30-minute upper pad for traces straddling a window boundary. If that fetch fails the window still ingests on message-derived usage; `derived.usage_source` records which, and `agent_tokens`'s fill rate in the run row is the alert.

**The code executor is instrumented.** A Langfuse generation span around `_call_model` reports `usage_metadata`, mapping Gemini's keys onto Langfuse's (cached tokens split out of `input`, thinking tokens folded into `output`). One span covers the retry loop, so its latency is the wall clock the caller waited. Not rewritten onto `ChatGoogleGenerativeAI`: the executor depends on `executable_code` / `code_execution_result` / `inline_data`, which LangChain models poorly.

**Out-of-turn calls are traced.** Thread naming, custom-area naming and language detection each ran in their own request with no ambient handler. They now get `auxiliary_config(...)` — their own handler, tagged `auxiliary`, joined to the thread by session id. Ingest drops tagged traces: they carry no `AgentState`, so they would land as zero-token `EMPTY` rows and dilute every per-turn average. Their cost stays visible in Langfuse under the thread's session.

**Chains are named** (`select_aoi`, `select_dataset`, `search_blogs_agent`, …) so components are attributable. Verified that passing `run_name` alone still inherits ambient callbacks.

**`langfuse-model-prices`** reports models Langfuse records usage for but prices at zero — an unrecognised model name silently zeroes that model's whole share of cost.

## Two notes for review

**A bug I introduced and caught.** I first fetched only `type=GENERATION`. But the agent/tool label lives on a generation's **ancestors** — both an agent call and a tool's call are named `ChatGoogleGenerativeAI` — so the parent walk found nothing and the whole turn read as tool spend. Ingest now fetches all types; `test_component_attribution_needs_the_ancestor_spans` pins it. Related: `derived.usage_split_agrees` compares the observation-derived `agent_tokens` against the independent message-derived figure, so if LangGraph renames its `model` node, drift surfaces as `False` instead of a silent zero — which a fill-rate check cannot catch, because zero is not null.

**`trace.output` arrives double-JSON-encoded.** `parse_trace` required a dict, and `parse_state` classified a non-dict output as "not applicable" rather than a violation — so it would zero every metric *and* keep the drift monitor quiet. `parse_trace` now decodes JSON-string `output`/`input`. The raw downloaded export parses completely, including `aoi_name` and `primary_dataset_name` that a string output had been discarding.

## Migration

`f3a8c1d5b204` adds five nullable columns and recreates `langfuse_traces_analytics`. Verified up → down → up on a throwaway database.

`PARSER_VERSION` → 3. **`turn_tokens` changes meaning**: it steps up for any turn whose tools call an LLM. Re-run `ingest-langfuse-traces --backfill --since` over the window you analyse, or the series has a step where the parser version changes.

## Testing

661 unit + 354 API tests pass. New: `test_langfuse_fetch.py` (8, the fetch client had none), `test_langfuse_tracing.py` (12), `test_gemini_executor_tracing.py` (4), plus 17 in the parse/ingest suites. Validated end-to-end by running the real production trace through `build_row`: `turn_tokens` 35,466 → 44,491, `total_cost` NULL → $0.016605 ($0.011132 agent / $0.005473 tool).

## Known remaining gap

Embeddings are still unaccounted. `pick_dataset`'s retriever call goes through LangChain's `GoogleGenerativeAIEmbeddings`, so it *is* traced — it appears as a `RETRIEVER` observation — but LangChain embeddings report no token usage, so Langfuse records it with empty usage and zero cost (visible in this trace as `[RETRIEVER] VectorStoreRetriever usage={} cost=0`). It is one short query embedding per `pick_dataset` call, so the amount is small, but it is not zero and this PR does not fix it.

## Not in scope

`src/api/services/nrt_summary.py` is on an unmerged branch; its summary call still needs a `run_name` when that lands.
