### PR TITLE
fix(pick_dataset): report the date range applied to the tile URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.8"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -206,6 +206,42 @@ async def select_best_dataset(
     )
 
 
+def _applied_date_range_note(
+    requested_start: Optional[str],
+    requested_end: Optional[str],
+    effective_start: str,
+    effective_end: str,
+    range_clamped: bool,
+) -> str:
+    """Explain how the applied date range relates to the requested one.
+
+    The tile URL is scoped to the applied range (see
+    get_tile_services_for_dataset), so a range the model did not intend
+    silently changes what the map shows. Returns "" when the applied range
+    is exactly what was asked for and needs no explanation.
+    """
+    if requested_start is None and requested_end is None:
+        return (
+            "No date range was requested, so this is the dataset's full "
+            "coverage. The map layer is scoped to this range. If the user "
+            "asked for a shorter period, call pick_dataset again with "
+            "start_date and end_date."
+        )
+    if requested_start is None or requested_end is None:
+        bound = "start" if requested_start is None else "end"
+        return (
+            f"No {bound} date was requested, so the dataset's own {bound} of "
+            "coverage was used. The map layer is scoped to the range above."
+        )
+    if range_clamped:
+        return (
+            f"The requested range ({requested_start} to {requested_end}) "
+            "falls outside the dataset's coverage, so it was adjusted to the "
+            "range above. Tell the user about this adjustment."
+        )
+    return ""
+
+
 class DatasetSelector:
     """Dataset-selection subagent: resolves a request to the best dataset.
 
@@ -322,7 +358,11 @@ class DatasetSelector:
             candidate_datasets.dataset_id == option.dataset_id
         ].iloc[0]
 
-        effective_start_date, effective_end_date, _ = await revise_date_range(
+        (
+            effective_start_date,
+            effective_end_date,
+            range_clamped,
+        ) = await revise_date_range(
             start_date,
             end_date,
             selected_row.dataset_id,
@@ -388,6 +428,22 @@ class DatasetSelector:
     ## Content date
 
     {dataset_result.content_date}
+
+    ## Applied date range
+
+    {dataset_result.start_date} to {dataset_result.end_date}
+    """
+
+        date_range_note = _applied_date_range_note(
+            start_date,
+            end_date,
+            effective_start_date,
+            effective_end_date,
+            range_clamped,
+        )
+        if date_range_note:
+            tool_message += f"""
+    {date_range_note}
     """
 
         if dataset_result.presentation_instructions:

