### PR TITLE
feat(dashboards): add analysis templates for curated sections

### DIFF
--- a/db/alembic/versions/b7d2f4a1c908_add_dashboard_section_type_and_config.py
+++ b/db/alembic/versions/b7d2f4a1c908_add_dashboard_section_type_and_config.py
@@ -1,0 +1,58 @@
+"""add dashboard_sections.type and dashboard_sections.config
+
+Revision ID: b7d2f4a1c908
+Revises: c9f1a2b3d4e5
+Create Date: 2026-09-09 00:00:00.000000
+
+Two columns that turn a section into something a builder can own.
+
+``type`` records how the section was built: "default" for a user- or
+agent-composed group, or the name of the analysis template that wrote it in
+one piece. ``config`` records what that template built it from — the window
+it covers and the parameters it was given — so a refresh knows what to
+replace and a reader can be told which period is on screen without sniffing
+the dates out of a widget's tile layer.
+
+Both take a server default, so every existing row is correct with no data
+migration. A templated section is read-only; that rule lives in the
+application (``analysis_templates.registry``), not here, so adding a
+template or an exception stays a code change.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "b7d2f4a1c908"
+down_revision: Union[str, None] = "c9f1a2b3d4e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dashboard_sections",
+        sa.Column(
+            "type",
+            sa.String(),
+            nullable=False,
+            server_default="default",
+        ),
+    )
+    op.add_column(
+        "dashboard_sections",
+        sa.Column(
+            "config",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dashboard_sections", "config")
+    op.drop_column("dashboard_sections", "type")

--- a/docs/analysis-templates.md
+++ b/docs/analysis-templates.md
@@ -1,0 +1,118 @@
+# Analysis templates
+
+*Scope: backend (`wri/project-zeno`). Related: `dashboards-mvp-plan.md`,
+`AGENT_ARCHITECTURE.md`.*
+
+An **analysis template** answers a standing question about an area — "what
+has been disturbed here in the last two weeks?" — by writing a whole
+dashboard section at once: a chart, the map layers that belong with it, and
+a title and description written from the data.
+
+It is not a chat workflow. Nothing is picked by a model along the way, so
+the same request always produces the same section. The only model call
+writes the words.
+
+Today the agent is the only caller, behind the experimental profile. The
+system is built so an HTTP route can be added later without changing a
+template.
+
+## The parts
+
+| Where | What |
+|---|---|
+| `analysis_templates/registry.py` | the templates, as metadata only |
+| `analysis_templates/base.py` | the interface, the result and error types, the shared helpers |
+| `analysis_templates/writer.py` | the two transactional writes, and the `config` shape |
+| `analysis_templates/<name>/` | one template |
+| `agent/tools/analysis_sections.py` | the two generic agent tools |
+| `skills_md/analysis-templates.md` | the workflow the model follows |
+
+The registry imports nothing else, and must stay that way. Two callers need
+to know a template exists without paying for what it does:
+`dashboard_writer` reads `SEALED_SECTION_TYPES` on every dashboard write,
+and the agent's tool prompt lists the templates at import time.
+`get_template()` imports a template's module on first use.
+
+A template's `name` is also the value stored in `dashboard_sections.type`,
+so there is one list of template names rather than two.
+
+## Sealed sections
+
+A section a template wrote is **read-only**. Its content is a record of one
+build — one area, one period, the data as it was — so editing it would make
+its own title and description untrue.
+
+`dashboard_writer` refuses every write that would change a sealed section or
+its widgets' content: retitling, restating, adding a widget, removing one,
+moving one in or out, replacing a widget's config. The API returns 409; the
+agent tools return an error that says what to do instead.
+
+Three details worth knowing:
+
+- **Layout is exempt.** `position`, and a config replacement whose only
+  differing keys are `size`/`sizes`. The check is a diff, not a field
+  allowlist, because PATCH replaces a config wholesale.
+- **Deleting a sealed section always takes its widgets**, whatever
+  `delete_widgets` says. Ungrouping would leave loose, editable copies of
+  content that is only meaningful inside its own section.
+- **`update_insight_display` refuses an insight a sealed widget shows.** It
+  is the one path that could rewrite a section's content without touching a
+  dashboard row.
+
+A template never meets the seal: it writes its section in one transaction
+(`add_section_with_widgets`) and replaces it in another
+(`replace_section_widgets`), neither of which is guarded.
+
+## Adding a template
+
+1. **Write the module.** `analysis_templates/<your_name>/` with a `recipe.py`
+   exporting `TEMPLATE` and a parameter model, and a `summary.py` if it
+   generates its own words. Copy the shape of `nrt_monitoring`.
+
+   - `build(dashboard, *, user_id, params, language)` and
+     `refresh(section, dashboard, ...)` both gather content and hand it to
+     `writer`. Sharing one gather step means a refreshed section is
+     assembled exactly like a new one.
+   - The template takes the loaded `DashboardOrm`, so it picks its own area
+     (`base.first_aoi`) and runs its own "already built" check.
+   - Its parameter model states its defaults and its bounds, and sets
+     `extra="forbid"` so a parameter it does not take is refused rather
+     than ignored.
+   - Everything it raises is a `TemplateError`, whose message is shown to
+     the user as written.
+   - It writes its own one-line `summary`, so no caller has to know what
+     the section contains.
+   - Record `start_date` and `end_date` in `SectionContent.config` if the
+     section covers a period; `base.describe_window` reads them back.
+
+2. **Register it.** One `TemplateEntry` in `registry.py`. `label`,
+   `when_to_use` and `params_help` are read by a model, so keep them to one
+   line each. `sealed=True` unless the section is genuinely editable
+   afterwards.
+
+3. **Document it for the model.** One `##` section in
+   `skills_md/analysis-templates.md`: what it builds, what its parameters
+   mean, and any caveat the model must pass on rather than apologise for.
+
+Nothing else changes: no new tool, no `agent_config` change, no
+`dashboard_writer` change, no migration, no router change. The tests in
+`tests/unit/api/analysis_templates/test_registry.py` cover every registered
+template, so a new one is covered by them the day it is added.
+
+Reuse what is already there: `resolve_dataset_layer` for a renderable tile
+URL, `widget_configs` for a map widget's config, `DETERMINISTIC_GENERATORS`
+for a curated chart, `AnalyzeService` for the pull, `persist_insight` for a
+chart widget's insight.
+
+## Known limits
+
+- **One area.** A template covers the dashboard's first AOI
+  (`base.first_aoi`). Portfolios of areas are a dashboard-level question,
+  and that is the one place it will change.
+- **One shared parameter in the agent's tools.** Both tools pass `days`. A
+  template needing another input adds a field to its parameter model and a
+  line to `params_help`, and the tools gain that argument once — not once
+  per template.
+- **Synchronous.** A build runs to completion before it answers, which
+  takes tens of seconds. When a route is added, that decision gets made
+  again.

--- a/docs/analysis-templates.md
+++ b/docs/analysis-templates.md
@@ -24,7 +24,7 @@ template.
 | `analysis_templates/base.py` | the interface, the result and error types, the shared helpers |
 | `analysis_templates/writer.py` | the two transactional writes, and the `config` shape |
 | `analysis_templates/<name>/` | one template |
-| `agent/tools/analysis_sections.py` | the two generic agent tools |
+| `agent/tools/analysis_sections.py` | the three generic agent tools |
 | `skills_md/analysis-templates.md` | the workflow the model follows |
 
 The registry imports nothing else, and must stay that way. Two callers need
@@ -35,6 +35,29 @@ and the agent's tool prompt lists the templates at import time.
 
 A template's `name` is also the value stored in `dashboard_sections.type`,
 so there is one list of template names rather than two.
+
+## The three verbs
+
+| The user says | Tool | What runs |
+|---|---|---|
+| "monitor this area" | `add_analysis_section(template, params?)` | `template.build()` |
+| "refresh it", "anything new?" | `refresh_analysis_section(section?)` | `template.refresh()` with the parameters the section recorded |
+| "show me 3 months instead" | `reconfigure_analysis_section(params, confirmed, section?)` | `template.refresh()` with new parameters |
+
+A template implements `build` and `refresh` and cannot tell the last two
+apart, which is the point: re-running a section and moving it are the same
+operation with different parameters.
+
+**Nothing in the generic layer names a parameter.** `params` is a dict the
+template's own model validates, and the section records what it was built
+with (`base.stored_params`), so a template driven by a threshold or a
+comparison area rather than a date range uses the same three tools
+unchanged. `template.describe(section)` renders the current parameters for a
+message, because only the template knows what they mean.
+
+Only `reconfigure` is confirmed, and only because it answers a different
+question than the one on screen. `refresh` asks the same question again, so
+there is nothing to agree to.
 
 ## Sealed sections
 
@@ -71,8 +94,11 @@ A template never meets the seal: it writes its section in one transaction
 
    - `build(dashboard, *, user_id, params, language)` and
      `refresh(section, dashboard, ...)` both gather content and hand it to
-     `writer`. Sharing one gather step means a refreshed section is
-     assembled exactly like a new one.
+     `writer`, along with the `params` they ran with. Sharing one gather
+     step means a rebuilt section is assembled exactly like a new one.
+   - `describe(section) -> str` says what the section currently covers, in
+     the template's own words. It is read back from the section's stored
+     `config`, never from a widget.
    - The template takes the loaded `DashboardOrm`, so it picks its own area
      (`base.first_aoi`) and runs its own "already built" check.
    - Its parameter model states its defaults and its bounds, and sets
@@ -82,13 +108,15 @@ A template never meets the seal: it writes its section in one transaction
      the user as written.
    - It writes its own one-line `summary`, so no caller has to know what
      the section contains.
-   - Record `start_date` and `end_date` in `SectionContent.config` if the
-     section covers a period; `base.describe_window` reads them back.
+   - `SectionContent.config` is free-form: nothing generic reads it, only
+     the template that wrote it. `writer` adds the template's name and its
+     parameters alongside.
 
 2. **Register it.** One `TemplateEntry` in `registry.py`. `label`,
-   `when_to_use` and `params_help` are read by a model, so keep them to one
-   line each. `sealed=True` unless the section is genuinely editable
-   afterwards.
+   `when_to_use`, `params_help` and `change_warning` are read by a model, so
+   keep them to one line each — `params_help` must name every field, its
+   default and its bounds, because it is all the model is told.
+   `sealed=True` unless the section is genuinely editable afterwards.
 
 3. **Document it for the model.** One `##` section in
    `skills_md/analysis-templates.md`: what it builds, what its parameters
@@ -109,10 +137,11 @@ chart widget's insight.
 - **One area.** A template covers the dashboard's first AOI
   (`base.first_aoi`). Portfolios of areas are a dashboard-level question,
   and that is the one place it will change.
-- **One shared parameter in the agent's tools.** Both tools pass `days`. A
-  template needing another input adds a field to its parameter model and a
-  line to `params_help`, and the tools gain that argument once — not once
-  per template.
+- **Parameters reach the model as a dict.** A template's fields are
+  described in `params_help` rather than in a tool signature, so the model
+  is told the shape rather than shown it. If that proves unreliable as
+  templates grow, the answer is per-template tools generated from the
+  registry, not a parameter in the generic layer.
 - **Synchronous.** A build runs to completion before it answers, which
   takes tens of seconds. When a route is added, that decision gets made
   again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-zeno"
-version = "2026.9.2.1"
+version = "2026.9.9"
 description = "Language Interface for Maps & WRI/LCL data APIs."
 readme = "README.md"
 requires-python = "==3.12.8"

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -57,7 +57,10 @@ from src.agent.tools.add_text_widget import SPEC as add_text_widget_spec
 from src.agent.tools.add_to_dashboard import SPEC as add_to_dashboard_spec
 from src.agent.tools.analysis_sections import ADD_SPEC as add_analysis_spec
 from src.agent.tools.analysis_sections import (
-    UPDATE_SPEC as update_analysis_spec,
+    RECONFIGURE_SPEC as reconfigure_analysis_spec,
+)
+from src.agent.tools.analysis_sections import (
+    REFRESH_SPEC as refresh_analysis_spec,
 )
 from src.agent.tools.create_dashboard import SPEC as create_dashboard_spec
 from src.agent.tools.edit_dashboard_section import (
@@ -106,7 +109,8 @@ ALL_SPECS = (
     edit_text_widget_spec,
     add_dashboard_section_spec,
     add_analysis_spec,
-    update_analysis_spec,
+    refresh_analysis_spec,
+    reconfigure_analysis_spec,
     edit_dashboard_section_spec,
     move_dashboard_widget_spec,
     send_nudge_spec,

--- a/src/agent/agent_config.py
+++ b/src/agent/agent_config.py
@@ -55,6 +55,10 @@ from src.agent.tools.add_dashboard_section import (
 from src.agent.tools.add_map_widget import SPEC as add_map_widget_spec
 from src.agent.tools.add_text_widget import SPEC as add_text_widget_spec
 from src.agent.tools.add_to_dashboard import SPEC as add_to_dashboard_spec
+from src.agent.tools.analysis_sections import ADD_SPEC as add_analysis_spec
+from src.agent.tools.analysis_sections import (
+    UPDATE_SPEC as update_analysis_spec,
+)
 from src.agent.tools.create_dashboard import SPEC as create_dashboard_spec
 from src.agent.tools.edit_dashboard_section import (
     SPEC as edit_dashboard_section_spec,
@@ -101,6 +105,8 @@ ALL_SPECS = (
     add_text_widget_spec,
     edit_text_widget_spec,
     add_dashboard_section_spec,
+    add_analysis_spec,
+    update_analysis_spec,
     edit_dashboard_section_spec,
     move_dashboard_widget_spec,
     send_nudge_spec,
@@ -141,7 +147,7 @@ DEFAULT_EXCLUDED_DATASETS = frozenset({"Land GHG Monitoring System (LGMS)"})
 # sections and widget ids is part of that workflow, not a standalone
 # debugging aid).
 EXPERIMENTAL_PROFILE = "experimental"
-EXPERIMENTAL_SKILLS = ("show-imagery-planet",)
+EXPERIMENTAL_SKILLS = ("show-imagery-planet", "analysis-templates")
 EXPERIMENTAL_TOOLS = (update_insight_display_spec,)
 
 

--- a/src/agent/datasets/layers.py
+++ b/src/agent/datasets/layers.py
@@ -1,0 +1,178 @@
+"""Resolve a catalog dataset into a renderable map layer.
+
+A dataset's ``tile_url`` in the catalog is a template: it may be relative to
+the eoapi host, and it may carry a canopy-cover threshold, a year, or a date
+range that only the caller knows. Turning it into a URL a map can render is
+the same job whether the dataset was picked by the LLM in chat or named by an
+API caller, so it lives here rather than inside the dataset-selection
+subagent.
+
+``pick_dataset`` adapts its own selection objects onto this function; the
+the analysis templates call it directly. One definition means a map widget
+built by a template and one built from chat carry the same URL.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Optional
+
+from src.agent.datasets.config import DATASETS
+from src.agent.datasets.handlers.analytics_handler import (
+    FOREST_CARBON_FLUX_ID,
+    GRASSLANDS_ID,
+    INTEGRATED_ALERTS_ID,
+    LAND_COVER_CHANGE_ID,
+    TREE_COVER_ID,
+    TREE_COVER_LOSS_BY_DRIVER_ID,
+    TREE_COVER_LOSS_BY_FIRES_ID,
+    TREE_COVER_LOSS_ID,
+)
+from src.shared.config import SharedSettings
+
+#: Datasets whose tiles are cut at a canopy-cover threshold.
+_THRESHOLD_DATASETS = (
+    TREE_COVER_LOSS_ID,
+    TREE_COVER_ID,
+    TREE_COVER_LOSS_BY_DRIVER_ID,
+    TREE_COVER_LOSS_BY_FIRES_ID,
+    FOREST_CARBON_FLUX_ID,
+)
+DEFAULT_CANOPY_COVER = 30
+
+#: Tree cover loss tiles carry whole years, and only these are published.
+TCL_TILE_YEARS = range(2001, 2026)
+
+
+@dataclass(frozen=True)
+class DatasetLayer:
+    """One dataset rendered for one date range: what a map needs, nothing
+    else. The prose fields of the catalog record stay out by design — this
+    is what gets snapshotted into a dashboard widget."""
+
+    dataset_id: int
+    dataset_name: str
+    tile_url: str
+    start_date: str
+    end_date: str
+    context_layer: Optional[str] = None
+    #: Companion layers to draw with the dataset, as
+    #: ``{"name": ..., "tile_url": ...}``.
+    context_layers: list[dict] = field(default_factory=list)
+    #: The parameters the tile URL was built with, as
+    #: ``{"name": ..., "values": [...]}``.
+    parameters: Optional[list[dict]] = None
+
+
+def get_dataset_record(dataset_id: int) -> dict:
+    """The catalog record for a dataset id; raises ``ValueError`` if unknown."""
+    record = next(
+        (ds for ds in DATASETS if ds["dataset_id"] == dataset_id), None
+    )
+    if record is None:
+        raise ValueError(f"Dataset not found: {dataset_id}")
+    return record
+
+
+def _canopy_cover(parameters: Optional[list[dict]]) -> int:
+    for parameter in parameters or []:
+        if parameter.get("name") == "canopy_cover" and parameter.get("values"):
+            return max(parameter["values"])
+    return DEFAULT_CANOPY_COVER
+
+
+def resolve_dataset_layer(
+    dataset_id: int,
+    start_date: str,
+    end_date: str,
+    *,
+    context_layer: Optional[str] = None,
+    parameters: Optional[list[dict]] = None,
+    record: Optional[dict] = None,
+) -> DatasetLayer:
+    """Build the renderable layer for a dataset over a date range.
+
+    ``start_date`` / ``end_date`` are ISO dates the caller has already
+    clamped to the dataset's coverage (``datasets.dates.revise_date_range``).
+    ``context_layer`` names one of the dataset's context layers by its
+    catalog ``value``; ``parameters`` are ``{"name", "values"}`` dicts, of
+    which only ``canopy_cover`` currently changes a URL.
+
+    ``record`` overrides the catalog lookup with the dataset row the caller
+    already holds. ``pick_dataset`` passes its candidate row, whose context
+    layers have been filtered to the ones that actually cover the selected
+    area — resolving from the catalog instead would quietly undo that
+    filter.
+    """
+    record = record if record is not None else get_dataset_record(dataset_id)
+    start = date.fromisoformat(start_date)
+    end = date.fromisoformat(end_date)
+
+    tile_url = record["tile_url"] or ""
+    if tile_url and not tile_url.startswith("http"):
+        tile_url = SharedSettings.eoapi_base_url + tile_url
+
+    context_layers: list[dict] = []
+    if context_layer and record.get("context_layers"):
+        selected = next(
+            (
+                layer
+                for layer in record["context_layers"]
+                if layer.get("value") == context_layer
+            ),
+            None,
+        )
+        if selected:
+            context_layers.append(
+                {
+                    "name": selected.get("value"),
+                    "tile_url": selected.get("tile_url"),
+                }
+            )
+
+    if dataset_id in _THRESHOLD_DATASETS:
+        canopy_cover = _canopy_cover(parameters)
+        if dataset_id != TREE_COVER_ID:
+            canopy_tile_url = next(
+                (
+                    parameter["tile_url"]
+                    for parameter in record.get("parameters") or []
+                    if parameter["name"] == "canopy_cover"
+                ),
+                None,
+            )
+            if canopy_tile_url:
+                context_layers.append(
+                    {
+                        "name": "canopy_cover",
+                        "tile_url": canopy_tile_url.replace(
+                            "{threshold}", str(canopy_cover)
+                        ),
+                    }
+                )
+        tile_url = tile_url.replace("{threshold}", str(canopy_cover))
+
+    if dataset_id in (TREE_COVER_LOSS_ID, TREE_COVER_LOSS_BY_FIRES_ID):
+        if end.year in TCL_TILE_YEARS:
+            tile_url += f"&start_year={start.year}&end_year={end.year}"
+        else:
+            tile_url += (
+                f"&start_year={TCL_TILE_YEARS.start}"
+                f"&end_year={TCL_TILE_YEARS.stop - 1}"
+            )
+    elif dataset_id == INTEGRATED_ALERTS_ID:
+        tile_url += f"&start_date={start_date}&end_date={end_date}"
+    elif dataset_id in (LAND_COVER_CHANGE_ID, GRASSLANDS_ID):
+        # Annual raster item in the URL; the dates are already clamped to the
+        # dataset's own coverage.
+        tile_url = tile_url.format(year=end.year)
+
+    return DatasetLayer(
+        dataset_id=dataset_id,
+        dataset_name=record["dataset_name"],
+        tile_url=tile_url,
+        start_date=start_date,
+        end_date=end_date,
+        context_layer=context_layer,
+        context_layers=context_layers,
+        parameters=parameters,
+    )

