### PR TITLE
feat(datasets): declare tile date conventions and serve them from the catalog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.8"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/datasets/catalog/global_land_cover.yml
+++ b/src/agent/datasets/catalog/global_land_cover.yml
@@ -4,6 +4,7 @@ context_layers: null
 parameters: null
 variables: null
 tile_url: /raster/collections/global-land-cover-v-2/items/global-land-cover-{year}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?colormap=%7B%221%22%3A%20%5B254%2C%20254%2C%20204%2C%20255%5D%2C%20%222%22%3A%20%5B185%2C%20185%2C%2030%5D%2C%20%223%22%3A%20%5B36%2C%20110%2C%2036%5D%2C%20%224%22%3A%20%5B116%2C%20214%2C%20180%5D%2C%20%225%22%3A%20%5B107%2C%20174%2C%20214%5D%2C%20%226%22%3A%20%5B172%2C%20209%2C%20232%5D%2C%20%227%22%3A%20%5B255%2C%20241%2C%20131%5D%2C%20%228%22%3A%20%5B232%2C%20118%2C%2093%5D%2C%20%229%22%3A%20%5B255%2C%20205%2C%20115%5D%7D&assets=asset&expression=asset%2A%28asset%3C10%29%2A%28asset%3E0%29&asset_as_band=True
+tile_date_filter: year_in_path
 license: CC by 4.0
 geographic_coverage: Global
 resolution: 30 x 30 meters

--- a/src/agent/datasets/catalog/global_natural_semi_natural_grassland_extent.yml
+++ b/src/agent/datasets/catalog/global_natural_semi_natural_grassland_extent.yml
@@ -4,6 +4,7 @@ context_layers: null
 parameters: null
 variables: Natural/Semi-Natural Grassland
 tile_url: /raster/collections/grasslands-v-1/items/grasslands-{year}/tiles/WebMercatorQuad/{{z}}/{{x}}/{{y}}.png?colormap=%7B%220%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%221%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%222%22%3A%20%5B255%2C%20153%2C%2022%2C%20255%5D%2C%20%223%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True
+tile_date_filter: year_in_path
 license: CC by 4.0
 geographic_coverage: 90°N to 90°S
 resolution: 30 x 30 meters

--- a/src/agent/datasets/catalog/integrated_alerts.yml
+++ b/src/agent/datasets/catalog/integrated_alerts.yml
@@ -4,6 +4,7 @@ context_layers: null
 parameters: null
 variables: null
 tile_url: https://tiles.globalforestwatch.org/gfw_integrated_dist_alerts/latest/dynamic/{z}/{x}/{y}.png?render_type=true_color
+tile_date_filter: date_params
 license: CC by 4.0
 geographic_coverage: Global
 resolution: 10 x 10 meters

--- a/src/agent/datasets/catalog/tree_cover_loss.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss.yml
@@ -16,6 +16,7 @@ parameters:
   values: [10, 15, 20, 25, 30, 50, 75]
   tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
 tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_loss/v1.13/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold={threshold}&render_type=true_color
+tile_date_filter: year_params
 license: CC by 4.0
 geographic_coverage: Global land area (excluding Antarctica and other Arctic islands)
 resolution: 30 x 30 meters

--- a/src/agent/datasets/catalog/tree_cover_loss_from_fires.yml
+++ b/src/agent/datasets/catalog/tree_cover_loss_from_fires.yml
@@ -16,6 +16,7 @@ parameters:
   values: [10, 15, 20, 25, 30, 50, 75]
   tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_density_2000/v1.8/tcd_{threshold}/{z}/{x}/{y}.png
 tile_url: https://tiles.globalforestwatch.org/umd_tree_cover_loss_from_fires/v1.13/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold={threshold}&render_type=true_color
+tile_date_filter: year_params
 license: CC by 4.0
 geographic_coverage: Global land area (excluding Antarctica and other Arctic islands)
 resolution: 30 x 30 meters