--- a/tests/unit/agent/tools/test_pick_dataset_date_note.py
+++ b/tests/unit/agent/tools/test_pick_dataset_date_note.py
@@ -1,0 +1,143 @@
+"""pick_dataset reports the date range it applied.
+
+The tile URL is scoped to that range for date-driven layers (see
+test_tile_services), so a range the model did not intend silently changes
+what the map shows. These cover the note that makes it visible.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.agent.datasets.config import DATASETS
+from src.agent.datasets.handlers.analytics_handler import INTEGRATED_ALERTS_ID
+from src.agent.subagents.pick_dataset import (
+    DatasetSelectionResult,
+    pick_dataset,
+)
+from src.agent.subagents.pick_dataset.schema import DatasetSelectionResponse
+from src.agent.subagents.pick_dataset.tool import _applied_date_range_note
+
+
+def test_no_dates_requested_explains_the_default():
+    note = _applied_date_range_note(
+        None, None, "2023-12-01", "2026-09-08", False
+    )
+
+    assert "No date range was requested" in note
+    assert "call pick_dataset again" in note
+
+
+def test_missing_start_names_that_bound():
+    note = _applied_date_range_note(
+        None, "2026-09-08", "2023-12-01", "2026-09-08", False
+    )
+
+    assert "No start date was requested" in note
+    assert "No end date" not in note
+
+
+def test_missing_end_names_that_bound():
+    note = _applied_date_range_note(
+        "2026-08-25", None, "2026-08-25", "2026-09-08", False
+    )
+
+    assert "No end date was requested" in note
+
+
+def test_clamped_range_quotes_what_was_requested():
+    note = _applied_date_range_note(
+        "2019-01-01", "2026-09-08", "2023-12-01", "2026-09-08", True
+    )
+
+    assert "2019-01-01 to 2026-09-08" in note
+    assert "adjusted" in note
+
+
+def test_honoured_range_needs_no_note():
+    """A range applied exactly as asked is already on the range line."""
+    note = _applied_date_range_note(
+        "2026-08-25", "2026-09-08", "2026-08-25", "2026-09-08", False
+    )
+
+    assert note == ""
+
+
+async def _resolve_integrated_alerts(start_date, end_date):
+    """Run pick_dataset for Integrated alerts with the selector mocked out."""
+    import pandas as pd
+
+    ds = next(d for d in DATASETS if d["dataset_id"] == INTEGRATED_ALERTS_ID)
+    selected = DatasetSelectionResult(
+        dataset_id=ds["dataset_id"],
+        dataset_name=ds["dataset_name"],
+        context_layer=None,
+        reason="test",
+        tile_url=ds["tile_url"],
+        analytics_api_endpoint=ds.get("analytics_api_endpoint", ""),
+        description=ds.get("description", ""),
+        prompt_instructions=ds.get("prompt_instructions", ""),
+        methodology=ds.get("methodology", ""),
+        cautions=ds.get("cautions", ""),
+        function_usage_notes=ds.get("function_usage_notes", ""),
+        citation=ds.get("citation", ""),
+        content_date=ds.get("content_date", ""),
+    )
+    tool_call_id = str(uuid.uuid4())
+
+    with (
+        patch(
+            "src.agent.subagents.pick_dataset.tool.rag_candidate_datasets",
+            new_callable=AsyncMock,
+            return_value=pd.DataFrame([ds]),
+        ),
+        patch(
+            "src.agent.subagents.pick_dataset.tool.select_best_dataset",
+            new_callable=AsyncMock,
+            return_value=DatasetSelectionResponse(
+                selected_dataset=selected, reason="test"
+            ),
+        ),
+    ):
+        return await pick_dataset.ainvoke(
+            {
+                "type": "tool_call",
+                "name": "pick_dataset",
+                "id": tool_call_id,
+                "args": {
+                    "query": "alerts",
+                    "start_date": start_date,
+                    "end_date": end_date,
+                    # Set so resolve_language() is not consulted.
+                    "state": {"language": "en"},
+                    "tool_call_id": tool_call_id,
+                },
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_tool_message_reports_the_range_the_tile_url_uses():
+    command = await _resolve_integrated_alerts("2026-08-25", "2026-09-08")
+
+    message = command.update["messages"][0].content
+    assert "## Applied date range" in message
+    assert "2026-08-25 to 2026-09-08" in message
+
+    tile_url = command.update["dataset"]["tile_url"]
+    assert "start_date=2026-08-25" in tile_url
+    assert "end_date=2026-09-08" in tile_url
+
+
+@pytest.mark.asyncio
+async def test_omitted_dates_are_called_out_in_the_tool_message():
+    """The bug this guards: no dates in, full coverage on the map, silently."""
+    command = await _resolve_integrated_alerts(None, None)
+
+    message = command.update["messages"][0].content
+    assert "No date range was requested" in message
+
+    dataset = command.update["dataset"]
+    assert dataset["start_date"] == "2023-12-01"
+    assert f"start_date={dataset['start_date']}" in dataset["tile_url"]

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Where the problem comes from

`pick_dataset` builds the tile URL for date-driven layers and appends the date filter itself
(`src/agent/subagents/pick_dataset/tool.py`, the `INTEGRATED_ALERTS_ID` branch of
`get_tile_services_for_dataset`):

```python
elif selection_result.dataset_id == INTEGRATED_ALERTS_ID:
    tile_url += f"&start_date={start_date}&end_date={end_date}"
```

The GFW tile service honours those params — verified against
`gfw_integrated_dist_alerts` at z9/167/268 (Rondônia), which returns a different
raster per window:

| query | bytes |
|---|---|
| none | 17766 |
| `start_date=2024-01-01&end_date=2024-01-31` | 15483 |
| `start_date=2023-12-01&end_date=2026-09-08` | 20341 |

So the filter works. What fails is the range fed into it.

`start_date` / `end_date` are **optional** tool args on `pick_dataset`. When the model
omits them, `revise_date_range` fills them from the dataset's own coverage:

```python
if start_date is None:
    start_date = available_start   # 2023-12-01 for Integrated alerts
if end_date is None:
    end_date = available_end       # date.today(), the YAML has no end_date
```

The tile URL then covers the full ~21 months. `pull_data` takes its own
`start_date`/`end_date` and re-resolves them independently, so the chart shows the
window the user asked for while the map shows everything — the reported symptom
("selected the last two weeks, it showed the last year").

Nothing made that visible:

- `pick_dataset` discarded the clamp flag `revise_date_range` returns, into `_`.
- The flag would not have fired anyway: `range_clamped` is computed **after** the
  `None` fill-in, so omitted args are indistinguishable from a request for exactly
  the full coverage.
- The tool message never named the applied range. Its only date field is
  `content_date`, the dataset's static YAML coverage string
  (`"1 December 2023 - present"`), not the window that was applied.
- The session block (`src/agent/middleware.py`) renders `Date range:` from the
  top-level `state["start_date"]`/`["end_date"]`, which only `pull_data` writes.
  `pick_dataset` puts its dates under `state["dataset"]`.

The agent therefore had no way to know which window it had put on the map, and
neither did the user.

## What this changes

Adds an `## Applied date range` section to the `pick_dataset` tool message, followed
by a note when the applied range is not what was asked for:

- **nothing requested** — says so, states that the map layer is scoped to the full
  coverage, and tells the model to call `pick_dataset` again with dates if the user
  wanted a shorter period
- **one bound missing** — names which one was defaulted
- **clamped** — quotes the requested range and says to tell the user about the
  adjustment (matching the wording `pull_data` already uses)
- **applied as asked** — no note, the range line already says it

`revise_date_range` keeps its signature. Whether a bound was defaulted is read from
the incoming tool args, which `resolve()` already has, so this needs no change to
`dates.py` and no churn in its 17 existing test call sites.

## Scope

Reporting only — this makes the mismatch visible to the model and in traces. It does
not change which dates get applied. Still open, deliberately out of scope:

- `pick_dataset` does not write the top-level `state["start_date"]`/`["end_date"]`, so
  the session block still shows the previous `pull_data` range while the model decides
  the next call.
- The `analyze` / `pull-data` skills mention computing dates but never say to pass them
  to `pick_dataset`, and the tool docstring calls them "optional … narrow the range",
  which reads as skippable.
- The frontend legend truncates any range to years (`buildYearParam`), so a two-week
  filter renders as `YEAR 2026` regardless. Separate PR in `project-zeno-next`.

## Tests

`tests/unit/agent/tools/test_pick_dataset_date_note.py` — five cases on the note
itself, plus two that drive `pick_dataset.ainvoke` with the selector mocked out and
assert the message and the tile URL agree. One of those reproduces the reported bug:
no dates in, full coverage on the tile URL, note now present.

```
7 passed in 0.10s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Part of #821.