--- a/src/agent/skills/skills_md/analysis-templates.md
+++ b/src/agent/skills/skills_md/analysis-templates.md
@@ -1,0 +1,85 @@
+---
+name: analysis-templates
+description: Build a curated analysis section on a dashboard — a chart, its map layers and the words that go with them, for one area and one period, in one step.
+when_to_use: User asks to monitor or watch an area, asks for recent/near-real-time disturbance on a dashboard, or asks to change the time window / period / date range of a curated section. Not for a one-off look at data without a dashboard — use `analyze`, or `show-imagery` for imagery alone.
+requires: add_analysis_section, update_analysis_section, send_nudge, create_dashboard, pick_aoi, inspect_view_context
+---
+
+# Curated analysis sections
+
+An **analysis template** builds a whole dashboard section in one call: a
+chart, the map layers that belong with it, and a title and description
+written from the data. `add_analysis_section(template, days?)` runs one.
+
+It is not like the other dashboard tools. They snapshot work the
+conversation already did; a template does the work itself.
+
+# Steps
+
+1. The dashboard: reuse the one the user is viewing or made earlier this
+   conversation. If there is none, `pick_aoi` then `create_dashboard` — the
+   section covers the dashboard's own area, so the dashboard has to exist
+   and have one.
+2. `add_analysis_section` with the template that fits the request. Pass
+   `days` when the user named a period; leave it out for the template's own
+   default.
+3. Report what the tool message says was built, including the period.
+
+# Do not pre-fetch
+
+Do **not** run `pick_dataset`, `pull_data`, `generate_insights` or
+`show_imagery` for a template. It pulls its own data, builds its own chart,
+resolves its own map layers and writes its own words. Running those first
+duplicates the work and leaves stray widgets and insights behind.
+
+# Changing the window ("show me the last 3 months instead")
+
+`update_analysis_section(days, confirmed, section?)` moves an existing
+section to a new window. The template rebuilds everything for that period
+and rewrites the title and description, because they state the period.
+
+**Confirm before you apply it.** A window change replaces every figure the
+user is looking at, and the old numbers are gone afterwards. So:
+
+1. Call `send_nudge(nudge_type="time_range_choice", options=[...])` with the
+   windows that fit what they asked — e.g. `["Last 2 weeks", "Last 30 days",
+   "Last 90 days"]` — and wait for their answer.
+2. Then call `update_analysis_section(days=<their choice>, confirmed=True)`.
+
+`confirmed=True` means "the user has told me which window they want". Set it
+only when they have: either they answered your nudge, or they named the exact
+window in the same breath as the request ("change it to the last 30 days"),
+which *is* their answer — nudge then only if it is unclear which section or
+which period they mean. Never set it on a request that names no window ("can
+I see more history?"); ask first.
+
+Never reach for `add_analysis_section` to change a period — that builds a
+second section next to the first.
+
+# What to tell the user
+
+- **It takes a while** — a data pull, sometimes a satellite scene search,
+  and a written summary. Say what you are doing before you call it, and do
+  not call it twice while waiting.
+- **The section's content is read-only** once built — see the `dashboard`
+  skill. Its period is the exception: `update_analysis_section` moves it.
+  Anything else means deleting it and building another. A template refuses
+  to build a second section for a period the dashboard already covers.
+- **A widget can be missing.** The tool message says what was not
+  available and why; pass that on rather than retrying or apologising.
+
+# The templates
+
+## `nrt-monitoring` — near-real-time monitoring
+
+Three widgets for the dashboard's area: a chart of integrated disturbance
+alerts over the period, a map of those alerts, and satellite imagery of the
+same area and period.
+
+- `days` is the alert window counted back from today. **Default 14** — the
+  last two weeks — maximum 365.
+- Satellite imagery is optional. Areas too large for a mosaic (bigger than
+  about 50,000 km², so most countries) and periods with no clear scenes
+  yield a two-widget section.
+- Alerts are **potential** disturbance, not confirmed deforestation. The
+  section's own description says this; do not contradict it.

--- a/src/agent/skills/skills_md/analysis-templates.md
+++ b/src/agent/skills/skills_md/analysis-templates.md
@@ -1,18 +1,26 @@
 ---
 name: analysis-templates
 description: Build a curated analysis section on a dashboard — a chart, its map layers and the words that go with them, for one area and one period, in one step.
-when_to_use: User asks to monitor or watch an area, asks for recent/near-real-time disturbance on a dashboard, or asks to change the time window / period / date range of a curated section. Not for a one-off look at data without a dashboard — use `analyze`, or `show-imagery` for imagery alone.
-requires: add_analysis_section, update_analysis_section, send_nudge, create_dashboard, pick_aoi, inspect_view_context
+when_to_use: User asks to monitor or watch an area, asks for recent/near-real-time disturbance on a dashboard, or asks to refresh or change what a curated section covers. Not for a one-off look at data without a dashboard — use `analyze`, or `show-imagery` for imagery alone.
+requires: add_analysis_section, refresh_analysis_section, reconfigure_analysis_section, send_nudge, create_dashboard, pick_aoi, inspect_view_context
 ---
 
 # Curated analysis sections
 
 An **analysis template** builds a whole dashboard section in one call: a
 chart, the map layers that belong with it, and a title and description
-written from the data. `add_analysis_section(template, days?)` runs one.
+written from the data. `add_analysis_section(template, params?)` runs one.
 
 It is not like the other dashboard tools. They snapshot work the
 conversation already did; a template does the work itself.
+
+Three verbs, because they are three different asks:
+
+| The user says | Tool | Confirm first? |
+|---|---|---|
+| "monitor this area" | `add_analysis_section` | no |
+| "refresh it", "anything new?" | `refresh_analysis_section` | no |
+| "show me 3 months instead" | `reconfigure_analysis_section` | **yes** |
 
 # Steps
 
@@ -21,8 +29,9 @@ conversation already did; a template does the work itself.
    section covers the dashboard's own area, so the dashboard has to exist
    and have one.
 2. `add_analysis_section` with the template that fits the request. Pass
-   `days` when the user named a period; leave it out for the template's own
-   default.
+   `params` only when the user named something specific, e.g.
+   `{"days": 30}`; leave it out for the template's own defaults, which are
+   the right answer otherwise. Each template's parameters are listed below.
 3. Report what the tool message says was built, including the period.
 
 # Do not pre-fetch
@@ -32,29 +41,40 @@ Do **not** run `pick_dataset`, `pull_data`, `generate_insights` or
 resolves its own map layers and writes its own words. Running those first
 duplicates the work and leaves stray widgets and insights behind.
 
-# Changing the window ("show me the last 3 months instead")
+# Bringing a section up to date ("refresh it", "anything new since?")
 
-`update_analysis_section(days, confirmed, section?)` moves an existing
-section to a new window. The template rebuilds everything for that period
-and rewrites the title and description, because they state the period.
+`refresh_analysis_section(section?)` runs the section again with the
+parameters it already has, so it shows today's data. The same question,
+asked again now.
 
-**Confirm before you apply it.** A window change replaces every figure the
-user is looking at, and the old numbers are gone afterwards. So:
+It takes **no parameters** and needs **no confirmation**: the user asked for
+exactly this, and nothing about what the section covers changes.
 
-1. Call `send_nudge(nudge_type="time_range_choice", options=[...])` with the
-   windows that fit what they asked — e.g. `["Last 2 weeks", "Last 30 days",
-   "Last 90 days"]` — and wait for their answer.
-2. Then call `update_analysis_section(days=<their choice>, confirmed=True)`.
+# Changing what a section covers ("show me the last 3 months instead")
 
-`confirmed=True` means "the user has told me which window they want". Set it
-only when they have: either they answered your nudge, or they named the exact
-window in the same breath as the request ("change it to the last 30 days"),
-which *is* their answer — nudge then only if it is unclear which section or
-which period they mean. Never set it on a request that names no window ("can
-I see more history?"); ask first.
+`reconfigure_analysis_section(params, confirmed, section?)` rebuilds the
+section for different parameters. That is a different question from the one
+on screen, and the previous answer is gone afterwards.
 
-Never reach for `add_analysis_section` to change a period — that builds a
-second section next to the first.
+**Confirm before you apply it.** So:
+
+1. Call `send_nudge` with the options that fit what they asked — for a
+   period, `send_nudge(nudge_type="time_range_choice", options=["Last 2
+   weeks", "Last 30 days", "Last 90 days"])` — and wait for their answer.
+2. Then call `reconfigure_analysis_section(params={...}, confirmed=True)`.
+
+`confirmed=True` means "the user has told me what they want". Set it only
+when they have: either they answered your nudge, or they named it exactly in
+the same breath as the request ("change it to the last 30 days"), which *is*
+their answer — nudge then only if it is unclear which section or which value
+they mean. Never set it on a request that names nothing ("can I see more
+history?"); ask first.
+
+If you pass a parameter a template does not take, the tool says so and lists
+what it does take. Read that and retry rather than guessing again.
+
+Never reach for `add_analysis_section` to change a section — that builds a
+second one next to the first.
 
 # What to tell the user
 
@@ -62,9 +82,10 @@ second section next to the first.
   and a written summary. Say what you are doing before you call it, and do
   not call it twice while waiting.
 - **The section's content is read-only** once built — see the `dashboard`
-  skill. Its period is the exception: `update_analysis_section` moves it.
-  Anything else means deleting it and building another. A template refuses
-  to build a second section for a period the dashboard already covers.
+  skill. Rebuilding the whole section is the exception, through the two
+  tools above. Anything else means deleting it and building another. A
+  template refuses to build a second section identical to one already
+  there; refresh that one instead.
 - **A widget can be missing.** The tool message says what was not
   available and why; pass that on rather than retrying or apologising.
 
@@ -76,8 +97,8 @@ Three widgets for the dashboard's area: a chart of integrated disturbance
 alerts over the period, a map of those alerts, and satellite imagery of the
 same area and period.
 
-- `days` is the alert window counted back from today. **Default 14** — the
-  last two weeks — maximum 365.
+- Parameters: `days`, the alert window counted back from today. **Default
+  14** — the last two weeks — maximum 365. So `{"days": 90}` for a quarter.
 - Satellite imagery is optional. Areas too large for a mosaic (bigger than
   about 50,000 km², so most countries) and periods with no clear scenes
   yield a two-widget section.

--- a/src/agent/skills/skills_md/dashboard.md
+++ b/src/agent/skills/skills_md/dashboard.md
@@ -31,11 +31,12 @@ offer to delete it and build a new one — deleting it removes its widgets
 with it. Never put a new widget in one, and never move a widget out of one:
 put it in another section or leave it ungrouped.
 
-The one thing that can change is the period the section covers, by
-rebuilding the whole section for it. That is `update_analysis_section`, the
-template's own tool, not an edit — see the `analysis-templates` skill if you
-have it. Without that tool, a period change is a delete and a rebuild like
-any other change.
+The one thing that can change is the whole section at once, rebuilt by the
+template that wrote it: `refresh_analysis_section` to bring it up to date,
+`reconfigure_analysis_section` to rebuild it for different parameters.
+Those are the template's own tools, not edits — see the
+`analysis-templates` skill if you have it. Without them, any change is a
+delete and a rebuild.
 
 Layout is the exception. A reader may rearrange and resize the widgets
 inside such a section in the app, because that changes how the section looks

--- a/src/agent/skills/skills_md/dashboard.md
+++ b/src/agent/skills/skills_md/dashboard.md
@@ -18,6 +18,31 @@ either belongs to one section or stays ungrouped; ungrouped widgets render
 above the first section. Order matters and is kept: sections render in their
 own order, widgets in order within their section.
 
+# Read-only sections
+
+Some sections are built by an analysis template in one piece rather than
+widget by widget — `inspect_view_context` marks them `read-only`. They are a
+record of one build, so **you cannot edit their content**: not the title, not
+the description, not what any widget shows. Widgets cannot be added,
+removed, or moved in or out. The tools refuse all of it.
+
+If the user asks to change the content of one, say it cannot be edited and
+offer to delete it and build a new one — deleting it removes its widgets
+with it. Never put a new widget in one, and never move a widget out of one:
+put it in another section or leave it ungrouped.
+
+The one thing that can change is the period the section covers, by
+rebuilding the whole section for it. That is `update_analysis_section`, the
+template's own tool, not an edit — see the `analysis-templates` skill if you
+have it. Without that tool, a period change is a delete and a rebuild like
+any other change.
+
+Layout is the exception. A reader may rearrange and resize the widgets
+inside such a section in the app, because that changes how the section looks
+and not what it says. You have no tool for that — if the user asks to make a
+widget wider or reorder one, tell them they can drag and resize it on the
+dashboard itself.
+
 # Which dashboard to use
 
 - If the user is viewing a dashboard (view_context has a `dashboard_id`, page

--- a/src/agent/subagents/pick_dataset/tool.py
+++ b/src/agent/subagents/pick_dataset/tool.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
 from typing import Annotated, Dict, Optional, Union
 
@@ -18,16 +18,7 @@ from src.agent.datasets.config import (
     DATASETS,
 )
 from src.agent.datasets.dates import revise_date_range
-from src.agent.datasets.handlers.analytics_handler import (
-    FOREST_CARBON_FLUX_ID,
-    GRASSLANDS_ID,
-    INTEGRATED_ALERTS_ID,
-    LAND_COVER_CHANGE_ID,
-    TREE_COVER_ID,
-    TREE_COVER_LOSS_BY_DRIVER_ID,
-    TREE_COVER_LOSS_BY_FIRES_ID,
-    TREE_COVER_LOSS_ID,
-)
+from src.agent.datasets.layers import resolve_dataset_layer
 from src.agent.i18n import t
 from src.agent.language import (
     DEFAULT_LANGUAGE,
@@ -512,86 +503,42 @@ def get_filtered_contextual_layers(
 def get_tile_services_for_dataset(
     selection_result, selected_row, start_date, end_date
 ):
-    context_layers = []
-    tile_url = selected_row.tile_url
-    start_date = datetime.strptime(start_date, "%Y-%m-%d").date()
-    end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
+    """Adapt the LLM's selection onto ``resolve_dataset_layer``.
 
-    if not selected_row.tile_url.startswith("http"):
-        tile_url = SharedSettings.eoapi_base_url + tile_url
+    The tile-URL rules live in ``src.agent.datasets.layers`` so that the
+    analysis templates produce the same layer without an LLM in the loop.
+    This function
+    stays as the chat-side shape: selection objects in, ``(tile_url,
+    [ContextLayer])`` out.
+    """
+    parameters = None
+    if selection_result.parameters is not None:
+        parameters = [
+            {"name": parameter.name, "values": parameter.values}
+            for parameter in selection_result.parameters
+        ]
 
-    if (
-        selection_result.context_layer
-        and selected_row.context_layers is not None
-    ):
-        selected_context_layer = next(
-            (
-                x
-                for x in selected_row.context_layers
-                if x["value"] == selection_result.context_layer
-            ),
-            None,
-        )
-        context_layer = ContextLayer(
-            name=selected_context_layer.get("value"),
-            tile_url=selected_context_layer.get("tile_url"),
-        )
-        context_layers.append(context_layer)
-
-    if selected_row.dataset_id in [
-        TREE_COVER_LOSS_ID,
-        TREE_COVER_ID,
-        TREE_COVER_LOSS_BY_DRIVER_ID,
-        TREE_COVER_LOSS_BY_FIRES_ID,
-        FOREST_CARBON_FLUX_ID,
-    ]:
-        canopy_cover = 30
-        if selection_result.parameters is not None:
-            for param in selection_result.parameters:
-                if param.name == "canopy_cover":
-                    canopy_cover = max(param.values)
-
-        if selected_row.dataset_id != TREE_COVER_ID:
-            canopy_cover_tile_url = next(
-                (
-                    param["tile_url"]
-                    for param in selected_row.parameters
-                    if param["name"] == "canopy_cover"
-                ),
-                None,
-            )
-
-            thresholded_tile_url = canopy_cover_tile_url.replace(
-                "{threshold}", str(canopy_cover)
-            )
-
-            context_layer = ContextLayer(
-                name="canopy_cover",
-                tile_url=thresholded_tile_url,
-            )
-            context_layers.append(context_layer)
-
-        tile_url = selected_row.tile_url.replace(
-            "{threshold}", str(canopy_cover)
-        )
-
-    if (
-        selected_row.dataset_id == TREE_COVER_LOSS_ID
-        or selected_row.dataset_id == TREE_COVER_LOSS_BY_FIRES_ID
-    ):
-        if end_date.year in range(2001, 2026):
-            tile_url += (
-                f"&start_year={start_date.year}&end_year={end_date.year}"
-            )
-        else:
-            tile_url += "&start_year=2001&end_year=2025"
-    elif selection_result.dataset_id == INTEGRATED_ALERTS_ID:
-        tile_url += f"&start_date={start_date}&end_date={end_date}"
-    elif selection_result.dataset_id in [LAND_COVER_CHANGE_ID, GRASSLANDS_ID]:
-        # Annual raster item in URL; start/end are already clamped to dataset YAML
-        tile_url = tile_url.format(year=end_date.year)
-
-    return tile_url, context_layers
+    layer = resolve_dataset_layer(
+        selected_row.dataset_id,
+        start_date,
+        end_date,
+        context_layer=selection_result.context_layer,
+        parameters=parameters,
+        # The candidate row, not the catalog: its context layers have already
+        # been filtered to those covering the selected area.
+        record={
+            "dataset_id": selected_row.dataset_id,
+            "dataset_name": selected_row.dataset_name,
+            "tile_url": selected_row.tile_url,
+            "context_layers": selected_row.context_layers,
+            "parameters": selected_row.parameters,
+        },
+    )
+    context_layers = [
+        ContextLayer(name=entry["name"], tile_url=entry["tile_url"])
+        for entry in layer.context_layers
+    ]
+    return layer.tile_url, context_layers
 
 
 def get_dates_for_dataset(

--- a/src/agent/tools/add_map_widget.py
+++ b/src/agent/tools/add_map_widget.py
@@ -7,9 +7,11 @@ show_imagery — into the widget's config, so the dashboard renders it without
 any chat state. The dashboard defaults to the one in state or the one the
 user is looking at (view_context). Owner-only, like the other primitives.
 
-The snapshot is an explicit key allowlist: only render-relevant fields are
-copied, so the prose fields on the dataset state (description, methodology,
-instructions, ...) can never leak into the database.
+The snapshot is an explicit key allowlist (in
+``src.api.services.widget_configs``, shared with the analysis templates):
+only render-relevant fields are copied, so the prose fields on the dataset
+state (description, methodology, instructions, ...) can never leak into the
+database.
 """
 
 from typing import Annotated, Callable, Dict, NamedTuple, Optional
@@ -28,58 +30,48 @@ from src.agent.tools.common import (
     resolve_section,
 )
 from src.api.repositories import dashboard_writer
+from src.api.services.widget_configs import (
+    dataset_snapshot,
+    imagery_snapshot,
+    map_widget_config,
+)
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-# Render-relevant fields of the imagery state (ImageryState) — all of it.
-_IMAGERY_KEYS = (
-    "provider",
-    "tile_url",
-    "tilejson_url",
-    "bounds",
-    "min_zoom",
-    "max_zoom",
-    "mosaic_id",
-    "item_count",
-    "start_date",
-    "end_date",
-    "mean_cloud_cover",
-    "min_cloud_cover",
-    "max_cloud_cover_observed",
-    "target_date",
-    "window_days",
-    "max_cloud_cover",
-    "aoi_names",
-)
 
 
 def _dataset_config(state: dict) -> Optional[dict]:
     """Project the dataset in state onto the widget-config snapshot.
 
-    Returns None when no dataset is selected or it carries no tile URL
-    (nothing to render). Dates fall back to the top-level effective range
-    set by pull_data.
+    Returns None when there is nothing renderable to snapshot: no dataset
+    selected, or one missing a field the map header reads.
+
+    The projection itself is shared with the analysis templates
+    (``src.api.services.widget_configs``), so a layer added from chat and
+    one added by a template render identically.
     """
     dataset = state.get("dataset") or {}
-    if not dataset.get("tile_url"):
+    # Dates fall back to the top-level effective range pull_data set.
+    snapshot = dataset_snapshot(
+        {
+            **dataset,
+            "start_date": dataset.get("start_date") or state.get("start_date"),
+            "end_date": dataset.get("end_date") or state.get("end_date"),
+        }
+    )
+    # Every field a map header reads has to be there. The dataset state
+    # declares most of them optional, and a widget written with a null date
+    # renders a header reading "None–None".
+    required = (
+        "dataset_id",
+        "dataset_name",
+        "tile_url",
+        "start_date",
+        "end_date",
+    )
+    if any(snapshot.get(key) in (None, "") for key in required):
         return None
-    parameters = dataset.get("parameters")
-    return {
-        "dataset_id": dataset.get("dataset_id"),
-        "dataset_name": dataset.get("dataset_name"),
-        "tile_url": dataset["tile_url"],
-        "context_layer": dataset.get("context_layer"),
-        "context_layers": dataset.get("context_layers"),
-        "parameters": [
-            {"name": p.get("name"), "values": p.get("values")}
-            for p in parameters
-        ]
-        if parameters
-        else None,
-        "start_date": dataset.get("start_date") or state.get("start_date"),
-        "end_date": dataset.get("end_date") or state.get("end_date"),
-    }
+    return snapshot
 
 
 def _imagery_config(state: dict) -> Optional[dict]:
@@ -91,7 +83,7 @@ def _imagery_config(state: dict) -> Optional[dict]:
     imagery = state.get("imagery") or {}
     if not imagery.get("tile_url") or not imagery.get("mosaic_id"):
         return None
-    return {key: imagery.get(key) for key in _IMAGERY_KEYS}
+    return imagery_snapshot(imagery)
 
 
 def _dataset_summary(snapshot: dict) -> str:
@@ -138,13 +130,6 @@ LAYER_HANDLERS = {
         ),
     ),
 }
-
-
-def _widget_config(layer: str, snapshot: dict, title: Optional[str]) -> dict:
-    config: dict = {"default_view": "map", layer: snapshot}
-    if title:
-        config["title"] = title
-    return config
 
 
 @tool("add_map_widget")
@@ -209,7 +194,7 @@ async def add_map_widget(
     widget_id = await dashboard_writer.add_widget(
         str(target_dashboard),
         widget_type="map",
-        config=_widget_config(layer, snapshot, title),
+        config=map_widget_config(layer, snapshot, title),
         section_id=str(target_section.id) if target_section else None,
     )
     if widget_id is None:

--- a/src/agent/tools/analysis_sections.py
+++ b/src/agent/tools/analysis_sections.py
@@ -1,0 +1,336 @@
+"""The agent's two doors onto the analysis templates.
+
+An analysis template builds a whole dashboard section in one call — see
+``src.api.services.analysis_templates``. These two tools are generic: they
+resolve the dashboard, look the named template up in the registry, hand it
+its own validated parameters and report the summary it wrote. Neither knows
+what any template contains, so a new template needs no new tool and no
+change here — it is one registry entry and one skill section.
+
+Unlike the other dashboard primitives, these do not snapshot work the
+conversation already did: the template does the work itself. So neither
+needs pick_dataset or show_imagery to have run — only a dashboard with an
+area.
+
+A section a template writes is sealed afterwards: the editing tools refuse
+its content. ``update_analysis_section`` is the one exception, and it
+rebuilds the section rather than editing it.
+"""
+
+from typing import Annotated, Dict, Optional
+
+from langchain_core.tools import tool
+from langchain_core.tools.base import InjectedToolCallId
+from langgraph.prebuilt import InjectedState
+from langgraph.types import Command
+from pydantic import ValidationError
+
+from src.agent.language import DEFAULT_LANGUAGE
+from src.agent.tool_spec import ToolCategory, ToolSpec
+from src.agent.tools.common import (
+    dashboard_updated_command,
+    error_command,
+    load_editable_dashboard,
+    require_current_user_id,
+    resolve_dashboard_id,
+)
+from src.api.services.analysis_templates import registry
+from src.api.services.analysis_templates.base import (
+    AlreadyBuiltError,
+    TemplateError,
+    describe_window,
+    templated_sections,
+)
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+CONFIRM_FIRST = (
+    "Changing the window changes every number in the section, so ask first. "
+    'Call send_nudge(nudge_type="time_range_choice", options=["Last 2 '
+    'weeks", "Last 30 days", "Last 90 days"]) — or options that match what '
+    "the user asked for — and wait for their answer. Call this tool again "
+    "with confirmed=True only after they have chosen."
+)
+
+
+def _params(template, days: Optional[int]):
+    """The template's own parameter object, from what the model passed.
+
+    Each template states its defaults and its bounds in its parameter
+    model, and refuses a parameter it does not take, so this is the only
+    validation either tool needs.
+    """
+    given = {} if days is None else {"days": days}
+    return template.params_model(**given)
+
+
+def _caveats(result) -> str:
+    """The warnings a build reported, as a sentence for the model."""
+    if not result.warnings:
+        return ""
+    return " Not everything was available: " + " ".join(result.warnings)
+
+
+@tool("add_analysis_section")
+async def add_analysis_section(
+    template: str,
+    days: Optional[int] = None,
+    dashboard_id: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Build a curated analysis section on a dashboard, in one call.
+
+    `template` names the analysis template to run — see the
+    `analysis-templates` skill for what each one builds. The template pulls
+    its own data, so do NOT run pick_dataset, pull_data, generate_insights
+    or show_imagery first. `days` is the period the section covers, counted
+    back from today, and defaults to the template's own window.
+    `dashboard_id` defaults to the dashboard in state or the one the user is
+    viewing.
+
+    The section's content is read-only once built. To put it on a different
+    period use update_analysis_section; to change anything else, delete it
+    and build a new one. It takes a while — say what you are doing first.
+    """
+    state = state or {}
+
+    try:
+        recipe = registry.get_template(template)
+    except registry.UnknownTemplateError as error:
+        return error_command(str(error), tool_call_id)
+
+    try:
+        params = _params(recipe, days)
+    except ValidationError as error:
+        return error_command(
+            f"Those parameters do not fit the '{template}' template: "
+            f"{error.errors()[0]['msg']}.",
+            tool_call_id,
+        )
+
+    target_dashboard = resolve_dashboard_id(state, dashboard_id)
+    if not target_dashboard:
+        return error_command(
+            "No dashboard to add the section to. Create one with "
+            "create_dashboard, or pass a dashboard_id.",
+            tool_call_id,
+        )
+
+    dashboard = await load_editable_dashboard(
+        target_dashboard, "add_analysis_section"
+    )
+    if dashboard is None:
+        return error_command(
+            f"Dashboard {target_dashboard} not found or not editable.",
+            tool_call_id,
+        )
+
+    logger.info(
+        "add_analysis_section tool called",
+        template=template,
+        dashboard_id=str(target_dashboard),
+        params=params.model_dump(),
+    )
+
+    try:
+        result = await recipe.build(
+            dashboard,
+            user_id=require_current_user_id("add_analysis_section"),
+            params=params,
+            language=state.get("language") or DEFAULT_LANGUAGE,
+        )
+    except AlreadyBuiltError as error:
+        # Not a failure: the section the user asked for is already there.
+        return error_command(
+            f"{error} Tell the user it is already there rather than "
+            "building a second one; to rebuild it, delete that section "
+            "first.",
+            tool_call_id,
+        )
+    except TemplateError as error:
+        return error_command(str(error), tool_call_id)
+
+    return dashboard_updated_command(
+        dashboard.id,
+        str(dashboard.name),
+        (
+            f"Added {result.summary} to dashboard '{dashboard.name}' "
+            f"({dashboard.id}), as section {result.section_id}. The "
+            "section's content is read-only: use update_analysis_section to "
+            "move it to another period, or delete it to change anything "
+            f"else.{_caveats(result)}"
+        ),
+        tool_call_id,
+    )
+
+
+@tool("update_analysis_section")
+async def update_analysis_section(
+    days: int,
+    confirmed: bool = False,
+    section: Optional[str] = None,
+    dashboard_id: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Move a curated analysis section to a different time window.
+
+    `days` is the new period, counted back from today. Every widget in the
+    section moves to it together, and the section's title and description
+    are rewritten to match — the template rebuilds the whole section.
+
+    You MUST confirm the change with the user before applying it: call
+    send_nudge first, then call this again with `confirmed=True`. Without
+    that this tool does nothing.
+
+    `section` names the section by title or id when the dashboard has more
+    than one; `dashboard_id` defaults to the dashboard in state or the one
+    the user is viewing. Rebuilding takes a while — say what you are doing
+    first.
+    """
+    state = state or {}
+
+    target_dashboard = resolve_dashboard_id(state, dashboard_id)
+    if not target_dashboard:
+        return error_command(
+            "No dashboard in view. Pass a dashboard_id, or run "
+            "inspect_view_context to see what is on screen.",
+            tool_call_id,
+        )
+
+    dashboard = await load_editable_dashboard(
+        target_dashboard, "update_analysis_section"
+    )
+    if dashboard is None:
+        return error_command(
+            f"Dashboard {target_dashboard} not found or not editable.",
+            tool_call_id,
+        )
+
+    candidates = templated_sections(dashboard)
+    if not candidates:
+        return error_command(
+            f"Dashboard '{dashboard.name}' has no curated analysis section "
+            "to move. Build one with add_analysis_section.",
+            tool_call_id,
+        )
+
+    if section:
+        wanted = str(section).strip()
+        target = next(
+            (
+                row
+                for row in candidates
+                if str(row.id) == wanted
+                or row.title.casefold() == wanted.casefold()
+            ),
+            None,
+        )
+        if target is None:
+            return error_command(
+                f"No curated section '{section}' on dashboard "
+                f"'{dashboard.name}'. Existing ones: "
+                + "; ".join(f"'{r.title}' ({r.id})" for r in candidates)
+                + ".",
+                tool_call_id,
+            )
+    elif len(candidates) > 1:
+        return error_command(
+            f"Dashboard '{dashboard.name}' has more than one curated "
+            "section — name the one to update with `section`: "
+            + "; ".join(
+                f"'{r.title}' ({r.id}, {describe_window(r)})"
+                for r in candidates
+            )
+            + ".",
+            tool_call_id,
+        )
+    else:
+        target = candidates[0]
+
+    try:
+        recipe = registry.get_template(str(target.type))
+    except registry.UnknownTemplateError:
+        return error_command(
+            f"Section '{target.title}' was built by '{target.type}', which "
+            "is no longer available, so it cannot be rebuilt. It can only "
+            "be deleted.",
+            tool_call_id,
+        )
+
+    try:
+        params = _params(recipe, days)
+    except ValidationError as error:
+        return error_command(
+            f"Those parameters do not fit the '{target.type}' template: "
+            f"{error.errors()[0]['msg']}.",
+            tool_call_id,
+        )
+
+    # The refusal is the guard, not the instruction above: a window change
+    # replaces every figure on screen and deletes the previous ones, and a
+    # model can retry past an instruction but not past a refusal.
+    if not confirmed:
+        return error_command(
+            f"Section '{target.title}' currently covers "
+            f"{describe_window(target)}. {CONFIRM_FIRST}",
+            tool_call_id,
+        )
+
+    logger.info(
+        "update_analysis_section tool called",
+        template=str(target.type),
+        dashboard_id=str(target_dashboard),
+        section_id=str(target.id),
+        params=params.model_dump(),
+    )
+
+    try:
+        result = await recipe.refresh(
+            target,
+            dashboard,
+            user_id=require_current_user_id("update_analysis_section"),
+            params=params,
+            language=state.get("language") or DEFAULT_LANGUAGE,
+        )
+    except TemplateError as error:
+        return error_command(str(error), tool_call_id)
+
+    return dashboard_updated_command(
+        dashboard.id,
+        str(dashboard.name),
+        (
+            f"Rebuilt section {result.section_id} on dashboard "
+            f"'{dashboard.name}': {result.summary}.{_caveats(result)}"
+        ),
+        tool_call_id,
+    )
+
+
+ADD_SPEC = ToolSpec(
+    tool=add_analysis_section,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- add_analysis_section(template, days?, dashboard_id?): build a "
+        "curated analysis section — a chart, its map layers and the words "
+        "that go with them — on a dashboard in one call. The template pulls "
+        "its own data, so do NOT run pick_dataset, pull_data, "
+        "generate_insights or show_imagery for it. The section it writes is "
+        "read-only. Templates:\n" + registry.describe_templates()
+    ),
+)
+
+UPDATE_SPEC = ToolSpec(
+    tool=update_analysis_section,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- update_analysis_section(days, confirmed, section?, "
+        "dashboard_id?): move a curated analysis section to a different "
+        "time window, rebuilding every widget in it for the new period. "
+        "Confirm with the user via send_nudge first, then call with "
+        "confirmed=True. Use when the user asks to change the period, date "
+        "range or time window of such a section."
+    ),
+)

--- a/src/agent/tools/analysis_sections.py
+++ b/src/agent/tools/analysis_sections.py
@@ -1,20 +1,30 @@
-"""The agent's two doors onto the analysis templates.
+"""The agent's doors onto the analysis templates.
 
 An analysis template builds a whole dashboard section in one call — see
-``src.api.services.analysis_templates``. These two tools are generic: they
-resolve the dashboard, look the named template up in the registry, hand it
-its own validated parameters and report the summary it wrote. Neither knows
-what any template contains, so a new template needs no new tool and no
-change here — it is one registry entry and one skill section.
+``src.api.services.analysis_templates``. These tools are generic: they
+resolve the dashboard, look the template up in the registry, hand it its own
+validated parameters and report the summary it wrote. None of them knows
+what any template contains or what its parameters mean, so a new template
+needs no new tool and no change here — it is one registry entry and one
+skill section.
+
+Three verbs, because they are three different asks:
+
+* ``add_analysis_section`` — build one.
+* ``refresh_analysis_section`` — run an existing one again, unchanged, so it
+  shows today's data. It takes no parameters at all: the section records
+  what it was built with.
+* ``reconfigure_analysis_section`` — rebuild an existing one for different
+  parameters. That is the one the user has to agree to, because it answers a
+  different question than the one on screen.
 
 Unlike the other dashboard primitives, these do not snapshot work the
-conversation already did: the template does the work itself. So neither
-needs pick_dataset or show_imagery to have run — only a dashboard with an
-area.
+conversation already did: the template does the work itself. So none needs
+pick_dataset or show_imagery to have run — only a dashboard with an area.
 
-A section a template writes is sealed afterwards: the editing tools refuse
-its content. ``update_analysis_section`` is the one exception, and it
-rebuilds the section rather than editing it.
+A section a template writes is sealed: the editing tools refuse its content.
+The two rebuild verbs are the exception, and they replace the section
+wholesale on the template's own terms rather than editing it.
 """
 
 from typing import Annotated, Dict, Optional
@@ -23,7 +33,7 @@ from langchain_core.tools import tool
 from langchain_core.tools.base import InjectedToolCallId
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from src.agent.language import DEFAULT_LANGUAGE
 from src.agent.tool_spec import ToolCategory, ToolSpec
@@ -38,31 +48,34 @@ from src.api.services.analysis_templates import registry
 from src.api.services.analysis_templates.base import (
     AlreadyBuiltError,
     TemplateError,
-    describe_window,
+    stored_params,
     templated_sections,
 )
 from src.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-CONFIRM_FIRST = (
-    "Changing the window changes every number in the section, so ask first. "
-    'Call send_nudge(nudge_type="time_range_choice", options=["Last 2 '
-    'weeks", "Last 30 days", "Last 90 days"]) — or options that match what '
-    "the user asked for — and wait for their answer. Call this tool again "
-    "with confirmed=True only after they have chosen."
-)
 
-
-def _params(template, days: Optional[int]):
+def _parse_params(template, params: Optional[dict]):
     """The template's own parameter object, from what the model passed.
 
-    Each template states its defaults and its bounds in its parameter
-    model, and refuses a parameter it does not take, so this is the only
-    validation either tool needs.
+    Each template states its defaults and its bounds in its parameter model
+    and refuses a parameter it does not take, so this is the only validation
+    any of these tools needs.
     """
-    given = {} if days is None else {"days": days}
-    return template.params_model(**given)
+    return template.params_model(**(params or {}))
+
+
+def _params_error(template, error: ValidationError, tool_call_id):
+    """A refusal that says what the template does take, so the model can
+    retry rather than guess again."""
+    detail = error.errors()[0]
+    field = ".".join(str(part) for part in detail.get("loc") or ()) or "params"
+    return error_command(
+        f"`{field}` does not fit the '{template.entry.name}' template: "
+        f"{detail['msg']}. It takes — {template.entry.params_help}.",
+        tool_call_id,
+    )
 
 
 def _caveats(result) -> str:
@@ -72,27 +85,159 @@ def _caveats(result) -> str:
     return " Not everything was available: " + " ".join(result.warnings)
 
 
+async def _resolve_target(state, dashboard_id, section, tool_call_id, verb):
+    """The dashboard, the templated section to act on and its template.
+
+    Shared by the two rebuild verbs. Returns ``(dashboard, section,
+    template)`` or ``(None, None, error_command)``.
+    """
+    target_dashboard = resolve_dashboard_id(state, dashboard_id)
+    if not target_dashboard:
+        return (
+            None,
+            None,
+            error_command(
+                "No dashboard in view. Pass a dashboard_id, or run "
+                "inspect_view_context to see what is on screen.",
+                tool_call_id,
+            ),
+        )
+
+    dashboard = await load_editable_dashboard(target_dashboard, verb)
+    if dashboard is None:
+        return (
+            None,
+            None,
+            error_command(
+                f"Dashboard {target_dashboard} not found or not editable.",
+                tool_call_id,
+            ),
+        )
+
+    candidates = templated_sections(dashboard)
+    if not candidates:
+        return (
+            None,
+            None,
+            error_command(
+                f"Dashboard '{dashboard.name}' has no curated analysis "
+                "section. Build one with add_analysis_section.",
+                tool_call_id,
+            ),
+        )
+
+    if section:
+        wanted = str(section).strip()
+        target = next(
+            (
+                row
+                for row in candidates
+                if str(row.id) == wanted
+                or row.title.casefold() == wanted.casefold()
+            ),
+            None,
+        )
+        if target is None:
+            return (
+                None,
+                None,
+                error_command(
+                    f"No curated section '{section}' on dashboard "
+                    f"'{dashboard.name}'. Existing ones: "
+                    + "; ".join(f"'{r.title}' ({r.id})" for r in candidates)
+                    + ".",
+                    tool_call_id,
+                ),
+            )
+    elif len(candidates) > 1:
+        return (
+            None,
+            None,
+            error_command(
+                f"Dashboard '{dashboard.name}' has more than one curated "
+                "section — name the one to act on with `section`: "
+                + "; ".join(f"'{r.title}' ({r.id})" for r in candidates)
+                + ".",
+                tool_call_id,
+            ),
+        )
+    else:
+        target = candidates[0]
+
+    try:
+        template = registry.get_template(str(target.type))
+    except registry.UnknownTemplateError:
+        return (
+            None,
+            None,
+            error_command(
+                f"Section '{target.title}' was built by '{target.type}', "
+                "which is no longer available, so it cannot be rebuilt. It "
+                "can only be deleted.",
+                tool_call_id,
+            ),
+        )
+    return dashboard, target, template
+
+
+async def _rebuild(
+    dashboard, section, template, params: BaseModel, state, tool_call_id, verb
+) -> Command:
+    """Run a template over one of its own sections and report the result."""
+    logger.info(
+        f"{verb} tool called",
+        template=template.entry.name,
+        dashboard_id=str(dashboard.id),
+        section_id=str(section.id),
+        params=params.model_dump(),
+    )
+    try:
+        result = await template.refresh(
+            section,
+            dashboard,
+            user_id=require_current_user_id(verb),
+            params=params,
+            language=state.get("language") or DEFAULT_LANGUAGE,
+        )
+    except TemplateError as error:
+        return error_command(str(error), tool_call_id)
+
+    return dashboard_updated_command(
+        dashboard.id,
+        str(dashboard.name),
+        (
+            f"Rebuilt section {result.section_id} on dashboard "
+            f"'{dashboard.name}': {result.summary}.{_caveats(result)}"
+        ),
+        tool_call_id,
+    )
+
+
 @tool("add_analysis_section")
 async def add_analysis_section(
     template: str,
-    days: Optional[int] = None,
+    params: Optional[dict] = None,
     dashboard_id: Optional[str] = None,
     state: Annotated[Dict, InjectedState] | None = None,
     tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
     """Build a curated analysis section on a dashboard, in one call.
 
-    `template` names the analysis template to run — see the
-    `analysis-templates` skill for what each one builds. The template pulls
-    its own data, so do NOT run pick_dataset, pull_data, generate_insights
-    or show_imagery first. `days` is the period the section covers, counted
-    back from today, and defaults to the template's own window.
-    `dashboard_id` defaults to the dashboard in state or the one the user is
-    viewing.
+    `template` names the analysis template to run. Each one lists what it
+    builds and what it takes — see the `analysis-templates` skill. The
+    template pulls its own data, so do NOT run pick_dataset, pull_data,
+    generate_insights or show_imagery first.
 
-    The section's content is read-only once built. To put it on a different
-    period use update_analysis_section; to change anything else, delete it
-    and build a new one. It takes a while — say what you are doing first.
+    `params` is that template's own parameters as an object, e.g.
+    `{"days": 30}`. Leave it out for the template's own defaults, which are
+    the right answer whenever the user named none. `dashboard_id` defaults
+    to the dashboard in state or the one the user is viewing.
+
+    The section's content is read-only once built. Use
+    refresh_analysis_section to bring it up to date, or
+    reconfigure_analysis_section to rebuild it differently; to change
+    anything else, delete it and build a new one. It takes a while — say
+    what you are doing first.
     """
     state = state or {}
 
@@ -102,13 +247,9 @@ async def add_analysis_section(
         return error_command(str(error), tool_call_id)
 
     try:
-        params = _params(recipe, days)
+        parsed = _parse_params(recipe, params)
     except ValidationError as error:
-        return error_command(
-            f"Those parameters do not fit the '{template}' template: "
-            f"{error.errors()[0]['msg']}.",
-            tool_call_id,
-        )
+        return _params_error(recipe, error, tool_call_id)
 
     target_dashboard = resolve_dashboard_id(state, dashboard_id)
     if not target_dashboard:
@@ -131,22 +272,22 @@ async def add_analysis_section(
         "add_analysis_section tool called",
         template=template,
         dashboard_id=str(target_dashboard),
-        params=params.model_dump(),
+        params=parsed.model_dump(),
     )
 
     try:
         result = await recipe.build(
             dashboard,
             user_id=require_current_user_id("add_analysis_section"),
-            params=params,
+            params=parsed,
             language=state.get("language") or DEFAULT_LANGUAGE,
         )
     except AlreadyBuiltError as error:
         # Not a failure: the section the user asked for is already there.
         return error_command(
             f"{error} Tell the user it is already there rather than "
-            "building a second one; to rebuild it, delete that section "
-            "first.",
+            "building a second one. To bring it up to date use "
+            "refresh_analysis_section.",
             tool_call_id,
         )
     except TemplateError as error:
@@ -158,32 +299,28 @@ async def add_analysis_section(
         (
             f"Added {result.summary} to dashboard '{dashboard.name}' "
             f"({dashboard.id}), as section {result.section_id}. The "
-            "section's content is read-only: use update_analysis_section to "
-            "move it to another period, or delete it to change anything "
-            f"else.{_caveats(result)}"
+            "section's content is read-only: use refresh_analysis_section "
+            "or reconfigure_analysis_section to rebuild it, or delete it to "
+            f"change anything else.{_caveats(result)}"
         ),
         tool_call_id,
     )
 
 
-@tool("update_analysis_section")
-async def update_analysis_section(
-    days: int,
-    confirmed: bool = False,
+@tool("refresh_analysis_section")
+async def refresh_analysis_section(
     section: Optional[str] = None,
     dashboard_id: Optional[str] = None,
     state: Annotated[Dict, InjectedState] | None = None,
     tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
 ) -> Command:
-    """Move a curated analysis section to a different time window.
+    """Run a curated analysis section again, so it shows today's data.
 
-    `days` is the new period, counted back from today. Every widget in the
-    section moves to it together, and the section's title and description
-    are rewritten to match — the template rebuilds the whole section.
-
-    You MUST confirm the change with the user before applying it: call
-    send_nudge first, then call this again with `confirmed=True`. Without
-    that this tool does nothing.
+    It keeps the parameters the section was built with — the same question,
+    asked again now — so it takes none. Use it when the user asks to
+    refresh, update or re-run a section, or asks whether anything has
+    changed since. To ask a *different* question of it, e.g. over another
+    period, use reconfigure_analysis_section.
 
     `section` names the section by title or id when the dashboard has more
     than one; `dashboard_id` defaults to the dashboard in state or the one
@@ -191,121 +328,89 @@ async def update_analysis_section(
     first.
     """
     state = state or {}
-
-    target_dashboard = resolve_dashboard_id(state, dashboard_id)
-    if not target_dashboard:
-        return error_command(
-            "No dashboard in view. Pass a dashboard_id, or run "
-            "inspect_view_context to see what is on screen.",
-            tool_call_id,
-        )
-
-    dashboard = await load_editable_dashboard(
-        target_dashboard, "update_analysis_section"
+    dashboard, target, template = await _resolve_target(
+        state, dashboard_id, section, tool_call_id, "refresh_analysis_section"
     )
     if dashboard is None:
-        return error_command(
-            f"Dashboard {target_dashboard} not found or not editable.",
-            tool_call_id,
-        )
+        return template  # the error command
 
-    candidates = templated_sections(dashboard)
-    if not candidates:
-        return error_command(
-            f"Dashboard '{dashboard.name}' has no curated analysis section "
-            "to move. Build one with add_analysis_section.",
-            tool_call_id,
-        )
+    return await _rebuild(
+        dashboard,
+        target,
+        template,
+        stored_params(template, target),
+        state,
+        tool_call_id,
+        "refresh_analysis_section",
+    )
 
-    if section:
-        wanted = str(section).strip()
-        target = next(
-            (
-                row
-                for row in candidates
-                if str(row.id) == wanted
-                or row.title.casefold() == wanted.casefold()
-            ),
-            None,
-        )
-        if target is None:
-            return error_command(
-                f"No curated section '{section}' on dashboard "
-                f"'{dashboard.name}'. Existing ones: "
-                + "; ".join(f"'{r.title}' ({r.id})" for r in candidates)
-                + ".",
-                tool_call_id,
-            )
-    elif len(candidates) > 1:
-        return error_command(
-            f"Dashboard '{dashboard.name}' has more than one curated "
-            "section — name the one to update with `section`: "
-            + "; ".join(
-                f"'{r.title}' ({r.id}, {describe_window(r)})"
-                for r in candidates
-            )
-            + ".",
-            tool_call_id,
-        )
-    else:
-        target = candidates[0]
 
-    try:
-        recipe = registry.get_template(str(target.type))
-    except registry.UnknownTemplateError:
-        return error_command(
-            f"Section '{target.title}' was built by '{target.type}', which "
-            "is no longer available, so it cannot be rebuilt. It can only "
-            "be deleted.",
-            tool_call_id,
-        )
+@tool("reconfigure_analysis_section")
+async def reconfigure_analysis_section(
+    params: dict,
+    confirmed: bool = False,
+    section: Optional[str] = None,
+    dashboard_id: Optional[str] = None,
+    state: Annotated[Dict, InjectedState] | None = None,
+    tool_call_id: Annotated[Optional[str], InjectedToolCallId] = None,
+) -> Command:
+    """Rebuild a curated analysis section for different parameters.
+
+    `params` is the template's own parameters as an object, e.g.
+    `{"days": 90}` — what each template takes is in the
+    `analysis-templates` skill, and the tool tells you if you get it wrong.
+    The whole section is rebuilt for them: every widget, and the title and
+    description, which state what the section covers.
+
+    You MUST confirm the change with the user before applying it: call
+    send_nudge first, then call this again with `confirmed=True`. Without
+    that this tool does nothing. Use refresh_analysis_section instead when
+    the user only wants the section brought up to date — that needs no
+    confirmation.
+
+    `section` names the section by title or id when the dashboard has more
+    than one; `dashboard_id` defaults to the dashboard in state or the one
+    the user is viewing. Rebuilding takes a while — say what you are doing
+    first.
+    """
+    state = state or {}
+    dashboard, target, template = await _resolve_target(
+        state,
+        dashboard_id,
+        section,
+        tool_call_id,
+        "reconfigure_analysis_section",
+    )
+    if dashboard is None:
+        return template  # the error command
 
     try:
-        params = _params(recipe, days)
+        parsed = _parse_params(template, params)
     except ValidationError as error:
-        return error_command(
-            f"Those parameters do not fit the '{target.type}' template: "
-            f"{error.errors()[0]['msg']}.",
-            tool_call_id,
-        )
+        return _params_error(template, error, tool_call_id)
 
-    # The refusal is the guard, not the instruction above: a window change
-    # replaces every figure on screen and deletes the previous ones, and a
-    # model can retry past an instruction but not past a refusal.
+    # The refusal is the guard, not the instruction in the docstring: this
+    # answers a different question than the one on screen, and the previous
+    # answer is deleted. A model can retry past an instruction, not past a
+    # refusal.
     if not confirmed:
         return error_command(
             f"Section '{target.title}' currently covers "
-            f"{describe_window(target)}. {CONFIRM_FIRST}",
+            f"{template.describe(target)}. Rebuilding it "
+            f"{template.entry.change_warning}, so ask first: call send_nudge "
+            "with the options that match what the user asked for, wait for "
+            "their answer, then call this tool again with confirmed=True.",
             tool_call_id,
         )
 
-    logger.info(
-        "update_analysis_section tool called",
-        template=str(target.type),
-        dashboard_id=str(target_dashboard),
-        section_id=str(target.id),
-        params=params.model_dump(),
-    )
-
-    try:
-        result = await recipe.refresh(
-            target,
-            dashboard,
-            user_id=require_current_user_id("update_analysis_section"),
-            params=params,
-            language=state.get("language") or DEFAULT_LANGUAGE,
-        )
-    except TemplateError as error:
-        return error_command(str(error), tool_call_id)
-
-    return dashboard_updated_command(
-        dashboard.id,
-        str(dashboard.name),
-        (
-            f"Rebuilt section {result.section_id} on dashboard "
-            f"'{dashboard.name}': {result.summary}.{_caveats(result)}"
-        ),
+    return await _rebuild(
+        dashboard,
+        target,
+        template,
+        parsed,
+        state,
         tool_call_id,
+        "reconfigure_analysis_section",
     )
 
 
@@ -313,7 +418,7 @@ ADD_SPEC = ToolSpec(
     tool=add_analysis_section,
     category=ToolCategory.PRIMITIVE,
     prompt_fragment=(
-        "- add_analysis_section(template, days?, dashboard_id?): build a "
+        "- add_analysis_section(template, params?, dashboard_id?): build a "
         "curated analysis section — a chart, its map layers and the words "
         "that go with them — on a dashboard in one call. The template pulls "
         "its own data, so do NOT run pick_dataset, pull_data, "
@@ -322,15 +427,27 @@ ADD_SPEC = ToolSpec(
     ),
 )
 
-UPDATE_SPEC = ToolSpec(
-    tool=update_analysis_section,
+REFRESH_SPEC = ToolSpec(
+    tool=refresh_analysis_section,
     category=ToolCategory.PRIMITIVE,
     prompt_fragment=(
-        "- update_analysis_section(days, confirmed, section?, "
-        "dashboard_id?): move a curated analysis section to a different "
-        "time window, rebuilding every widget in it for the new period. "
-        "Confirm with the user via send_nudge first, then call with "
-        "confirmed=True. Use when the user asks to change the period, date "
-        "range or time window of such a section."
+        "- refresh_analysis_section(section?, dashboard_id?): run a curated "
+        "analysis section again with the parameters it already has, so it "
+        "shows today's data. Takes no parameters and needs no confirmation. "
+        "Use when the user asks to refresh or re-run a section, or whether "
+        "anything has changed since."
+    ),
+)
+
+RECONFIGURE_SPEC = ToolSpec(
+    tool=reconfigure_analysis_section,
+    category=ToolCategory.PRIMITIVE,
+    prompt_fragment=(
+        "- reconfigure_analysis_section(params, confirmed, section?, "
+        "dashboard_id?): rebuild a curated analysis section for different "
+        "parameters — another period, another threshold, whatever that "
+        "template takes. Confirm with the user via send_nudge first, then "
+        "call with confirmed=True. Use when the user asks to change what a "
+        "section covers, not merely to bring it up to date."
     ),
 )

--- a/src/agent/tools/common.py
+++ b/src/agent/tools/common.py
@@ -84,9 +84,11 @@ def sealed_error_command(
         "Its title, description and the content of its widgets cannot be "
         "changed, and widgets cannot be added, removed or moved in or out. "
         "Tell the user the content cannot be edited. Such a section can "
-        "still be rebuilt for a different period with "
-        "update_analysis_section, and its widgets rearranged and resized in "
-        "the app; anything else means deleting it and building a new one.",
+        "still be brought up to date with refresh_analysis_section or "
+        "rebuilt for different parameters with "
+        "reconfigure_analysis_section, and its widgets rearranged and "
+        "resized in the app; anything else means deleting it and building a "
+        "new one.",
         tool_call_id,
     )
 

--- a/src/agent/tools/common.py
+++ b/src/agent/tools/common.py
@@ -68,6 +68,29 @@ def error_command(message: str, tool_call_id: Optional[str]) -> Command:
     )
 
 
+def sealed_error_command(
+    error: dashboard_writer.SealedSectionError, tool_call_id: Optional[str]
+) -> Command:
+    """Reply for a write the repository refused as read-only.
+
+    The write paths that do not pass through ``resolve_section`` (editing a
+    section, editing or moving a widget already on a dashboard) only learn
+    the section is sealed when the repository raises. The reply names the
+    only ways forward, so the model explains rather than retries.
+    """
+    return error_command(
+        f"Section {error.section_id} is read-only: the "
+        f"'{error.section_type}' analysis template built it in one piece. "
+        "Its title, description and the content of its widgets cannot be "
+        "changed, and widgets cannot be added, removed or moved in or out. "
+        "Tell the user the content cannot be edited. Such a section can "
+        "still be rebuilt for a different period with "
+        "update_analysis_section, and its widgets rearranged and resized in "
+        "the app; anything else means deleting it and building a new one.",
+        tool_call_id,
+    )
+
+
 def resolve_dashboard_id(
     state: dict, explicit: Optional[str]
 ) -> Optional[str]:
@@ -98,8 +121,27 @@ def format_sections(dashboard: DashboardOrm) -> str:
     if not sections:
         return "none"
     return "; ".join(
-        f"'{section.title}' ({section.id})" for section in sections
+        f"'{section.title}' ({section.id})"
+        + (
+            " [read-only]"
+            if section.type in dashboard_writer.SEALED_SECTION_TYPES
+            else ""
+        )
+        for section in sections
     )
+
+
+def _section_or_sealed(row):
+    """The matched section, or an error when a template sealed it: a sealed
+    section is built in one piece and cannot take a widget the model
+    adds."""
+    if row.type in dashboard_writer.SEALED_SECTION_TYPES:
+        return None, (
+            f"Section '{row.title}' ({row.id}) is read-only — it was built "
+            "in one piece and cannot take new widgets. Put the widget in "
+            "another section, or leave `section` out to add it ungrouped."
+        )
+    return row, None
 
 
 def resolve_section(dashboard: DashboardOrm, section: Optional[str]):
@@ -116,6 +158,10 @@ def resolve_section(dashboard: DashboardOrm, section: Optional[str]):
     sections made in the UI can share a title. Rather than silently picking
     one, an ambiguous title is an error that lists the candidate ids for the
     model to choose from.
+
+    A sealed section (one an analysis template built in one piece) is
+    refused here rather than at the write: the repository would raise
+    anyway, and the model gets a reply that says what to do instead.
     """
     if not section:
         return None, None
@@ -123,12 +169,12 @@ def resolve_section(dashboard: DashboardOrm, section: Optional[str]):
     rows = dashboard.sections or []
     for row in rows:
         if str(row.id) == wanted:
-            return row, None
+            return _section_or_sealed(row)
     by_title = [
         row for row in rows if row.title.casefold() == wanted.casefold()
     ]
     if len(by_title) == 1:
-        return by_title[0], None
+        return _section_or_sealed(by_title[0])
     if by_title:
         ids = ", ".join(str(row.id) for row in by_title)
         return None, (

--- a/src/agent/tools/edit_dashboard_section.py
+++ b/src/agent/tools/edit_dashboard_section.py
@@ -22,6 +22,7 @@ from src.agent.tools.common import (
     load_editable_dashboard,
     resolve_dashboard_id,
     resolve_section,
+    sealed_error_command,
 )
 from src.api.repositories import dashboard_writer
 from src.api.schemas import SECTION_TITLE_MAX_LENGTH
@@ -108,15 +109,18 @@ async def edit_dashboard_section(
         section_id=str(row.id),
     )
 
-    updated = await dashboard_writer.update_section(
-        row.id,
-        title=new_title,
-        description=(
-            new_description
-            if new_description is not None
-            else dashboard_writer.UNSET
-        ),
-    )
+    try:
+        updated = await dashboard_writer.update_section(
+            row.id,
+            title=new_title,
+            description=(
+                new_description
+                if new_description is not None
+                else dashboard_writer.UNSET
+            ),
+        )
+    except dashboard_writer.SealedSectionError as error:
+        return sealed_error_command(error, tool_call_id)
     if not updated:
         return error_command(
             f"Section {row.id} disappeared before it could be edited.",

--- a/src/agent/tools/inspect_view_context.py
+++ b/src/agent/tools/inspect_view_context.py
@@ -435,9 +435,16 @@ async def format_dashboard(dashboard: DashboardOrm) -> str:
 
     for section in dashboard.sections or []:
         members = by_section.get(section.id) or []
+        # A sealed section is marked here so the model sees it before it
+        # tries to edit or fill one.
+        sealed = (
+            " [read-only: built in one piece by an analysis template]"
+            if section.type in dashboard_writer.SEALED_SECTION_TYPES
+            else ""
+        )
         lines.append(
             f"  Section {section.position}: '{section.title}' "
-            f"({section.id}) — {len(members)} widget(s)"
+            f"({section.id}) — {len(members)} widget(s){sealed}"
         )
         if section.description:
             lines.append(f"    Description: {section.description}")

--- a/src/agent/tools/move_dashboard_widget.py
+++ b/src/agent/tools/move_dashboard_widget.py
@@ -23,6 +23,7 @@ from src.agent.tools.common import (
     error_command,
     load_editable_dashboard,
     resolve_section,
+    sealed_error_command,
 )
 from src.api.repositories import dashboard_writer
 from src.shared.logging_config import get_logger
@@ -109,11 +110,14 @@ async def move_dashboard_widget(
         section_id=str(target_section.id) if target_section else None,
     )
 
-    moved = await dashboard_writer.update_widget(
-        widget.id,
-        position=position,
-        section_id=str(target_section.id) if target_section else None,
-    )
+    try:
+        moved = await dashboard_writer.update_widget(
+            widget.id,
+            position=position,
+            section_id=str(target_section.id) if target_section else None,
+        )
+    except dashboard_writer.SealedSectionError as error:
+        return sealed_error_command(error, tool_call_id)
     if not moved:
         return error_command(
             f"Widget {widget.id} disappeared before it could be moved.",

--- a/src/agent/tools/update_insight_display.py
+++ b/src/agent/tools/update_insight_display.py
@@ -9,6 +9,10 @@ underlying chart rows are preserved untouched.
 The target is the current insight in state (the last one generated this thread)
 unless an explicit ``insight_id`` is given. The revised insight is persisted in
 place and pushed back onto state so the frontend re-renders it.
+
+An insight that a sealed dashboard section shows is refused: that section's
+content is a record of one build, and this is the only path that could
+rewrite it without touching a dashboard row.
 """
 
 from typing import Annotated, Dict, Optional
@@ -37,6 +41,7 @@ from src.agent.tools.common import (
     require_current_user_id,
 )
 from src.api.data_models import InsightOrm
+from src.api.repositories.dashboard_writer import insight_is_sealed
 from src.api.repositories.insight_access import is_editable_by_user
 from src.api.repositories.insight_writer import update_insight
 from src.shared.database import get_session_from_pool
@@ -170,6 +175,18 @@ async def update_insight_display(
     if row is None:
         return error_command(
             f"Insight {target_id} not found or not editable.", tool_call_id
+        )
+
+    # An insight shown by a sealed dashboard section is that section's
+    # content: restyling it here would change what the section shows without
+    # touching a dashboard row, which is the one way around the seal.
+    if await insight_is_sealed(row.id):
+        return error_command(
+            f"Insight {target_id} is the content of a read-only dashboard "
+            "section, built in one piece by an analysis template, so its "
+            "display cannot be changed. Tell the user that section cannot "
+            "be edited — it can only be deleted and rebuilt.",
+            tool_call_id,
         )
 
     current = Insight.from_orm_row(row)

--- a/src/api/data_models.py
+++ b/src/api/data_models.py
@@ -551,6 +551,18 @@ class DashboardSectionOrm(Base):
     # Free-form intent of the section ("why these widgets belong together"),
     # written by the user or composed by the agent.
     description = Column(String, nullable=True)
+    # How the section was built, and how the frontend renders it: "default"
+    # for a user- or agent-composed group, or the name of the analysis
+    # template that wrote it in one piece. Templated sections are read-only
+    # — see ``analysis_templates.registry.SEALED_SECTION_TYPES``.
+    type = Column(String, nullable=False, server_default="default")
+    # What the template built this section from: the window it covers
+    # ("start_date", "end_date"), the parameters it was given, and the
+    # template's own name. Empty for a hand-composed section. This is how a
+    # refresh knows what to replace, and how a reader is told what period is
+    # on screen — the period must not be re-derived by reading the widgets'
+    # own configs.
+    config = Column(JSONB, nullable=False, server_default="{}")
     # Order of the section within the dashboard.
     position = Column(Integer, nullable=False, server_default="0")
     created_at = Column(DateTime, nullable=False, default=datetime.now)

--- a/src/api/repositories/dashboard_writer.py
+++ b/src/api/repositories/dashboard_writer.py
@@ -332,11 +332,15 @@ async def add_section(
     title: str,
     description: Optional[str] = None,
     position: Optional[int] = None,
+    type: str = "default",
 ) -> Optional[str]:
     """Append a section to a dashboard; return the new section id (str).
 
-    Position defaults to max+1 (last section on the dashboard). Returns None
-    if the dashboard does not exist or the id is malformed.
+    Position defaults to max+1 (last section on the dashboard). ``type``
+    records how the section was built and defaults to a hand-composed
+    group; a templated section is written by
+    ``add_section_with_widgets`` instead, in one piece. Returns None if the
+    dashboard does not exist or the id is malformed.
     """
     target = _parse_uuid(dashboard_id)
     if target is None:
@@ -361,6 +365,7 @@ async def add_section(
             title=title,
             description=description,
             position=position,
+            type=type,
         )
         session.add(section)
         await session.commit()
@@ -371,8 +376,214 @@ async def add_section(
         dashboard_id=str(target),
         section_id=section_id,
         title=title,
+        type=type,
     )
     return section_id
+
+
+async def add_section_with_widgets(
+    dashboard_id,
+    *,
+    title: str,
+    description: Optional[str] = None,
+    type: str = "default",
+    config: Optional[dict] = None,
+    widgets: Optional[list[dict]] = None,
+) -> Optional[tuple[str, list[str]]]:
+    """Create a section and its widgets in one transaction.
+
+    The write path for the analysis templates: a section a reader may only
+    ever see complete must not appear widget by widget, and a failure
+    half-way must leave nothing behind. Each entry of ``widgets`` is
+    ``{"widget_type": ..., "insight_id": ..., "config": ...}``; they take
+    positions 0..n-1 in the order given. Returns ``(section_id, widget_ids)``,
+    or None if the dashboard does not exist.
+    """
+    target = _parse_uuid(dashboard_id)
+    if target is None:
+        return None
+
+    async with get_session_from_pool() as session:
+        exists = await session.scalar(
+            select(DashboardOrm.id).where(DashboardOrm.id == target)
+        )
+        if exists is None:
+            return None
+
+        max_position = await session.scalar(
+            select(func.max(DashboardSectionOrm.position)).where(
+                DashboardSectionOrm.dashboard_id == target
+            )
+        )
+        section = DashboardSectionOrm(
+            dashboard_id=target,
+            title=title,
+            description=description,
+            position=0 if max_position is None else max_position + 1,
+            type=type,
+            config=config or {},
+        )
+        session.add(section)
+        await session.flush()
+
+        rows = []
+        insight_ids = []
+        for position, spec in enumerate(widgets or []):
+            insight_id = spec.get("insight_id")
+            if insight_id:
+                insight_ids.append(str(insight_id))
+            rows.append(
+                DashboardWidgetOrm(
+                    dashboard_id=target,
+                    widget_type=spec["widget_type"],
+                    insight_id=(
+                        _parse_uuid(insight_id) if insight_id else None
+                    ),
+                    config=relativize_widget_config(spec.get("config")) or {},
+                    position=position,
+                    section_id=section.id,
+                )
+            )
+        session.add_all(rows)
+        try:
+            await session.commit()
+        except IntegrityError as exc:
+            if "uq_dashboard_widgets_dashboard_insight" not in str(exc.orig):
+                raise
+            # One of the insights is already on this dashboard, so the whole
+            # section is rolled back rather than built without its chart.
+            # The index does not say which, so the error names the batch.
+            logger.warning(
+                "dashboard_section_widget_duplicate",
+                dashboard_id=str(target),
+                type=type,
+                insight_ids=insight_ids,
+            )
+            raise DuplicateInsightWidgetError(
+                str(target), ", ".join(insight_ids)
+            ) from exc
+
+        section_id = str(section.id)
+        widget_ids = [str(row.id) for row in rows]
+
+    logger.info(
+        "dashboard_section_added_with_widgets",
+        dashboard_id=str(target),
+        section_id=section_id,
+        type=type,
+        widgets=len(widget_ids),
+    )
+    return section_id, widget_ids
+
+
+async def replace_section_widgets(
+    section_id,
+    *,
+    title: str,
+    description: Optional[str] = None,
+    config: Optional[dict] = None,
+    widgets: Optional[list[dict]] = None,
+) -> Optional[tuple[list[str], list[str]]]:
+    """Swap a section's whole contents in one transaction.
+
+    The write path for refreshing a templated section: the section row survives
+    (so its id, its place on the dashboard and any link to it hold), while
+    its widgets, its words and its recorded window are all replaced
+    together. A reader either sees the old period or the new one, never a
+    chart from one and a map from the other.
+
+    Returns ``(new_widget_ids, replaced_insight_ids)`` — the second is the
+    insights the old widgets referenced, which the caller may then delete if
+    nothing else points at them. Returns None if the section is gone.
+
+    Deliberately unguarded by the seal: this *is* the mechanism a sealed
+    section is refreshed through, and only the templates call it.
+    """
+    target = _parse_uuid(section_id)
+    if target is None:
+        return None
+
+    async with get_session_from_pool() as session:
+        section = await session.get(DashboardSectionOrm, target)
+        if section is None:
+            return None
+
+        previous = await session.execute(
+            select(DashboardWidgetOrm).where(
+                DashboardWidgetOrm.section_id == target
+            )
+        )
+        replaced_insight_ids = []
+        for widget in previous.scalars().all():
+            if widget.insight_id:
+                replaced_insight_ids.append(str(widget.insight_id))
+            await session.delete(widget)
+        # The deletes must land before the inserts: the partial unique index
+        # on (dashboard_id, insight_id) would otherwise reject a refresh that
+        # happens to reuse an insight.
+        await session.flush()
+
+        section.title = title
+        section.description = description
+        if config is not None:
+            section.config = config
+
+        rows = []
+        for position, spec in enumerate(widgets or []):
+            insight_id = spec.get("insight_id")
+            rows.append(
+                DashboardWidgetOrm(
+                    dashboard_id=section.dashboard_id,
+                    widget_type=spec["widget_type"],
+                    insight_id=(
+                        _parse_uuid(insight_id) if insight_id else None
+                    ),
+                    config=relativize_widget_config(spec.get("config")) or {},
+                    position=position,
+                    section_id=target,
+                )
+            )
+        session.add_all(rows)
+        await session.commit()
+        widget_ids = [str(row.id) for row in rows]
+
+    logger.info(
+        "dashboard_section_widgets_replaced",
+        section_id=str(target),
+        widgets=len(widget_ids),
+        replaced_insights=len(replaced_insight_ids),
+    )
+    return widget_ids, replaced_insight_ids
+
+
+async def delete_unreferenced_insights(insight_ids: list[str]) -> int:
+    """Delete insights that no dashboard widget points at any more.
+
+    A refreshed templated section leaves its previous chart behind. It was
+    machine-made content owned by that section, so it goes — unless some
+    other widget (another dashboard, say) still shows it.
+    """
+    deleted = 0
+    async with get_session_from_pool() as session:
+        for raw in insight_ids:
+            insight_id = _parse_uuid(raw)
+            if insight_id is None:
+                continue
+            still_used = await session.scalar(
+                select(DashboardWidgetOrm.id)
+                .where(DashboardWidgetOrm.insight_id == insight_id)
+                .limit(1)
+            )
+            if still_used is not None:
+                continue
+            row = await session.get(InsightOrm, insight_id)
+            if row is not None:
+                await session.delete(row)
+                deleted += 1
+        await session.commit()
+    if deleted:
+        logger.info("orphaned_insights_deleted", count=deleted)
+    return deleted
 
 
 async def get_section(section_id) -> Optional[DashboardSectionOrm]:

--- a/src/api/repositories/dashboard_writer.py
+++ b/src/api/repositories/dashboard_writer.py
@@ -6,6 +6,14 @@ place that mapping lives.
 Ownership checks live in the callers (router/tools) via ``dashboard_access``
 — the same split as insights. Malformed UUIDs are treated as not-found
 (None/False) rather than raising.
+
+One rule does live here rather than in a caller: a section written by an
+analysis template is **sealed**, and every write that would change its
+content or its widgets' content raises ``SealedSectionError``. It belongs
+here because the agent tools bypass the routers entirely, so a check in the
+router would guard one door of two. It is not a database constraint because
+it is product policy that grows types and exceptions — the seal list comes
+from ``analysis_templates.registry``, and layout changes are exempt.
 """
 
 from typing import Optional
@@ -21,6 +29,9 @@ from src.api.data_models import (
     DashboardSectionOrm,
     DashboardWidgetOrm,
     InsightOrm,
+)
+from src.api.services.analysis_templates.registry import (
+    SEALED_SECTION_TYPES,
 )
 from src.shared.database import get_session_from_pool
 from src.shared.logging_config import get_logger
@@ -62,6 +73,56 @@ class UnknownSectionError(Exception):
         )
 
 
+#: Widget-config keys that describe how a widget is laid out rather than what
+#: it shows. The frontend already writes these (``size`` is "single"/"double",
+#: ``sizes`` the per-chart map), and they are the one part of a sealed
+#: section's widget a reader may change: rearranging what a template built
+#: does not change what it says. Everything else in a config — the layer, the
+#: dates, the text, the title — is content.
+LAYOUT_CONFIG_KEYS = frozenset({"size", "sizes"})
+
+
+def _config_changes_content(
+    stored: Optional[dict], incoming: Optional[dict]
+) -> bool:
+    """Whether replacing ``stored`` with ``incoming`` changes anything but
+    layout.
+
+    ``PATCH`` replaces a widget's config wholesale, so "only resize it" and
+    "resize it and swap its tile_url" arrive as the same shape of request.
+    The difference is in the diff, which is why it is taken here. Both sides
+    must already be in the stored (relativized) representation, or an
+    unchanged eoapi tile URL reads as a change.
+    """
+    stored = stored or {}
+    incoming = incoming or {}
+    changed = {
+        key
+        for key in set(stored) | set(incoming)
+        if stored.get(key) != incoming.get(key)
+    }
+    return bool(changed - LAYOUT_CONFIG_KEYS)
+
+
+class SealedSectionError(Exception):
+    """The write targets a section whose type is read-only.
+
+    Raised by the section and widget writers for every caller — the API
+    router maps it to 409, the agent tools to a tool error. An analysis
+    template never meets it: it writes its section in one transaction
+    (``add_section_with_widgets``) and replaces it in another
+    (``replace_section_widgets``), neither of which comes through the
+    guarded paths.
+    """
+
+    def __init__(self, section_id: str, section_type: str):
+        self.section_id = section_id
+        self.section_type = section_type
+        super().__init__(
+            f"section {section_id} is read-only (type: {section_type})"
+        )
+
+
 class _Unset:
     """Marker for "argument not supplied" where None is a real value."""
 
@@ -69,6 +130,19 @@ class _Unset:
 #: Sentinel default for ``section_id``: passing ``None`` moves a widget to
 #: the ungrouped top level, omitting it leaves the widget where it is.
 UNSET = _Unset()
+
+
+def _guard_sealed(section: Optional[DashboardSectionOrm]) -> None:
+    """Raise if the section is one an analysis template built and sealed."""
+    if section is not None and section.type in SEALED_SECTION_TYPES:
+        raise SealedSectionError(str(section.id), str(section.type))
+
+
+async def _guard_sealed_id(session, section_id) -> None:
+    """Raise if ``section_id`` names a sealed section (None is never one)."""
+    if section_id is None:
+        return
+    _guard_sealed(await session.get(DashboardSectionOrm, section_id))
 
 
 def _parse_uuid(value) -> Optional[UUID]:
@@ -193,7 +267,9 @@ async def add_widget(
     None (the default) leaves it ungrouped at the top level. Position
     defaults to max+1 *within that container*. Returns None if the dashboard
     does not exist or an id is malformed; raises ``UnknownSectionError`` when
-    the section is not on this dashboard.
+    the section is not on this dashboard, and ``SealedSectionError`` when it
+    is one a template sealed. A template fills its own section in one
+    transaction (``add_section_with_widgets``) and never comes through here.
     """
     target = _parse_uuid(dashboard_id)
     if target is None:
@@ -220,6 +296,8 @@ async def add_widget(
             session, target, section_uuid
         ):
             raise UnknownSectionError(str(target), str(section_id))
+
+        await _guard_sealed_id(session, section_uuid)
 
         if position is None:
             position = await _next_position(session, target, section_uuid)
@@ -273,7 +351,12 @@ async def update_widget(
     it back to the ungrouped top level. Moving without an explicit
     ``position`` appends the widget to the end of its new container. Raises
     ``UnknownSectionError`` when the section is not on the widget's own
-    dashboard.
+    dashboard, and ``SealedSectionError`` when a *content* change targets a
+    sealed section. Layout is exempt: a sealed section's widget takes a
+    ``position`` change, and a config replacement whose only differences are
+    ``LAYOUT_CONFIG_KEYS``. Moving in or out of a sealed section stays
+    blocked either way. Same split as ``update_section``, which allows
+    ``position`` but not a retitle.
     """
     target = _parse_uuid(widget_id)
     if target is None:
@@ -283,7 +366,20 @@ async def update_widget(
         if widget is None:
             return False
 
-        if not isinstance(section_id, _Unset):
+        # Only a content change is guarded, and a move is always one: a
+        # widget cannot leave a sealed section, and (below) cannot join one.
+        # A layout-only call — reposition, resize — is allowed through.
+        moving = not isinstance(section_id, _Unset)
+        relativized = (
+            relativize_widget_config(config) if config is not None else None
+        )
+        if moving or (
+            config is not None
+            and _config_changes_content(widget.config, relativized)
+        ):
+            await _guard_sealed_id(session, widget.section_id)
+
+        if moving:
             section_uuid = None
             if section_id is not None:
                 section_uuid = _parse_uuid(section_id)
@@ -293,6 +389,7 @@ async def update_widget(
                     raise UnknownSectionError(
                         str(widget.dashboard_id), str(section_id)
                     )
+                await _guard_sealed_id(session, section_uuid)
             if section_uuid != widget.section_id:
                 widget.section_id = section_uuid
                 if position is None:
@@ -303,7 +400,7 @@ async def update_widget(
         if position is not None:
             widget.position = position
         if config is not None:
-            widget.config = relativize_widget_config(config)
+            widget.config = relativized
         await session.commit()
 
     logger.info("dashboard_widget_updated", widget_id=str(target))
@@ -311,7 +408,11 @@ async def update_widget(
 
 
 async def remove_widget(widget_id) -> bool:
-    """Delete a widget; the referenced insight is left intact."""
+    """Delete a widget; the referenced insight is left intact.
+
+    Raises ``SealedSectionError`` for a widget in a sealed section: those go
+    only with the whole section (``remove_section``).
+    """
     target = _parse_uuid(widget_id)
     if target is None:
         return False
@@ -319,6 +420,7 @@ async def remove_widget(widget_id) -> bool:
         widget = await session.get(DashboardWidgetOrm, target)
         if widget is None:
             return False
+        await _guard_sealed_id(session, widget.section_id)
         await session.delete(widget)
         await session.commit()
 
@@ -586,6 +688,36 @@ async def delete_unreferenced_insights(insight_ids: list[str]) -> int:
     return deleted
 
 
+async def insight_is_sealed(insight_id) -> bool:
+    """Whether an insight is the content of a sealed dashboard section.
+
+    A sealed section refuses edits to its widgets, but a widget's insight is
+    a row of its own: rewriting that insight's charts or narrative would
+    change what the section shows without touching a single dashboard row.
+    So the display-editing path asks here first.
+
+    Errs on the side of *not* sealing: an insight on no dashboard, or on an
+    ordinary section, stays editable.
+    """
+    target = _parse_uuid(insight_id)
+    if target is None:
+        return False
+    async with get_session_from_pool() as session:
+        found = await session.scalar(
+            select(DashboardSectionOrm.id)
+            .join(
+                DashboardWidgetOrm,
+                DashboardWidgetOrm.section_id == DashboardSectionOrm.id,
+            )
+            .where(
+                DashboardWidgetOrm.insight_id == target,
+                DashboardSectionOrm.type.in_(SEALED_SECTION_TYPES),
+            )
+            .limit(1)
+        )
+    return found is not None
+
+
 async def get_section(section_id) -> Optional[DashboardSectionOrm]:
     """Load a single section by id; the caller applies access checks via the
     owning dashboard. Malformed ids are not-found (None), never an error."""
@@ -607,6 +739,10 @@ async def update_section(
 
     ``description`` is three-valued like ``update_widget``'s ``section_id``:
     omit it to leave the text alone, pass None to clear it.
+
+    A sealed section takes a ``position`` change — that orders the dashboard
+    rather than editing the section — but raises ``SealedSectionError`` for
+    its title or description.
     """
     target = _parse_uuid(section_id)
     if target is None:
@@ -615,6 +751,8 @@ async def update_section(
         section = await session.get(DashboardSectionOrm, target)
         if section is None:
             return False
+        if title is not None or not isinstance(description, _Unset):
+            _guard_sealed(section)
         if title is not None:
             section.title = title
         if not isinstance(description, _Unset):
@@ -633,6 +771,10 @@ async def remove_section(section_id, *, delete_widgets: bool = False) -> bool:
     ``delete_widgets=True`` removes the section's widgets with it — the
     destructive variant, requested explicitly by the caller. Insights the
     deleted widgets referenced are left intact, as with ``remove_widget``.
+
+    Deleting a sealed section is allowed, but it always takes its widgets:
+    ungrouping them would leave loose, editable copies of content that is
+    only meaningful — and only sealed — inside its own section.
     """
     target = _parse_uuid(section_id)
     if target is None:
@@ -641,6 +783,9 @@ async def remove_section(section_id, *, delete_widgets: bool = False) -> bool:
         section = await session.get(DashboardSectionOrm, target)
         if section is None:
             return False
+
+        if section.type in SEALED_SECTION_TYPES:
+            delete_widgets = True
 
         if delete_widgets:
             result = await session.execute(

--- a/src/api/routers/dashboards.py
+++ b/src/api/routers/dashboards.py
@@ -105,6 +105,18 @@ def _row_to_response(
     )
 
 
+def _sealed_conflict(error: dashboard_writer.SealedSectionError):
+    """409 for a write to a section an analysis template sealed.
+
+    A conflict, not a permission error: the owner is refused because of what
+    the section *is*, and the same call against any other section succeeds.
+    """
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=f"Section is read-only (type: {error.section_type})",
+    )
+
+
 async def _get_owned_dashboard(
     dashboard_id: UUID, user: UserModel
 ) -> DashboardOrm:
@@ -273,6 +285,7 @@ async def add_section(
         title=body.title,
         description=body.description,
         position=body.position,
+        type=body.type,
     )
     return _row_to_response(await _refetch_dashboard(dashboard_id))
 
@@ -298,12 +311,15 @@ async def update_section(
     description: object = dashboard_writer.UNSET
     if "description" in body.model_fields_set:
         description = body.description
-    await dashboard_writer.update_section(
-        section_id,
-        title=body.title,
-        description=description,
-        position=body.position,
-    )
+    try:
+        await dashboard_writer.update_section(
+            section_id,
+            title=body.title,
+            description=description,
+            position=body.position,
+        )
+    except dashboard_writer.SealedSectionError as error:
+        raise _sealed_conflict(error)
     return _row_to_response(await _refetch_dashboard(dashboard_id))
 
 
@@ -330,6 +346,11 @@ async def remove_section(
     section's widgets stay on the dashboard and fall back to the ungrouped
     top level, renumbered after the widgets already there. Pass
     ``delete_widgets=true`` to remove them with the section.
+
+    A read-only section built by an analysis template (``type`` other than
+    ``default``) is the exception: deleting it always removes its widgets,
+    whatever ``delete_widgets`` says, because those widgets are only
+    editable — and only meaningful — inside their own section.
     """
     row = await _get_owned_dashboard(dashboard_id, user)
     if section_id not in {s.id for s in row.sections}:
@@ -386,6 +407,8 @@ async def add_widget(
         )
     except dashboard_writer.UnknownSectionError:
         raise HTTPException(status_code=404, detail="Section not found")
+    except dashboard_writer.SealedSectionError as error:
+        raise _sealed_conflict(error)
     return _row_to_response(await _refetch_dashboard(dashboard_id))
 
 
@@ -421,6 +444,8 @@ async def update_widget(
         )
     except dashboard_writer.UnknownSectionError:
         raise HTTPException(status_code=404, detail="Section not found")
+    except dashboard_writer.SealedSectionError as error:
+        raise _sealed_conflict(error)
     return _row_to_response(await _refetch_dashboard(dashboard_id))
 
 
@@ -438,7 +463,10 @@ async def remove_widget(
     row = await _get_owned_dashboard(dashboard_id, user)
     if widget_id not in {w.id for w in row.widgets}:
         raise HTTPException(status_code=404, detail="Widget not found")
-    await dashboard_writer.remove_widget(widget_id)
+    try:
+        await dashboard_writer.remove_widget(widget_id)
+    except dashboard_writer.SealedSectionError as error:
+        raise _sealed_conflict(error)
 
 
 @router.delete(

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -650,6 +650,11 @@ class DashboardSectionCreateRequest(BaseModel):
 
 
 class DashboardSectionUpdateRequest(BaseModel):
+    # ``type`` is deliberately absent, here and on the create request: it
+    # records how the section was built. A section that could be typed — or
+    # retyped — from outside would be one PATCH away from unsealed, and a
+    # templated section created by hand would be one nothing can ever fill.
+    # Templates write their own sections, type included.
     title: Optional[str] = Field(
         default=None, min_length=1, max_length=SECTION_TITLE_MAX_LENGTH
     )
@@ -768,6 +773,15 @@ class DashboardSectionResponse(BaseModel):
     title: str
     description: Optional[str] = None
     position: int
+    # "default", or the analysis template that wrote the section. Anything
+    # other than "default" is read-only: the API rejects writes to it with
+    # 409.
+    type: str = "default"
+    # What the template built this section from — its own name, the window
+    # it covers and the parameters it was given. Empty for a hand-composed
+    # section. Show the period from here rather than reading a widget's
+    # tile layer.
+    config: dict = {}
     created_at: datetime
 
 

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from geojson_pydantic import Polygon
@@ -638,6 +638,21 @@ class DashboardSectionCreateRequest(BaseModel):
         min_length=1,
         max_length=SECTION_TITLE_MAX_LENGTH,
         description="Section heading, e.g. `Deforestation`.",
+    )
+    # Only "default" is creatable here. A templated type such as
+    # "nrt-monitoring" is sealed the moment it exists
+    # (``analysis_templates.registry.SEALED_SECTION_TYPES``), so accepting
+    # one on this path would hand a caller a section that can never be
+    # titled, filled or edited — only deleted. Refused rather than ignored,
+    # so a caller that tries is told.
+    type: Literal["default"] = Field(
+        default="default",
+        description=(
+            "How the section was built. Only `default` — a group you compose "
+            "widget by widget — can be created here. Templated types such "
+            "as `nrt-monitoring` are written by their analysis template and "
+            "are read-only afterwards."
+        ),
     )
     description: Optional[str] = Field(
         default=None,

--- a/src/api/services/analysis_templates/__init__.py
+++ b/src/api/services/analysis_templates/__init__.py
@@ -1,0 +1,26 @@
+"""Analysis templates: curated dashboard sections built in one call.
+
+An analysis template answers a standing question about an area — "what has
+been disturbed here in the last two weeks?" — by writing a whole dashboard
+section at once: the chart, the map layers and the words that go with them.
+It is not a chat workflow. Nothing is picked by a model along the way, so
+the same request always produces the same section.
+
+A section a template wrote is **sealed**: its content is a record of one
+build, over one area and one period, so editing it would make its own title
+untrue. Only the template that wrote it may replace its contents, and only
+wholesale (a refresh onto a new period).
+
+The parts:
+
+* ``registry`` — the list of templates, as metadata only. Import-light, so
+  the repository layer can read the seal list without pulling in an
+  analytics client or a model.
+* ``base`` — the interface a template implements, its result and error
+  types, and the helpers every template shares.
+* ``writer`` — the two transactional writes, and the one place the
+  section's ``config`` shape is decided.
+* one package per template, e.g. ``nrt_monitoring``.
+
+To add a template, see ``docs/analysis-templates.md``.
+"""

--- a/src/api/services/analysis_templates/base.py
+++ b/src/api/services/analysis_templates/base.py
@@ -80,6 +80,9 @@ class SectionContent:
     #: ``{"widget_type": ..., "insight_id": ..., "config": ...}`` each, in
     #: render order.
     widgets: list[dict]
+    #: Anything else the template wants on the section row, beside its name
+    #: and the parameters ``writer`` records for it. Free-form: nothing in
+    #: the generic layer reads it, only the template that wrote it.
     config: dict[str, Any] = field(default_factory=dict)
     #: One line for a tool message: what was built, in the template's own
     #: words. No ids — the caller adds those.
@@ -141,7 +144,21 @@ class AnalysisTemplate(Protocol[ParamsT]):
         params: ParamsT,
         language: str,
     ) -> TemplateResult:
-        """Rebuild one of this template's own sections, in place."""
+        """Rebuild one of this template's own sections, in place.
+
+        Called both to re-run a section unchanged, with today's data, and to
+        rebuild it for different parameters. The template cannot tell the
+        two apart, and does not need to.
+        """
+        ...
+
+    def describe(self, section: DashboardSectionOrm) -> str:
+        """What this section currently covers, in one phrase for a message.
+
+        The template's own words, because only it knows what its parameters
+        mean: a period for one, a threshold or a comparison for the next.
+        Read from the section's stored ``config``, never from a widget.
+        """
         ...
 
 
@@ -184,15 +201,15 @@ def templated_sections(
     ]
 
 
-def describe_window(section: DashboardSectionOrm) -> str:
-    """The period a templated section records, for a message to the user.
+def stored_params(
+    template: "AnalysisTemplate[Any]", section: DashboardSectionOrm
+) -> BaseModel:
+    """The parameters a section was last built with.
 
-    ``writer`` stores ``start_date`` and ``end_date`` on the section
-    ``config`` whenever a template covers a period, so this reads the same
-    way for every template — never by sniffing a widget's tile layer.
+    ``writer`` records them on the section row under ``params``, so
+    re-running a section unchanged needs nothing from the caller and nothing
+    template-specific here. A section written before a parameter existed
+    falls back to that parameter's default.
     """
     config = dict(section.config or {})
-    start, end = config.get("start_date"), config.get("end_date")
-    if start and end:
-        return f"{start} to {end}"
-    return "an unrecorded period"
+    return template.params_model(**(config.get("params") or {}))

--- a/src/api/services/analysis_templates/base.py
+++ b/src/api/services/analysis_templates/base.py
@@ -1,0 +1,198 @@
+"""What an analysis template is, and what every template shares.
+
+A template implements two operations over a dashboard:
+
+* ``build`` — write a new section for a set of parameters;
+* ``refresh`` — rebuild an existing one of its own sections for different
+  parameters, in place.
+
+Both take the loaded dashboard rather than an id, so a template picks its
+own area and runs its own "already built" check without the caller needing
+a hook for either. Both return a ``TemplateResult`` whose ``summary`` the
+template writes itself, so no caller has to know what the section contains.
+
+Everything a caller must handle is a ``TemplateError``: its message is
+written for the user, so a tool or a route needs one ``except`` clause and
+no knowledge of any particular template.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol, TypeVar, runtime_checkable
+
+from pydantic import BaseModel
+
+from src.api.data_models import DashboardOrm, DashboardSectionOrm
+from src.api.services.analysis_templates.registry import (
+    SEALED_SECTION_TYPES,
+    TemplateEntry,
+)
+
+
+class TemplateError(Exception):
+    """A build or refresh that cannot go ahead, in words for the user.
+
+    Every subclass keeps that promise: ``str(error)`` is shown as-is. A
+    caller catches this one type.
+    """
+
+
+class DataUnavailableError(TemplateError):
+    """The data the section is made of could not be pulled.
+
+    Fatal for the build: a section without its data says nothing.
+    """
+
+
+class AlreadyBuiltError(TemplateError):
+    """The dashboard already carries this section, for these parameters.
+
+    Building again costs a data pull and a model call, and leaves the reader
+    two identical sections.
+    """
+
+    def __init__(self, message: str, section_id: str):
+        self.section_id = section_id
+        super().__init__(message)
+
+
+class TargetGoneError(TemplateError):
+    """The dashboard or section being written to no longer exists.
+
+    Its own type, not a bare ``ValueError``: a build calls out to an
+    analytics API, a catalog, an imagery provider and a model, any of which
+    raises ``ValueError`` for its own reasons.
+    """
+
+
+@dataclass
+class SectionContent:
+    """A section gathered but not yet written.
+
+    Building and refreshing differ only in where this lands, so a template
+    has one gather step and two short write paths. ``config`` is the
+    template's own record of what it built from — the window, the
+    parameters — which ``writer`` stores on the section row alongside the
+    template's name.
+    """
+
+    title: str
+    description: str
+    #: ``{"widget_type": ..., "insight_id": ..., "config": ...}`` each, in
+    #: render order.
+    widgets: list[dict]
+    config: dict[str, Any] = field(default_factory=dict)
+    #: One line for a tool message: what was built, in the template's own
+    #: words. No ids — the caller adds those.
+    summary: str = ""
+    #: Why a widget is missing, in words a caller can show the user.
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TemplateResult:
+    """What a build or a refresh wrote."""
+
+    template: str
+    section_id: str
+    widget_ids: list[str]
+    summary: str
+    warnings: list[str] = field(default_factory=list)
+
+
+#: A template's own parameter model: it accepts that type and no other.
+ParamsT = TypeVar("ParamsT", bound=BaseModel)
+
+
+@runtime_checkable
+class AnalysisTemplate(Protocol[ParamsT]):
+    """The interface ``registry.get_template`` returns.
+
+    A template module exports one instance of this as ``TEMPLATE``. It is
+    generic in its parameter model, so a template types its own ``build``
+    and ``refresh`` against ``NrtParams`` (say) rather than against
+    ``BaseModel``.
+    """
+
+    #: The template's own registry metadata.
+    entry: TemplateEntry
+    #: The template's parameters. Callers construct it from what they were
+    #: given, so its field defaults are the template's defaults and its
+    #: bounds are the only bounds. Forbid extra fields, so a parameter this
+    #: template does not take is refused rather than ignored.
+    params_model: type[ParamsT]
+
+    async def build(
+        self,
+        dashboard: DashboardOrm,
+        *,
+        user_id: str,
+        params: ParamsT,
+        language: str,
+    ) -> TemplateResult:
+        """Write a new section on this dashboard."""
+        ...
+
+    async def refresh(
+        self,
+        section: DashboardSectionOrm,
+        dashboard: DashboardOrm,
+        *,
+        user_id: str,
+        params: ParamsT,
+        language: str,
+    ) -> TemplateResult:
+        """Rebuild one of this template's own sections, in place."""
+        ...
+
+
+def aoi_ref(aoi) -> dict:
+    """A dashboard AOI row as the reference a template's pull takes.
+
+    One projection, so every template hands the same four fields to the
+    same handlers.
+    """
+    return {
+        "source": aoi.source,
+        "src_id": aoi.src_id,
+        "subtype": aoi.subtype,
+        "name": aoi.name,
+    }
+
+
+def first_aoi(dashboard: DashboardOrm):
+    """The area a template covers, or None.
+
+    Today a section covers the dashboard's first area. Portfolios of areas
+    are a dashboard-level question, not a per-template one, so this is the
+    one place it will change.
+    """
+    return dashboard.aois[0] if dashboard.aois else None
+
+
+def templated_sections(
+    dashboard: DashboardOrm, name: Optional[str] = None
+) -> list[DashboardSectionOrm]:
+    """The template-built sections on a dashboard, in render order.
+
+    ``name`` narrows to one template; without it, every sealed section.
+    """
+    wanted = {name} if name else SEALED_SECTION_TYPES
+    return [
+        section
+        for section in dashboard.sections or []
+        if section.type in wanted
+    ]
+
+
+def describe_window(section: DashboardSectionOrm) -> str:
+    """The period a templated section records, for a message to the user.
+
+    ``writer`` stores ``start_date`` and ``end_date`` on the section
+    ``config`` whenever a template covers a period, so this reads the same
+    way for every template — never by sniffing a widget's tile layer.
+    """
+    config = dict(section.config or {})
+    start, end = config.get("start_date"), config.get("end_date")
+    if start and end:
+        return f"{start} to {end}"
+    return "an unrecorded period"

--- a/src/api/services/analysis_templates/nrt_monitoring/__init__.py
+++ b/src/api/services/analysis_templates/nrt_monitoring/__init__.py
@@ -1,0 +1,12 @@
+"""The near-real-time monitoring template.
+
+``registry`` imports this module by name and reads ``TEMPLATE``.
+"""
+
+from src.api.services.analysis_templates.nrt_monitoring.recipe import (
+    NAME,
+    TEMPLATE,
+    NrtParams,
+)
+
+__all__ = ["NAME", "TEMPLATE", "NrtParams"]

--- a/src/api/services/analysis_templates/nrt_monitoring/recipe.py
+++ b/src/api/services/analysis_templates/nrt_monitoring/recipe.py
@@ -283,7 +283,9 @@ class NrtMonitoringTemplate:
             days=params.days,
             language=language,
         )
-        return await writer.write_section(str(dashboard.id), self, content)
+        return await writer.write_section(
+            str(dashboard.id), self, content, params
+        )
 
     async def refresh(
         self,
@@ -294,11 +296,13 @@ class NrtMonitoringTemplate:
         params: NrtParams,
         language: str = DEFAULT_LANGUAGE,
     ) -> TemplateResult:
-        """Rebuild the section for a new window, in place.
+        """Rebuild the section, in place, for ``params``.
 
-        Everything the section shows moves to the new period together — the
-        chart, the alerts layer and the imagery — and its title and
-        description are rewritten, because they state the period.
+        Everything it shows is gathered again together — the chart, the
+        alerts layer and the imagery — and its title and description are
+        rewritten, because they state the period. Passing the parameters it
+        already has re-runs it against today's data; passing different ones
+        moves it to another window. This does not tell the two apart.
         """
         aoi = first_aoi(dashboard)
         if aoi is None:
@@ -323,7 +327,17 @@ class NrtMonitoringTemplate:
             f" to {content.config['end_date']} ({params.days} days); every "
             f"widget in it now covers that period"
         )
-        return await writer.replace_section(str(section.id), self, content)
+        return await writer.replace_section(
+            str(section.id), self, content, params
+        )
+
+    def describe(self, section: DashboardSectionOrm) -> str:
+        """The period the section covers, from what it recorded."""
+        config = dict(section.config or {})
+        start, end = config.get("start_date"), config.get("end_date")
+        if start and end:
+            return f"{start} to {end}"
+        return "an unrecorded period"
 
 
 TEMPLATE = NrtMonitoringTemplate()

--- a/src/api/services/analysis_templates/nrt_monitoring/recipe.py
+++ b/src/api/services/analysis_templates/nrt_monitoring/recipe.py
@@ -1,0 +1,329 @@
+"""Near-real-time monitoring: what has been disturbed here, recently.
+
+One build, one section: a chart of integrated disturbance alerts over the
+period, a map of those alerts, and satellite imagery of the same area and
+period. Everything comes from parts that already exist — the curated alerts
+chart generator, the dataset layer resolver, the Sentinel-2 mosaic service —
+so no model chooses anything except the words.
+
+What can fail, and what happens:
+
+- the analytics pull fails → the build fails, since a section without its
+  data says nothing;
+- the mosaic fails (the area is too large, no scenes, STAC down) → the
+  section is built without the imagery widget, and the reason is reported
+  in ``warnings``;
+- the summary call fails → a templated title and description are used
+  (``summary.fallback_summary``);
+- the dashboard is deleted mid-build → the insight row is already written
+  and is left orphaned. Harmless dead data no dashboard points at, the same
+  trade the deterministic analysis job makes.
+"""
+
+from dataclasses import asdict
+from datetime import date, timedelta
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.agent.datasets.dates import revise_date_range
+from src.agent.datasets.handlers.analytics_handler import (
+    INTEGRATED_ALERTS_ID,
+    AnalyticsHandler,
+)
+from src.agent.datasets.layers import (
+    get_dataset_record,
+    resolve_dataset_layer,
+)
+from src.agent.imagery import ImageryRequest, Sentinel2ImageryProvider
+from src.agent.language import DEFAULT_LANGUAGE
+from src.agent.subagents.analyst.charts.model import Insight
+from src.api.data_models import DashboardOrm, DashboardSectionOrm
+from src.api.repositories.insight_writer import persist_insight
+from src.api.services.analysis_templates import writer
+from src.api.services.analysis_templates.base import (
+    AlreadyBuiltError,
+    DataUnavailableError,
+    SectionContent,
+    TemplateResult,
+    aoi_ref,
+    first_aoi,
+    templated_sections,
+)
+from src.api.services.analysis_templates.nrt_monitoring.summary import (
+    generate_section_summary,
+)
+from src.api.services.analysis_templates.registry import ENTRIES_BY_NAME
+from src.api.services.analyze import AnalyzeService
+from src.api.services.charts import DETERMINISTIC_GENERATORS
+from src.api.services.widget_configs import (
+    dataset_snapshot,
+    imagery_snapshot,
+    map_widget_config,
+)
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+NAME = "nrt-monitoring"
+
+#: Satellite imagery search window, ±N days around the end of the period,
+#: and the cloud limit for a scene. Constants, not parameters: the point of
+#: this template is that a caller asks for a period and nothing else.
+_IMAGERY_WINDOW_DAYS = 7
+_MAX_CLOUD_COVER = 20
+
+_IMAGERY_PROVIDER = Sentinel2ImageryProvider()
+
+
+class NrtParams(BaseModel):
+    """The one thing a caller chooses: how far back to look."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    days: int = Field(
+        default=14,
+        ge=1,
+        le=365,
+        description=(
+            "Length of the alert window, counted back from today. Two weeks "
+            "by default: these sections are for what is happening now. "
+            "Clamped to the dataset's own coverage."
+        ),
+    )
+
+
+async def resolve_period(days: int) -> tuple[str, str]:
+    """The alert window: ``days`` back from today, clamped to the dataset.
+
+    Integrated alerts start on 2023-12-01 and have no fixed end, so the
+    clamp normally only moves the start of a very long window. It happens
+    here, once, because the "already built" check matches on the period a
+    previous build *stored*: comparing an unclamped range against a clamped
+    one would never match, and every request would build again.
+    """
+    today = date.today()
+    start, end, _ = await revise_date_range(
+        (today - timedelta(days=days)).isoformat(),
+        today.isoformat(),
+        INTEGRATED_ALERTS_ID,
+    )
+    return start, end
+
+
+def _find_built(
+    dashboard: DashboardOrm, start_date: str, end_date: str
+) -> Optional[DashboardSectionOrm]:
+    """A monitoring section already on this dashboard for the same period."""
+    for section in templated_sections(dashboard, NAME):
+        config = dict(section.config or {})
+        if (
+            config.get("start_date") == start_date
+            and config.get("end_date") == end_date
+        ):
+            return section
+    return None
+
+
+async def _gather(
+    aoi: dict,
+    *,
+    user_id: str,
+    days: int,
+    language: str,
+) -> SectionContent:
+    """Pull the data, build the widgets, write the words — no section yet.
+
+    Shared by the build and every refresh, so a refreshed section is
+    assembled exactly like a new one.
+    """
+    language = language or DEFAULT_LANGUAGE
+    start_date, end_date = await resolve_period(days)
+    warnings: list[str] = []
+
+    # Each consumer below gets its own copy of the AOI (``dict(aoi)`` at
+    # every call site). The analytics handler rewrites its input in place —
+    # it strips the GADM level suffix, so "BRA.16.197_2" becomes
+    # "BRA.16.197" — and the imagery lookup that follows needs the canonical
+    # id the dashboard stored, not that one.
+
+    # 1. Alert data, and the curated chart for it.
+    service = AnalyzeService(AnalyticsHandler(), DETERMINISTIC_GENERATORS)
+    analysis = await service.analyze(
+        aois=[dict(aoi)],
+        dataset_id=INTEGRATED_ALERTS_ID,
+        start_date=start_date,
+        end_date=end_date,
+        language=language,
+    )
+    if not analysis.data.success:
+        raise DataUnavailableError(
+            f"Could not retrieve alert data for '{aoi['name']}': "
+            f"{analysis.data.message}"
+        )
+
+    # Charts only, no narrative: the section's description carries the words.
+    insight_id = await persist_insight(
+        Insight(charts=analysis.charts),
+        user_id=user_id,
+        thread_id="",
+    )
+
+    # 2. The alerts layer, over the same period as the chart.
+    alerts_layer = resolve_dataset_layer(
+        INTEGRATED_ALERTS_ID, start_date, end_date
+    )
+
+    # 3. Satellite imagery for the end of the period. Optional: a failure
+    #    here costs the third widget, not the section.
+    imagery = await _IMAGERY_PROVIDER.get_imagery(
+        ImageryRequest(
+            aois=[dict(aoi)],
+            target_date=date.fromisoformat(end_date),
+            language=language,
+            window_days=_IMAGERY_WINDOW_DAYS,
+            max_cloud_cover=_MAX_CLOUD_COVER,
+        )
+    )
+    if imagery.imagery is None:
+        warnings.append(imagery.message)
+        logger.info("nrt_section_imagery_unavailable", reason=imagery.message)
+
+    # 4. The words. They state the period, so a refresh rewrites them.
+    summary = await generate_section_summary(
+        analysis.charts,
+        aoi_name=aoi["name"],
+        start_date=start_date,
+        end_date=end_date,
+        presentation_instructions=get_dataset_record(INTEGRATED_ALERTS_ID).get(
+            "presentation_instructions"
+        ),
+        language=language,
+    )
+
+    widgets: list[dict] = [
+        {"widget_type": "insight", "insight_id": insight_id},
+        {
+            "widget_type": "map",
+            "config": map_widget_config(
+                "dataset",
+                dataset_snapshot(asdict(alerts_layer)),
+                alerts_layer.dataset_name,
+            ),
+        },
+    ]
+    if imagery.imagery is not None:
+        widgets.append(
+            {
+                "widget_type": "map",
+                "config": map_widget_config(
+                    "imagery",
+                    imagery_snapshot(imagery.imagery.model_dump()),
+                    "Satellite imagery",
+                ),
+            }
+        )
+
+    return SectionContent(
+        title=summary.title,
+        description=summary.description,
+        widgets=widgets,
+        config={
+            "days": days,
+            "start_date": start_date,
+            "end_date": end_date,
+        },
+        summary=(
+            f"a near-real-time monitoring section for '{aoi['name']}' "
+            f"covering {start_date} to {end_date}, with "
+            f"{len(widgets)} widgets"
+        ),
+        warnings=warnings,
+    )
+
+
+class NrtMonitoringTemplate:
+    """The template object the registry hands out."""
+
+    entry = ENTRIES_BY_NAME[NAME]
+    params_model = NrtParams
+
+    async def build(
+        self,
+        dashboard: DashboardOrm,
+        *,
+        user_id: str,
+        params: NrtParams,
+        language: str = DEFAULT_LANGUAGE,
+    ) -> TemplateResult:
+        aoi = first_aoi(dashboard)
+        if aoi is None:
+            raise DataUnavailableError(
+                f"Dashboard '{dashboard.name}' has no area to monitor."
+            )
+
+        start_date, end_date = await resolve_period(params.days)
+        built = _find_built(dashboard, start_date, end_date)
+        if built is not None:
+            raise AlreadyBuiltError(
+                f"Dashboard '{dashboard.name}' already has the monitoring "
+                f"section '{built.title}' for {start_date} to {end_date}.",
+                str(built.id),
+            )
+
+        logger.info(
+            "nrt_section_build_started",
+            dashboard_id=str(dashboard.id),
+            aoi=f"{aoi.source}/{aoi.src_id}",
+            days=params.days,
+        )
+        content = await _gather(
+            aoi_ref(aoi),
+            user_id=user_id,
+            days=params.days,
+            language=language,
+        )
+        return await writer.write_section(str(dashboard.id), self, content)
+
+    async def refresh(
+        self,
+        section: DashboardSectionOrm,
+        dashboard: DashboardOrm,
+        *,
+        user_id: str,
+        params: NrtParams,
+        language: str = DEFAULT_LANGUAGE,
+    ) -> TemplateResult:
+        """Rebuild the section for a new window, in place.
+
+        Everything the section shows moves to the new period together — the
+        chart, the alerts layer and the imagery — and its title and
+        description are rewritten, because they state the period.
+        """
+        aoi = first_aoi(dashboard)
+        if aoi is None:
+            raise DataUnavailableError(
+                f"Dashboard '{dashboard.name}' has no area to monitor."
+            )
+
+        logger.info(
+            "nrt_section_refresh_started",
+            section_id=str(section.id),
+            aoi=f"{aoi.source}/{aoi.src_id}",
+            days=params.days,
+        )
+        content = await _gather(
+            aoi_ref(aoi),
+            user_id=user_id,
+            days=params.days,
+            language=language,
+        )
+        content.summary = (
+            f"moved the monitoring section onto {content.config['start_date']}"
+            f" to {content.config['end_date']} ({params.days} days); every "
+            f"widget in it now covers that period"
+        )
+        return await writer.replace_section(str(section.id), self, content)
+
+
+TEMPLATE = NrtMonitoringTemplate()

--- a/src/api/services/analysis_templates/nrt_monitoring/summary.py
+++ b/src/api/services/analysis_templates/nrt_monitoring/summary.py
@@ -1,0 +1,177 @@
+"""The title and description of a near-real-time monitoring section.
+
+A recipe-built section has to say what it shows, because nobody typed a
+heading for it. One model call reads the chart rows the deterministic
+generator produced and writes both: a short title, and a description that
+states the figures a reader would otherwise have to work out from the chart.
+
+Grounding is the chart data plus the dataset's own presentation rules —
+never conversation state. Same shape as
+``src.agent.subagents.analyst.text_generator``, which does this job for
+insights.
+
+Every template that writes its own words does this much; none of it is
+shared yet, because a second template would want a different prompt and the
+only common part is the fallback rule: a section whose data is already
+gathered must never be lost to a model failure.
+"""
+
+from typing import List, Optional
+
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field
+
+from src.agent.language import DEFAULT_LANGUAGE, language_name
+from src.agent.llms import SMALL_MODEL
+from src.agent.subagents.analyst.charts.model import InsightChart
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+TITLE_MAX_CHARS = 60
+
+
+class SectionSummary(BaseModel):
+    """Structured output of the summary call."""
+
+    title: str = Field(
+        description=(
+            "Section heading naming the area and the period, at most "
+            f"{TITLE_MAX_CHARS} characters. No trailing period."
+        )
+    )
+    description: str = Field(
+        description=(
+            "Two to four sentences: what the section shows, then the key "
+            "figures from the chart data."
+        )
+    )
+
+
+_SYSTEM = """You write the heading and the summary of a monitoring section on \
+a dashboard. The section shows a chart of disturbance alerts over time, a map \
+of those alerts, and satellite imagery of the same area and period.
+
+Write a `title` that names the area and the period, at most \
+{title_max_chars} characters.
+
+Write a `description` of two to four sentences: first what the section shows, \
+then the figures that matter. Take every figure from the chart data below — \
+do not compute new ones, and do not describe the chart mechanics. State the \
+unit with every area, and round every figure the way a report would: whole \
+hectares above 100, at most one decimal below that, thousands separated. \
+Never quote a raw value like 153409.28893796972. Name the confidence tiers \
+the data actually contains.
+
+Follow the dataset's presentation rules below, including any caution they \
+require about what the alerts mean.
+
+Write both in {language}, regardless of the language of the data or the \
+instructions below.
+
+Write plain prose. No HTML, and no markdown beyond `**bold**` for a name or \
+a term you want to stress. The `title` carries no markup at all."""
+
+_USER = """## Area
+{aoi_name}
+
+## Period
+{start_date} to {end_date}
+
+## How to describe this dataset
+{presentation_instructions}
+
+## Charts (spec + data)
+{charts}"""
+
+_PROMPT = ChatPromptTemplate.from_messages(
+    [("system", _SYSTEM), ("user", _USER)]
+)
+
+
+def _rounded(chart: InsightChart) -> InsightChart:
+    """The chart with its numbers rounded for the prompt only.
+
+    Analytics areas arrive at full float precision, and a model asked to
+    quote a figure exactly will happily write "153409.28893796972 ha". The
+    stored chart keeps its precision — only the copy the model reads is
+    rounded.
+    """
+    rounded = chart.model_copy(deep=True)
+    for row in rounded.chart_data:
+        for key, value in row.items():
+            if isinstance(value, float):
+                row[key] = round(value, 1 if abs(value) < 100 else None)
+    return rounded
+
+
+def fallback_summary(
+    aoi_name: str, start_date: str, end_date: str
+) -> SectionSummary:
+    """Title and description that need no model call.
+
+    Used when the model is unavailable or returns nothing usable: a section
+    with a plain heading is worth building, an aborted build is not. States
+    no figures, since the point of the generated text is exactly the figures
+    this cannot supply.
+    """
+    return SectionSummary(
+        title=f"Near-real-time monitoring — {aoi_name}",
+        description=(
+            f"Disturbance alerts for {aoi_name} between {start_date} and "
+            f"{end_date}, with a map of the alerts and satellite imagery of "
+            "the same period. Alerts indicate potential disturbance, not "
+            "confirmed deforestation."
+        ),
+    )
+
+
+async def generate_section_summary(
+    charts: List[InsightChart],
+    *,
+    aoi_name: str,
+    start_date: str,
+    end_date: str,
+    presentation_instructions: Optional[str] = None,
+    language: str = DEFAULT_LANGUAGE,
+    model=SMALL_MODEL,
+) -> SectionSummary:
+    """The section's title and description, or the fallback pair.
+
+    Never raises: the summary is the last step of a build whose data is
+    already gathered, so a model failure must not lose the section.
+    """
+    if not charts:
+        return fallback_summary(aoi_name, start_date, end_date)
+
+    chain = _PROMPT | model.with_structured_output(SectionSummary)
+    inputs = {
+        "title_max_chars": TITLE_MAX_CHARS,
+        "language": language_name(language or DEFAULT_LANGUAGE),
+        "aoi_name": aoi_name,
+        "start_date": start_date,
+        "end_date": end_date,
+        "presentation_instructions": presentation_instructions or "(none)",
+        "charts": "\n".join(
+            _rounded(chart).model_dump_json(exclude={"insight"})
+            for chart in charts
+        ),
+    }
+    try:
+        result: SectionSummary = await chain.ainvoke(inputs)
+    except Exception as error:
+        logger.warning(
+            "nrt_section_summary_failed",
+            error=str(error),
+            aoi_name=aoi_name,
+        )
+        return fallback_summary(aoi_name, start_date, end_date)
+
+    title = (result.title or "").strip()
+    description = (result.description or "").strip()
+    if not title or not description:
+        logger.warning("nrt_section_summary_empty", aoi_name=aoi_name)
+        return fallback_summary(aoi_name, start_date, end_date)
+    return SectionSummary(
+        title=title[:TITLE_MAX_CHARS], description=description
+    )

--- a/src/api/services/analysis_templates/registry.py
+++ b/src/api/services/analysis_templates/registry.py
@@ -58,10 +58,14 @@ class TemplateEntry:
     label: str
     #: When to reach for this template, in one sentence.
     when_to_use: str
-    #: The template's own parameters, in one sentence.
+    #: The template's own parameters, in one sentence. Read by a model, so
+    #: it must name each field, its default and its bounds.
     params_help: str
     #: Module under this package that exports ``TEMPLATE``.
     module: str
+    #: What changing those parameters costs the reader, in one phrase. It
+    #: goes into the confirmation the agent must get first.
+    change_warning: str = "replaces what the section shows"
     #: Whether the section it writes is read-only afterwards. Templates that
     #: gather data for one period are; a template that only laid out
     #: existing widgets would not be.
@@ -79,6 +83,10 @@ ENTRIES: tuple[TemplateEntry, ...] = (
         params_help=(
             "days: length of the alert window counted back from today "
             "(default 14, max 365)"
+        ),
+        change_warning=(
+            "changes every figure in the section, and the previous ones "
+            "are deleted"
         ),
         module="nrt_monitoring",
     ),

--- a/src/api/services/analysis_templates/registry.py
+++ b/src/api/services/analysis_templates/registry.py
@@ -1,0 +1,130 @@
+"""The list of analysis templates, as metadata only.
+
+This module imports nothing from the rest of the application, and it must
+stay that way. Two callers need to know that a template exists without
+paying for what it does:
+
+* ``dashboard_writer`` reads ``SEALED_SECTION_TYPES`` to refuse edits to a
+  templated section. Importing a template there would drag the analytics
+  client, the imagery provider and a model client into every dashboard
+  write.
+* the agent's tool prompt lists the templates at import time, and needs
+  only their names and one line each.
+
+``get_template`` imports the template's own module on first use and returns
+its ``TEMPLATE`` object.
+
+One entry per template. The ``name`` is also the value stored in
+``dashboard_sections.type``, so there is one list of template names, not
+two.
+"""
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle broken for runtime
+    from src.api.services.analysis_templates.base import AnalysisTemplate
+
+#: The type of a section a user or the agent composed widget by widget.
+DEFAULT_SECTION_TYPE = "default"
+
+_PACKAGE = "src.api.services.analysis_templates"
+
+
+class UnknownTemplateError(Exception):
+    """No template goes by that name."""
+
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(
+            f"unknown analysis template '{name}'; "
+            f"known: {', '.join(TEMPLATE_NAMES)}"
+        )
+
+
+@dataclass(frozen=True)
+class TemplateEntry:
+    """What is known about a template without importing it.
+
+    ``label``, ``when_to_use`` and ``params_help`` are written for a model
+    to read: they go into the tool prompt that offers the templates. Keep
+    them to one line each.
+    """
+
+    #: Stored in ``dashboard_sections.type``. Lower-case, hyphenated.
+    name: str
+    #: Short human name, for a tool message.
+    label: str
+    #: When to reach for this template, in one sentence.
+    when_to_use: str
+    #: The template's own parameters, in one sentence.
+    params_help: str
+    #: Module under this package that exports ``TEMPLATE``.
+    module: str
+    #: Whether the section it writes is read-only afterwards. Templates that
+    #: gather data for one period are; a template that only laid out
+    #: existing widgets would not be.
+    sealed: bool = True
+
+
+ENTRIES: tuple[TemplateEntry, ...] = (
+    TemplateEntry(
+        name="nrt-monitoring",
+        label="near-real-time monitoring",
+        when_to_use=(
+            "the user wants to monitor an area, or asks what has been "
+            "disturbed there recently"
+        ),
+        params_help=(
+            "days: length of the alert window counted back from today "
+            "(default 14, max 365)"
+        ),
+        module="nrt_monitoring",
+    ),
+)
+
+ENTRIES_BY_NAME: dict[str, TemplateEntry] = {
+    entry.name: entry for entry in ENTRIES
+}
+
+TEMPLATE_NAMES: tuple[str, ...] = tuple(entry.name for entry in ENTRIES)
+
+#: Section types no caller may edit. Read by ``dashboard_writer``.
+SEALED_SECTION_TYPES = frozenset(
+    entry.name for entry in ENTRIES if entry.sealed
+)
+
+
+def get_entry(name: str) -> Optional[TemplateEntry]:
+    """The metadata for a template name, or None."""
+    return ENTRIES_BY_NAME.get(name)
+
+
+def get_template(name: str) -> "AnalysisTemplate[Any]":
+    """The template itself, importing its module on first use.
+
+    Raises ``UnknownTemplateError`` for a name no entry claims — including
+    the type of a section written before a template was removed.
+    """
+    entry = ENTRIES_BY_NAME.get(name)
+    if entry is None:
+        raise UnknownTemplateError(name)
+    module = import_module(f"{_PACKAGE}.{entry.module}")
+    template = module.TEMPLATE
+    # The registry and the module each name the template. They must agree,
+    # or a section would be written under a type nothing can refresh.
+    assert template.entry.name == entry.name, (
+        f"{entry.module}.TEMPLATE is '{template.entry.name}', "
+        f"registered as '{entry.name}'"
+    )
+    return template
+
+
+def describe_templates() -> str:
+    """The templates as prompt lines, for the tool that offers them."""
+    return "\n".join(
+        f"  - `{entry.name}` — {entry.label}. Use when {entry.when_to_use}. "
+        f"Parameters: {entry.params_help}."
+        for entry in ENTRIES
+    )

--- a/src/api/services/analysis_templates/writer.py
+++ b/src/api/services/analysis_templates/writer.py
@@ -6,15 +6,18 @@ a reader may only ever see complete must not appear widget by widget.
 This module decides one thing of its own — what lands in
 ``dashboard_sections.config``:
 
-    {"template": <name>, **the template's own record}
+    {"template": <name>, "params": {...}, **the template's own record}
 
-The template's name is always there, so a refresh knows which template owns
-the section, and a reader is told which period is on screen without reading
-a widget's tile layer. By convention a template that covers a period records
-``start_date`` and ``end_date`` (see ``base.describe_window``).
+Two of those three keys are read by the generic layer and nothing else. The
+name says which template owns the section, so a refresh knows what to
+re-run. The parameters say what it was built with, so re-running it
+unchanged needs nothing from the caller (``base.stored_params``). The rest
+is the template's own record, read only by the template that wrote it.
 """
 
 from typing import Any
+
+from pydantic import BaseModel
 
 from src.api.repositories import dashboard_writer
 from src.api.services.analysis_templates.base import (
@@ -29,27 +32,35 @@ logger = get_logger(__name__)
 
 
 def _config(
-    template: "AnalysisTemplate[Any]", content: SectionContent
+    template: "AnalysisTemplate[Any]",
+    content: SectionContent,
+    params: BaseModel,
 ) -> dict:
-    return {"template": template.entry.name, **content.config}
+    return {
+        "template": template.entry.name,
+        "params": params.model_dump(mode="json"),
+        **content.config,
+    }
 
 
 async def write_section(
     dashboard_id: str,
     template: "AnalysisTemplate[Any]",
     content: SectionContent,
+    params: BaseModel,
 ) -> TemplateResult:
     """Write a gathered section onto a dashboard.
 
-    Raises ``TargetGoneError`` when the dashboard was deleted while the
-    content was being gathered.
+    ``params`` are recorded on the section row, so the section can later be
+    re-run exactly as it was built. Raises ``TargetGoneError`` when the
+    dashboard was deleted while the content was being gathered.
     """
     written = await dashboard_writer.add_section_with_widgets(
         dashboard_id,
         title=content.title,
         description=content.description,
         type=template.entry.name,
-        config=_config(template, content),
+        config=_config(template, content, params),
         widgets=content.widgets,
     )
     if written is None:
@@ -79,6 +90,7 @@ async def replace_section(
     section_id: str,
     template: "AnalysisTemplate[Any]",
     content: SectionContent,
+    params: BaseModel,
 ) -> TemplateResult:
     """Swap a section's whole contents for freshly gathered ones.
 
@@ -91,7 +103,7 @@ async def replace_section(
         section_id,
         title=content.title,
         description=content.description,
-        config=_config(template, content),
+        config=_config(template, content, params),
         widgets=content.widgets,
     )
     if written is None:

--- a/src/api/services/analysis_templates/writer.py
+++ b/src/api/services/analysis_templates/writer.py
@@ -1,0 +1,118 @@
+"""The two writes a template makes, and the shape of what it records.
+
+Both go through ``dashboard_writer``, which owns the transaction: a section
+a reader may only ever see complete must not appear widget by widget.
+
+This module decides one thing of its own — what lands in
+``dashboard_sections.config``:
+
+    {"template": <name>, **the template's own record}
+
+The template's name is always there, so a refresh knows which template owns
+the section, and a reader is told which period is on screen without reading
+a widget's tile layer. By convention a template that covers a period records
+``start_date`` and ``end_date`` (see ``base.describe_window``).
+"""
+
+from typing import Any
+
+from src.api.repositories import dashboard_writer
+from src.api.services.analysis_templates.base import (
+    AnalysisTemplate,
+    SectionContent,
+    TargetGoneError,
+    TemplateResult,
+)
+from src.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _config(
+    template: "AnalysisTemplate[Any]", content: SectionContent
+) -> dict:
+    return {"template": template.entry.name, **content.config}
+
+
+async def write_section(
+    dashboard_id: str,
+    template: "AnalysisTemplate[Any]",
+    content: SectionContent,
+) -> TemplateResult:
+    """Write a gathered section onto a dashboard.
+
+    Raises ``TargetGoneError`` when the dashboard was deleted while the
+    content was being gathered.
+    """
+    written = await dashboard_writer.add_section_with_widgets(
+        dashboard_id,
+        title=content.title,
+        description=content.description,
+        type=template.entry.name,
+        config=_config(template, content),
+        widgets=content.widgets,
+    )
+    if written is None:
+        raise TargetGoneError(
+            f"Dashboard {dashboard_id} no longer exists, so the "
+            f"{template.entry.label} section could not be added."
+        )
+    section_id, widget_ids = written
+    logger.info(
+        "analysis_template_section_written",
+        template=template.entry.name,
+        dashboard_id=str(dashboard_id),
+        section_id=section_id,
+        widgets=len(widget_ids),
+        warnings=len(content.warnings),
+    )
+    return TemplateResult(
+        template=template.entry.name,
+        section_id=section_id,
+        widget_ids=widget_ids,
+        summary=content.summary,
+        warnings=content.warnings,
+    )
+
+
+async def replace_section(
+    section_id: str,
+    template: "AnalysisTemplate[Any]",
+    content: SectionContent,
+) -> TemplateResult:
+    """Swap a section's whole contents for freshly gathered ones.
+
+    The section row survives, so its id and its place on the dashboard
+    hold. Insights the previous widgets showed are deleted once nothing
+    points at them: they were this section's own content, for parameters
+    the section no longer covers.
+    """
+    written = await dashboard_writer.replace_section_widgets(
+        section_id,
+        title=content.title,
+        description=content.description,
+        config=_config(template, content),
+        widgets=content.widgets,
+    )
+    if written is None:
+        raise TargetGoneError(
+            f"Section {section_id} no longer exists, so it could not be "
+            "rebuilt."
+        )
+    widget_ids, replaced_insight_ids = written
+    await dashboard_writer.delete_unreferenced_insights(replaced_insight_ids)
+    logger.info(
+        "analysis_template_section_replaced",
+        template=template.entry.name,
+        section_id=str(section_id),
+        widgets=len(widget_ids),
+        replaced_insights=len(replaced_insight_ids),
+        warnings=len(content.warnings),
+    )
+    return TemplateResult(
+        template=template.entry.name,
+        section_id=str(section_id),
+        widget_ids=widget_ids,
+        summary=content.summary,
+        warnings=content.warnings,
+    )

--- a/src/api/services/widget_configs.py
+++ b/src/api/services/widget_configs.py
@@ -1,0 +1,86 @@
+"""The map-widget config contract, in one place.
+
+A map widget is a self-contained snapshot: the frontend renders
+``config["dataset"]["tile_url"]`` or ``config["imagery"]["tile_url"]``
+directly, with no catalog lookup and no chat state. Both the agent tool
+(``add_map_widget``) and the analysis templates write that snapshot, so
+the projection lives here — one definition, one set of keys.
+
+The projections are explicit key allowlists. A dataset record carries prose
+(description, methodology, instructions) and an imagery state may grow
+fields; neither belongs in a widget's JSONB config, and an allowlist means
+new upstream fields cannot leak into it by default.
+"""
+
+from typing import Mapping, Optional
+
+#: Render-relevant fields of the imagery state (``ImageryState``) — all of it.
+IMAGERY_KEYS = (
+    "provider",
+    "tile_url",
+    "tilejson_url",
+    "bounds",
+    "min_zoom",
+    "max_zoom",
+    "mosaic_id",
+    "item_count",
+    "start_date",
+    "end_date",
+    "mean_cloud_cover",
+    "min_cloud_cover",
+    "max_cloud_cover_observed",
+    "target_date",
+    "window_days",
+    "max_cloud_cover",
+    "aoi_names",
+)
+
+
+def dataset_snapshot(dataset: Mapping) -> dict:
+    """The ``dataset`` sub-object of a map widget's config.
+
+    Takes a mapping, so both callers hand over what they already hold: the
+    agent passes the dataset in its own state, a template passes
+    ``asdict()`` of a resolved ``DatasetLayer``. The keys of the two are the
+    same by design — a layer resolved from chat and one resolved by a
+    template must render identically.
+    """
+    parameters = dataset.get("parameters")
+    return {
+        "dataset_id": dataset.get("dataset_id"),
+        "dataset_name": dataset.get("dataset_name"),
+        "tile_url": dataset.get("tile_url"),
+        "context_layer": dataset.get("context_layer"),
+        "context_layers": dataset.get("context_layers") or None,
+        "parameters": [
+            {"name": p.get("name"), "values": p.get("values")}
+            for p in parameters
+        ]
+        if parameters
+        else None,
+        "start_date": dataset.get("start_date"),
+        "end_date": dataset.get("end_date"),
+    }
+
+
+def imagery_snapshot(imagery: Mapping) -> dict:
+    """The ``imagery`` sub-object of a map widget's config.
+
+    Takes the ``ImageryState`` shape as a dict (``model_dump()`` or the agent
+    state), so the imagery providers and the mosaic service share one path.
+    """
+    return {key: imagery.get(key) for key in IMAGERY_KEYS}
+
+
+def map_widget_config(
+    layer_key: str, snapshot: dict, title: Optional[str] = None
+) -> dict:
+    """A whole map-widget config around one layer snapshot.
+
+    ``layer_key`` is ``"dataset"`` or ``"imagery"`` — exactly one, which is
+    what ``DashboardWidgetCreateRequest`` validates on the REST path.
+    """
+    config: dict = {"default_view": "map", layer_key: snapshot}
+    if title:
+        config["title"] = title
+    return config

--- a/tests/agent/test_add_map_widget.py
+++ b/tests/agent/test_add_map_widget.py
@@ -287,6 +287,16 @@ def test_dataset_config_none_without_tile_url():
     assert _dataset_config({"dataset": {"tile_url": ""}}) is None
 
 
+def test_dataset_config_none_when_a_layer_field_is_missing():
+    """The dataset state declares the id and the dates optional, and a
+    widget written without them renders a header reading "None–None". No
+    complete layer, no snapshot."""
+    for key in ("dataset_id", "dataset_name", "start_date", "end_date"):
+        dataset = _dataset_state()
+        dataset[key] = None
+        assert _dataset_config({"dataset": dataset}) is None, key
+
+
 def test_imagery_config_none_without_essentials():
     assert _imagery_config({}) is None
     assert _imagery_config({"imagery": {"tile_url": "x"}}) is None

--- a/tests/agent/test_dashboard_sections.py
+++ b/tests/agent/test_dashboard_sections.py
@@ -31,9 +31,15 @@ def _status(command):
     return command.update["messages"][0].status
 
 
-def _section(title="Deforestation", description=None, position=0):
+def _section(
+    title="Deforestation", description=None, position=0, type="default"
+):
     return SimpleNamespace(
-        id=uuid4(), title=title, description=description, position=position
+        id=uuid4(),
+        title=title,
+        description=description,
+        position=position,
+        type=type,
     )
 
 

--- a/tests/api/test_analysis_templates.py
+++ b/tests/api/test_analysis_templates.py
@@ -1,0 +1,394 @@
+"""Tests for what an analysis template writes, against a real database.
+
+The template composes three slow things — an analytics pull, a mosaic build
+and a model call — so every test here stands them in. What is under test is
+the composition: what the section contains, what happens when a part fails,
+that a second build does not produce a second section, and that a refresh
+moves every widget together while the section row survives.
+
+These go through the template object, which is what the agent tools call.
+The rows are read back through the repository, so a claim about a widget's
+config is a claim about what is stored.
+"""
+
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.agent.datasets.handlers.analytics_handler import INTEGRATED_ALERTS_ID
+from src.agent.datasets.handlers.base import DataPullResult
+from src.agent.imagery.base import ImageryProviderResult
+from src.agent.models import ImageryState
+from src.api.data_models import UserOrm
+from src.api.repositories import dashboard_writer
+from src.api.services.analysis_templates import registry
+from src.api.services.analysis_templates.base import (
+    AlreadyBuiltError,
+    DataUnavailableError,
+)
+from src.api.services.analysis_templates.nrt_monitoring import (
+    NAME,
+    NrtParams,
+)
+from src.api.services.analysis_templates.nrt_monitoring.summary import (
+    SectionSummary,
+)
+from tests.conftest import async_session_maker
+
+PARANA = {
+    "source": "gadm",
+    "src_id": "BRA.16_1",
+    "subtype": "state-province",
+    "name": "Paraná",
+}
+
+# Column-oriented, the shape the analytics API returns.
+ALERT_DATA = {
+    "alert_date": ["2026-08-30", "2026-08-31", "2026-09-01"],
+    "alert_confidence": ["high", "highest", "high"],
+    "area_ha": [12.5, 30.0, 8.0],
+    "aoi_id": ["BRA.16_1", "BRA.16_1", "BRA.16_1"],
+}
+
+IMAGERY = ImageryState(
+    provider="sentinel-2",
+    tile_url="https://tiles.globalforestwatch.org/cog/mosaic/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3",
+    tilejson_url="https://tiles.globalforestwatch.org/cog/mosaic/WebMercatorQuad/tilejson.json?url=s3",
+    mosaic_id="token-1",
+    item_count=8,
+    target_date="2026-09-02",
+    window_days=7,
+    max_cloud_cover=20,
+    aoi_names=["Paraná"],
+)
+
+SUMMARY = SectionSummary(
+    title="Alerts in Paraná, last 90 days",
+    description="50.5 ha of alerts, mostly high confidence.",
+)
+
+TEMPLATE = registry.get_template(NAME)
+
+
+async def _create_user(user_id: str) -> UserOrm:
+    async with async_session_maker() as session:
+        user = UserOrm(
+            id=user_id, name=user_id, email=f"{user_id}@example.com"
+        )
+        session.add(user)
+        await session.commit()
+        return user
+
+
+async def _dashboard(user_id: str, aois=(PARANA,)):
+    """A dashboard row, loaded the way the tools load it.
+
+    ``aois`` defaults to one area; pass ``[]`` for a dashboard with none.
+    """
+    await _create_user(user_id)
+    dashboard_id = await dashboard_writer.create_dashboard(
+        user_id=user_id, name="Paraná", aois=list(aois)
+    )
+    return await dashboard_writer.get_dashboard(dashboard_id)
+
+
+async def _reload(dashboard):
+    return await dashboard_writer.get_dashboard(str(dashboard.id))
+
+
+def _patches(
+    *,
+    pull_success: bool = True,
+    imagery: ImageryProviderResult | None = None,
+    imagery_spy: dict | None = None,
+):
+    """Stand in for the three slow collaborators of the template.
+
+    The pull stand-in **mutates its ``aois`` argument** exactly as the real
+    ``AnalyticsHandler`` does (it strips the GADM level suffix in place), so
+    a template that shares one AOI dict between the data pull and the
+    imagery lookup fails here rather than only in production.
+    """
+    pull = DataPullResult(
+        success=pull_success,
+        data=ALERT_DATA if pull_success else None,
+        message="ok" if pull_success else "analytics api unavailable",
+        data_points_count=3,
+        analytics_api_url="https://api.example/analytics/1",
+    )
+
+    async def _pull_data(*_args, aois, **_kwargs):
+        for entry in aois:
+            if entry["src_id"][-2:] in ("_1", "_2", "_3", "_4", "_5"):
+                entry["src_id"] = entry["src_id"][:-2]
+        return pull
+
+    async def _get_imagery(request):
+        if imagery_spy is not None:
+            imagery_spy["src_id"] = request.aois[0]["src_id"]
+        return imagery or ImageryProviderResult(
+            status="success", message="built", imagery=IMAGERY
+        )
+
+    return (
+        patch(
+            "src.agent.datasets.handlers.analytics_handler.AnalyticsHandler.pull_data",
+            _pull_data,
+        ),
+        patch(
+            "src.api.services.analysis_templates.nrt_monitoring.recipe."
+            "_IMAGERY_PROVIDER.get_imagery",
+            _get_imagery,
+        ),
+        patch(
+            "src.api.services.analysis_templates.nrt_monitoring.recipe."
+            "generate_section_summary",
+            AsyncMock(return_value=SUMMARY),
+        ),
+    )
+
+
+async def _build(dashboard, *, user_id, days=None):
+    params = NrtParams(**({} if days is None else {"days": days}))
+    return await TEMPLATE.build(
+        dashboard, user_id=user_id, params=params, language="en"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Building
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_builds_a_sealed_section_with_three_widgets():
+    dashboard = await _dashboard("tpl-owner")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        result = await _build(dashboard, user_id="tpl-owner")
+
+    assert result.template == NAME
+    assert result.warnings == []
+
+    stored = await _reload(dashboard)
+    (section,) = stored.sections
+    assert str(section.id) == result.section_id
+    # Sealed by being registered, not by anything the template did.
+    assert section.type == NAME
+    assert section.type in dashboard_writer.SEALED_SECTION_TYPES
+    assert section.title == SUMMARY.title
+    assert section.description == SUMMARY.description
+    # The section records which template owns it, so a refresh knows.
+    assert section.config["template"] == NAME
+
+    widgets = sorted(stored.widgets, key=lambda w: w.position)
+    assert [w.widget_type for w in widgets] == ["insight", "map", "map"]
+    assert all(w.section_id == section.id for w in widgets)
+
+    # The alerts layer covers the same period the chart does.
+    alerts = widgets[1].config["dataset"]
+    assert alerts["dataset_id"] == INTEGRATED_ALERTS_ID
+    assert f"start_date={alerts['start_date']}" in alerts["tile_url"]
+    assert alerts["end_date"] == date.today().isoformat()
+
+    assert widgets[2].config["imagery"]["mosaic_id"] == "token-1"
+
+
+@pytest.mark.asyncio
+async def test_default_window_is_two_weeks():
+    """Near-real-time means the last couple of weeks, not a quarter."""
+    dashboard = await _dashboard("tpl-default-window")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        await _build(dashboard, user_id="tpl-default-window")
+
+    (section,) = (await _reload(dashboard)).sections
+    # The section records its own window, so nothing has to read it back out
+    # of a tile layer's dates.
+    assert section.config["days"] == 14
+    assert section.config["end_date"] == date.today().isoformat()
+    assert (
+        section.config["start_date"]
+        == (date.today() - timedelta(days=14)).isoformat()
+    )
+
+
+@pytest.mark.asyncio
+async def test_imagery_failure_still_builds_the_section():
+    dashboard = await _dashboard("tpl-no-imagery")
+
+    pull, imagery, summary = _patches(
+        imagery=ImageryProviderResult(
+            status="error", message="AOI is too large for mosaics."
+        )
+    )
+    with pull, imagery, summary:
+        result = await _build(dashboard, user_id="tpl-no-imagery")
+
+    assert result.warnings == ["AOI is too large for mosaics."]
+    stored = await _reload(dashboard)
+    assert len(stored.sections) == 1
+    assert [w.widget_type for w in stored.widgets] == ["insight", "map"]
+
+
+@pytest.mark.asyncio
+async def test_analytics_failure_builds_nothing():
+    """A section without its data says nothing, so none is written."""
+    dashboard = await _dashboard("tpl-no-data")
+
+    pull, imagery, summary = _patches(pull_success=False)
+    with pull, imagery, summary:
+        with pytest.raises(DataUnavailableError):
+            await _build(dashboard, user_id="tpl-no-data")
+
+    stored = await _reload(dashboard)
+    assert stored.sections == []
+    assert stored.widgets == []
+
+
+@pytest.mark.asyncio
+async def test_second_build_for_the_same_period_is_refused():
+    dashboard = await _dashboard("tpl-twice")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        first = await _build(dashboard, user_id="tpl-twice")
+        with pytest.raises(AlreadyBuiltError) as error:
+            await _build(await _reload(dashboard), user_id="tpl-twice")
+
+    assert error.value.section_id == first.section_id
+    assert len((await _reload(dashboard)).sections) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_different_period_builds_a_second_section():
+    """The guard is against a double click, not against two windows."""
+    dashboard = await _dashboard("tpl-two-windows")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        await _build(dashboard, user_id="tpl-two-windows", days=14)
+        await _build(
+            await _reload(dashboard), user_id="tpl-two-windows", days=90
+        )
+
+    assert len((await _reload(dashboard)).sections) == 2
+
+
+@pytest.mark.asyncio
+async def test_dashboard_without_an_area_is_refused():
+    """Refused before anything is pulled: the section covers an area."""
+    dashboard = await _dashboard("tpl-no-aoi", aois=[])
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        with pytest.raises(DataUnavailableError):
+            await _build(dashboard, user_id="tpl-no-aoi")
+
+    assert (await _reload(dashboard)).sections == []
+
+
+@pytest.mark.asyncio
+async def test_imagery_gets_the_canonical_aoi_id():
+    """The data pull rewrites its input in place — the analytics API wants a
+    GADM id without the level suffix. The imagery lookup that follows must
+    still see the id the dashboard stored, or it resolves no geometry and
+    the section silently loses its satellite widget."""
+    dashboard = await _dashboard("tpl-aoi-id")
+    seen: dict = {}
+
+    pull, imagery, summary = _patches(imagery_spy=seen)
+    with pull, imagery, summary:
+        await _build(dashboard, user_id="tpl-aoi-id")
+
+    assert seen["src_id"] == PARANA["src_id"] == "BRA.16_1"
+    stored = await _reload(dashboard)
+    assert [w.widget_type for w in stored.widgets] == [
+        "insight",
+        "map",
+        "map",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Refreshing
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_refresh_moves_every_widget_to_the_new_window():
+    dashboard = await _dashboard("tpl-refresh")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        built = await _build(dashboard, user_id="tpl-refresh")
+        stored = await _reload(dashboard)
+        (section,) = stored.sections
+        old_insight = sorted(stored.widgets, key=lambda w: w.position)[
+            0
+        ].insight_id
+
+        refreshed = await TEMPLATE.refresh(
+            section,
+            stored,
+            user_id="tpl-refresh",
+            params=NrtParams(days=90),
+            language="en",
+        )
+
+    # The section survives: same id, same place, so a link to it holds.
+    assert refreshed.section_id == built.section_id
+
+    stored = await _reload(dashboard)
+    (section,) = stored.sections
+    assert section.config["days"] == 90
+    assert (
+        section.config["start_date"]
+        == (date.today() - timedelta(days=90)).isoformat()
+    )
+
+    # Every widget moved together — the alerts layer covers the new window.
+    widgets = sorted(stored.widgets, key=lambda w: w.position)
+    assert [w.widget_type for w in widgets] == ["insight", "map", "map"]
+    alerts = widgets[1].config["dataset"]
+    assert alerts["start_date"] == section.config["start_date"]
+    assert f"start_date={section.config['start_date']}" in alerts["tile_url"]
+
+    # The chart was recomputed, not reused, and the old one is gone: it was
+    # this section's own content, for a period it no longer covers.
+    assert widgets[0].insight_id != old_insight
+    async with async_session_maker() as session:
+        from src.api.data_models import InsightOrm
+
+        assert await session.get(InsightOrm, old_insight) is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_rewrites_the_words_because_they_state_the_period():
+    dashboard = await _dashboard("tpl-refresh-words")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        await _build(dashboard, user_id="tpl-refresh-words")
+        stored = await _reload(dashboard)
+        (section,) = stored.sections
+
+        moved = SectionSummary(
+            title="Alerts in Paraná, last 30 days",
+            description="14.0 ha of alerts.",
+        )
+        with patch(
+            "src.api.services.analysis_templates.nrt_monitoring.recipe."
+            "generate_section_summary",
+            AsyncMock(return_value=moved),
+        ):
+            await TEMPLATE.refresh(
+                section,
+                stored,
+                user_id="tpl-refresh-words",
+                params=NrtParams(days=30),
+                language="en",
+            )
+
+    (section,) = (await _reload(dashboard)).sections
+    assert section.title == moved.title
+    assert section.description == moved.description

--- a/tests/api/test_analysis_templates.py
+++ b/tests/api/test_analysis_templates.py
@@ -26,6 +26,7 @@ from src.api.services.analysis_templates import registry
 from src.api.services.analysis_templates.base import (
     AlreadyBuiltError,
     DataUnavailableError,
+    stored_params,
 )
 from src.api.services.analysis_templates.nrt_monitoring import (
     NAME,
@@ -178,8 +179,10 @@ async def test_builds_a_sealed_section_with_three_widgets():
     assert section.type in dashboard_writer.SEALED_SECTION_TYPES
     assert section.title == SUMMARY.title
     assert section.description == SUMMARY.description
-    # The section records which template owns it, so a refresh knows.
+    # The section records which template owns it, so a rebuild knows what
+    # to re-run, and the parameters it ran with, so a refresh needs none.
     assert section.config["template"] == NAME
+    assert section.config["params"] == {"days": 14}
 
     widgets = sorted(stored.widgets, key=lambda w: w.position)
     assert [w.widget_type for w in widgets] == ["insight", "map", "map"]
@@ -360,6 +363,51 @@ async def test_refresh_moves_every_widget_to_the_new_window():
         from src.api.data_models import InsightOrm
 
         assert await session.get(InsightOrm, old_insight) is None
+
+
+@pytest.mark.asyncio
+async def test_a_section_can_be_re_run_from_what_it_recorded():
+    """The round trip a refresh depends on: the parameters a section stored
+    rebuild it without the caller naming any."""
+    dashboard = await _dashboard("tpl-round-trip")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        await _build(dashboard, user_id="tpl-round-trip", days=30)
+        stored = await _reload(dashboard)
+        (section,) = stored.sections
+
+        await TEMPLATE.refresh(
+            section,
+            stored,
+            user_id="tpl-round-trip",
+            params=stored_params(TEMPLATE, section),
+            language="en",
+        )
+
+    (section,) = (await _reload(dashboard)).sections
+    assert section.config["params"] == {"days": 30}
+    assert (
+        section.config["start_date"]
+        == (date.today() - timedelta(days=30)).isoformat()
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_template_describes_its_own_section():
+    """A caller is told what the section covers without reading its config
+    or a widget's tile layer."""
+    dashboard = await _dashboard("tpl-describe")
+
+    pull, imagery, summary = _patches()
+    with pull, imagery, summary:
+        await _build(dashboard, user_id="tpl-describe", days=30)
+
+    (section,) = (await _reload(dashboard)).sections
+    assert TEMPLATE.describe(section) == (
+        f"{(date.today() - timedelta(days=30)).isoformat()} to "
+        f"{date.today().isoformat()}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_dashboards.py
+++ b/tests/api/test_dashboards.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 
 from src.api.data_models import InsightOrm, UserOrm
+from src.api.repositories import dashboard_writer
 from src.shared.config import SharedSettings
 from tests.conftest import async_session_maker
 
@@ -1112,3 +1113,379 @@ async def test_delete_section_keeps_widgets_by_default(
     (widget,) = body["widgets"]
     assert widget["config"] == {"text": "note"}
     assert widget["section_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Section types and the seal
+# ---------------------------------------------------------------------------
+async def _create_sealed_section(dashboard_id, *, insight_id=None) -> str:
+    """Write an ``nrt-monitoring`` section the way a template does.
+
+    Straight through the repository, because the REST path deliberately
+    cannot create one: an analysis template writes its section and its
+    contents in the same transaction.
+    """
+    written = await dashboard_writer.add_section_with_widgets(
+        dashboard_id,
+        title="Recent disturbance",
+        description="120 ha of alerts.",
+        type="nrt-monitoring",
+        widgets=[
+            {"widget_type": "text", "config": {"text": "sealed note"}},
+            *(
+                [{"widget_type": "insight", "insight_id": str(insight_id)}]
+                if insight_id
+                else []
+            ),
+        ],
+    )
+    assert written is not None
+    return written
+
+
+@pytest.mark.asyncio
+async def test_section_type_defaults_to_default(client, auth_override):
+    user = await _create_user("section-type-default")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    section = await _create_section(client, dashboard["id"])
+
+    assert section["type"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_sealed_section_type_cannot_be_created_directly(
+    client, auth_override
+):
+    """The create path must not hand out a section it can never fill.
+
+    A template's type is sealed the moment the row exists, so a section
+    created this way could never be titled, filled or edited — only
+    deleted. Templated sections are written by their own template, content
+    and all, in one transaction.
+    """
+    user = await _create_user("section-type-sealed")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/sections",
+        headers=AUTH,
+        json={"title": "Alerts", "type": "nrt-monitoring"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_unknown_section_type_rejected(client, auth_override):
+    user = await _create_user("section-type-unknown")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/sections",
+        headers=AUTH,
+        json={"title": "Alerts", "type": "not-a-type"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sealed_section_rejects_retitle_and_restate(
+    client, auth_override
+):
+    user = await _create_user("sealed-retitle")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    section_id, _ = await _create_sealed_section(dashboard["id"])
+
+    for body in ({"title": "Renamed"}, {"description": "Rewritten"}):
+        response = await client.patch(
+            f"/api/dashboards/{dashboard['id']}/sections/{section_id}",
+            headers=AUTH,
+            json=body,
+        )
+        assert response.status_code == 409
+        assert "read-only" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_sealed_section_accepts_reordering(client, auth_override):
+    """Position orders the dashboard; it does not change the section."""
+    user = await _create_user("sealed-reorder")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    section_id, _ = await _create_sealed_section(dashboard["id"])
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/sections/{section_id}",
+        headers=AUTH,
+        json={"position": 5},
+    )
+    assert response.status_code == 200
+    (section,) = response.json()["sections"]
+    assert section["position"] == 5
+    assert section["type"] == "nrt-monitoring"
+
+
+@pytest.mark.asyncio
+async def test_sealed_section_rejects_new_widgets(client, auth_override):
+    user = await _create_user("sealed-add-widget")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    section_id, _ = await _create_sealed_section(dashboard["id"])
+
+    response = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={
+            "widget_type": "text",
+            "config": {"text": "intruder"},
+            "section_id": section_id,
+        },
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_widget_cannot_leave_a_sealed_section(client, auth_override):
+    user = await _create_user("sealed-move-out")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    _, widget_ids = await _create_sealed_section(dashboard["id"])
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_ids[0]}",
+        headers=AUTH,
+        json={"section_id": None},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_widget_cannot_move_into_a_sealed_section(client, auth_override):
+    user = await _create_user("sealed-move-in")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    section_id, _ = await _create_sealed_section(dashboard["id"])
+    loose = await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "text", "config": {"text": "outsider"}},
+    )
+    widget_id = loose.json()["widgets"][-1]["id"]
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_id}",
+        headers=AUTH,
+        json={"section_id": section_id},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_sealed_widget_config_cannot_be_replaced(client, auth_override):
+    user = await _create_user("sealed-config")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    _, widget_ids = await _create_sealed_section(dashboard["id"])
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_ids[0]}",
+        headers=AUTH,
+        json={"config": {"text": "rewritten"}},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_sealed_widget_cannot_be_deleted_alone(client, auth_override):
+    user = await _create_user("sealed-delete-widget")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    _, widget_ids = await _create_sealed_section(dashboard["id"])
+
+    response = await client.delete(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_ids[0]}",
+        headers=AUTH,
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["", "?delete_widgets=false"])
+async def test_deleting_a_sealed_section_always_takes_its_widgets(
+    client, auth_override, query
+):
+    """Ungrouping would leave loose, editable copies of sealed content."""
+    user = await _create_user(f"sealed-delete-{len(query)}")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    section_id, _ = await _create_sealed_section(dashboard["id"])
+
+    response = await client.delete(
+        f"/api/dashboards/{dashboard['id']}/sections/{section_id}{query}",
+        headers=AUTH,
+    )
+    assert response.status_code == 204
+
+    body = (
+        await client.get(f"/api/dashboards/{dashboard['id']}", headers=AUTH)
+    ).json()
+    assert body["sections"] == []
+    assert body["widgets"] == []
+
+
+@pytest.mark.asyncio
+async def test_insight_in_a_sealed_section_reports_as_sealed(
+    client, auth_override
+):
+    """The insight behind a sealed widget is that section's content.
+
+    ``update_insight_display`` asks this before restyling, because rewriting
+    the insight would change what the section shows without touching a
+    single dashboard row.
+    """
+    user = await _create_user("sealed-insight")
+    auth_override(user.id)
+    insight = await _create_insight(user_id=user.id)
+    loose_insight = await _create_insight(user_id=user.id)
+    dashboard = await _create_dashboard(client)
+    await _create_sealed_section(dashboard["id"], insight_id=insight.id)
+    await client.post(
+        f"/api/dashboards/{dashboard['id']}/widgets",
+        headers=AUTH,
+        json={"widget_type": "insight", "insight_id": str(loose_insight.id)},
+    )
+
+    assert await dashboard_writer.insight_is_sealed(insight.id) is True
+    # An insight on the same dashboard but outside the section stays editable.
+    assert await dashboard_writer.insight_is_sealed(loose_insight.id) is False
+    assert await dashboard_writer.insight_is_sealed(uuid.uuid4()) is False
+
+
+# ---------------------------------------------------------------------------
+# Layout edits inside a sealed section
+# ---------------------------------------------------------------------------
+#
+# `config.size` ("single" | "double") is the frontend's own wide-vs-not
+# setting, and `config.sizes` its per-chart map. They are layout, so a sealed
+# section takes them; everything else in a config is content and does not.
+async def _sealed_map_widget(client, dashboard_id) -> tuple[str, str, dict]:
+    """A sealed section holding one map widget; returns ids plus its config."""
+    section_id, widget_ids = await dashboard_writer.add_section_with_widgets(
+        dashboard_id,
+        title="Recent disturbance",
+        type="nrt-monitoring",
+        widgets=[
+            {
+                "widget_type": "map",
+                "config": {
+                    "default_view": "map",
+                    "size": "single",
+                    "dataset": {
+                        "dataset_id": 11,
+                        "tile_url": "https://tiles.example/{z}/{x}/{y}.png",
+                        "start_date": "2026-06-04",
+                        "end_date": "2026-09-02",
+                    },
+                },
+            }
+        ],
+    )
+    body = (
+        await client.get(f"/api/dashboards/{dashboard_id}", headers=AUTH)
+    ).json()
+    (widget,) = body["widgets"]
+    return section_id, widget_ids[0], widget["config"]
+
+
+@pytest.mark.asyncio
+async def test_sealed_widget_can_be_resized(client, auth_override):
+    user = await _create_user("sealed-resize")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    _, widget_id, config = await _sealed_map_widget(client, dashboard["id"])
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_id}",
+        headers=AUTH,
+        json={"config": {**config, "size": "double"}},
+    )
+
+    assert response.status_code == 200
+    (widget,) = response.json()["widgets"]
+    assert widget["config"]["size"] == "double"
+    # The layer it shows is untouched.
+    assert widget["config"]["dataset"]["dataset_id"] == 11
+
+
+@pytest.mark.asyncio
+async def test_sealed_widget_can_be_repositioned(client, auth_override):
+    user = await _create_user("sealed-reposition")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    _, widget_id, _ = await _sealed_map_widget(client, dashboard["id"])
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_id}",
+        headers=AUTH,
+        json={"position": 3},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["widgets"][0]["position"] == 3
+
+
+@pytest.mark.asyncio
+async def test_sealed_widget_resize_cannot_carry_a_content_change(
+    client, auth_override
+):
+    """The whole reason the check is a diff: "resize" and "resize and swap
+    the tile_url" arrive as the same shape of request."""
+    user = await _create_user("sealed-resize-smuggle")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    _, widget_id, config = await _sealed_map_widget(client, dashboard["id"])
+
+    smuggled = {
+        **config,
+        "size": "double",
+        "dataset": {**config["dataset"], "tile_url": "https://evil/{z}.png"},
+    }
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_id}",
+        headers=AUTH,
+        json={"config": smuggled},
+    )
+
+    assert response.status_code == 409
+    body = (
+        await client.get(f"/api/dashboards/{dashboard['id']}", headers=AUTH)
+    ).json()
+    (widget,) = body["widgets"]
+    assert (
+        widget["config"]["dataset"]["tile_url"]
+        == config["dataset"]["tile_url"]
+    )
+    assert widget["config"]["size"] == "single"
+
+
+@pytest.mark.asyncio
+async def test_sealed_widget_title_change_is_still_refused(
+    client, auth_override
+):
+    """A title is words, not layout."""
+    user = await _create_user("sealed-retitle-widget")
+    auth_override(user.id)
+    dashboard = await _create_dashboard(client)
+    _, widget_id, config = await _sealed_map_widget(client, dashboard["id"])
+
+    response = await client.patch(
+        f"/api/dashboards/{dashboard['id']}/widgets/{widget_id}",
+        headers=AUTH,
+        json={"config": {**config, "title": "My own heading"}},
+    )
+
+    assert response.status_code == 409

--- a/tests/unit/agent/test_dataset_layers.py
+++ b/tests/unit/agent/test_dataset_layers.py
@@ -1,0 +1,86 @@
+"""Tests for resolving a catalog dataset into a renderable map layer.
+
+The point of these is parity: the rules moved out of the dataset-selection
+subagent so the analysis templates could use them, and a tile URL that
+changes shape silently breaks every map widget written after it.
+"""
+
+import pytest
+
+from src.agent.datasets.handlers.analytics_handler import (
+    GRASSLANDS_ID,
+    INTEGRATED_ALERTS_ID,
+    LAND_COVER_CHANGE_ID,
+    TREE_COVER_ID,
+    TREE_COVER_LOSS_ID,
+)
+from src.agent.datasets.layers import (
+    DEFAULT_CANOPY_COVER,
+    resolve_dataset_layer,
+)
+from src.shared.config import SharedSettings
+
+
+def test_integrated_alerts_carries_the_date_range():
+    layer = resolve_dataset_layer(
+        INTEGRATED_ALERTS_ID, "2026-06-04", "2026-09-02"
+    )
+
+    assert layer.dataset_id == INTEGRATED_ALERTS_ID
+    assert layer.dataset_name == "Integrated alerts"
+    assert "start_date=2026-06-04" in layer.tile_url
+    assert "end_date=2026-09-02" in layer.tile_url
+    assert layer.start_date == "2026-06-04"
+    assert layer.end_date == "2026-09-02"
+    # No context layers or parameters exist for this dataset.
+    assert layer.context_layers == []
+    assert layer.parameters is None
+
+
+def test_tree_cover_loss_bakes_in_threshold_and_years():
+    layer = resolve_dataset_layer(
+        TREE_COVER_LOSS_ID,
+        "2020-01-01",
+        "2024-12-31",
+        parameters=[{"name": "canopy_cover", "values": [50]}],
+    )
+
+    assert "tree_cover_density_threshold=50" in layer.tile_url
+    assert "start_year=2020&end_year=2024" in layer.tile_url
+    # The threshold also comes back as a companion layer to draw.
+    assert [entry["name"] for entry in layer.context_layers] == [
+        "canopy_cover"
+    ]
+    assert "tcd_50" in layer.context_layers[0]["tile_url"]
+
+
+def test_tree_cover_loss_falls_back_to_published_years():
+    """A period outside the published tiles gets the full range, not a URL
+    pointing at tiles that do not exist."""
+    layer = resolve_dataset_layer(
+        TREE_COVER_LOSS_ID, "2030-01-01", "2030-12-31"
+    )
+
+    assert "start_year=2001&end_year=2025" in layer.tile_url
+
+
+def test_default_threshold_applies_when_no_parameter_is_given():
+    layer = resolve_dataset_layer(TREE_COVER_ID, "2000-01-01", "2000-12-31")
+
+    assert f"tcd_{DEFAULT_CANOPY_COVER}" in layer.tile_url
+    # Tree cover *is* the threshold layer, so it gets no companion copy.
+    assert layer.context_layers == []
+
+
+@pytest.mark.parametrize("dataset_id", [LAND_COVER_CHANGE_ID, GRASSLANDS_ID])
+def test_annual_rasters_resolve_the_year_and_the_eoapi_host(dataset_id):
+    layer = resolve_dataset_layer(dataset_id, "2015-01-01", "2020-12-31")
+
+    assert layer.tile_url.startswith(SharedSettings.eoapi_base_url)
+    assert "2020" in layer.tile_url
+    assert "{year}" not in layer.tile_url
+
+
+def test_unknown_dataset_is_an_error():
+    with pytest.raises(ValueError, match="Dataset not found"):
+        resolve_dataset_layer(999999, "2026-01-01", "2026-01-31")

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -346,6 +346,8 @@ def test_experimental_profile_derives_exactly_the_experimental_tools():
             "add_text_widget",
             "edit_text_widget",
             "add_dashboard_section",
+            "add_analysis_section",
+            "update_analysis_section",
             "edit_dashboard_section",
             "move_dashboard_widget",
             "send_nudge",
@@ -377,7 +379,8 @@ async def test_fetch_zeno_binds_the_resolved_configs_availability():
 
 def test_experimental_config_adds_standalone_tools_and_planet():
     """dashboard and explore graduated into the default set; experimental now
-    layers standalone tools plus the opt-in Planet imagery recipe."""
+    layers standalone tools plus the opt-in skills (Planet imagery, the
+    analysis templates)."""
     default = default_registry.resolve(DEFAULT_PROFILE)
     experimental = default_registry.resolve(EXPERIMENTAL_PROFILE)
 
@@ -391,14 +394,21 @@ def test_experimental_config_adds_standalone_tools_and_planet():
         # sections and widget ids before grouping or moving anything.
         "inspect_view_context",
     } <= default_tools
-    assert {"update_insight_display"} <= (experimental_tools - default_tools)
+    assert {
+        "update_insight_display",
+        "add_analysis_section",
+        "update_analysis_section",
+    } <= (experimental_tools - default_tools)
 
     default_skills = {s.name for s in default.skill_metas()}
     experimental_skills = {s.name for s in experimental.skill_metas()}
     assert {"show-imagery", "explore", "wri-insights", "dashboard"} <= (
         default_skills
     )
-    assert experimental_skills - default_skills == {"show-imagery-planet"}
+    assert experimental_skills - default_skills == {
+        "show-imagery-planet",
+        "analysis-templates",
+    }
 
 
 # --- excluded_datasets enforcement in pick_dataset ---------------------------

--- a/tests/unit/agent/test_feature_flag.py
+++ b/tests/unit/agent/test_feature_flag.py
@@ -347,7 +347,8 @@ def test_experimental_profile_derives_exactly_the_experimental_tools():
             "edit_text_widget",
             "add_dashboard_section",
             "add_analysis_section",
-            "update_analysis_section",
+            "refresh_analysis_section",
+            "reconfigure_analysis_section",
             "edit_dashboard_section",
             "move_dashboard_widget",
             "send_nudge",
@@ -397,7 +398,8 @@ def test_experimental_config_adds_standalone_tools_and_planet():
     assert {
         "update_insight_display",
         "add_analysis_section",
-        "update_analysis_section",
+        "refresh_analysis_section",
+        "reconfigure_analysis_section",
     } <= (experimental_tools - default_tools)
 
     default_skills = {s.name for s in default.skill_metas()}

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -64,7 +64,7 @@ tools:
 EXPERIMENTAL_MANIFEST = """\
 profile: experimental
 skills:
-  - analysis-templates (requires: add_analysis_section, update_analysis_section, send_nudge, create_dashboard, pick_aoi, inspect_view_context)
+  - analysis-templates (requires: add_analysis_section, refresh_analysis_section, reconfigure_analysis_section, send_nudge, create_dashboard, pick_aoi, inspect_view_context)
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
   - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, add_dashboard_section, edit_dashboard_section, move_dashboard_widget, inspect_view_context, send_nudge, search_insights)
@@ -93,7 +93,8 @@ tools:
   - edit_text_widget
   - add_dashboard_section
   - add_analysis_section
-  - update_analysis_section
+  - refresh_analysis_section
+  - reconfigure_analysis_section
   - edit_dashboard_section
   - move_dashboard_widget
   - send_nudge"""

--- a/tests/unit/agent/test_profile_manifest.py
+++ b/tests/unit/agent/test_profile_manifest.py
@@ -64,6 +64,7 @@ tools:
 EXPERIMENTAL_MANIFEST = """\
 profile: experimental
 skills:
+  - analysis-templates (requires: add_analysis_section, update_analysis_section, send_nudge, create_dashboard, pick_aoi, inspect_view_context)
   - analyze (requires: pick_aoi, pick_dataset, pull_data, generate_insights)
   - capabilities
   - dashboard (requires: create_dashboard, add_to_dashboard, add_map_widget, add_text_widget, edit_text_widget, add_dashboard_section, edit_dashboard_section, move_dashboard_widget, inspect_view_context, send_nudge, search_insights)
@@ -91,6 +92,8 @@ tools:
   - add_text_widget
   - edit_text_widget
   - add_dashboard_section
+  - add_analysis_section
+  - update_analysis_section
   - edit_dashboard_section
   - move_dashboard_widget
   - send_nudge"""

--- a/tests/unit/agent/tools/skills/test_skills.py
+++ b/tests/unit/agent/tools/skills/test_skills.py
@@ -38,9 +38,10 @@ def test_load_skills():
     assert "ui-selections" not in names
 
 
-def test_skills_registry_is_the_eight_recipes():
+def test_skills_registry_is_the_nine_skills():
     assert {s.name for s in all_skills()} == {
         "analyze",
+        "analysis-templates",
         "capabilities",
         "dashboard",
         "explore",

--- a/tests/unit/agent/tools/test_analysis_section_tools.py
+++ b/tests/unit/agent/tools/test_analysis_section_tools.py
@@ -1,11 +1,19 @@
 """The generic agent tools over the analysis templates.
 
-Two things matter here and neither belongs to any one template. First,
-dispatch: the tools look a template up in the registry, hand it its own
+Three things matter here and none belongs to any one template.
+
+**Dispatch.** The tools look a template up in the registry, hand it its own
 validated parameters and report what it returned, so a new template needs no
-change in this layer. Second, the nudge before a window change is a rule and
-not an instruction — moving a section to a new window replaces every figure
-the user is looking at, and the previous ones are deleted, so a prompt
+change in this layer. Nothing here names a parameter: `params` is a dict the
+template's own model validates, which is what lets a template that is not
+driven by a date range use the same tools.
+
+**The two rebuild verbs are different asks.** `refresh` re-runs a section
+with the parameters it already has — the same question, asked again now —
+and takes none. `reconfigure` asks a different question, and the previous
+answer is deleted.
+
+**The nudge before a reconfigure is a rule, not an instruction.** A prompt
 asking the model to check first is a hope where a refusal is a guarantee.
 """
 
@@ -17,7 +25,8 @@ import pytest
 
 from src.agent.tools.analysis_sections import (
     add_analysis_section,
-    update_analysis_section,
+    reconfigure_analysis_section,
+    refresh_analysis_section,
 )
 from src.api.services.analysis_templates.base import (
     AlreadyBuiltError,
@@ -35,7 +44,12 @@ def _section(title="Recent disturbance", type=TEMPLATE, **config):
         title=title,
         type=type,
         config=config
-        or {"days": 14, "start_date": "2026-08-20", "end_date": "2026-09-03"},
+        or {
+            "template": TEMPLATE,
+            "params": {"days": 14},
+            "start_date": "2026-08-20",
+            "end_date": "2026-09-03",
+        },
     )
 
 
@@ -85,6 +99,9 @@ def _fake_template(**methods):
         params_model=NrtParams,
         build=methods.get("build", AsyncMock(return_value=_result())),
         refresh=methods.get("refresh", AsyncMock(return_value=_result())),
+        describe=methods.get(
+            "describe", lambda section: "2026-08-20 to 2026-09-03"
+        ),
     )
 
 
@@ -111,8 +128,7 @@ async def _add(dashboard, template=None, **kwargs):
     return command, recipe
 
 
-async def _update(dashboard, template=None, **kwargs):
-    kwargs.setdefault("days", 90)
+async def _rebuild(tool, dashboard, template=None, **kwargs):
     kwargs.setdefault("state", {"dashboard_id": str(dashboard.id)})
     recipe = template if template is not None else _fake_template()
     with (
@@ -126,10 +142,21 @@ async def _update(dashboard, template=None, **kwargs):
         ),
         bound_user_id("user-1"),
     ):
-        command = await update_analysis_section.coroutine(
-            **kwargs, tool_call_id="call-1"
-        )
+        command = await tool.coroutine(**kwargs, tool_call_id="call-1")
     return command, recipe
+
+
+async def _refresh(dashboard, template=None, **kwargs):
+    return await _rebuild(
+        refresh_analysis_section, dashboard, template, **kwargs
+    )
+
+
+async def _reconfigure(dashboard, template=None, **kwargs):
+    kwargs.setdefault("params", {"days": 90})
+    return await _rebuild(
+        reconfigure_analysis_section, dashboard, template, **kwargs
+    )
 
 
 # --- add: dispatch ----------------------------------------------------------
@@ -139,7 +166,7 @@ async def _update(dashboard, template=None, **kwargs):
 async def test_build_dispatches_to_the_named_template():
     dashboard = _dashboard()
 
-    command, recipe = await _add(dashboard, days=30)
+    command, recipe = await _add(dashboard, params={"days": 30})
 
     recipe.build.assert_awaited_once()
     assert recipe.build.await_args.kwargs["params"].days == 30
@@ -182,13 +209,29 @@ async def test_unknown_template_names_the_known_ones():
 
 
 @pytest.mark.asyncio
+async def test_a_parameter_the_template_does_not_take_is_refused():
+    """`extra="forbid"` on the model: nothing here knows what a parameter
+    means, so the template's own refusal is what the model sees."""
+    dashboard = _dashboard()
+
+    command, recipe = await _add(dashboard, params={"threshold": 30})
+
+    recipe.build.assert_not_called()
+    assert "does not fit" in _content(command)
+
+
+@pytest.mark.asyncio
 async def test_out_of_range_parameter_is_refused_before_the_build():
     dashboard = _dashboard()
 
-    command, recipe = await _add(dashboard, days=400)
+    command, recipe = await _add(dashboard, params={"days": 400})
 
     recipe.build.assert_not_called()
-    assert "do not fit" in _content(command)
+    body = _content(command)
+    assert "`days` does not fit" in body
+    # The refusal lists what the template does take, so the model retries
+    # rather than guessing again.
+    assert "max 365" in body
 
 
 @pytest.mark.asyncio
@@ -209,6 +252,7 @@ async def test_already_built_tells_the_model_not_to_build_a_second():
     body = _content(command)
     assert "already has" in body
     assert "rather than building a second one" in body
+    assert "refresh_analysis_section" in body
 
 
 @pytest.mark.asyncio
@@ -252,28 +296,78 @@ async def test_build_without_a_dashboard_says_how_to_get_one():
     assert "create_dashboard" in _content(command)
 
 
-# --- update: the confirmation rule ------------------------------------------
+# --- refresh: same question, asked again now --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_reuses_the_parameters_the_section_was_built_with():
+    """It takes none: the section records what it was built with.
+
+    Built with 30 days, not the template's default of 14, so a refresh that
+    quietly fell back to the default would fail here.
+    """
+    dashboard = _dashboard(
+        _section(
+            template=TEMPLATE,
+            params={"days": 30},
+            start_date="2026-08-04",
+            end_date="2026-09-03",
+        )
+    )
+
+    command, recipe = await _refresh(dashboard)
+
+    recipe.refresh.assert_awaited_once()
+    assert recipe.refresh.await_args.kwargs["params"].days == 30
+    assert command.update["dashboard_id"] == str(dashboard.id)
+
+
+@pytest.mark.asyncio
+async def test_refresh_needs_no_confirmation():
+    """The user asked for exactly this, and what the section covers does
+    not change — so there is nothing to agree to."""
+    dashboard = _dashboard(_section())
+
+    _, recipe = await _refresh(dashboard)
+
+    recipe.refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_of_a_section_with_no_recorded_parameters():
+    """A section written before a parameter existed falls back to the
+    template's default rather than failing."""
+    dashboard = _dashboard(_section(template=TEMPLATE))
+
+    _, recipe = await _refresh(dashboard)
+
+    assert recipe.refresh.await_args.kwargs["params"].days == 14
+
+
+# --- reconfigure: a different question, so it is confirmed ------------------
 
 
 @pytest.mark.asyncio
 async def test_unconfirmed_change_does_nothing_and_asks():
     dashboard = _dashboard(_section())
 
-    command, recipe = await _update(dashboard)
+    command, recipe = await _reconfigure(dashboard)
 
     recipe.refresh.assert_not_called()
     body = _content(command)
     assert "send_nudge" in body
-    assert "time_range_choice" in body
-    # It states what is on screen now, so the model can offer real options.
-    assert "2026-08-20" in body and "2026-09-03" in body
+    # It states what is on screen now, in the template's own words, so the
+    # model can offer real options.
+    assert "2026-08-20 to 2026-09-03" in body
+    # And what the change costs, which the template's registry entry says.
+    assert "previous ones are deleted" in body
 
 
 @pytest.mark.asyncio
 async def test_confirmed_change_applies():
     dashboard = _dashboard(_section())
 
-    command, recipe = await _update(dashboard, confirmed=True)
+    command, recipe = await _reconfigure(dashboard, confirmed=True)
 
     recipe.refresh.assert_awaited_once()
     assert recipe.refresh.await_args.kwargs["params"].days == 90
@@ -282,13 +376,18 @@ async def test_confirmed_change_applies():
 
 
 @pytest.mark.asyncio
-async def test_out_of_range_window_refused_before_anything_else():
+async def test_out_of_range_parameter_refused_before_anything_else():
     dashboard = _dashboard(_section())
 
-    command, recipe = await _update(dashboard, days=400, confirmed=True)
+    command, recipe = await _reconfigure(
+        dashboard, params={"days": 400}, confirmed=True
+    )
 
     recipe.refresh.assert_not_called()
-    assert "do not fit" in _content(command)
+    assert "does not fit" in _content(command)
+
+
+# --- both rebuild verbs share how they find a section -----------------------
 
 
 @pytest.mark.asyncio
@@ -297,7 +396,7 @@ async def test_two_templated_sections_must_be_named():
         _section(title="Alerts, August"), _section(title="Alerts, July")
     )
 
-    command, recipe = await _update(dashboard, confirmed=True)
+    command, recipe = await _reconfigure(dashboard, confirmed=True)
 
     recipe.refresh.assert_not_called()
     body = _content(command)
@@ -307,14 +406,12 @@ async def test_two_templated_sections_must_be_named():
 
 @pytest.mark.asyncio
 async def test_a_named_section_is_dispatched_on_its_own_type():
-    """The refresh runs whichever template built the section, not a
+    """The rebuild runs whichever template built the section, not a
     caller-named one."""
     august = _section(title="Alerts, August")
     dashboard = _dashboard(august, _section(title="Alerts, July"))
 
-    command, recipe = await _update(
-        dashboard, section="Alerts, August", confirmed=True
-    )
+    command, recipe = await _refresh(dashboard, section="Alerts, August")
 
     recipe.refresh.assert_awaited_once()
     assert recipe.refresh.await_args.args[0] is august
@@ -324,7 +421,7 @@ async def test_a_named_section_is_dispatched_on_its_own_type():
 async def test_dashboard_without_a_templated_section():
     dashboard = _dashboard(_section(type="default"))
 
-    command, recipe = await _update(dashboard, confirmed=True)
+    command, recipe = await _refresh(dashboard)
 
     recipe.refresh.assert_not_called()
     assert "add_analysis_section" in _content(command)

--- a/tests/unit/agent/tools/test_analysis_section_tools.py
+++ b/tests/unit/agent/tools/test_analysis_section_tools.py
@@ -1,0 +1,330 @@
+"""The generic agent tools over the analysis templates.
+
+Two things matter here and neither belongs to any one template. First,
+dispatch: the tools look a template up in the registry, hand it its own
+validated parameters and report what it returned, so a new template needs no
+change in this layer. Second, the nudge before a window change is a rule and
+not an instruction — moving a section to a new window replaces every figure
+the user is looking at, and the previous ones are deleted, so a prompt
+asking the model to check first is a hope where a refusal is a guarantee.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.agent.tools.analysis_sections import (
+    add_analysis_section,
+    update_analysis_section,
+)
+from src.api.services.analysis_templates.base import (
+    AlreadyBuiltError,
+    DataUnavailableError,
+    TemplateResult,
+)
+from src.shared.request_context import bound_user_id
+
+TEMPLATE = "nrt-monitoring"
+
+
+def _section(title="Recent disturbance", type=TEMPLATE, **config):
+    return SimpleNamespace(
+        id=uuid4(),
+        title=title,
+        type=type,
+        config=config
+        or {"days": 14, "start_date": "2026-08-20", "end_date": "2026-09-03"},
+    )
+
+
+def _dashboard(*sections, aois=True):
+    return SimpleNamespace(
+        id=uuid4(),
+        name="Genève",
+        sections=list(sections),
+        aois=[
+            SimpleNamespace(
+                source="gadm",
+                src_id="CHE.8_1",
+                subtype="state-province",
+                name="Genève",
+            )
+        ]
+        if aois
+        else [],
+    )
+
+
+def _result(**kwargs):
+    return TemplateResult(
+        **{
+            "template": TEMPLATE,
+            "section_id": "sec-1",
+            "widget_ids": ["w1", "w2", "w3"],
+            "summary": "a monitoring section covering 2026-06-05 to 2026-09-03",
+            "warnings": [],
+            **kwargs,
+        }
+    )
+
+
+def _content(command):
+    (message,) = command.update["messages"]
+    return message.content
+
+
+def _fake_template(**methods):
+    """A stand-in template with the real one's parameter model."""
+    from src.api.services.analysis_templates.nrt_monitoring import NrtParams
+    from src.api.services.analysis_templates.registry import ENTRIES_BY_NAME
+
+    return SimpleNamespace(
+        entry=ENTRIES_BY_NAME[TEMPLATE],
+        params_model=NrtParams,
+        build=methods.get("build", AsyncMock(return_value=_result())),
+        refresh=methods.get("refresh", AsyncMock(return_value=_result())),
+    )
+
+
+async def _add(dashboard, template=None, **kwargs):
+    kwargs.setdefault("template", TEMPLATE)
+    kwargs.setdefault("state", {"dashboard_id": str(dashboard.id)})
+    recipe = template if template is not None else _fake_template()
+    with (
+        patch(
+            "src.agent.tools.analysis_sections.load_editable_dashboard",
+            AsyncMock(return_value=dashboard),
+        ),
+        patch(
+            "src.agent.tools.analysis_sections.registry.get_template",
+            return_value=recipe,
+        ),
+        bound_user_id("user-1"),
+    ):
+        # .coroutine bypasses the injected-argument plumbing, as the other
+        # dashboard tool tests do.
+        command = await add_analysis_section.coroutine(
+            **kwargs, tool_call_id="call-1"
+        )
+    return command, recipe
+
+
+async def _update(dashboard, template=None, **kwargs):
+    kwargs.setdefault("days", 90)
+    kwargs.setdefault("state", {"dashboard_id": str(dashboard.id)})
+    recipe = template if template is not None else _fake_template()
+    with (
+        patch(
+            "src.agent.tools.analysis_sections.load_editable_dashboard",
+            AsyncMock(return_value=dashboard),
+        ),
+        patch(
+            "src.agent.tools.analysis_sections.registry.get_template",
+            return_value=recipe,
+        ),
+        bound_user_id("user-1"),
+    ):
+        command = await update_analysis_section.coroutine(
+            **kwargs, tool_call_id="call-1"
+        )
+    return command, recipe
+
+
+# --- add: dispatch ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_dispatches_to_the_named_template():
+    dashboard = _dashboard()
+
+    command, recipe = await _add(dashboard, days=30)
+
+    recipe.build.assert_awaited_once()
+    assert recipe.build.await_args.kwargs["params"].days == 30
+    assert recipe.build.await_args.args[0] is dashboard
+    # The tool reports the template's own words, not its own.
+    assert "a monitoring section covering" in _content(command)
+    assert command.update["dashboard_id"] == str(dashboard.id)
+
+
+@pytest.mark.asyncio
+async def test_omitted_parameters_use_the_templates_own_defaults():
+    dashboard = _dashboard()
+
+    _, recipe = await _add(dashboard)
+
+    assert recipe.build.await_args.kwargs["params"].days == 14
+
+
+@pytest.mark.asyncio
+async def test_unknown_template_names_the_known_ones():
+    """The registry's own error reaches the model unchanged, so it can
+    retry with a name that exists."""
+    dashboard = _dashboard()
+    with (
+        patch(
+            "src.agent.tools.analysis_sections.load_editable_dashboard",
+            AsyncMock(return_value=dashboard),
+        ),
+        bound_user_id("user-1"),
+    ):
+        command = await add_analysis_section.coroutine(
+            template="no-such-template",
+            state={"dashboard_id": str(dashboard.id)},
+            tool_call_id="call-1",
+        )
+
+    body = _content(command)
+    assert "no-such-template" in body
+    assert TEMPLATE in body
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_parameter_is_refused_before_the_build():
+    dashboard = _dashboard()
+
+    command, recipe = await _add(dashboard, days=400)
+
+    recipe.build.assert_not_called()
+    assert "do not fit" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_already_built_tells_the_model_not_to_build_a_second():
+    dashboard = _dashboard(_section())
+    recipe = _fake_template(
+        build=AsyncMock(
+            side_effect=AlreadyBuiltError(
+                "Dashboard 'Genève' already has the monitoring section "
+                "'Recent disturbance' for 2026-08-20 to 2026-09-03.",
+                "sec-1",
+            )
+        )
+    )
+
+    command, _ = await _add(dashboard, template=recipe)
+
+    body = _content(command)
+    assert "already has" in body
+    assert "rather than building a second one" in body
+
+
+@pytest.mark.asyncio
+async def test_a_template_failure_is_reported_in_its_own_words():
+    dashboard = _dashboard()
+    recipe = _fake_template(
+        build=AsyncMock(
+            side_effect=DataUnavailableError(
+                "Could not retrieve alert data for 'Genève': upstream 503"
+            )
+        )
+    )
+
+    command, _ = await _add(dashboard, template=recipe)
+
+    assert "upstream 503" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_warnings_are_passed_on_rather_than_swallowed():
+    dashboard = _dashboard()
+    recipe = _fake_template(
+        build=AsyncMock(
+            return_value=_result(
+                widget_ids=["w1", "w2"],
+                warnings=["The area is too large for satellite imagery."],
+            )
+        )
+    )
+
+    command, _ = await _add(dashboard, template=recipe)
+
+    assert "too large for satellite imagery" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_build_without_a_dashboard_says_how_to_get_one():
+    command, recipe = await _add(_dashboard(), state={})
+
+    recipe.build.assert_not_called()
+    assert "create_dashboard" in _content(command)
+
+
+# --- update: the confirmation rule ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unconfirmed_change_does_nothing_and_asks():
+    dashboard = _dashboard(_section())
+
+    command, recipe = await _update(dashboard)
+
+    recipe.refresh.assert_not_called()
+    body = _content(command)
+    assert "send_nudge" in body
+    assert "time_range_choice" in body
+    # It states what is on screen now, so the model can offer real options.
+    assert "2026-08-20" in body and "2026-09-03" in body
+
+
+@pytest.mark.asyncio
+async def test_confirmed_change_applies():
+    dashboard = _dashboard(_section())
+
+    command, recipe = await _update(dashboard, confirmed=True)
+
+    recipe.refresh.assert_awaited_once()
+    assert recipe.refresh.await_args.kwargs["params"].days == 90
+    assert "2026-06-05" in _content(command)
+    assert command.update["dashboard_id"] == str(dashboard.id)
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_window_refused_before_anything_else():
+    dashboard = _dashboard(_section())
+
+    command, recipe = await _update(dashboard, days=400, confirmed=True)
+
+    recipe.refresh.assert_not_called()
+    assert "do not fit" in _content(command)
+
+
+@pytest.mark.asyncio
+async def test_two_templated_sections_must_be_named():
+    dashboard = _dashboard(
+        _section(title="Alerts, August"), _section(title="Alerts, July")
+    )
+
+    command, recipe = await _update(dashboard, confirmed=True)
+
+    recipe.refresh.assert_not_called()
+    body = _content(command)
+    assert "more than one curated section" in body
+    assert "Alerts, August" in body and "Alerts, July" in body
+
+
+@pytest.mark.asyncio
+async def test_a_named_section_is_dispatched_on_its_own_type():
+    """The refresh runs whichever template built the section, not a
+    caller-named one."""
+    august = _section(title="Alerts, August")
+    dashboard = _dashboard(august, _section(title="Alerts, July"))
+
+    command, recipe = await _update(
+        dashboard, section="Alerts, August", confirmed=True
+    )
+
+    recipe.refresh.assert_awaited_once()
+    assert recipe.refresh.await_args.args[0] is august
+
+
+@pytest.mark.asyncio
+async def test_dashboard_without_a_templated_section():
+    dashboard = _dashboard(_section(type="default"))
+
+    command, recipe = await _update(dashboard, confirmed=True)
+
+    recipe.refresh.assert_not_called()
+    assert "add_analysis_section" in _content(command)

--- a/tests/unit/agent/tools/test_sealed_sections.py
+++ b/tests/unit/agent/tools/test_sealed_sections.py
@@ -80,6 +80,7 @@ def test_sealed_reply_names_the_ways_forward():
     assert "read-only" in message.content
     # All three ways forward, so the model explains rather than retries.
     assert "deleting it and building a new one" in message.content
-    assert "update_analysis_section" in message.content
+    assert "refresh_analysis_section" in message.content
+    assert "reconfigure_analysis_section" in message.content
     # Layout is editable, so the reply must not claim otherwise.
     assert "resize" in message.content

--- a/tests/unit/agent/tools/test_sealed_sections.py
+++ b/tests/unit/agent/tools/test_sealed_sections.py
@@ -1,0 +1,85 @@
+"""The agent-side half of the section seal.
+
+The repository is what actually refuses a write to a sealed section; these
+cover the layer above it, whose job is to keep the model from trying: a
+sealed section is not offered as a place to put a widget, and it is marked
+as read-only wherever sections are listed.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from src.agent.tools.common import (
+    format_sections,
+    resolve_section,
+    sealed_error_command,
+)
+from src.api.repositories.dashboard_writer import SealedSectionError
+
+
+def _section(title: str, type: str = "default"):
+    return SimpleNamespace(id=uuid4(), title=title, type=type)
+
+
+def _dashboard(*sections):
+    return SimpleNamespace(id=uuid4(), name="Paraná", sections=list(sections))
+
+
+def test_ordinary_section_resolves_by_title():
+    section = _section("Deforestation")
+    dashboard = _dashboard(section)
+
+    resolved, message = resolve_section(dashboard, "deforestation")
+
+    assert resolved is section
+    assert message is None
+
+
+def test_sealed_section_is_refused_as_a_widget_target():
+    sealed = _section("Recent disturbance", type="nrt-monitoring")
+    dashboard = _dashboard(sealed)
+
+    resolved, message = resolve_section(dashboard, "Recent disturbance")
+
+    assert resolved is None
+    assert "read-only" in message
+    # The reply has to say what to do instead, or the model just retries.
+    assert "another section" in message
+
+
+def test_sealed_section_is_refused_by_id_too():
+    sealed = _section("Recent disturbance", type="nrt-monitoring")
+    dashboard = _dashboard(sealed)
+
+    resolved, message = resolve_section(dashboard, str(sealed.id))
+
+    assert resolved is None
+    assert "read-only" in message
+
+
+def test_listing_marks_sealed_sections():
+    listing = format_sections(
+        _dashboard(
+            _section("Deforestation"),
+            _section("Recent disturbance", type="nrt-monitoring"),
+        )
+    )
+
+    assert "'Deforestation'" in listing
+    assert listing.count("[read-only]") == 1
+    assert "'Recent disturbance'" in listing.split("[read-only]")[0]
+
+
+def test_sealed_reply_names_the_ways_forward():
+    command = sealed_error_command(
+        SealedSectionError("sec-1", "nrt-monitoring"), "call-1"
+    )
+
+    (message,) = command.update["messages"]
+    assert message.status == "error"
+    assert "read-only" in message.content
+    # All three ways forward, so the model explains rather than retries.
+    assert "deleting it and building a new one" in message.content
+    assert "update_analysis_section" in message.content
+    # Layout is editable, so the reply must not claim otherwise.
+    assert "resize" in message.content

--- a/tests/unit/agent/tools/test_tile_services.py
+++ b/tests/unit/agent/tools/test_tile_services.py
@@ -21,6 +21,8 @@ def test_integrated_alerts_tile_url_gets_date_params():
     )
     row = SimpleNamespace(
         dataset_id=INTEGRATED_ALERTS_ID,
+        # Every candidate row carries a name (a required catalog column).
+        dataset_name="Integrated alerts",
         tile_url=IA_TILE,
         context_layers=None,
         parameters=None,

--- a/tests/unit/api/analysis_templates/test_nrt_summary.py
+++ b/tests/unit/api/analysis_templates/test_nrt_summary.py
@@ -1,0 +1,177 @@
+"""Tests for the generated title and description of a monitoring section.
+
+The generator is the last step of a build whose data is already gathered, so
+what matters most here is that it never takes the section down with it.
+"""
+
+import pytest
+from langchain_core.runnables import RunnableLambda
+
+from src.agent.subagents.analyst.charts import InsightChart
+from src.api.services.analysis_templates.nrt_monitoring.summary import (
+    TITLE_MAX_CHARS,
+    SectionSummary,
+    _rounded,
+    fallback_summary,
+    generate_section_summary,
+)
+
+CHARTS = [
+    InsightChart(
+        position=0,
+        title="Disturbance alerts by confidence",
+        chart_type="line",
+        x_axis="alert_date",
+        y_axis="area_ha",
+        color_field="alert_confidence",
+        chart_data=[
+            {
+                "alert_date": "2026-07-14",
+                "alert_confidence": "high",
+                "area_ha": 120.5,
+            }
+        ],
+    )
+]
+
+PERIOD = {"start_date": "2026-06-04", "end_date": "2026-09-02"}
+
+
+class _FakeModel:
+    """A model whose structured output is fixed, or which raises.
+
+    The generator composes ``_PROMPT | model.with_structured_output(...)``,
+    so the stand-in has to be a real runnable — hence RunnableLambda rather
+    than a mock.
+    """
+
+    def __init__(self, result):
+        self._result = result
+        self.calls = 0
+
+    def with_structured_output(self, _schema):
+        def _invoke(_inputs):
+            self.calls += 1
+            if isinstance(self._result, Exception):
+                raise self._result
+            return self._result
+
+        return RunnableLambda(_invoke)
+
+
+@pytest.mark.asyncio
+async def test_uses_the_model_output():
+    summary = SectionSummary(
+        title="Alerts in Paraná, last 90 days",
+        description="120.5 ha of high-confidence alerts.",
+    )
+    result = await generate_section_summary(
+        CHARTS, aoi_name="Paraná", **PERIOD, model=_FakeModel(summary)
+    )
+
+    assert result.title == "Alerts in Paraná, last 90 days"
+    assert result.description == "120.5 ha of high-confidence alerts."
+
+
+@pytest.mark.asyncio
+async def test_model_failure_falls_back_instead_of_raising():
+    result = await generate_section_summary(
+        CHARTS,
+        aoi_name="Paraná",
+        **PERIOD,
+        model=_FakeModel(RuntimeError("model unavailable")),
+    )
+
+    assert result == fallback_summary("Paraná", **PERIOD)
+    assert "Paraná" in result.title
+
+
+@pytest.mark.asyncio
+async def test_blank_model_output_falls_back():
+    result = await generate_section_summary(
+        CHARTS,
+        aoi_name="Paraná",
+        **PERIOD,
+        model=_FakeModel(SectionSummary(title="  ", description="  ")),
+    )
+
+    assert result == fallback_summary("Paraná", **PERIOD)
+
+
+@pytest.mark.asyncio
+async def test_no_charts_skips_the_model_entirely():
+    model = _FakeModel(SectionSummary(title="unused", description="unused"))
+    result = await generate_section_summary(
+        [], aoi_name="Paraná", **PERIOD, model=model
+    )
+
+    assert model.calls == 0
+    assert result == fallback_summary("Paraná", **PERIOD)
+
+
+@pytest.mark.asyncio
+async def test_overlong_title_is_trimmed():
+    result = await generate_section_summary(
+        CHARTS,
+        aoi_name="Paraná",
+        **PERIOD,
+        model=_FakeModel(
+            SectionSummary(title="A" * 200, description="Some text.")
+        ),
+    )
+
+    assert len(result.title) == TITLE_MAX_CHARS
+
+
+def test_fallback_states_the_period_and_the_caveat():
+    summary = fallback_summary("Paraná", "2026-06-04", "2026-09-02")
+
+    assert "2026-06-04" in summary.description
+    assert "2026-09-02" in summary.description
+    assert "potential disturbance" in summary.description
+
+
+def test_prompt_sees_rounded_figures_but_the_chart_keeps_precision():
+    """Analytics areas arrive at full float precision, and a model told to
+    quote a figure exactly will write "153409.28893796972 ha"."""
+    chart = InsightChart(
+        position=0,
+        title="Alerts",
+        chart_type="line",
+        x_axis="alert_date",
+        y_axis="area_ha",
+        chart_data=[
+            {"alert_date": "2026-07-14", "area_ha": 153409.28893796972},
+            {"alert_date": "2026-08-02", "area_ha": 15.0812345},
+        ],
+    )
+
+    rounded = _rounded(chart)
+
+    assert [row["area_ha"] for row in rounded.chart_data] == [153409, 15.1]
+    # The stored chart is untouched: only the prompt copy is rounded.
+    assert chart.chart_data[0]["area_ha"] == 153409.28893796972
+
+
+def test_rounding_leaves_non_numeric_columns_alone():
+    chart = InsightChart(
+        position=0,
+        title="Alerts",
+        chart_type="line",
+        x_axis="alert_date",
+        y_axis="area_ha",
+        color_field="alert_confidence",
+        chart_data=[
+            {
+                "alert_date": "2026-07-14",
+                "alert_confidence": "high",
+                "area_ha": 1.234,
+            }
+        ],
+    )
+
+    (row,) = _rounded(chart).chart_data
+
+    assert row["alert_date"] == "2026-07-14"
+    assert row["alert_confidence"] == "high"
+    assert row["area_ha"] == 1.2

--- a/tests/unit/api/analysis_templates/test_registry.py
+++ b/tests/unit/api/analysis_templates/test_registry.py
@@ -7,6 +7,8 @@ contract for every registered template, so a new one is covered by them the
 day it is added.
 """
 
+from types import SimpleNamespace
+
 import pytest
 from pydantic import BaseModel
 
@@ -58,8 +60,21 @@ def test_entry_metadata_is_prompt_ready():
         assert entry.name == entry.name.lower()
         assert " " not in entry.name
         assert entry.label and entry.when_to_use and entry.params_help
+        # Shown when the agent asks the user to confirm a reconfigure.
+        assert entry.change_warning
     for name in registry.TEMPLATE_NAMES:
         assert name in registry.describe_templates()
+
+
+def test_every_template_describes_its_own_sections():
+    """Nothing generic may read a template's config: only the template knows
+    whether its parameters mean a period, a threshold or an area."""
+    for name in registry.TEMPLATE_NAMES:
+        template = registry.get_template(name)
+        described = template.describe(
+            SimpleNamespace(config={"template": name, "params": {}})
+        )
+        assert isinstance(described, str) and described
 
 
 def test_the_registry_stays_import_light():

--- a/tests/unit/api/analysis_templates/test_registry.py
+++ b/tests/unit/api/analysis_templates/test_registry.py
@@ -1,0 +1,85 @@
+"""Tests for the analysis-template registry.
+
+The registry is the extension point: every template is reachable through
+it, and two callers — the dashboard writer's seal and the agent's tool
+prompt — read it without importing a template. These tests hold that
+contract for every registered template, so a new one is covered by them the
+day it is added.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from src.api.services.analysis_templates import registry
+from src.api.services.analysis_templates.base import AnalysisTemplate
+
+
+def test_every_entry_resolves_to_a_template():
+    for name in registry.TEMPLATE_NAMES:
+        template = registry.get_template(name)
+        assert isinstance(template, AnalysisTemplate)
+        assert template.entry.name == name
+        assert issubclass(template.params_model, BaseModel)
+
+
+def test_default_params_are_usable_without_arguments():
+    """A caller that names no parameters must still get a valid build."""
+    for name in registry.TEMPLATE_NAMES:
+        template = registry.get_template(name)
+        assert isinstance(template.params_model(), BaseModel)
+
+
+def test_params_refuse_what_the_template_does_not_take():
+    """`extra="forbid"`: an unknown parameter is an error, never ignored."""
+    for name in registry.TEMPLATE_NAMES:
+        template = registry.get_template(name)
+        with pytest.raises(Exception):
+            template.params_model(not_a_real_parameter=1)
+
+
+def test_sealed_types_come_from_the_entries():
+    assert registry.SEALED_SECTION_TYPES == {
+        entry.name for entry in registry.ENTRIES if entry.sealed
+    }
+    assert registry.DEFAULT_SECTION_TYPE not in registry.SEALED_SECTION_TYPES
+
+
+def test_unknown_template_names_itself_and_the_known_ones():
+    with pytest.raises(registry.UnknownTemplateError) as error:
+        registry.get_template("no-such-template")
+    assert "no-such-template" in str(error.value)
+    for name in registry.TEMPLATE_NAMES:
+        assert name in str(error.value)
+
+
+def test_entry_metadata_is_prompt_ready():
+    """The tool prompt is built from these strings, so they must be there."""
+    for entry in registry.ENTRIES:
+        assert entry.name == entry.name.lower()
+        assert " " not in entry.name
+        assert entry.label and entry.when_to_use and entry.params_help
+    for name in registry.TEMPLATE_NAMES:
+        assert name in registry.describe_templates()
+
+
+def test_the_registry_stays_import_light():
+    """The seal list must not cost an analytics client or a model client.
+
+    ``dashboard_writer`` imports this module on every dashboard write.
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys;"
+        "import src.api.services.analysis_templates.registry as r;"
+        "assert r.SEALED_SECTION_TYPES;"
+        "loaded = set(sys.modules);"
+        "assert not [m for m in loaded if 'analysis_templates.nrt' in m], "
+        "'a template module was imported';"
+        "assert 'langchain_core' not in loaded, 'a model client was imported'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Replaces the near-real-time part of #813, rebuilt as a **system** rather than
one feature. #813 stays open as the source of the pieces this leaves out.

## What this is

An **analysis template** answers a standing question about an area — "what
has been disturbed here in the last two weeks?" — by writing a whole
dashboard section at once: a chart, the map layers that belong with it, and
a title and description written from the data.

It is not a chat workflow. Nothing is picked by a model along the way, so
the same request always produces the same section. The only model call
writes the words.

`nrt-monitoring` is the first template: a chart of integrated disturbance
alerts, a map of those alerts, and satellite imagery of the same area and
period.

**The agent is the only caller**, behind the experimental profile. No REST
endpoints in this PR — the system is built so a route can be added later
without changing a template.

## The measure of success

A second template is **one module, one registry entry, one skill section**.
No new tool, no `agent_config` change, no `dashboard_writer` change, no
migration, no router change. `docs/analysis-templates.md` is that recipe.

## The parts

| Where | What |
|---|---|
| `analysis_templates/registry.py` | the templates, as metadata only |
| `analysis_templates/base.py` | the interface, the result and error types, the shared helpers |
| `analysis_templates/writer.py` | the two transactional writes, and the `config` shape |
| `analysis_templates/nrt_monitoring/` | the first template |
| `agent/tools/analysis_sections.py` | two generic agent tools |
| `skills_md/analysis-templates.md` | the workflow the model follows |

## Decisions worth reviewing

**The registry holds metadata, not templates.** It imports nothing else, and
a test enforces that. Two callers need to know a template exists without
paying for what it does: `dashboard_writer` reads `SEALED_SECTION_TYPES` on
every dashboard write, and the agent's tool prompt lists the templates at
import time. `get_template()` imports a module on first use. A template's
`name` **is** its `dashboard_sections.type`, so there is one list of names
rather than two.

**A template takes the loaded dashboard, not an id.** It then picks its own
area and runs its own "already built" check, so the generic layer needs no
hook for either. It writes its own one-line summary, so the tools never
mention alerts, imagery or periods.

**One error family.** Everything a template raises is a `TemplateError`
whose message is written for the user. Each tool has one `except` clause; a
new template adds no error handling anywhere.

**Parameters are the template's own pydantic model**, with
`extra="forbid"`. Bounds are stated once, and a parameter a template does
not take is refused rather than ignored.

**Three generic agent tools**, not a set per template. Nothing in them names
a parameter — `params` is a dict the template's own model validates — so a
template driven by a threshold or a comparison area rather than a date range
uses them unchanged.

| The user says | Tool | What runs |
|---|---|---|
| "monitor this area" | `add_analysis_section(template, params?)` | `template.build()` |
| "refresh it", "anything new?" | `refresh_analysis_section(section?)` | `template.refresh()` with the parameters the section recorded |
| "show me 3 months instead" | `reconfigure_analysis_section(params, confirmed, section?)` | `template.refresh()` with new parameters |

A template implements one `refresh` and cannot tell the last two apart,
which is the point: re-running a section and moving it are the same
operation with different parameters. `writer` records what a section was
built with, so a refresh needs nothing from the caller
(`base.stored_params`), and `template.describe(section)` renders those
parameters for a message, because only the template knows what they mean.

Only `reconfigure` is confirmed, and it is gated by a **refusal**, not a
prompt: without `confirmed=True` the tool does nothing and tells the model
to `send_nudge` first. It answers a different question than the one on
screen and the previous answer is deleted, and a model can retry past an
instruction but not past a refusal. `refresh` asks the same question again,
so there is nothing to agree to.

## Sealed sections

A section a template wrote is read-only: its content is a record of one
build — one area, one period, the data as it was — so editing it would make
its own title and description untrue.

The rule lives in `dashboard_writer`, not the router, because the agent
tools bypass routers entirely. The router maps `SealedSectionError` to 409,
the agent tools to a reply that says what to do instead.

**Layout is exempt**: `position`, and a config replacement whose only
differing keys are `size`/`sizes`. The check is a **diff**, not a field
allowlist — PATCH replaces a config wholesale, so "resize it" and "resize it
and swap the tile_url" are the same shape of request.

Three back doors are closed with it:

- deleting a sealed section always cascades, or ungrouping would leave
  loose, editable widgets behind;
- `type` is absent from the update request and fixed to `"default"` on the
  create request, or a section would be one PATCH away from unsealed and a
  caller could create a section nothing can ever fill;
- `update_insight_display` refuses an insight a sealed widget references —
  the one path that could rewrite a section's content without touching a
  dashboard row.

The seal is ~198 lines of code over 8 files: one frozenset, two guard
functions, six call sites in the writer. A template never meets it — it
writes in one transaction and replaces in another, neither of which is
guarded.

## The refactor that carries its own weight

`resolve_dataset_layer()` (`src/agent/datasets/layers.py`) lifts the
tile-URL rules out of the dataset-selection subagent, where they needed an
LLM selection object and a pandas row. A dataset's catalog `tile_url` is a
template — relative to the eoapi host, carrying a canopy-cover threshold, a
year or a date range — and nothing outside a chat turn could resolve one.
`get_tile_services_for_dataset()` is now the adapter over it, passing its
*candidate* row so the extent filter on context layers is not quietly
undone.

`widget_configs.py` holds the map-widget config projections that lived
inside `add_map_widget` (`+46` new, `−49` deleted there), so a layer added
from chat and one added by a template are byte-identical.

**This is the commit with real regression risk** — it rewrites the
`pick_dataset` path every chat turn uses. It is `b31394fc`, self-contained,
and can be pulled into its own PR if you would rather review it separately.

## Deliberately not here

| Left out | Why |
|---|---|
| the text-highlight markup (#813 `0132ec8d`) | unrelated feature, its own PR |
| `POST .../sections/nrt-monitoring` and the refresh route, the `NrtSection*` schemas | the agent is the only caller for now |
| `MosaicCreateResponse.tile_url` / `tilejson_url` | unrelated to sections |
| the two frontend handoff docs (475 lines) | a contract for endpoints this PR does not add |
| `title`, `description`, `force`, `window_days`, `max_cloud_cover` | no caller passed them; the imagery ones are template constants |
| alerts bucketed by day instead of month | changes `POST /api/analyze` output for existing clients — see below |

## Known limits, written down rather than solved

- **One area.** A template covers the dashboard's first AOI. Portfolios are
  a dashboard-level question.
- **Parameters reach the model as a dict**, described in the registry's
  `params_help` rather than shown in a tool signature. If that proves
  unreliable as templates grow, the answer is per-template tools generated
  from the registry, not a parameter in the generic layer.
- **Synchronous.** A build runs to completion, which takes tens of seconds.
  That decision gets made again when a route is added.
- **The alerts chart is still monthly**, so the 14-day default window
  renders as one or two points. Moving it to daily buckets renames the
  chart's `x_axis` from `month` to `alert_date`, which is visible to
  existing `/api/analyze` clients, so it is left for its own PR.

## Verification

775 tests pass. New: `tests/api/test_analysis_templates.py` (built section,
imagery degradation, analytics failure, already-built guard, the
parameter round trip a refresh depends on),
`tests/unit/agent/tools/test_analysis_section_tools.py` (dispatch, the
two rebuild verbs, the enforced confirmation), `tests/unit/api/analysis_templates/test_registry.py`
(loops over **every** registered template, so a new one is covered the day
it is added — its parameter model, its `describe`, and the registry's
import-lightness),
`tests/api/test_dashboards.py` (one test per blocked action, layout allowed,
the smuggling refusal), plus the layer resolver and summary tests.

The migration round-trips up and down against a scratch database.

Two behaviours the mocked tests of #813 could not have found, kept here with
assertions: every consumer gets its own copy of the AOI, because
`AnalyticsHandler.pull_data` rewrites its input in place; and the figures
the model reads are rounded, because it will otherwise quote
`153409.28893796972 ha`.

PZB-1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs3qv4aWbUtdHEKS7uX8ZJ