--- a/src/agent/datasets/layers.py
+++ b/src/agent/datasets/layers.py
@@ -1,0 +1,151 @@
+"""
+Canonical map-layer registry: the tile URL for each dataset and how that URL
+takes a date filter, derived from the `tile_url` / `tile_date_filter` keys in
+the catalog YAMLs (`src/agent/datasets/catalog/*.yml`).
+
+Date filtering is per-dataset: Integrated alerts takes `start_date`/`end_date`
+query params, annual tree-cover layers take `start_year`/`end_year`, and the
+annual rasters carry the year in the item path. `tile_date_filter` names the
+convention so both the agent (get_tile_services_for_dataset, which builds the
+URL the map renders) and API clients (which build it for layers added outside
+a conversation) resolve it from the same place, instead of each keeping its
+own list of dataset ids.
+
+Served URLs are absolute and carry their remaining placeholders literally:
+`{z}`/`{x}`/`{y}` always, `{threshold}` on the canopy-cover datasets, and
+`{year}` on the annual rasters.
+"""
+
+from typing import Optional, TypedDict
+
+from src.agent.datasets.config import DATASETS
+from src.shared.config import SharedSettings
+
+# Query params appended to the tile URL, e.g.
+# `&start_date=2026-08-25&end_date=2026-09-08` (Integrated alerts).
+DATE_PARAMS = "date_params"
+# Year-granular query params, e.g. `&start_year=2001&end_year=2025`
+# (annual tree cover loss).
+YEAR_PARAMS = "year_params"
+# The year identifies the raster item in the URL path, so the URL carries a
+# `{year}` placeholder instead of a filter (annual land cover, grasslands).
+YEAR_IN_PATH = "year_in_path"
+# The layer has no time dimension to filter on.
+NO_DATE_FILTER = "none"
+
+TILE_DATE_FILTERS = frozenset(
+    {DATE_PARAMS, YEAR_PARAMS, YEAR_IN_PATH, NO_DATE_FILTER}
+)
+
+# Canopy-cover threshold applied when a request names none. Shared with
+# get_tile_services_for_dataset so a `{threshold}` URL resolves the same way
+# whoever fills it in.
+DEFAULT_CANOPY_COVER = 30
+
+_CANOPY_COVER = "canopy_cover"
+_THRESHOLD_PLACEHOLDER = "{threshold}"
+
+
+class DatasetLayer(TypedDict):
+    dataset_id: int
+    dataset_name: str
+    # Absolute, with `{z}`/`{x}`/`{y}` and any `{threshold}`/`{year}` left for
+    # the client to fill.
+    tile_url: str
+    # One of TILE_DATE_FILTERS: how to scope this URL to a date range.
+    date_filter: str
+    # First date the dataset covers.
+    start_date: str
+    # Last date covered, or None when the dataset is ongoing (use today).
+    end_date: Optional[str]
+    # True when the dataset covers one fixed period that a request cannot
+    # narrow — clients should show the full range rather than a requested one.
+    content_date_fixed: bool
+    # Allowed canopy-cover values, and the one to use by default. Both None
+    # unless the tile URL carries a `{threshold}` placeholder.
+    threshold_values: Optional[list[int]]
+    default_threshold: Optional[int]
+
+
+def _public_tile_url(dataset: dict, date_filter: str) -> str:
+    tile_url: str = dataset["tile_url"]
+    if date_filter == YEAR_IN_PATH:
+        # These are str.format templates on `year`, so the YAML escapes the
+        # tile scheme as {{z}}/{{x}}/{{y}}. Clients get it unescaped.
+        tile_url = tile_url.replace("{{", "{").replace("}}", "}")
+    if not tile_url.startswith("http"):
+        tile_url = SharedSettings.eoapi_base_url.rstrip("/") + tile_url
+    return tile_url
+
+
+def _threshold_values(dataset: dict) -> Optional[list[int]]:
+    for parameter in dataset.get("parameters") or []:
+        if parameter.get("name") == _CANOPY_COVER:
+            return list(parameter.get("values") or [])
+    return None
+
+
+def _build_layers() -> dict[int, DatasetLayer]:
+    layers: dict[int, DatasetLayer] = {}
+    for dataset in DATASETS:
+        if not dataset.get("tile_url"):
+            continue
+
+        dataset_id = dataset["dataset_id"]
+        context = f"dataset_id={dataset_id} ({dataset['dataset_name']})"
+
+        date_filter = dataset.get("tile_date_filter") or NO_DATE_FILTER
+        if date_filter not in TILE_DATE_FILTERS:
+            raise ValueError(
+                f"unknown tile_date_filter {date_filter!r} in {context}; "
+                f"expected one of {sorted(TILE_DATE_FILTERS)}"
+            )
+
+        tile_url = _public_tile_url(dataset, date_filter)
+
+        # The two param conventions append with `&`, so the URL must already
+        # carry a query string, and a `{year}` layer must have somewhere to
+        # put the year. Catching these here beats serving a URL that 404s.
+        if date_filter in (DATE_PARAMS, YEAR_PARAMS) and "?" not in tile_url:
+            raise ValueError(
+                f"tile_date_filter {date_filter!r} appends query params but "
+                f"the tile_url in {context} has no query string"
+            )
+        if date_filter == YEAR_IN_PATH and "{year}" not in tile_url:
+            raise ValueError(
+                f"tile_date_filter {YEAR_IN_PATH!r} needs a {{year}} "
+                f"placeholder, missing from the tile_url in {context}"
+            )
+
+        threshold_values: Optional[list[int]] = None
+        if _THRESHOLD_PLACEHOLDER in tile_url:
+            threshold_values = _threshold_values(dataset)
+            if not threshold_values:
+                raise ValueError(
+                    f"the tile_url in {context} has a "
+                    f"{_THRESHOLD_PLACEHOLDER} placeholder but no "
+                    f"{_CANOPY_COVER} parameter values"
+                )
+
+        layers[dataset_id] = DatasetLayer(
+            dataset_id=dataset_id,
+            dataset_name=dataset["dataset_name"],
+            tile_url=tile_url,
+            date_filter=date_filter,
+            start_date=dataset["start_date"],
+            end_date=dataset.get("end_date"),
+            content_date_fixed=bool(dataset.get("content_date_fixed")),
+            threshold_values=threshold_values,
+            default_threshold=(
+                DEFAULT_CANOPY_COVER if threshold_values else None
+            ),
+        )
+    return layers
+
+
+LAYERS: dict[int, DatasetLayer] = _build_layers()
+
+
+def get_dataset_layer(dataset_id: int) -> Optional[DatasetLayer]:
+    """Return the map-layer entry for a dataset, or None if it has no tiles."""
+    return LAYERS.get(dataset_id)

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -20,13 +20,16 @@ from src.agent.datasets.config import (
 from src.agent.datasets.dates import revise_date_range
 from src.agent.datasets.handlers.analytics_handler import (
     FOREST_CARBON_FLUX_ID,
-    GRASSLANDS_ID,
-    INTEGRATED_ALERTS_ID,
-    LAND_COVER_CHANGE_ID,
     TREE_COVER_ID,
     TREE_COVER_LOSS_BY_DRIVER_ID,
     TREE_COVER_LOSS_BY_FIRES_ID,
     TREE_COVER_LOSS_ID,
+)
+from src.agent.datasets.layers import (
+    DATE_PARAMS,
+    DEFAULT_CANOPY_COVER,
+    YEAR_IN_PATH,
+    YEAR_PARAMS,
 )
 from src.agent.i18n import t
 from src.agent.language import (
@@ -545,7 +548,7 @@ def get_tile_services_for_dataset(
         TREE_COVER_LOSS_BY_FIRES_ID,
         FOREST_CARBON_FLUX_ID,
     ]:
-        canopy_cover = 30
+        canopy_cover = DEFAULT_CANOPY_COVER
         if selection_result.parameters is not None:
             for param in selection_result.parameters:
                 if param.name == "canopy_cover":
@@ -575,19 +578,20 @@ def get_tile_services_for_dataset(
             "{threshold}", str(canopy_cover)
         )
 
-    if (
-        selected_row.dataset_id == TREE_COVER_LOSS_ID
-        or selected_row.dataset_id == TREE_COVER_LOSS_BY_FIRES_ID
-    ):
+    # How this layer takes a date filter is declared per dataset in the
+    # catalog YAML — see src.agent.datasets.layers, which serves the same
+    # convention to API clients that build tile URLs outside a conversation.
+    date_filter = getattr(selected_row, "tile_date_filter", None)
+    if date_filter == YEAR_PARAMS:
         if end_date.year in range(2001, 2026):
             tile_url += (
                 f"&start_year={start_date.year}&end_year={end_date.year}"
             )
         else:
             tile_url += "&start_year=2001&end_year=2025"
-    elif selection_result.dataset_id == INTEGRATED_ALERTS_ID:
+    elif date_filter == DATE_PARAMS:
         tile_url += f"&start_date={start_date}&end_date={end_date}"
-    elif selection_result.dataset_id in [LAND_COVER_CHANGE_ID, GRASSLANDS_ID]:
+    elif date_filter == YEAR_IN_PATH:
         # Annual raster item in URL; start/end are already clamped to dataset YAML
         tile_url = tile_url.format(year=end_date.year)
 

--- a/src/api/routers/metadata.py
+++ b/src/api/routers/metadata.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from src.agent.config import AgentSettings
+from src.agent.datasets.layers import LAYERS
 from src.agent.datasets.palette import PALETTES
 from src.agent.llms import get_model, get_small_model
 from src.api.schemas import DatasetCatalogResponse
@@ -50,13 +51,23 @@ async def api_metadata() -> dict:
 @router.get("/api/datasets/catalog")
 async def datasets_catalog() -> DatasetCatalogResponse:
     """
-    Returns the canonical color registry for each dataset: category colors
-    (keyed by a stable English slug, not a translated label), single-series
-    colors, and divergent (positive/negative) colors.
+    Returns the canonical registries a client needs to render a dataset the
+    way the agent would.
 
-    This is the single source of truth for chart and map-legend colors —
-    see docs/insight-chart-colors-plan.md. Only datasets with color data
-    defined in their catalog YAML are included.
+    `datasets` carries the color registry: category colors (keyed by a stable
+    English slug, not a translated label), single-series colors, and
+    divergent (positive/negative) colors. This is the single source of truth
+    for chart and map-legend colors — see docs/insight-chart-colors-plan.md.
+    Only datasets with color data defined in their catalog YAML are included.
+
+    `layers` carries the map-layer registry: the absolute tile URL and the
+    convention it takes a date filter by, so a client adding a layer outside
+    a conversation (a catalog browse, a suggested-dataset pick) scopes it the
+    same way pick_dataset does, instead of keeping its own copy of the URLs.
+    Only datasets with a tile URL are included.
     """
     ordered = sorted(PALETTES.values(), key=lambda p: p["dataset_id"])
-    return DatasetCatalogResponse.model_validate({"datasets": ordered})
+    layers = sorted(LAYERS.values(), key=lambda layer: layer["dataset_id"])
+    return DatasetCatalogResponse.model_validate(
+        {"datasets": ordered, "layers": layers}
+    )

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -834,5 +834,30 @@ class DatasetPaletteResponse(BaseModel):
     legend_categories: bool = True
 
 
+class DatasetLayerResponse(BaseModel):
+    dataset_id: int
+    dataset_name: str
+    # Absolute. Carries `{z}`/`{x}`/`{y}`, plus `{threshold}` when
+    # `threshold_values` is set and `{year}` when date_filter is
+    # "year_in_path", for the client to substitute.
+    tile_url: str
+    # How to scope tile_url to a date range: "date_params" appends
+    # &start_date=&end_date=, "year_params" appends &start_year=&end_year=,
+    # "year_in_path" fills the {year} placeholder, "none" takes no filter.
+    date_filter: str
+    start_date: str
+    # None when the dataset is ongoing — treat today as the end.
+    end_date: Optional[str] = None
+    # True when the coverage is one fixed period a request cannot narrow.
+    content_date_fixed: bool
+    threshold_values: Optional[List[int]] = None
+    default_threshold: Optional[int] = None
+
+
 class DatasetCatalogResponse(BaseModel):
     datasets: List[DatasetPaletteResponse]
+    # Tile URLs and date conventions, so a client adding a layer outside a
+    # conversation builds the same URL the agent would. Keyed by dataset_id
+    # like `datasets`, but listed separately: a dataset can have tiles
+    # without colors and colors without tiles.
+    layers: List[DatasetLayerResponse] = []

--- a/tests/api/test_metadata.py
+++ b/tests/api/test_metadata.py
@@ -141,3 +141,71 @@ async def test_datasets_catalog_only_includes_datasets_with_colors(client):
 
     dataset_ids = {d["dataset_id"] for d in datasets}
     assert dataset_ids == {1, 2, 3, 4, 5, 6, 7, 8}
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_serves_tile_urls(client):
+    """`layers` carries the tile URL for every dataset that has one, absolute
+    and with its placeholders left for the client."""
+    response = await client.get("/api/datasets/catalog")
+    layers = response.json()["layers"]
+
+    assert {layer["dataset_id"] for layer in layers} == {
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        10,
+        11,
+    }
+    for layer in layers:
+        assert layer["tile_url"].startswith("http")
+        assert "{z}/{x}/{y}" in layer["tile_url"]
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_declares_the_date_filter_convention(client):
+    """The convention differs per dataset, which is why it is served rather
+    than left for each client to hardcode."""
+    response = await client.get("/api/datasets/catalog")
+    by_id = {layer["dataset_id"]: layer for layer in response.json()["layers"]}
+
+    # Integrated alerts: daily, so day-granular query params.
+    alerts = by_id[11]
+    assert alerts["date_filter"] == "date_params"
+    assert alerts["start_date"] == "2023-12-01"
+    assert alerts["end_date"] is None  # ongoing
+    assert alerts["content_date_fixed"] is False
+
+    # Annual tree cover loss: year-granular query params, plus a threshold.
+    assert by_id[4]["date_filter"] == "year_params"
+    assert by_id[4]["default_threshold"] == 30
+    assert 30 in by_id[4]["threshold_values"]
+    assert "{threshold}" in by_id[4]["tile_url"]
+
+    # Annual land cover: the year picks the raster item.
+    assert by_id[1]["date_filter"] == "year_in_path"
+    assert "{year}" in by_id[1]["tile_url"]
+
+    # Tree cover gain has no time dimension to filter on.
+    assert by_id[5]["date_filter"] == "none"
+    assert by_id[5]["threshold_values"] is None
+
+
+@pytest.mark.asyncio
+async def test_datasets_catalog_keeps_colors_and_layers_independent(client):
+    """A dataset can have tiles without colors, or colors without tiles, so
+    the two lists are not expected to match."""
+    response = await client.get("/api/datasets/catalog")
+    body = response.json()
+
+    with_colors = {d["dataset_id"] for d in body["datasets"]}
+    with_tiles = {layer["dataset_id"] for layer in body["layers"]}
+
+    # Integrated alerts and tree cover loss due to fires render on the map
+    # but define no palette of their own.
+    assert with_tiles - with_colors == {10, 11}

--- a/tests/unit/agent/test_dataset_layers.py
+++ b/tests/unit/agent/test_dataset_layers.py
@@ -1,0 +1,125 @@
+"""The map-layer registry derived from the catalog YAMLs.
+
+`tile_date_filter` is the one place the date convention is declared: the agent
+reads it to build the tile URL it puts on the map, and /api/datasets/catalog
+serves it to clients that add layers outside a conversation. A typo or a URL
+that cannot carry its filter has to fail at import, not at render time.
+"""
+
+import pytest
+
+from src.agent.datasets import layers as layers_module
+from src.agent.datasets.layers import (
+    DATE_PARAMS,
+    LAYERS,
+    NO_DATE_FILTER,
+    YEAR_IN_PATH,
+    get_dataset_layer,
+)
+
+_ALERTS = 11
+
+
+def _catalog_entry(**overrides) -> dict:
+    entry = {
+        "dataset_id": 99,
+        "dataset_name": "Test dataset",
+        "tile_url": "https://tiles.example.org/x/{z}/{x}/{y}.png?render=true",
+        "start_date": "2020-01-01",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _build(entry: dict, monkeypatch) -> dict:
+    monkeypatch.setattr(layers_module, "DATASETS", [entry])
+    return layers_module._build_layers()
+
+
+def test_datasets_without_tiles_are_omitted():
+    """sLUC emission factors (9) and LGMS (12) have an empty tile_url."""
+    assert 9 not in LAYERS
+    assert 12 not in LAYERS
+    assert get_dataset_layer(9) is None
+
+
+def test_integrated_alerts_declares_day_granular_filtering():
+    alerts = get_dataset_layer(_ALERTS)
+
+    assert alerts is not None
+    assert alerts["date_filter"] == DATE_PARAMS
+    assert alerts["end_date"] is None
+    assert alerts["tile_url"].startswith("https://")
+
+
+def test_relative_tile_urls_are_absolutised(monkeypatch):
+    layer = _build(
+        _catalog_entry(tile_url="/raster/collections/x/{z}/{x}/{y}.png"),
+        monkeypatch,
+    )[99]
+
+    assert layer["tile_url"].startswith("http")
+    assert "//raster" not in layer["tile_url"]
+
+
+def test_year_in_path_urls_are_unescaped(monkeypatch):
+    """The YAML doubles the tile-scheme braces so str.format can fill {year};
+    clients get them single."""
+    layer = _build(
+        _catalog_entry(
+            tile_url="https://t.example.org/items/x-{year}/{{z}}/{{x}}/{{y}}.png",
+            tile_date_filter=YEAR_IN_PATH,
+        ),
+        monkeypatch,
+    )[99]
+
+    assert layer["tile_url"] == (
+        "https://t.example.org/items/x-{year}/{z}/{x}/{y}.png"
+    )
+
+
+def test_absent_convention_means_no_filter(monkeypatch):
+    layer = _build(_catalog_entry(), monkeypatch)[99]
+
+    assert layer["date_filter"] == NO_DATE_FILTER
+    assert layer["threshold_values"] is None
+    assert layer["default_threshold"] is None
+
+
+def test_unknown_convention_is_rejected(monkeypatch):
+    with pytest.raises(ValueError, match="unknown tile_date_filter"):
+        _build(_catalog_entry(tile_date_filter="last_two_weeks"), monkeypatch)
+
+
+def test_query_param_filter_needs_a_query_string(monkeypatch):
+    """The agent appends these with `&`, so a URL with no `?` would 404."""
+    with pytest.raises(ValueError, match="no query string"):
+        _build(
+            _catalog_entry(
+                tile_url="https://t.example.org/x/{z}/{x}/{y}.png",
+                tile_date_filter=DATE_PARAMS,
+            ),
+            monkeypatch,
+        )
+
+
+def test_year_in_path_needs_a_year_placeholder(monkeypatch):
+    with pytest.raises(ValueError, match="needs a .year. placeholder"):
+        _build(
+            _catalog_entry(
+                tile_url="https://t.example.org/x/{{z}}/{{x}}/{{y}}.png",
+                tile_date_filter=YEAR_IN_PATH,
+            ),
+            monkeypatch,
+        )
+
+
+def test_threshold_placeholder_needs_declared_values(monkeypatch):
+    with pytest.raises(ValueError, match="no canopy_cover parameter values"):
+        _build(
+            _catalog_entry(
+                tile_url="https://t.example.org/tcd_{threshold}/{z}/{x}/{y}.png",
+                parameters=[{"name": "something_else", "values": [1]}],
+            ),
+            monkeypatch,
+        )

--- a/tests/unit/agent/tools/test_tile_services.py
+++ b/tests/unit/agent/tools/test_tile_services.py
@@ -1,36 +1,122 @@
-"""get_tile_services_for_dataset appends the requested date range to the tile
-URL for date-driven alert layers (Integrated alerts), so the map shows alerts
-only within the queried window."""
+"""get_tile_services_for_dataset scopes the tile URL to the requested date
+range, using the convention the dataset declares in its catalog YAML
+(`tile_date_filter`) rather than a hardcoded list of dataset ids."""
 
 from types import SimpleNamespace
 
-from src.agent.datasets.handlers.analytics_handler import INTEGRATED_ALERTS_ID
+from src.agent.datasets.config import DATASETS
+from src.agent.datasets.handlers.analytics_handler import (
+    INTEGRATED_ALERTS_ID,
+    LAND_COVER_CHANGE_ID,
+    TREE_COVER_LOSS_ID,
+)
+from src.agent.datasets.layers import (
+    DATE_PARAMS,
+    YEAR_IN_PATH,
+    YEAR_PARAMS,
+)
 from src.agent.subagents.pick_dataset.tool import (
     get_tile_services_for_dataset,
 )
 
 IA_TILE = (
-    "https://tiles.globalforestwatch.org/gfw_integrated_alerts/latest/"
+    "https://tiles.globalforestwatch.org/gfw_integrated_dist_alerts/latest/"
     "dynamic/{z}/{x}/{y}.png?render_type=true_color"
 )
 
 
-def test_integrated_alerts_tile_url_gets_date_params():
-    selection = SimpleNamespace(
-        dataset_id=INTEGRATED_ALERTS_ID, context_layer=None, parameters=None
-    )
-    row = SimpleNamespace(
-        dataset_id=INTEGRATED_ALERTS_ID,
-        tile_url=IA_TILE,
+def _row(dataset_id, tile_url, date_filter, parameters=None):
+    return SimpleNamespace(
+        dataset_id=dataset_id,
+        tile_url=tile_url,
+        tile_date_filter=date_filter,
         context_layers=None,
-        parameters=None,
+        parameters=parameters,
     )
 
+
+def _selection(dataset_id):
+    return SimpleNamespace(
+        dataset_id=dataset_id, context_layer=None, parameters=None
+    )
+
+
+def test_integrated_alerts_tile_url_gets_date_params():
     tile_url, context_layers = get_tile_services_for_dataset(
-        selection, row, "2024-03-01", "2024-10-31"
+        _selection(INTEGRATED_ALERTS_ID),
+        _row(INTEGRATED_ALERTS_ID, IA_TILE, DATE_PARAMS),
+        "2024-03-01",
+        "2024-10-31",
     )
 
     assert "start_date=2024-03-01" in tile_url
     assert "end_date=2024-10-31" in tile_url
     assert tile_url.startswith(IA_TILE)  # date params appended, base preserved
     assert context_layers == []
+
+
+def test_year_params_layer_gets_year_granular_bounds():
+    """Annual tree cover loss filters by year, not by date."""
+    tile_url, _ = get_tile_services_for_dataset(
+        _selection(TREE_COVER_LOSS_ID),
+        _row(
+            TREE_COVER_LOSS_ID,
+            "https://tiles.example.org/tcl/{z}/{x}/{y}.png?tcd={threshold}",
+            YEAR_PARAMS,
+            # Tree cover loss also carries a canopy-cover threshold, whose
+            # own layer comes back as a context layer.
+            parameters=[
+                {
+                    "name": "canopy_cover",
+                    "tile_url": "https://tiles.example.org/tcd_{threshold}/{z}/{x}/{y}.png",
+                }
+            ],
+        ),
+        "2015-06-01",
+        "2020-02-28",
+    )
+
+    assert "&start_year=2015&end_year=2020" in tile_url
+    assert "start_date=" not in tile_url
+
+
+def test_year_in_path_layer_substitutes_the_end_year():
+    """Annual rasters name the year in the item path instead of filtering."""
+    tile_url, _ = get_tile_services_for_dataset(
+        _selection(LAND_COVER_CHANGE_ID),
+        _row(
+            LAND_COVER_CHANGE_ID,
+            "https://tiles.example.org/items/land-cover-{year}/{{z}}/{{x}}/{{y}}.png",
+            YEAR_IN_PATH,
+        ),
+        "2015-01-01",
+        "2024-12-31",
+    )
+
+    assert tile_url == (
+        "https://tiles.example.org/items/land-cover-2024/{z}/{x}/{y}.png"
+    )
+
+
+def test_layer_without_a_date_convention_is_left_alone():
+    bare = "https://tiles.example.org/gain/{z}/{x}/{y}.png"
+
+    tile_url, _ = get_tile_services_for_dataset(
+        _selection(5),
+        _row(5, bare, None),
+        "2001-01-01",
+        "2020-12-31",
+    )
+
+    assert tile_url == bare
+
+
+def test_every_catalog_date_convention_is_exercised_above():
+    """Guard against a new convention landing with no coverage here."""
+    declared = {
+        d.get("tile_date_filter")
+        for d in DATASETS
+        if d.get("tile_date_filter")
+    }
+
+    assert declared == {DATE_PARAMS, YEAR_PARAMS, YEAR_IN_PATH}

--- a/uv.lock
+++ b/uv.lock
@@ -3028,7 +3028,7 @@ wheels = [
 
 [[package]]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Where the problem comes from

Tile URLs exist in two hand-maintained copies. The backend owns them in
`src/agent/datasets/catalog/*.yml`; the frontend keeps a second copy in
`project-zeno-next/app/constants/datasets.ts` (`DATASET_CARDS[].tile_url`).
Nothing syncs them and no test compares them.

The frontend copy exists because only one of its three "add layer to map" paths
goes through the agent:

| path | tile URL source |
|---|---|
| chat `pick_dataset` | backend `dataset.tile_url` — correct |
| Data Catalog / default card | `DATASET_CARDS[].tile_url` — local copy |
| suggested-dataset nudge | `DATASET_BY_ID[id].tile_url` — local copy, even though a backend nudge triggered it |

So a layer's URL depends on how it was added. The copies have already drifted:

- **Global land cover** — backend templates the year and fills it from the
  resolved range (`items/global-land-cover-{year}`); the frontend pins
  `items/global-land-cover-2024`. Their colormaps also differ, class 1 being
  `[254, 254, 204, 255]` on the backend and `[254, 254, 204]` on the frontend.
- **Grasslands** — same shape: `items/grasslands-{year}` vs a pinned
  `items/grasslands-2022`.
- **Integrated alerts** — the case that surfaced this. The backend appends
  `&start_date=&end_date=`; the frontend card has no date params, and its only
  date-scoping code appends `&start_year=&end_year=`, which is the tree-cover-loss
  convention and wrong for this layer. The card also declares no default years,
  so nothing is appended at all and the layer renders unfiltered.

That last one is the general problem. **The date-filtering convention is
per-dataset** — query params by date, query params by year, or a year in the item
path — and the frontend hardcodes exactly one of the three. Worse, the backend did
not declare the convention either: `get_tile_services_for_dataset` inferred it from
hardcoded lists of dataset ids, so any second consumer had to re-derive it.

## What this changes

Makes the convention declarative and serves it, so there is one source of truth
instead of two copies and two inference sites.

**1. `tile_date_filter` in the catalog YAML** — one of `date_params`,
`year_params`, `year_in_path`, or absent for a layer with no time dimension.
Added to the five datasets that have one.

**2. `get_tile_services_for_dataset` reads it** instead of matching dataset ids:

```python
date_filter = getattr(selected_row, "tile_date_filter", None)
if date_filter == YEAR_PARAMS:
    ...
elif date_filter == DATE_PARAMS:
    tile_url += f"&start_date={start_date}&end_date={end_date}"
elif date_filter == YEAR_IN_PATH:
    tile_url = tile_url.format(year=end_date.year)
```

Behaviour is unchanged for every dataset — same branches, same output, keyed off
the YAML rather than `INTEGRATED_ALERTS_ID` / `LAND_COVER_CHANGE_ID` /
`GRASSLANDS_ID`, which are no longer imported here. The magic `canopy_cover = 30`
becomes `DEFAULT_CANOPY_COVER`, shared with the registry.

**3. `src/agent/datasets/layers.py`** — a `LAYERS` registry alongside the existing
`PALETTES` one, deriving per dataset: absolute `tile_url`, `date_filter`,
`start_date`, `end_date` (None = ongoing), `content_date_fixed`, and
`threshold_values` / `default_threshold` when the URL carries `{threshold}`.

Served URLs are absolute and keep their placeholders literal — `{z}/{x}/{y}`
always, plus `{threshold}` and `{year}` where they apply. `year_in_path` URLs are
`str.format` templates in the YAML, so their tile scheme is escaped as
`{{z}}/{{x}}/{{y}}`; the registry unescapes it. Relative eoapi paths are
absolutised with `rstrip("/")`, matching `src/shared/tile_urls.py` — the frontend's
`EOAPI_HOST` default has a trailing slash and currently produces `//raster/`.

Three invariants fail at import rather than at render time: an unknown
`tile_date_filter`, a param-appending convention on a URL with no query string
(the append uses `&`), and `year_in_path` with no `{year}`. A fourth — a
`{threshold}` placeholder with no `canopy_cover` values to fill it — was found by
its own test and is now enforced too.

**4. `/api/datasets/catalog` gains a `layers` array.** Additive: `datasets`
(colors) is untouched, and the frontend's Zod schema strips unknown keys, so the
deployed client is unaffected. The two lists stay independent because a dataset can
have tiles without colors (Integrated alerts, tree cover loss due to fires) and
colors without tiles.

## Scope

Backend only. The frontend PR that consumes `layers` and deletes
`DATASET_CARDS[].tile_url` depends on this being deployed, and is separate.

Not addressed here: the legend truncates any range to years
(`buildYearParam`), so a two-week filter renders as `YEAR 2026` whatever the
tile URL says. Also frontend, also separate.

## Tests

- `tests/unit/agent/test_dataset_layers.py` — registry derivation, placeholder
  unescaping, absolutisation, and each of the four import-time invariants.
- `tests/unit/agent/tools/test_tile_services.py` — rewritten: one case per
  convention plus a no-convention case, and a guard that fails if a new
  convention lands in the catalog with no coverage here.
- `tests/api/test_metadata.py` — three cases on the new array: every tiled
  dataset present with absolute URLs, the per-dataset conventions, and the
  colors/layers independence.

```
27 passed in 4.62s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Part of #821.
